### PR TITLE
fix edge case with lightgbm 2.2.1 where trees may exist but have no nodes causing error in TreeExplainer

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -610,7 +610,7 @@ class TreeEnsemble:
             raise Exception("Model type not yet supported by TreeExplainer: " + str(type(model)))
         
         # build a dense numpy version of all the tree objects
-        if self.trees is not None:
+        if self.trees is not None and self.trees:
             max_nodes = np.max([len(t.values) for t in self.trees])
             assert len(np.unique([t.values.shape[1] for t in self.trees])) == 1, "All trees in the ensemble must have the same output dimension!"
             ntrees = len(self.trees)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -276,6 +276,52 @@ def test_lightgbm():
     # explain the model's predictions using SHAP values
     shap_values = shap.TreeExplainer(model).shap_values(X)
 
+def test_lightgbm_constant_prediction():
+    # note: this test used to fail with lightgbm 2.2.1 with error:
+    # ValueError: zero-size array to reduction operation maximum which has no identity
+    # on TreeExplainer when trying to compute max nodes:
+    # max_nodes = np.max([len(t.values) for t in self.trees])
+    # The test does not fail with latest lightgbm 2.2.3 however
+    try:
+        import lightgbm
+    except:
+        print("Skipping test_lightgbm_constant_prediction!")
+        return
+    import shap
+
+    # train lightgbm model with a constant value for y
+    X, y = shap.datasets.boston()
+    # use the mean for all values
+    mean = np.mean(y)
+    y.fill(mean)
+    model = lightgbm.sklearn.LGBMRegressor(n_estimators=1)
+    model.fit(X, y)
+
+    # explain the model's predictions using SHAP values
+    shap_values = shap.TreeExplainer(model).shap_values(X)
+
+def test_lightgbm_constant_multiclass():
+    # note: this test used to fail with lightgbm 2.2.1 with error:
+    # ValueError: zero-size array to reduction operation maximum which has no identity
+    # on TreeExplainer when trying to compute max nodes:
+    # max_nodes = np.max([len(t.values) for t in self.trees])
+    # The test does not fail with latest lightgbm 2.2.3 however
+    try:
+        import lightgbm
+    except:
+        print("Skipping test_lightgbm_constant_multiclass!")
+        return
+    import shap
+
+    # train lightgbm model
+    X, Y = shap.datasets.iris()
+    Y.fill(1)
+    model = lightgbm.sklearn.LGBMClassifier(num_classes=3, objective="multiclass")
+    model.fit(X, Y)
+
+    # explain the model's predictions using SHAP values
+    shap_values = shap.TreeExplainer(model).shap_values(X)
+
 def test_lightgbm_multiclass():
     try:
         import lightgbm


### PR DESCRIPTION
In some edge cases, eg where a regressor is trained on constant labels, lightgbm can produce empty trees which fails with TreeExplainer, giving the error:

>       return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
E       ValueError: zero-size array to reduction operation maximum which has no identity

with stack trace:

..\..\shap\explainers\tree.py:96: in __init__
    self.model = TreeEnsemble(model, self.data, self.data_missing)
..\..\shap\explainers\tree.py:614: in __init__
    max_nodes = np.max([len(t.values) for t in self.trees])
c:\users\ilmat\appdata\local\continuum\miniconda3\envs\sh\lib\site-packages\numpy\core\fromnumeric.py:2505: in amax
    initial=initial)

Note this only seems to occur with lightgbm older than 2.2.1, as latest lightgbm 2.2.3 doesn't seem to have this issue.  However, the check seems simple enough to be a good edge case scenario to add in for robustness.