### PR TITLE
fixed benchmark import error

### DIFF
--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -11,5 +11,5 @@ from .plots.dependence import dependence_plot
 from .plots.force import force_plot, initjs
 from .plots.image import image_plot
 from . import datasets
-from . import benchmark
+import benchmark
 from .explainers import other

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -11,5 +11,5 @@ from .plots.dependence import dependence_plot
 from .plots.force import force_plot, initjs
 from .plots.image import image_plot
 from . import datasets
-import benchmark
+from .benchmark import *
 from .explainers import other


### PR DESCRIPTION
Hey @slundberg ,

When you go to import shap you get an error:

```
  File python2.7/site-packages/shap/__init__.py", line 14, in <module>
    from . import benchmark
ImportError: cannot import name benchmark

```

This also causes the conda-forge CI to fail:

https://circleci.com/gh/conda-forge/staged-recipes/29466?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

I made the change in the PR and tested installing locally so hopefully this should be g2g!
