### PR TITLE
Pytorch DeepExplainer: retain graph for multiple inputs

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -104,11 +104,12 @@ class PyTorchDeepExplainer(Explainer):
         selected = [val for val in outputs[:, idx]]
         if self.interim:
             interim_inputs = self.layer.target_input
-            grads = [torch.autograd.grad(selected, input)[0].cpu().numpy() for input in interim_inputs]
+            grads = [torch.autograd.grad(selected, input,
+                                         retain_graph=True)[0].cpu().numpy() for input in interim_inputs]
             del self.layer.target_input
             return grads, [i.detach().cpu().numpy() for i in interim_inputs]
         else:
-            grads = [torch.autograd.grad(selected, x)[0].cpu().numpy() for x in X]
+            grads = [torch.autograd.grad(selected, x, retain_graph=True)[0].cpu().numpy() for x in X]
             return grads
 
     def shap_values(self, X, ranked_outputs=None, output_rank_order="max"):

--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -105,11 +105,14 @@ class PyTorchDeepExplainer(Explainer):
         if self.interim:
             interim_inputs = self.layer.target_input
             grads = [torch.autograd.grad(selected, input,
-                                         retain_graph=True)[0].cpu().numpy() for input in interim_inputs]
+                                         retain_graph=True if idx + 1 < len(interim_inputs) else None)[0].cpu().numpy()
+                     for idx, input in enumerate(interim_inputs)]
             del self.layer.target_input
             return grads, [i.detach().cpu().numpy() for i in interim_inputs]
         else:
-            grads = [torch.autograd.grad(selected, x, retain_graph=True)[0].cpu().numpy() for x in X]
+            grads = [torch.autograd.grad(selected, x,
+                                         retain_graph=True if idx + 1 < len(X) else None)[0].cpu().numpy()
+                     for idx, x in enumerate(X)]
             return grads
 
     def shap_values(self, X, ranked_outputs=None, output_rank_order="max"):


### PR DESCRIPTION
Currently, if the DeepExplainer is used with multiple inputs, the following error is raised:
```
RuntimeError: Trying to backward through the graph a second time, but the buffers have already been freed. Specify retain_graph=True when calling backward the first time.
```
This PR ensures the graph is retained if necessary, and adds a test for a multi-input model.