### PR TITLE
give an expected_value for each output of multi-target estimators

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -34,6 +34,16 @@ def boston(display=False):
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
     return df, d.target # pylint: disable=E1101
 
+
+def linnerud(display=False):
+    """ Return the linnerud data in a nice package (multi-target regression). """
+
+    d = sklearn.datasets.load_linnerud()
+    X = pd.DataFrame(d.data, columns=d.feature_names) # pylint: disable=E1101
+    y = pd.DataFrame(d.target, columns=d.target_names) # pylint: disable=E1101
+    return X, y # pylint: disable=E1101
+
+
 def imdb(display=False):
     """ Return the clssic IMDB sentiment analysis training data in a nice package.
 

--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -122,7 +122,9 @@ class TreeExplainer(Explainer):
             if hasattr(self.expected_value, '__len__') and len(self.expected_value) == 1:
                 self.expected_value = self.expected_value[0]
         elif hasattr(self.model, "node_sample_weight"):
-            self.expected_value = self.model.values[:,0].sum(0)[0]
+            self.expected_value = self.model.values[:,0].sum(0)
+            if self.expected_value.size == 1:
+                self.expected_value = self.expected_value[0]
             self.expected_value += self.model.base_offset
 
     def __dynamic_expected_value(self, y):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -482,6 +482,45 @@ def test_single_row_gradient_boosting_regressor():
     assert np.abs(shap_values.sum() + ex.expected_value - predicted[0]) < 1e-6, \
         "SHAP values don't sum to model output!"
 
+
+def test_multi_target_random_forest():
+    import shap
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    from sklearn.ensemble import RandomForestRegressor
+
+    X_train, X_test, Y_train, Y_test = train_test_split(*shap.datasets.linnerud(), test_size=0.2, random_state=0)
+    est = RandomForestRegressor(random_state=202, n_estimators=10, max_depth=10)
+    est.fit(X_train, Y_train)
+    predicted = est.predict(X_test)
+
+    explainer = shap.TreeExplainer(est)
+    expected_values = np.asarray(explainer.expected_value)
+    assert len(expected_values) == est.n_outputs_, "Length of expected_values doesn't match n_outputs_"
+    shap_values = np.asarray(explainer.shap_values(X_test)).reshape(est.n_outputs_ * X_test.shape[0], X_test.shape[1])
+    phi = np.hstack((shap_values, np.repeat(expected_values, X_test.shape[0]).reshape(-1, 1)))
+    assert np.allclose(phi.sum(1), predicted.flatten(order="F"), atol=1e-6)
+
+
+def test_multi_target_extra_trees():
+    import shap
+    import numpy as np
+    from sklearn.model_selection import train_test_split
+    from sklearn.ensemble import ExtraTreesRegressor
+
+    X_train, X_test, Y_train, Y_test = train_test_split(*shap.datasets.linnerud(), test_size=0.2, random_state=0)
+    est = ExtraTreesRegressor(random_state=202, n_estimators=10, max_depth=10)
+    est.fit(X_train, Y_train)
+    predicted = est.predict(X_test)
+
+    explainer = shap.TreeExplainer(est)
+    expected_values = np.asarray(explainer.expected_value)
+    assert len(expected_values) == est.n_outputs_, "Length of expected_values doesn't match n_outputs_"
+    shap_values = np.asarray(explainer.shap_values(X_test)).reshape(est.n_outputs_ * X_test.shape[0], X_test.shape[1])
+    phi = np.hstack((shap_values, np.repeat(expected_values, X_test.shape[0]).reshape(-1, 1)))
+    assert np.allclose(phi.sum(1), predicted.flatten(order="F"), atol=1e-6)
+
+
 def test_provided_background_tree_path_dependent():
     try:
         import xgboost


### PR DESCRIPTION
changes made in https://github.com/slundberg/shap/commit/f616f76b14a19e61c9a2087d039fc93dfa1e3012 (version `0.29.3`) caused `explainer.expected_value` to only output the first expected_value for multi-target estimators, which was not the case in version `0.29.2`

* only unwraps a 1-element array rather than truncating a sequence
* adds testing for multi-target regression