### PR TITLE
Allow deep_pytorch to use cuda models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,15 @@ os:
   - linux
 python:
   - '3.6'
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update
+  - sudo apt-get install -y gcc-4.9 g++-4.9
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+  - sudo apt-get install -y libgomp1
 install:
   - pip install .
-  - pip install tensorflow keras
+  - pip install tensorflow keras xgboost
 script: python setup.py nosetests
 before_script:
   - export DISPLAY=:99.0

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True):
         package_data={'shap': ['plots/resources/*', 'tree_shap.h']},
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy'],
-        install_requires=['numpy', 'scipy', 'scikit-learn', 'matplotlib', 'pandas', 'tqdm', 'ipython', 'scikit-image'],
+        install_requires=['numpy', 'scipy', 'scikit-learn', 'matplotlib', 'pandas', 'tqdm>4.25.0', 'ipython', 'scikit-image'],
         test_suite='nose.collector',
         tests_require=tests_require,
         ext_modules=ext_modules,

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -1,5 +1,5 @@
 import numpy as np
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 import gc
 import warnings
 import sklearn.utils

--- a/shap/explainers/deep/__init__.py
+++ b/shap/explainers/deep/__init__.py
@@ -26,10 +26,10 @@ class DeepExplainer(Explainer):
 
         Parameters
         ----------
-        model : if framework == 'tensorflow', (input : [tf.Operation], output : tf.Operation)
-             A pair of TensorFlow operations (or a list and an op) that specifies the input and
+        model : if framework == 'tensorflow', (input : [tf.Tensor], output : tf.Tensor)
+             A pair of TensorFlow tensors (or a list and a tensor) that specifies the input and
             output of the model to be explained. Note that SHAP values are specific to a single
-            output value, so the output tf.Operation should be a single dimensional output (,1).
+            output value, so the output tf.Tensor should be a single dimensional output (,1).
 
             if framework == 'pytorch', an nn.Module object (model), or a tuple (model, layer),
                 where both are nn.Module objects
@@ -42,7 +42,7 @@ class DeepExplainer(Explainer):
             if framework == 'tensorflow': [numpy.array] or [pandas.DataFrame]
             if framework == 'pytorch': [torch.tensor]
             The background dataset to use for integrating out features. DeepExplainer integrates
-            over these samples. The data passed here must match the input operations given in the
+            over these samples. The data passed here must match the input tensors given in the
             first argument. Note that since these samples are integrated over for each sample you
             should only something like 100 or 1000 random background samples, not the whole training
             dataset.

--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -55,7 +55,7 @@ class PyTorchDeepExplainer(Explainer):
             if outputs.shape[1] > 1:
                 self.multi_output = True
                 self.num_outputs = outputs.shape[1]
-            self.expected_value = outputs.mean(0).numpy()
+            self.expected_value = outputs.mean(0).cpu().numpy()
 
     def add_target_handle(self, layer):
         input_handle = layer.register_forward_hook(get_target_input)
@@ -172,7 +172,7 @@ class PyTorchDeepExplainer(Explainer):
                         phis[l][j] = (sample_phis[l][self.data[l].shape[0]:]* (x[l] - data[l])).mean(0)
                 else:
                     for l in range(len(X)):
-                        phis[l][j] = (torch.from_numpy(sample_phis[l][self.data[l].shape[0]:]) * (X[l][j: j + 1] - self.data[l])).mean(0)
+                        phis[l][j] = (torch.from_numpy(sample_phis[l][self.data[l].shape[0]:]).to(X[l].device) * (X[l][j: j + 1] - self.data[l])).cpu().numpy().mean(0)
             output_phis.append(phis[0] if not self.multi_input else phis)
         # cleanup; remove all gradient handles
         for handle in handles:

--- a/shap/explainers/gradient.py
+++ b/shap/explainers/gradient.py
@@ -31,10 +31,10 @@ class GradientExplainer(Explainer):
 
         Parameters
         ----------
-        model : if framework == 'tensorflow', (input : [tf.Operation], output : tf.Operation)
-             A pair of TensorFlow operations (or a list and an op) that specifies the input and
+        model : if framework == 'tensorflow', (input : [tf.Tensor], output : tf.Tensor)
+             A pair of TensorFlow tensors (or a list and a tensor) that specifies the input and
             output of the model to be explained. Note that SHAP values are specific to a single
-            output value, so the output tf.Operation should be a single dimensional output (,1).
+            output value, so the output tf.Tensor should be a single dimensional output (,1).
 
             if framework == 'pytorch', an nn.Module object (model), or a tuple (model, layer),
                 where both are nn.Module objects
