### PR TITLE
improve performance for sparse matrix input in kernel explainer

### DIFF
--- a/shap/common.py
+++ b/shap/common.py
@@ -1,6 +1,7 @@
 import re
 import pandas as pd
 import numpy as np
+import scipy as sp
 
 
 class Instance:
@@ -149,7 +150,9 @@ def convert_to_data(val, keep_index=False):
             return DenseDataWithIndex(val.values, list(val.columns), val.index.values, val.index.name)
         else:
             return DenseData(val.values, list(val.columns))
-    elif str(type(val)).endswith("scipy.sparse.csr.csr_matrix'>"):
+    elif sp.sparse.issparse(val):
+        if not sp.sparse.isspmatrix_csr(val):
+            val = val.tocsr()
         return SparseData(val)
     else:
         assert False, "Unknown type passed as data object: "+str(type(val))

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -54,13 +54,13 @@ def test_kernel_shap_with_dataframe():
     explainer = shap.KernelExplainer(linear_model.predict, df_X, keep_index=True)
     shap_values = explainer.shap_values(df_X)
 
-def test_kernel_shap_with_a1a_csr():
+def test_kernel_shap_with_a1a_sparse():
     from sklearn.model_selection import train_test_split
     from sklearn.linear_model import LinearRegression
     import shap
 
     X, y = shap.datasets.a1a()
-    x_train, x_test, y_train, y_test = train_test_split(X, y, test_size=0.02, random_state=0)
+    x_train, x_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)
     linear_model = LinearRegression()
     linear_model.fit(x_train, y_train)
 
@@ -70,7 +70,7 @@ def test_kernel_shap_with_a1a_csr():
     explainer = shap.KernelExplainer(linear_model.predict, background)
     explainer.shap_values(x_test)
 
-def test_kernel_shap_with_high_dim_csr():
+def test_kernel_shap_with_high_dim_sparse():
     # verifies we can run on very sparse data produced from feature hashing
     from sklearn.model_selection import train_test_split
     from sklearn.linear_model import LinearRegression
@@ -87,7 +87,7 @@ def test_kernel_shap_with_high_dim_csr():
                         shuffle=True, random_state=42,
                         remove=remove)
     x_train, x_test, y_train, y_validation = train_test_split(ngroups.data, ngroups.target,
-                                                                    test_size=0.001, random_state=42)
+                                                                    test_size=0.01, random_state=42)
     from sklearn.feature_extraction.text import HashingVectorizer
     vectorizer = HashingVectorizer(stop_words='english', alternate_sign=False,
                                 n_features=2**16)


### PR DESCRIPTION
Improve performance for sparse matrix input in kernel explainer - by converting the background dataset to lil and the examples to lil format the performance was improved by 10X-20X.
Also, this PR changes the interface to allow any sparse matrix to be accepted.