### PR TITLE
WIP: Made most dependencies be declared as extras in setup.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ os:
 python:
   - '2.7'
   - '3.6'
-install:
-  - pip install .
-  - pip install tensorflow keras
 script: python setup.py nosetests
 before_script:
   - export DISPLAY=:99.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
-  - "%PYTHON%\\python.exe -m pip install tensorflow keras"
 
 build: off
 

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ extras_require = {
     'xgboost': ['XGBoost>=v0.81'],  # A bug in XGBoost fixed in v0.81 makes XGBClassifier fail to give margin outputs
     'lightgbm': ['lightgbm'],
     'tensorflow': ['keras>=2.1.0', 'tensorflow>=1.4.0'],
-    'torch': ['pytorch>=0.4'],
-    'torchvision': ['pytorch>=0.4', 'torchvision']
+    'torch': ['torch>=0.4'],
+    'torchvision': ['torch>=0.4', 'torchvision']
 }
 
 

--- a/shap/plots/colors.py
+++ b/shap/plots/colors.py
@@ -4,9 +4,9 @@
 from __future__ import division
 
 import numpy as np
-import skimage.color
 
 try:
+    import skimage.color
     import matplotlib.pyplot as pl
     import matplotlib
     from matplotlib.colors import LinearSegmentedColormap


### PR DESCRIPTION
The goal of this PR is to reduce the number of dependencies that are installed when installing shap, see #466 

Essentially, there are two types of dependencies

1. core dependencies: `['numpy', 'scipy', 'scikit-learn', 'pandas', 'tqdm']`
2. non-core dependencies

Non-core dependencies are dependencies of a given `feature` of the package. In Python, this can be achieved through `extras_require` keyword on `setup.py`. This PR does exactly that. It also generalizes the testing to gracefully handle uninstallable dependencies (this was limited to `xgboost` and `lightgbm`).

This PR proposes that the package contains a `extra_requires` that enumerates the features of this package:

```
extras_require = {
    'plots': ['matplotlib', 'scikit-image', 'ipython'],
    'xgboost': ['XGBoost>=v0.81'],  # A bug in XGBoost fixed in v0.81 makes XGBClassifier fail to give margin outputs
    'lightgbm': ['lightgbm'],
    'tensorflow': ['keras>=2.1.0', 'tensorflow>=1.4.0'],
    'torch': ['pytorch>=0.4'],
    'torchvision': ['pytorch>=0.4', 'torchvision']
}
```

**This change changes the installation script:** the user now has to run `pip install shap[plots]` to obtain the same behavior as before. On the other hand, `pip install shap[plots,tensorflow]` is now possible :)

There are still a couple of changes for this PR to be completed:

[ ] Document new way of installing package
[ ] Add extra dependency `catboost`, that this package also depends on.
[ ] Check that tests run.

