### PR TITLE
fix zero division in compute_expectations

### DIFF
--- a/shap/tree_shap.h
+++ b/shap/tree_shap.h
@@ -506,8 +506,12 @@ inline int compute_expectations(TreeEnsemble &tree, int i = 0, int depth = 0) {
         const unsigned ri_offset = ri * tree.num_outputs;
         const unsigned i_offset = i * tree.num_outputs;
         for (unsigned j = 0; j < tree.num_outputs; ++j) {
-            const tfloat v = (left_weight * tree.values[li_offset + j] + right_weight * tree.values[ri_offset + j]) / (left_weight + right_weight);
-            tree.values[i_offset + j] = v;
+            if ((left_weight == 0) && (right_weight == 0)) {
+                tree.values[i_offset + j] = 0.0;
+            } else {
+                const tfloat v = (left_weight * tree.values[li_offset + j] + right_weight * tree.values[ri_offset + j]) / (left_weight + right_weight);
+                tree.values[i_offset + j] = v;
+            }
         }
         max_depth = std::max(depth_left, depth_right) + 1;
     }


### PR DESCRIPTION
Hello, @slundberg ) Thank you for writing this tool.

I have a request with a really short implementation. 

I want to add new SHAP functionality to Yandex CatBoost. But due to the special structure of trees in CatBoost, there might be nodes with right and left leafs with both zero sample weights in them. As a result, after calling the `_cext.compute_expectations` function https://github.com/slundberg/shap/blob/master/shap/explainers/tree.py#L899
which calls `compute_expectations` function here https://github.com/slundberg/shap/blob/master/shap/_cext.cc#L99 and finally calling `compute_expectations` function here https://github.com/slundberg/shap/blob/master/shap/tree_shap.h#L509, if `(left_weight + right_weight)` equals to `0`, this leads to zero division and `nan`s in returned Python array of expected values in nodes of trees.

In other tree-based algorithms, such as XGBClassifier and RandomForestClassifier, at least one sample must be in each leaf, so this problem does not appear. But in CatBoost trees it appears.

I just have added additional if-statement to check that `left_weight` and `right_weight` are not zeroes.  