### PR TITLE
expose Tree object + fix breaking test of kernel shap for dataframe input

### DIFF
--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -6,7 +6,7 @@ from iml.links import Link, IdentityLink, LogitLink
 from iml.common import Instance, Model
 from .explainers.kernel import KernelExplainer, kmeans
 from .explainers.sampling import SamplingExplainer
-from .explainers.tree import TreeExplainer
+from .explainers.tree import TreeExplainer, Tree
 from .plots import visualize, plot, summary_plot, joint_plot, interaction_plot, dependence_plot, force_plot
 from iml.visualizers import initjs, SimpleListVisualizer, SimpleListVisualizer, AdditiveForceVisualizer, \
     AdditiveForceArrayVisualizer

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -122,7 +122,7 @@ class KernelExplainer(object):
 
         # see if we have a vector output
         self.vector_out = True
-        if len(self.fnull.shape) == 0:
+        if len(self.fnull.shape) == 0 or (len(self.fnull.shape) == 1 and self.fnull.shape[0] == 1):
             self.vector_out = False
             self.fnull = np.array([self.fnull])
             self.D = 1
@@ -367,7 +367,6 @@ class KernelExplainer(object):
             phi = np.squeeze(phi, axis=1)
             phi_var = np.squeeze(phi_var, axis=1)
             self.fx = self.fx[0]
-            self.fnull = self.fnull[0]
 
         # return the Shapley values along with variances of the estimates
         # note that if features were eliminated by l1 regression their

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -122,7 +122,7 @@ class KernelExplainer(object):
 
         # see if we have a vector output
         self.vector_out = True
-        if len(self.fnull.shape) == 0 or (len(self.fnull.shape) == 1 and self.fnull.shape[0] == 1):
+        if len(self.fnull.shape) == 0:
             self.vector_out = False
             self.fnull = np.array([self.fnull])
             self.D = 1
@@ -367,6 +367,7 @@ class KernelExplainer(object):
             phi = np.squeeze(phi, axis=1)
             phi_var = np.squeeze(phi_var, axis=1)
             self.fx = self.fx[0]
+            self.fnull = self.fnull[0]
 
         # return the Shapley values along with variances of the estimates
         # note that if features were eliminated by l1 regression their

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -36,3 +36,23 @@ def test_front_page_model_agnostic():
 
     # plot the SHAP values for the Setosa output of the first instance
     shap.force_plot(shap_values[0][0, :], X_test.iloc[0, :], link="logit")
+
+def test_kernel_shap_with_dataframe():
+    from sklearn.linear_model import LinearRegression
+    import shap
+    import pandas as pd
+    import numpy as np
+    np.random.seed(3)
+
+    df_X = pd.DataFrame(np.random.random((10, 3)), columns=list('abc'))
+    df_X.index = pd.date_range('2018-01-01', periods=10, freq='D', tz='UTC')
+
+    df_y = df_X.eval('a - 2 * b + 3 * c')
+    df_y = df_y + np.random.normal(0.0, 0.1, df_y.shape)
+
+    linear_model = LinearRegression()
+    linear_model.fit(df_X, df_y)
+
+    explainer = shap.KernelExplainer(linear_model.predict, df_X)
+    shap_values = explainer.shap_values(df_X)
+


### PR DESCRIPTION
Change 1: expose Tree object so that I can run tree shap with my tree based model

Change 2: recent change in kernel shap broke my local test for the case of pandas dataframe input. Here I submit a proposed change along with my test case.

Please feel free to let me know if you have any concerns.
Thanks!