### PR TITLE
Ability to change plot labels

### DIFF
--- a/shap/plots.py
+++ b/shap/plots.py
@@ -132,7 +132,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         else:
             proj_shap_values = shap_values[:, ind2, :] * 2  # off-diag values are split in half
 
-        # TODO: remove sick ugly recursion
+        # TODO: remove recursion; generally the functions should be shorter for more maintainable code
         dependence_plot(
             ind1, proj_shap_values, features, feature_names=feature_names,
             interaction_index=ind2, display_features=display_features, show=False

--- a/shap/plots.py
+++ b/shap/plots.py
@@ -47,18 +47,19 @@ try:
 except ImportError:
     pass
 
-
-SHAP_MAIN_EFFECT = "SHAP main effect value for\n%s"
-SHAP_INTERACTION_VALUE = "SHAP interaction value"
-SHAP_INTERACTION_EFFECT = "SHAP interaction value for\n%s and %s"
-SHAP_VALUE = "SHAP value (impact on model output)"
-SHAP_VALUE_FOR = "SHAP value for\n%s"
-SHAP_PLOT_FOR = "SHAP plot for %s"
-SHAP_FEATURE = "Feature %s"
-SHAP_FEATURE_VALUE = "Feature value"
-SHAP_FEATURE_VALUE_LOW = "Low"
-SHAP_FEATURE_VALUE_HIGH = "High"
-SHAP_JOINT_VALUE = "Joint SHAP value"
+labels = {
+    'MAIN_EFFECT': "SHAP main effect value for\n%s",
+    'INTERACTION_VALUE': "SHAP interaction value",
+    'INTERACTION_EFFECT': "SHAP interaction value for\n%s and %s",
+    'VALUE': "SHAP value (impact on model output)",
+    'VALUE_FOR': "SHAP value for\n%s",
+    'PLOT_FOR': "SHAP plot for %s",
+    'FEATURE': "Feature %s",
+    'FEATURE_VALUE': "Feature value",
+    'FEATURE_VALUE_LOW': "Low",
+    'FEATURE_VALUE_HIGH': "High",
+    'JOINT_VALUE': "Joint SHAP value"
+}
 
 
 # TODO: remove color argument / use color argument
@@ -102,7 +103,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         display_features = features
 
     if feature_names is None:
-        feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
+        feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1] - 1)]
 
     # allow vectors to be passed
     if len(shap_values.shape) == 1:
@@ -138,16 +139,17 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
             interaction_index=ind2, display_features=display_features, show=False
         )
         if ind1 == ind2:
-            pl.ylabel(SHAP_MAIN_EFFECT % feature_names[ind1])
+            pl.ylabel(labels['MAIN_EFFECT'] % feature_names[ind1])
         else:
-            pl.ylabel(SHAP_INTERACTION_EFFECT % (feature_names[ind1], feature_names[ind2]))
+            pl.ylabel(labels['INTERACTION_EFFECT'] % (feature_names[ind1], feature_names[ind2]))
 
         if show:
             pl.show()
         return
 
-    assert shap_values.shape[0] == features.shape[0], "'shap_values' and 'features' values must have the same number of rows!"
-    assert shap_values.shape[1] == features.shape[1]+1, "'shap_values' must have one more column than 'features'!"
+    assert shap_values.shape[0] == features.shape[
+        0], "'shap_values' and 'features' values must have the same number of rows!"
+    assert shap_values.shape[1] == features.shape[1] + 1, "'shap_values' must have one more column than 'features'!"
 
     # get both the raw and display feature values
     xv = features[:, ind]
@@ -226,7 +228,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     else:
         pl.gcf().set_size_inches(6, 5)
     pl.xlabel(name, color=axis_color, fontsize=13)
-    pl.ylabel(SHAP_VALUE_FOR % name, color=axis_color, fontsize=13)
+    pl.ylabel(labels['VALUE_FOR'] % name, color=axis_color, fontsize=13)
     if title is not None:
         pl.title(title, color=axis_color, fontsize=13)
     pl.gca().xaxis.set_ticks_position('bottom')
