### PR TITLE
[minor] fix retrieving default session for tensorflow in TF DeepExplainer for 1.11.0

### DIFF
--- a/shap/explainers/deep/deep_tf.py
+++ b/shap/explainers/deep/deep_tf.py
@@ -115,7 +115,10 @@ class TFDeepExplainer(Explainer):
             if keras is not None and keras.backend.tensorflow_backend._SESSION is not None:
                 session = keras.backend.get_session()
             else:
-                session = tf.compat.v1.keras.backend.get_session()
+                try:
+                    session = tf.compat.v1.keras.backend.get_session()
+                except:
+                    session = tf.keras.backend.get_session()
         self.session = tf.get_default_session() if session is None else session
 
         # if no learning phase flags were given we go looking for them


### PR DESCRIPTION
I didn't add a test for this - to repro just run the existing tests with tensorflow version 1.11.0.  It seems that with latest 1.14.0 the code ```tf.compat.v1.keras``` works though.