### PR TITLE
Add BN to deep torch and fix a small Warning statement

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -149,7 +149,7 @@ class PyTorchDeepExplainer(Explainer):
             if op_handler[module_type].__name__ not in ['passthrough', 'linear_1d']:
                 return op_handler[module_type](module, grad_input, grad_output)
         else:
-            print('Warning: unrecognized nn.Module: {}'.format(type))
+            print('Warning: unrecognized nn.Module: {}'.format(module_type))
             return grad_input
 
     def gradient(self, idx, inputs):
@@ -323,6 +323,9 @@ op_handler['Linear'] = linear_1d
 op_handler['AvgPool1d'] = linear_1d
 op_handler['AvgPool2d'] = linear_1d
 op_handler['AvgPool3d'] = linear_1d
+op_handler['BatchNorm1d'] = linear_1d
+op_handler['BatchNorm2d'] = linear_1d
+op_handler['BatchNorm3d'] = linear_1d
 
 op_handler['ReLU'] = nonlinear_1d
 op_handler['ELU'] = nonlinear_1d

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -212,6 +212,7 @@ def test_pytorch_mnist_cnn():
                 )
                 self.fc_layers = nn.Sequential(
                     nn.Linear(320, 50),
+                    nn.BatchNorm1d(50),
                     nn.ReLU(),
                     nn.Linear(50, 10),
                     nn.ELU(),


### PR DESCRIPTION
Add BatchNorm layer to the deep torch. When the eval is open it is simply a linear layer.

Fix a bug in a warning statement.