### PR TITLE
x_jitter is now aware of NaNs

### DIFF
--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -151,9 +151,10 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
             xvals = xvals.astype(np.float)
             xvals = xvals[~np.isnan(xvals)]
         xvals = np.unique(xvals)
-        smallest_diff = np.min(np.diff(np.sort(xvals)))
-        jitter_amount = x_jitter * smallest_diff
-        xv += (np.random.ranf(size = len(xv))*jitter_amount) - (jitter_amount/2)
+        if len(xvals) >= 2:
+            smallest_diff = np.min(np.diff(np.sort(xvals)))
+            jitter_amount = x_jitter * smallest_diff
+            xv += (np.random.ranf(size = len(xv))*jitter_amount) - (jitter_amount/2)
 
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     if interaction_index is not None:

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -146,7 +146,11 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
     # optionally add jitter to feature values
     if x_jitter > 0:
         if x_jitter > 1: x_jitter = 1
-        xvals = np.unique(xv)
+        xvals = xv.copy()
+        if isinstance(xvals[0], float):
+            xvals = xvals.astype(np.float)
+            xvals = xvals[~np.isnan(xvals)]
+        xvals = np.unique(xvals)
         smallest_diff = np.min(np.diff(np.sort(xvals)))
         jitter_amount = x_jitter * smallest_diff
         xv += (np.random.ranf(size = len(xv))*jitter_amount) - (jitter_amount/2)


### PR DESCRIPTION
If x-values contained one or more NaNs, x_jitter would choke and cause a blank graph as output.  This is now fixed.  

We're also checking that we have at least 2 unique X-values after removing the NaNs, cause the code just below fails if that's not the case.

I'm not sure if
`if isinstance(xvals[0], float)`
is the best way to check if the elements inside the ndarray are floats.  I tried also `xvals.dtype` but this always returned 'object' even if the contents are floats.