### PR TITLE
Enable sum of errors for categorical classes instead of absolute error sum.

### DIFF
--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -416,7 +416,10 @@ class KernelExplainer(Explainer):
                         varying[i] = False
                         continue
                     x_group = x_group.todense()
-                num_mismatches = np.sum(np.abs(x_group - self.data.data[:, inds]) > 1e-7)
+                if type(x_group[0]) is str: 
+                    num_mismatches = np.sum(x_group[0] == self.data.data[:, inds])
+                else:
+                    num_mismatches = np.sum(np.abs(x_group - self.data.data[:, inds]) > 1e-7)
                 varying[i] = num_mismatches > 0
             return np.nonzero(varying)[0]
         else:


### PR DESCRIPTION
This PR contains a proposed modification in the code that performs the comparison of the classes with an equals match as opposed to an absolute error sum.

This change ensures that categorical variables are only compare, and errors are weighted the same for any class mismatch (as opposed to taking the numerical difference between the categorical values which may not make sense).