@@ -304,7 +306,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
     # default color:
     if color is None:
         color = "coolwarm" if plot_type == 'layered_violin' else "#ff0052"
-    
+
     # convert from a DataFrame or other types
     if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
         if feature_names is None:
@@ -319,7 +321,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
         features = None
 
     if feature_names is None:
-        feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
+        feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1] - 1)]
 
     # plotting SHAP interaction values
     if len(shap_values.shape) == 3:
@@ -371,7 +373,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
             pl.xlim((slow, shigh))
             pl.xlabel("")
             if i == max_display // 2:
-                pl.xlabel(SHAP_INTERACTION_VALUE)
+                pl.xlabel(labels['INTERACTION_VALUE'])
             pl.title(shorten_text(feature_names[ind], title_length_limit))
         pl.tight_layout(pad=0, w_pad=0, h_pad=0.0)
         pl.subplots_adjust(hspace=0, wspace=0.1)
@@ -406,7 +408,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
             shaps = shaps[inds]
             colored_feature = True
             try:
-                values = np.array(values, dtype=np.float64) # make sure this can be numeric
+                values = np.array(values, dtype=np.float64)  # make sure this can be numeric
             except:
                 colored_feature = False
             N = len(shaps)
@@ -488,7 +490,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
                     if leading_pos - trailing_pos > 0:
                         smooth_values[j] = running_sum / (leading_pos - trailing_pos)
                         for k in range(back_fill):
-                            smooth_values[j-k-1] = smooth_values[j]
+                            smooth_values[j - k - 1] = smooth_values[j]
                     else:
                         back_fill += 1
 
