### PR TITLE
update setup.py to bootstrap numpy installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,20 @@
 from setuptools import setup, Extension
-import numpy
+from setuptools.command.build_ext import build_ext as _build_ext
 
 # to publish use:
 # > python setup.py sdist upload
 # which depends on ~/.pypirc
+
+# Extend the default build_ext class to bootstrap numpy installation
+# that are needed to build C extensions.
+# see https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
+class build_ext(_build_ext):
+    def finialize_options(self):
+        _build_ext.finalize_options(self)
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+
 
 def run_setup(with_binary):
     ext_modules = []
@@ -21,6 +32,8 @@ def run_setup(with_binary):
         author_email='slund1@cs.washington.edu',
         license='MIT',
         packages=['shap', 'shap.explainers'],
+        cmdclass={'build_ext': build_ext},
+        setup_requires=['numpy'],
         install_requires=['numpy', 'scipy', 'iml>=0.6.0', 'scikit-learn', 'matplotlib', 'pandas', 'tqdm'],
         test_suite='nose.collector',
         tests_require=['nose', 'xgboost'],

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ from setuptools.command.build_ext import build_ext as _build_ext
 # that are needed to build C extensions.
 # see https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
 class build_ext(_build_ext):
-    def run(self):
-#         _build_ext.finalize_options(self)
-#         __builtins__.__NUMPY_SETUP__ = False
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        __builtins__.__NUMPY_SETUP__ = False
         import numpy
+        print("numpy.get_include()", numpy.get_include())
         self.include_dirs.append(numpy.get_include())
-        build_ext.run(self)
 
 
 def run_setup(with_binary):
@@ -34,6 +34,7 @@ def run_setup(with_binary):
         license='MIT',
         packages=['shap', 'shap.explainers'],
         cmdclass={'build_ext': build_ext},
+        setup_requires=['numpy'],
         install_requires=['numpy', 'scipy', 'iml>=0.6.0', 'scikit-learn', 'matplotlib', 'pandas', 'tqdm'],
         test_suite='nose.collector',
         tests_require=['nose', 'xgboost'],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def run_setup(with_binary):
 
 try:
     run_setup(True)
-except e:
+except Exception as e:
     print(e)
     print("WARNING: The C extension could not be compiled, sklearn tree models not supported.")
     run_setup(False)

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,12 @@ from setuptools.command.build_ext import build_ext as _build_ext
 # that are needed to build C extensions.
 # see https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
 class build_ext(_build_ext):
-    def finialize_options(self):
-        _build_ext.finalize_options(self)
-        __builtins__.__NUMPY_SETUP__ = False
+    def run(self):
+#         _build_ext.finalize_options(self)
+#         __builtins__.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
+        build_ext.run(self)
 
 
 def run_setup(with_binary):
@@ -33,7 +34,6 @@ def run_setup(with_binary):
         license='MIT',
         packages=['shap', 'shap.explainers'],
         cmdclass={'build_ext': build_ext},
-        setup_requires=['numpy'],
         install_requires=['numpy', 'scipy', 'iml>=0.6.0', 'scikit-learn', 'matplotlib', 'pandas', 'tqdm'],
         test_suite='nose.collector',
         tests_require=['nose', 'xgboost'],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def run_setup(with_binary):
     ext_modules = []
     if with_binary:
         ext_modules.append(
-            Extension('shap._cext', sources=['shap/_cext.cc'], include_dirs=[numpy.get_include()])
+            Extension('shap._cext', sources=['shap/_cext.cc'])
         )
 
     setup(

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ def run_setup(with_binary):
 
 try:
     run_setup(True)
-except:
+except e:
+    print(e)
     print("WARNING: The C extension could not be compiled, sklearn tree models not supported.")
     run_setup(False)


### PR DESCRIPTION
Building the shap package in an empty python environment fails because running the `setup.py` file requires `numpy`.

The following fix was suggested on StackOverflow [here](https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py). The `build_ext` class is extended to import numpy and include the headers only after installation. The disadvantage of this approach is that numpy is added to the `setup_requires` list, which builds whenever setup is invocated. 