### PR TITLE
fix the error found in kernel shap tests with dataframe input and fix test case

### DIFF
--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -117,7 +117,7 @@ class KernelExplainer(object):
         else:
             model_null = self.model.f(self.data.data)
         if isinstance(model_null, (pd.DataFrame, pd.Series)):
-            model_null = model_null.values
+            model_null = np.squeeze(model_null.values)
         self.fnull = np.sum((model_null.T * self.data.weights).T, 0)
 
         # see if we have a vector output
@@ -234,7 +234,7 @@ class KernelExplainer(object):
         else:
             model_out = self.model.f(instance.x)
         if isinstance(model_out, (pd.DataFrame, pd.Series)):
-            model_out = model_out.values[0]
+            model_out = model_out.values
         self.fx = model_out[0]
 
         if not self.vector_out:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -53,6 +53,6 @@ def test_kernel_shap_with_dataframe():
     linear_model = LinearRegression()
     linear_model.fit(df_X, df_y)
 
-    explainer = shap.KernelExplainer(linear_model.predict, df_X)
+    explainer = shap.KernelExplainer(linear_model.predict, df_X, keep_index=True)
     shap_values = explainer.shap_values(df_X)
 


### PR DESCRIPTION
Sorry my original test case didn't turn on the keep_index flag so the test isn't done correctly. This change should be able to fix the test for kernel shap on dataframe input. 
Thanks!
