### PR TITLE
Make kernel and sampling explainers have consistent nsamples defaults

### DIFF
--- a/shap/explainers/sampling.py
+++ b/shap/explainers/sampling.py
@@ -68,10 +68,10 @@ class SamplingExplainer(KernelExplainer):
         else:
 
             # pick a reasonable number of samples if the user didn't specify how many they wanted
-            self.nsamples = kwargs.get("nsamples", 0)
-            assert self.nsamples % 2 == 0, "nsamples must be divisible by 2!"
-            if self.nsamples == 0:
+            self.nsamples = kwargs.get("nsamples", "auto")
+            if self.nsamples == "auto":
                 self.nsamples = 1000 * self.M
+            assert self.nsamples % 2 == 0, "nsamples must be divisible by 2!"
 
             min_samples_per_feature = kwargs.get("min_samples_per_feature", 100)
             round1_samples = self.nsamples


### PR DESCRIPTION
In writing a wrapper for the shap library so people can specify default solver (e.g. kernel or sampling) I ran into an error which turned out to be an inconsistency in the "nsamples" default value between the two methods. This PR makes nsamples="auto" be the common default.