### PR TITLE
Change default color in layered_violin summary_plot

### DIFF
--- a/shap/plots.py
+++ b/shap/plots.py
@@ -261,7 +261,7 @@ def approx_interactions(index, shap_values, X):
 
 # TODO: remove unused title argument / use title argument
 def summary_plot(shap_values, features=None, feature_names=None, max_display=None, plot_type="dot",
-                 color="#ff0052", axis_color="#333333", title=None, alpha=1, show=True, sort=True,
+                 color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
                  color_bar=True, auto_size_plot=True, layered_violin_max_num_bins=20):
     """
     Create a SHAP summary plot, colored by feature values when they are provided.
@@ -286,6 +286,9 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
 
     assert len(shap_values.shape) != 1, "Summary plots need a matrix of shap_values, not a vector."
 
+    # default color:
+    color = "coolwarm" if plot_type == 'layered_violin' else "#ff0052"
+    
     # convert from a DataFrame or other types
     if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
         if feature_names is None:

--- a/shap/plots.py
+++ b/shap/plots.py
@@ -287,7 +287,8 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
     assert len(shap_values.shape) != 1, "Summary plots need a matrix of shap_values, not a vector."
 
     # default color:
-    color = "coolwarm" if plot_type == 'layered_violin' else "#ff0052"
+    if color is None:
+        color = "coolwarm" if plot_type == 'layered_violin' else "#ff0052"
     
     # convert from a DataFrame or other types
     if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":


### PR DESCRIPTION
```
import xgboost
import shap

X,y = shap.datasets.diabetes()
model = xgboost.train({}, xgboost.DMatrix(X, label=y), 100)
shap_values = shap.TreeExplainer(model).shap_values(X.iloc[:100,:])
shap.summary_plot(shap_values, X.iloc[:100,:], plot_type="layered_violin")
```

From below (which doesn't illustrate layers at all):

![image](https://user-images.githubusercontent.com/8204904/39554753-bc2ea960-4ec8-11e8-9931-bf787fb9a344.png)


To

![image](https://user-images.githubusercontent.com/8204904/39554748-af3f0902-4ec8-11e8-8612-2a20d05c9731.png)


Relevant to #62 