### PR TITLE
fix sparse nonzero background case in shap and add validation test

### DIFF
--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -426,12 +426,14 @@ class KernelExplainer(Explainer):
             varying_indices = np.unique(np.union1d(self.data.data.nonzero()[1], x.nonzero()[1]))
             remove_unvarying_indices = []
             for i in range(0, len(varying_indices)):
+                varying_index = varying_indices[i]
                 # now verify the nonzero values do vary
-                data_rows = self.data.data[:, [i]]
+                data_rows = self.data.data[:, [varying_index]]
                 nonzero_rows = data_rows.nonzero()[0]
-                if nonzero_rows:
-                    num_mismatches = np.sum(np.abs(data_rows[nonzero_rows] - x[0, [i]][0, 0]) > 1e-7)
-                    if num_mismatches > 0:
+
+                if nonzero_rows.size > 0:
+                    num_mismatches = np.sum(np.abs(data_rows[nonzero_rows].toarray() - x[0, [varying_index]][0, 0]) > 1e-7)
+                    if num_mismatches == 0:
                         remove_unvarying_indices.append(i)
             mask = np.ones(len(varying_indices), dtype=bool)
             mask[remove_unvarying_indices] = False


### PR DESCRIPTION
This fixes the issue found by @suzinyou here:
https://github.com/slundberg/shap/pull/200
When adding a test, I found several additional problems that made the sparse result differ from dense when there were non-zero values in the background dataset.  I never noticed this issue previously because I've only tested the case with sparse all-zero background values.
I also manually validated locally by printing the varying indices returned by the [varying groups method](https://github.com/slundberg/shap/blob/169fe9d889308fb1266ae1a42f36eea6d5c1d3c6/shap/explainers/kernel.py#L408) in both the sparse and dense case and manually comparing the two to ensure that they have the exact same indices.  This was partly how I was able to find and resolve the other issues.