@@ -510,7 +512,8 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
                 for i in range(len(xs) - 1):
                     if ds[i] > 0.05 or ds[i + 1] > 0.05:
                         pl.fill_between([xs[i], xs[i + 1]], [pos + ds[i], pos + ds[i + 1]],
-                                        [pos - ds[i], pos - ds[i + 1]], color=red_blue_solid(smooth_values[i]), zorder=2)
+                                        [pos - ds[i], pos - ds[i + 1]], color=red_blue_solid(smooth_values[i]),
+                                        zorder=2)
 
         else:
             parts = pl.violinplot(shap_values[:, feature_order], range(len(feature_order)), points=200, vert=False,
@@ -522,12 +525,13 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
                 pc.set_edgecolor('none')
                 pc.set_alpha(alpha)
 
-    elif plot_type == "layered_violin": # courtesy of @kodonnell
+    elif plot_type == "layered_violin":  # courtesy of @kodonnell
         num_x_points = 200
-        bins = np.linspace(0, features.shape[0], layered_violin_max_num_bins + 1).round(0).astype('int') # the indices of the feature data corresponding to each bin
-        shap_min, shap_max = np.min(shap_values[:,:-1]), np.max(shap_values[:,:-1])
+        bins = np.linspace(0, features.shape[0], layered_violin_max_num_bins + 1).round(0).astype(
+            'int')  # the indices of the feature data corresponding to each bin
+        shap_min, shap_max = np.min(shap_values[:, :-1]), np.max(shap_values[:, :-1])
         x_points = np.linspace(shap_min, shap_max, num_x_points)
-        
+
         # loop through each feature and plot:
         for pos, ind in enumerate(feature_order):
             # decide how to handle: if #unique < layered_violin_max_num_bins then split by unique value, otherwise use bins/percentiles.
@@ -552,8 +556,9 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
                 shaps = shap_values[order[thesebins[i]:thesebins[i + 1]], ind]
                 # if there's only one element, then we can't 
                 if shaps.shape[0] == 1:
-                    warnings.warn("not enough data in bin #%d for feature %s, so it'll be ignored. Try increasing the number of records to plot." 
-                    % (i, feature_names[ind]))
+                    warnings.warn(
+                        "not enough data in bin #%d for feature %s, so it'll be ignored. Try increasing the number of records to plot."
+                        % (i, feature_names[ind]))
                     # to ignore it, just set it to the previous y-values (so the area between them will be zero). Not ys is already 0, so there's
                     # nothing to do if i == 0
                     if i > 0:
@@ -573,10 +578,11 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
             # whitespace
             ys = np.cumsum(ys, axis=0)
             width = 0.8
-            scale = ys.max() * 2 / width # 2 is here as we plot both sides of x axis
+            scale = ys.max() * 2 / width  # 2 is here as we plot both sides of x axis
             for i in range(nbins - 1, -1, -1):
                 y = ys[i, :] / scale
-                c = pl.get_cmap(color)(i / (nbins - 1)) if color in pl.cm.datad else color # if color is a cmap, use it, otherwise use a color
+                c = pl.get_cmap(color)(i / (
+                            nbins - 1)) if color in pl.cm.datad else color  # if color is a cmap, use it, otherwise use a color
                 pl.fill_between(x_points, pos - y, pos + y, facecolor=c)
         pl.xlim(shap_min, shap_max)
 
@@ -584,10 +590,10 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
     if color_bar and features is not None and (plot_type != "layered_violin" or color in pl.cm.datad):
         import matplotlib.cm as cm
         m = cm.ScalarMappable(cmap=red_blue_solid if plot_type != "layered_violin" else pl.get_cmap(color))
-        m.set_array([0,1])
+        m.set_array([0, 1])
         cb = pl.colorbar(m, ticks=[0, 1], aspect=1000)
-        cb.set_ticklabels([SHAP_FEATURE_VALUE_LOW, SHAP_FEATURE_VALUE_HIGH])
-        cb.set_label(SHAP_FEATURE_VALUE, size=12, labelpad=0)
+        cb.set_ticklabels([labels['FEATURE_VALUE_LOW'], labels['FEATURE_VALUE_HIGH']])
+        cb.set_label(labels['FEATURE_VALUE'], size=12, labelpad=0)
         cb.ax.tick_params(labelsize=11, length=0)
         cb.set_alpha(1)
         cb.outline.set_visible(False)
@@ -605,7 +611,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
     pl.gca().tick_params('y', length=20, width=0.5, which='major')
     pl.gca().tick_params('x', labelsize=11)
     pl.ylim(-1, len(feature_order))
-    pl.xlabel(SHAP_VALUE, fontsize=13)
+    pl.xlabel(labels['VALUE'], fontsize=13)
     pl.tight_layout()
     if show:
         pl.show()
@@ -660,7 +666,7 @@ def force_plot(shap_values, features=None, feature_names=None, out_names=None, l
 
     if shap_values.shape[0] == 1:
         if feature_names is None:
-            feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
+            feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1] - 1)]
         if features is None:
             features = ["" for _ in range(len(feature_names))]
         if type(features) == np.ndarray:
@@ -686,7 +692,7 @@ def force_plot(shap_values, features=None, feature_names=None, out_names=None, l
         exps = []
         for i in range(shap_values.shape[0]):
             if feature_names is None:
-                feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
+                feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1] - 1)]
             if features is None:
                 display_features = ["" for i in range(len(feature_names))]
             else:
