### PR TITLE
Added test checking that DeepExplainer of a linear model (in tf keras) is correct.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - '3.6'
 install:
   - pip install .
+  - pip install tensorflow
 script: python setup.py nosetests
 before_script:
   - export DISPLAY=:99.0

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -105,6 +105,7 @@ def test_tf_keras_linear():
     from tensorflow.keras.layers import Dense, Input
     from tensorflow.keras.optimizers import SGD
     import tensorflow as tf
+    import shap
 
     np.random.seed(0)
 

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -89,14 +89,10 @@ def test_tf_keras_mnist_cnn():
 def test_tf_keras_linear():
     """Test verifying that a linear model with linear data gives the correct result."""
 
-    try:
-        from tensorflow.keras.models import Model
-        from tensorflow.keras.layers import Dense, Input
-        from tensorflow.keras.optimizers import SGD
-        import tensorflow as tf
-    except Exception as e:
-        print("Skipping test_tf_keras_mnist_cnn!")
-        return
+    from tensorflow.keras.models import Model
+    from tensorflow.keras.layers import Dense, Input
+    from tensorflow.keras.optimizers import SGD
+    import tensorflow as tf
 
     np.random.seed(0)
 

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -101,7 +101,7 @@ def test_tf_keras_linear():
 
     # generate data following a linear relationship
     x = np.random.normal(1, 10, size=(1000, len(coef)))
-    y = np.dot(x, coef) + 1 + np.random.normal(scale=0.01, size=1000)
+    y = np.dot(x, coef) + 1 + np.random.normal(scale=0.1, size=1000)
 
     # create a linear model
     inputs = Input(shape=(2,))
@@ -111,11 +111,7 @@ def test_tf_keras_linear():
     model.compile(optimizer=SGD(), loss='mse', metrics=['mse'])
     model.fit(x, y, epochs=30, shuffle=False, verbose=0)
 
-    # check that the weights are correct (not part of the this test per-se, but required for the test to make sense)
-    # - coefficients
-    np.testing.assert_allclose(model.layers[1].get_weights()[0].T[0], coef, rtol=0.01)
-    # - intercept
-    np.testing.assert_allclose(model.layers[1].get_weights()[1][0], 1, rtol=0.01)
+    fit_coef = model.layers[1].get_weights()[0].T[0]
 
     # explain
     e = shap.DeepExplainer((model.layers[0].input, model.layers[-1].output), x)
@@ -126,8 +122,8 @@ def test_tf_keras_linear():
 
     assert values.shape == (1000, 2)
 
-    expected = (x - x.mean(0)) * coef
-    np.testing.assert_allclose(expected - values, 0, atol=0.1)
+    expected = (x - x.mean(0)) * fit_coef
+    np.testing.assert_allclose(expected - values, 0, atol=1e-5)
 
 def test_keras_imdb_lstm():
     """ Basic LSTM example using keras

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -97,8 +97,10 @@ def test_tf_keras_mnist_cnn():
     assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % d
 
 def test_tf_keras_linear():
-    """Test verifying that a linear model with linear data gives the correct result."""
-
+    """Test verifying that a linear model with linear data gives the correct result.
+    """
+    _skip_if_no_tensorflow()
+    
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Dense, Input
     from tensorflow.keras.optimizers import SGD


### PR DESCRIPTION
This test consists in:

1. generate data with 2 independent features and a target `y = 1 + 2 x1 + x2 + small noise`
2. define a linear model with Keras
3. fit the model to the data
4. confirm that the model fits the data correctly
5. explain the fitted model
6. confirm that the shap values correspond to the expected values of a linear model, namely, what is described in the docs as `"Assuming features are independent leads to interventional SHAP values which for a linear model are coef[i] * (x[i] - x.mean(0)[i]) for the ith feature"`.

This test currently fails (check with tensorflow installed) because the shap values do not correspond to the equation.