### PR TITLE
 Add optional x_jitter to dependence_plot

### DIFF
--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -149,7 +149,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         xvals = np.unique(xv)
         smallest_diff = np.min(np.diff(np.sort(xvals)))
         jitter_amount = x_jitter * smallest_diff
-        for i in range(len(xv)):
+        xv += (np.random.ranf(size = len(xv))*jitter_amount) - (jitter_amount/2)
 
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     if interaction_index is not None:

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -150,7 +150,6 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         smallest_diff = np.min(np.diff(np.sort(xvals)))
         jitter_amount = x_jitter * smallest_diff
         for i in range(len(xv)):
-            xv[i] += (np.random.ranf(size=1)[0] * jitter_amount) - (jitter_amount/2)
 
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     if interaction_index is not None:

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -146,7 +146,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     # optionally add jitter to feature values
     if x_jitter > 0:
         if x_jitter > 1: x_jitter = 1
-        xvals = list(set(xv))
+        xvals = np.unique(xv)
         smallest_diff = np.min(np.diff(np.sort(xvals)))
         jitter_amount = x_jitter * smallest_diff
         for i in range(len(xv)):

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -144,7 +144,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         color_norm = matplotlib.colors.BoundaryNorm(bounds, colors.red_blue.N)
         
     # optionally add jitter to feature values
-    if (x_jitter > 0) and (len(set(xv)) < 20):
+    if x_jitter > 0:
         if x_jitter > 1: x_jitter = 1
         xvals = list(set(xv))
         smallest_diff = np.min(np.diff(np.sort(xvals)))

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -147,7 +147,7 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     if (noise > 0) and (len(set(xv)) < 20):
         if noise > 1: noise = 1
         xvals = list(set(xv))
-        smallest_diff = np.min([xvals[i] - xvals[i-1] for i in range(1, len(xvals))])
+        smallest_diff = np.min(np.diff(np.sort(xvals)))
         noise_amount = noise * smallest_diff
         for i in range(len(xv)):
             xv[i] += (np.random.ranf(size=1)[0] * noise_amount) - (noise_amount/2)

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -10,7 +10,7 @@ from . import colors
 # TODO: remove color argument / use color argument
 def dependence_plot(ind, shap_values, features, feature_names=None, display_features=None,
                     interaction_index="auto", color="#1E88E5", axis_color="#333333",
-                    dot_size=16, noise=0, alpha=1, title=None, show=True):
+                    dot_size=16, x_jitter=0, alpha=1, title=None, show=True):
     """
     Create a SHAP dependence plot, colored by an interaction feature.
 
@@ -34,8 +34,8 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     interaction_index : "auto", None, or int
         The index of the feature used to color the plot.
         
-    noise : float (0 - 1)
-        Adds random noise to feature values if feature has less than 20 unique values.
+    x_jitter : float (0 - 1)
+        Adds random jitter to feature values. 
         May increase plot readability when feature is non-continuous.
     """
 
@@ -143,14 +143,14 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
         bounds = np.linspace(clow, chigh, chigh - clow + 2)
         color_norm = matplotlib.colors.BoundaryNorm(bounds, colors.red_blue.N)
         
-    # optionally add noise if feature has less than 20 unique values
-    if (noise > 0) and (len(set(xv)) < 20):
-        if noise > 1: noise = 1
+    # optionally add jitter to feature values
+    if (x_jitter > 0) and (len(set(xv)) < 20):
+        if x_jitter > 1: x_jitter = 1
         xvals = list(set(xv))
         smallest_diff = np.min(np.diff(np.sort(xvals)))
-        noise_amount = noise * smallest_diff
+        jitter_amount = x_jitter * smallest_diff
         for i in range(len(xv)):
-            xv[i] += (np.random.ranf(size=1)[0] * noise_amount) - (noise_amount/2)
+            xv[i] += (np.random.ranf(size=1)[0] * jitter_amount) - (jitter_amount/2)
 
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     if interaction_index is not None:

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -10,7 +10,7 @@ from . import colors
 # TODO: remove color argument / use color argument
 def dependence_plot(ind, shap_values, features, feature_names=None, display_features=None,
                     interaction_index="auto", color="#1E88E5", axis_color="#333333",
-                    dot_size=16, alpha=1, title=None, show=True):
+                    dot_size=16, noise=0, alpha=1, title=None, show=True):
     """
     Create a SHAP dependence plot, colored by an interaction feature.
 
@@ -33,6 +33,10 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
 
     interaction_index : "auto", None, or int
         The index of the feature used to color the plot.
+        
+    noise : float (0 - 1)
+        Adds random noise to feature values if feature has less than 20 unique values.
+        May increase plot readability when feature is non-continuous.
     """
 
     # convert from DataFrames if we got any
@@ -138,6 +142,15 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     if categorical_interaction and clow != chigh:
         bounds = np.linspace(clow, chigh, chigh - clow + 2)
         color_norm = matplotlib.colors.BoundaryNorm(bounds, colors.red_blue.N)
+        
+    # optionally add noise if feature has less than 20 unique values
+    if (noise > 0) and (len(set(xv)) < 20):
+        if noise > 1: noise = 1
+        xvals = list(set(xv))
+        smallest_diff = np.min([xvals[i] - xvals[i-1] for i in range(1, len(xvals))])
+        noise_amount = noise * smallest_diff
+        for i in range(len(xv)):
+            xv[i] += (np.random.ranf(size=1)[0] * noise_amount) - (noise_amount/2)
 
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     if interaction_index is not None:


### PR DESCRIPTION
Optionally add random noise to feature values if feature has less than 20 unique values.  May increase plot readability when feature is non-continuous.

Attached example picture with noise set to 0.33.
Without the noise, most of the dots overlap, especially where X == 2.0
![plot_interaction_businesstravel_vs_age](https://user-images.githubusercontent.com/17611570/48430353-7085c080-e76f-11e8-8ac2-a078b92c117a.png)