@@ -47,7 +47,7 @@ class GradientExplainer(Explainer):
             if framework == 'tensorflow': [numpy.array] or [pandas.DataFrame]
             if framework == 'pytorch': [torch.tensor]
             The background dataset to use for integrating out features. GradientExplainer integrates
-            over these samples. The data passed here must match the input operations given in the
+            over these samples. The data passed here must match the input tensors given in the
             first argument.
         """
 

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -9,7 +9,7 @@ import itertools
 import warnings
 from sklearn.linear_model import LassoLarsIC, Lasso, lars_path
 from sklearn.cluster import KMeans
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 from .explainer import Explainer
 
 log = logging.getLogger('shap')

--- a/shap/explainers/linear.py
+++ b/shap/explainers/linear.py
@@ -1,6 +1,6 @@
 import numpy as np
 import warnings
-from tqdm import tqdm
+from tqdm.autonotebook import tqdm
 from .explainer import Explainer
 
 class LinearExplainer(Explainer):

--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -14,7 +14,7 @@ from ..common import convert_name, approximate_interactions
 
 def dependence_plot(ind, shap_values, features, feature_names=None, display_features=None,
                     interaction_index="auto",
-                    color="#1E88E5", axis_color="#333333", cmap=colors.red_blue,
+                    color="#1E88E5", axis_color="#333333", cmap=None,
                     dot_size=16, x_jitter=0, alpha=1, title=None, xmin=None, xmax=None, ax=None, show=True):
     """ Create a SHAP dependence plot, colored by an interaction feature.
 
@@ -72,6 +72,9 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
 
     """
 
+    if cmap is None:
+        cmap = colors.red_blue
+        
     # create a matplotlib figure, if `ax` hasn't been specified.
     if not ax:
         figsize = (7.5, 5) if interaction_index != ind else (6, 5)

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -106,21 +106,17 @@ def test_kernel_shap_with_a1a_sparse_nonzero_background():
     median_dense = csc_median_axis_0(x_train.tocsc())
     median = sp.sparse.csr_matrix(median_dense)
     explainer = shap.KernelExplainer(linear_model.predict, median)
-    shap_values = explainer.shap_values(x_test, l1_reg=0)
-    # Compare to dense results
-    x_train_dense = x_train.toarray()
+    shap_values = explainer.shap_values(x_test)
 
     def dense_to_sparse_predict(data):
         sparse_data = sp.sparse.csr_matrix(data)
         return linear_model.predict(sparse_data)
 
-    explainer_dense = shap.KernelExplainer(linear_model.predict, median_dense.reshape((1, len(median_dense))))
+    explainer_dense = shap.KernelExplainer(dense_to_sparse_predict, median_dense.reshape((1, len(median_dense))))
     x_test_dense = x_test.toarray()
-    shap_values_dense = explainer_dense.shap_values(x_test_dense, l1_reg=0)
+    shap_values_dense = explainer_dense.shap_values(x_test_dense)
     # Validate sparse and dense result is the same
-    # Note: The default tolerance is almost always fine, but in one out of every
-    # 20 runs or so it fails so decreasing it by two orders of magnitude from the default
-    #assert(np.allclose(shap_values, shap_values_dense, rtol=1e-02, atol=1e-04))
+    assert(np.allclose(shap_values, shap_values_dense, rtol=1e-02, atol=1e-01))
 
 def test_kernel_shap_with_high_dim_sparse():
     # verifies we can run on very sparse data produced from feature hashing


### PR DESCRIPTION
Current version fails using cuda model/data:

```
device = "cuda"
model.to(device)
de = DeepExplainer(model=model, data=torch.zeros(1, n_input).to(device))
print(de.shap_values(torch.randn(10, n_input).to(device)))
```

with the following error:

```
Traceback (most recent call last):
  File "/home/julius/research/rna/endoterm/ml2/play.py", line 45, in <module>
    print(de.shap_values(torch.randn(10, n_input).to(device)))
  File "/usr/local/lib/python3.6/dist-packages/shap/explainers/deep/__init__.py", line 119, in shap_values
    return self.explainer.shap_values(X, ranked_outputs, output_rank_order)
  File "/usr/local/lib/python3.6/dist-packages/shap/explainers/deep/deep_pytorch.py", line 175, in shap_values
    phis[l][j] = (torch.from_numpy(sample_phis[l][self.data[l].shape[0]:]) * (X[l][j: j + 1] - self.data[l])).mean(0)
RuntimeError: expected type torch.FloatTensor but got torch.cuda.FloatTensor
```

This pull request fixes this, but does not do any smart optimisations to avoid unnecessary gpu/cpu data transfer. Speed-up is still significant though.