@@ -724,7 +730,7 @@ def joint_plot(ind, X, shap_value_matrix, feature_names=None, other_ind=None, ot
             feature_names = X.columns
         X = X.as_matrix()
     if feature_names is None:
-        feature_names = [SHAP_FEATURE % str(i) for i in range(X.shape[1])]
+        feature_names = [labels['FEATURE'] % str(i) for i in range(X.shape[1])]
 
     x = X[:, ind]
     xname = feature_names[ind]
@@ -757,7 +763,7 @@ def joint_plot(ind, X, shap_value_matrix, feature_names=None, other_ind=None, ot
     sc = pl.scatter(x, y, s=20, c=joint_shap_values, edgecolor='', alpha=alpha, cmap=red_blue)
     pl.xlabel(xname, color=axis_color)
     pl.ylabel(yname, color=axis_color)
-    cb = pl.colorbar(sc, label=SHAP_JOINT_VALUE)
+    cb = pl.colorbar(sc, label=labels['JOINT_VALUE'])
     cb.set_alpha(1)
     cb.draw_all()
 
@@ -800,9 +806,9 @@ def interaction_plot(ind, X, shap_value_matrix, feature_names=None, interaction_
     cb.draw_all()
     # make the plot more readable
     pl.xlabel(name, color=axis_color)
-    pl.ylabel(SHAP_VALUE_FOR % name, color=axis_color)
+    pl.ylabel(labels['VALUE_FOR'] % name, color=axis_color)
     if title is not None:
-        pl.title(SHAP_PLOT_FOR % name, color=axis_color, fontsize=11)
+        pl.title(labels['PLOT_FOR'] % name, color=axis_color, fontsize=11)
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('left')
     pl.gca().spines['right'].set_visible(False)
@@ -832,9 +838,9 @@ def plot(x, shap_values, name, color="#ff0052", axis_color="#333333", alpha=1, t
 
     # make the plot more readable
     pl.xlabel(name, color=axis_color)
-    pl.ylabel(SHAP_VALUE_FOR % name, color=axis_color)
+    pl.ylabel(labels['VALUE_FOR'] % name, color=axis_color)
     if title is not None:
-        pl.title(SHAP_PLOT_FOR % name, color=axis_color, fontsize=11)
+        pl.title(labels['PLOT_FOR'] % name, color=axis_color, fontsize=11)
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('left')
     pl.gca().spines['right'].set_visible(False)

--- a/shap/plots.py
+++ b/shap/plots.py
@@ -48,6 +48,19 @@ except ImportError:
     pass
 
 
+SHAP_MAIN_EFFECT = "SHAP main effect value for\n%s"
+SHAP_INTERACTION_VALUE = "SHAP interaction value"
+SHAP_INTERACTION_EFFECT = "SHAP interaction value for\n%s and %s"
+SHAP_VALUE = "SHAP value (impact on model output)"
+SHAP_VALUE_FOR = "SHAP value for\n%s"
+SHAP_PLOT_FOR = "SHAP plot for %s"
+SHAP_FEATURE = "Feature %s"
+SHAP_FEATURE_VALUE = "Feature value"
+SHAP_FEATURE_VALUE_LOW = "Low"
+SHAP_FEATURE_VALUE_HIGH = "High"
+SHAP_JOINT_VALUE = "Joint SHAP value"
+
+
 # TODO: remove color argument / use color argument
 def dependence_plot(ind, shap_values, features, feature_names=None, display_features=None,
                     interaction_index="auto", color="#1E88E5", axis_color="#333333",
@@ -89,7 +102,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         display_features = features
 
     if feature_names is None:
-        feature_names = ["Feature " + str(i) for i in range(shap_values.shape[1] - 1)]
+        feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
 
     # allow vectors to be passed
     if len(shap_values.shape) == 1:
@@ -118,14 +131,16 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
             proj_shap_values = shap_values[:, ind2, :]
         else:
             proj_shap_values = shap_values[:, ind2, :] * 2  # off-diag values are split in half
+
+        # TODO: remove sick ugly recursion
         dependence_plot(
             ind1, proj_shap_values, features, feature_names=feature_names,
             interaction_index=ind2, display_features=display_features, show=False
         )
         if ind1 == ind2:
-            pl.ylabel("SHAP main effect value for\n" + feature_names[ind1])
+            pl.ylabel(SHAP_MAIN_EFFECT % feature_names[ind1])
         else:
-            pl.ylabel("SHAP interaction value for\n" + feature_names[ind1] + " and " + feature_names[ind2])
+            pl.ylabel(SHAP_INTERACTION_EFFECT % (feature_names[ind1], feature_names[ind2]))
 
         if show:
             pl.show()
@@ -211,7 +226,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     else:
         pl.gcf().set_size_inches(6, 5)
     pl.xlabel(name, color=axis_color, fontsize=13)
-    pl.ylabel("SHAP value for\n" + name, color=axis_color, fontsize=13)
+    pl.ylabel(SHAP_VALUE_FOR % name, color=axis_color, fontsize=13)
     if title is not None:
         pl.title(title, color=axis_color, fontsize=13)
     pl.gca().xaxis.set_ticks_position('bottom')
@@ -304,7 +319,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
         features = None
 
     if feature_names is None:
-        feature_names = ["Feature " + str(i) for i in range(shap_values.shape[1] - 1)]
+        feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
 
     # plotting SHAP interaction values
     if len(shap_values.shape) == 3:
@@ -356,7 +371,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
             pl.xlim((slow, shigh))
             pl.xlabel("")
             if i == max_display // 2:
-                pl.xlabel("SHAP interaction value")
+                pl.xlabel(SHAP_INTERACTION_VALUE)
             pl.title(shorten_text(feature_names[ind], title_length_limit))
         pl.tight_layout(pad=0, w_pad=0, h_pad=0.0)
         pl.subplots_adjust(hspace=0, wspace=0.1)
@@ -571,8 +586,8 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
         m = cm.ScalarMappable(cmap=red_blue_solid if plot_type != "layered_violin" else pl.get_cmap(color))
         m.set_array([0,1])
         cb = pl.colorbar(m, ticks=[0, 1], aspect=1000)
-        cb.set_ticklabels(["Low", "High"])
-        cb.set_label("Feature value", size=12, labelpad=0)
+        cb.set_ticklabels([SHAP_FEATURE_VALUE_LOW, SHAP_FEATURE_VALUE_HIGH])
+        cb.set_label(SHAP_FEATURE_VALUE, size=12, labelpad=0)
         cb.ax.tick_params(labelsize=11, length=0)
         cb.set_alpha(1)
         cb.outline.set_visible(False)
@@ -590,7 +605,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
     pl.gca().tick_params('y', length=20, width=0.5, which='major')
     pl.gca().tick_params('x', labelsize=11)
     pl.ylim(-1, len(feature_order))
-    pl.xlabel("SHAP value (impact on model output)", fontsize=13)
+    pl.xlabel(SHAP_VALUE, fontsize=13)
     pl.tight_layout()
     if show:
         pl.show()
@@ -645,7 +660,7 @@ def force_plot(shap_values, features=None, feature_names=None, out_names=None, l
 
     if shap_values.shape[0] == 1:
         if feature_names is None:
-            feature_names = ["Feature " + str(i) for i in range(shap_values.shape[1] - 1)]
+            feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
         if features is None:
             features = ["" for _ in range(len(feature_names))]
         if type(features) == np.ndarray:
@@ -671,7 +686,7 @@ def force_plot(shap_values, features=None, feature_names=None, out_names=None, l
         exps = []
         for i in range(shap_values.shape[0]):
             if feature_names is None:
-                feature_names = ["Feature " + str(i) for i in range(shap_values.shape[1] - 1)]
+                feature_names = [SHAP_FEATURE % str(i) for i in range(shap_values.shape[1] - 1)]
             if features is None:
                 display_features = ["" for i in range(len(feature_names))]
             else:
@@ -709,7 +724,7 @@ def joint_plot(ind, X, shap_value_matrix, feature_names=None, other_ind=None, ot
             feature_names = X.columns
         X = X.as_matrix()
     if feature_names is None:
-        feature_names = ["Feature %d" % i for i in range(X.shape[1])]
+        feature_names = [SHAP_FEATURE % str(i) for i in range(X.shape[1])]
 
     x = X[:, ind]
     xname = feature_names[ind]
@@ -742,7 +757,7 @@ def joint_plot(ind, X, shap_value_matrix, feature_names=None, other_ind=None, ot
     sc = pl.scatter(x, y, s=20, c=joint_shap_values, edgecolor='', alpha=alpha, cmap=red_blue)
     pl.xlabel(xname, color=axis_color)
     pl.ylabel(yname, color=axis_color)
-    cb = pl.colorbar(sc, label="Joint SHAP value")
+    cb = pl.colorbar(sc, label=SHAP_JOINT_VALUE)
     cb.set_alpha(1)
     cb.draw_all()
 
@@ -785,9 +800,9 @@ def interaction_plot(ind, X, shap_value_matrix, feature_names=None, interaction_
     cb.draw_all()
     # make the plot more readable
     pl.xlabel(name, color=axis_color)
-    pl.ylabel("SHAP value for " + name, color=axis_color)
+    pl.ylabel(SHAP_VALUE_FOR % name, color=axis_color)
     if title is not None:
-        pl.title("SHAP plot for " + name, color=axis_color, fontsize=11)
+        pl.title(SHAP_PLOT_FOR % name, color=axis_color, fontsize=11)
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('left')
     pl.gca().spines['right'].set_visible(False)
@@ -817,9 +832,9 @@ def plot(x, shap_values, name, color="#ff0052", axis_color="#333333", alpha=1, t
 
     # make the plot more readable
     pl.xlabel(name, color=axis_color)
-    pl.ylabel("SHAP value for " + name, color=axis_color)
+    pl.ylabel(SHAP_VALUE_FOR % name, color=axis_color)
     if title is not None:
-        pl.title("SHAP plot for " + name, color=axis_color, fontsize=11)
+        pl.title(SHAP_PLOT_FOR % name, color=axis_color, fontsize=11)
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('left')
     pl.gca().spines['right'].set_visible(False)

--- a/shap/plots.py
+++ b/shap/plots.py
@@ -1,11 +1,12 @@
 import warnings
-from scipy.stats import gaussian_kde
-from iml import Instance, Model, visualize
-from iml.explanations import AdditiveExplanation
-from iml.links import IdentityLink
-from iml.datatypes import DenseData
+
 import iml
 import numpy as np
+from iml import Instance, Model
+from iml.datatypes import DenseData
+from iml.explanations import AdditiveExplanation
+from iml.links import IdentityLink
+from scipy.stats import gaussian_kde
 
 try:
     import matplotlib.pyplot as pl
@@ -582,7 +583,7 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
             for i in range(nbins - 1, -1, -1):
                 y = ys[i, :] / scale
                 c = pl.get_cmap(color)(i / (
-                            nbins - 1)) if color in pl.cm.datad else color  # if color is a cmap, use it, otherwise use a color
+                        nbins - 1)) if color in pl.cm.datad else color  # if color is a cmap, use it, otherwise use a color
                 pl.fill_between(x_points, pos - y, pos + y, facecolor=c)
         pl.xlim(shap_min, shap_max)
 


### PR DESCRIPTION
Added the ability to change plot labels. Used this to translate the labels, but it could also be used for changing terminology (i.e. `feature` to `independent variable`, depending on your context ([1])).

Approach: the text values are moved from the plot functions into global constants. This technique is called Monkey Patching ([2]). It is a simple pattern to enable to change the texts of the plots without changing the functions.

Example code:
```
import shap

shap.plots.SHAP_MAIN_EFFECT = "Translation for SHAP main effect value for\n%s"
shap.plots.SHAP_INTERACTION_VALUE = "Translation for SHAP interaction value"
shap.plots.SHAP_INTERACTION_EFFECT = "Translation for SHAP interaction value for\n%s and %s"
shap.plots.SHAP_VALUE = "Translation for SHAP value (impact on model output)"
shap.plots.SHAP_VALUE_FOR = "Translation for SHAP value for\n%s"
shap.plots.SHAP_PLOT_FOR = "Translation for SHAP plot for %s"
shap.plots.SHAP_FEATURE = "Translation for Feature %s"
shap.plots.SHAP_FEATURE_VALUE = "Translation for Feature value"
shap.plots.SHAP_FEATURE_VALUE_LOW = "Translation for Low"
shap.plots.SHAP_FEATURE_VALUE_HIGH = "Translation for High"
shap.plots.SHAP_JOINT_VALUE = "Translation for Joint SHAP value"

# plot using shap
```

[1]: https://en.wikipedia.org/wiki/Dependent_and_independent_variables#Statistics_synonyms
[2]: https://en.wikipedia.org/wiki/Monkey_patch