### PR TITLE
Fix fatal crash on xgb gpu_hist model load

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -716,6 +716,8 @@ class Tree:
             self.thresholds = tree["threshold"]
             self.values = tree["value"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
+            self.children_left[self.children_left==0]=-1
+            self.children_right[self.children_right==0]=-1
 
         elif type(tree) == dict and 'tree_structure' in tree:
             start = tree['tree_structure']


### PR DESCRIPTION
I'm trying to resolve #452. When using an xgboost model trained with parameter
'tree_method':'gpu_hist' the shap.TreeExplainer crashes.
This crash is on the call to the C++ lib on line 873
function _cext.compute_expectations. This appears to be
due to the zeros that occur in the children_left and/or
children_right variables. The fix replaces the zeros with
-1's after the data is loaded from the xgboost gpu_hist model.