### PR TITLE
Do not open xserver in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ install:
   - pip install .
   - pip install tensorflow keras xgboost
 script: python setup.py nosetests
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
 # deploy:
 #   provider: pypi
 #   user: "shap_poster"


### PR DESCRIPTION
How to reproduce:

1. Clone the repo
2. Set up Travis CI with a fork

it fails due to the fact that xvfb is not present

What I want to get: green tests

I am quite new to Travis CI so I do not exactly understand why it works for you but not for me.
My guess there is either some configuration not commited to repo or just cached build images which for some reason have this `xvfb`

Also I did not quite get why do we use it. Here I may be doing a stupid mistake by removing `xvfb`