### PR TITLE
Set expected values in pytorch

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -55,6 +55,7 @@ class PyTorchDeepExplainer(Explainer):
             if outputs.shape[1] > 1:
                 self.multi_output = True
                 self.num_outputs = outputs.shape[1]
+                self.expected_value = outputs.mean(0).numpy()
 
     def add_target_handle(self, layer):
         input_handle = layer.register_forward_hook(self.get_target_input)

--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -55,7 +55,7 @@ class PyTorchDeepExplainer(Explainer):
             if outputs.shape[1] > 1:
                 self.multi_output = True
                 self.num_outputs = outputs.shape[1]
-                self.expected_value = outputs.mean(0).numpy()
+            self.expected_value = outputs.mean(0).numpy()
 
     def add_target_handle(self, layer):
         input_handle = layer.register_forward_hook(self.get_target_input)


### PR DESCRIPTION
Is this just missing or is there a special reason not to set self.expected_value in the constructor?