### PR TITLE
Integer division for np.linspace stepping parameter in line 35

### DIFF
--- a/shap/plots/colors.py
+++ b/shap/plots/colors.py
@@ -32,7 +32,7 @@ try:
     blues = []
     alphas = []
     nsteps = 100
-    l_vals = list(np.linspace(blue_lch[0], l_mid, nsteps/2)) + list(np.linspace(l_mid, red_lch[0], nsteps/2))
+    l_vals = list(np.linspace(blue_lch[0], l_mid, nsteps//2)) + list(np.linspace(l_mid, red_lch[0], nsteps//2))
     c_vals = np.linspace(blue_lch[1], red_lch[1], nsteps)
     h_vals = np.linspace(blue_lch[2], red_lch[2], nsteps)
     for pos,l,c,h in zip(np.linspace(0, 1, nsteps), l_vals, c_vals, h_vals):


### PR DESCRIPTION
Eliminates a `DeprecationWarning` issued by passing float valued stepping parameters to np.linspace in shap/plots/color.py:35