### PR TITLE
fixed broken keras multi input model in gradient explainer

### DIFF
--- a/shap/explainers/gradient.py
+++ b/shap/explainers/gradient.py
@@ -128,13 +128,13 @@ class _TFGradientExplainer(Explainer):
 
         # determine the model inputs and outputs
         if str(type(model)).endswith("keras.engine.sequential.Sequential'>"):
-            self.model_inputs = model.layers[0].input
+            self.model_inputs = model.inputs
             self.model_output = model.layers[-1].output
         elif str(type(model)).endswith("keras.models.Sequential'>"):
-            self.model_inputs = model.layers[0].input
+            self.model_inputs = model.inputs
             self.model_output = model.layers[-1].output
         elif str(type(model)).endswith("keras.engine.training.Model'>"):
-            self.model_inputs = model.layers[0].input
+            self.model_inputs = model.inputs
             self.model_output = model.layers[-1].output
         elif str(type(model)).endswith("tuple'>"):
             self.model_inputs = model[0]

--- a/shap/explainers/gradient.py
+++ b/shap/explainers/gradient.py
@@ -208,9 +208,16 @@ class _TFGradientExplainer(Explainer):
                 model_output_ranks = np.argsort(model_output_values)
             elif output_rank_order == "max_abs":
                 model_output_ranks = np.argsort(np.abs(model_output_values))
+            elif output_rank_order == "custom":
+                model_output_ranks = ranked_outputs
             else:
-                assert False, "output_rank_order must be max, min, or max_abs!"
-            model_output_ranks = model_output_ranks[:,:ranked_outputs]
+                assert False, "output_rank_order must be max, min, max_abs or custom!"
+
+            if output_rank_order in ["max", "min", "max_abs"]:
+                model_output_ranks = model_output_ranks[:,:ranked_outputs]
+                # when output_rank_order == "custom" the argument ranked_output contains the output node indices
+                # of interest, i.e., model_output_ranks contains those indices already in proper format
+                # shape: 
         else:
             model_output_ranks = np.tile(np.arange(len(self.gradients)), (X[0].shape[0], 1))
 

--- a/shap/explainers/gradient.py
+++ b/shap/explainers/gradient.py
@@ -189,7 +189,7 @@ class _TFGradientExplainer(Explainer):
             self.gradients[i] = tf.gradients(out, self.model_inputs)
         return self.gradients[i]
 
-    def shap_values(self, X, nsamples=200, ranked_outputs=None, output_rank_order="max"):
+    def shap_values(self, X, nsamples=200, ranked_outputs=None, output_rank_order="max", rseed=None):
 
         # check if we have multiple inputs
         if not self.multi_input:
@@ -215,9 +215,6 @@ class _TFGradientExplainer(Explainer):
 
             if output_rank_order in ["max", "min", "max_abs"]:
                 model_output_ranks = model_output_ranks[:,:ranked_outputs]
-                # when output_rank_order == "custom" the argument ranked_output contains the output node indices
-                # of interest, i.e., model_output_ranks contains those indices already in proper format
-                # shape: 
         else:
             model_output_ranks = np.tile(np.arange(len(self.gradients)), (X[0].shape[0], 1))
 
@@ -225,7 +222,10 @@ class _TFGradientExplainer(Explainer):
         output_phis = []
         samples_input = [np.zeros((nsamples,) + X[l].shape[1:]) for l in range(len(X))]
         samples_delta = [np.zeros((nsamples,) + X[l].shape[1:]) for l in range(len(X))]
-        rseed = np.random.randint(0,1e6)
+        # use random argument if no argument given
+        if rseed is None:
+            rseed = np.random.randint(0, 1e6)
+
         for i in range(model_output_ranks.shape[1]):
             np.random.seed(rseed) # so we get the same noise patterns for each output class
             phis = []


### PR DESCRIPTION
`DeepExplainer` worked nicely with my multi input keras model, but in order to make the `GradientExplainer` work as well I had to copy the respective lines from `deep/deep_tf.py` to `gradient.py`.

Without the fix I would be receiving the following errors when calling the `shap_values` method of the `GradientExplainer` object:
```
File "shap/explainers/gradient.py", line 196, in shap_values
    assert type(X) != list, "Expected a single tensor model input!"