### PR TITLE
Made pandas, matplotlib, ipython and scikit-image optional (on the source code alone)

### DIFF
--- a/shap/benchmark/plots.py
+++ b/shap/benchmark/plots.py
@@ -416,22 +416,23 @@ def make_grid(scores, dataset, model):
     
     return row_keys, col_keys, data
 
-from matplotlib.colors import LinearSegmentedColormap
-red_blue_solid = LinearSegmentedColormap('red_blue_solid', {
-    'red': ((0.0, 198./255, 198./255),
-            (1.0, 5./255, 5./255)),
 
-    'green': ((0.0, 34./255, 34./255),
-              (1.0, 198./255, 198./255)),
-
-    'blue': ((0.0, 5./255, 5./255),
-             (1.0, 24./255, 24./255)),
-
-    'alpha': ((0.0, 1, 1),
-              (1.0, 1, 1))
-})
-from IPython.core.display import HTML
 def plot_grids(dataset, model_names, out_dir=None):
+    from matplotlib.colors import LinearSegmentedColormap
+    red_blue_solid = LinearSegmentedColormap('red_blue_solid', {
+        'red': ((0.0, 198. / 255, 198. / 255),
+                (1.0, 5. / 255, 5. / 255)),
+
+        'green': ((0.0, 34. / 255, 34. / 255),
+                  (1.0, 198. / 255, 198. / 255)),
+
+        'blue': ((0.0, 5. / 255, 5. / 255),
+                 (1.0, 24. / 255, 24. / 255)),
+
+        'alpha': ((0.0, 1, 1),
+                  (1.0, 1, 1))
+    })
+    from IPython.core.display import HTML
 
     if out_dir is not None:
         os.mkdir(out_dir)

--- a/shap/common.py
+++ b/shap/common.py
@@ -1,5 +1,4 @@
 import re
-import pandas as pd
 import numpy as np
 import scipy as sp
 from scipy.spatial.distance import pdist
@@ -43,11 +42,17 @@ class InstanceWithIndex(Instance):
         self.column_name = column_name
 
     def convert_to_df(self):
+        import pandas as pd
         index = pd.DataFrame(self.index_value, columns=[self.index_name])
         data = pd.DataFrame(self.x, columns=self.column_name)
         df = pd.concat([index, data], axis=1)
         df = df.set_index(self.index_name)
         return df
+
+
+def is_pandas(instance):
+    return str(type(instance)).endswith("pandas.core.series.Series'>") or \
+           str(type(instance)).endswith("'pandas.core.frame.DataFrame'>")
 
 
 def convert_to_instance_with_index(val, column_name, index_value, index_name):
@@ -149,6 +154,7 @@ class DenseDataWithIndex(DenseData):
         self.index_name = index_name
 
     def convert_to_df(self):
+        import pandas as pd
         data = pd.DataFrame(self.data, columns=self.group_names)
         index = pd.DataFrame(self.index_value, columns=[self.index_name])
         df = pd.concat([index, data], axis=1)

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 import sklearn.datasets
 import os
@@ -29,6 +28,7 @@ def imagenet50(display=False, resolution=224):
 
 def boston(display=False):
     """ Return the boston housing data in a nice package. """
+    import pandas as pd
 
     d = sklearn.datasets.load_boston()
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
@@ -37,6 +37,7 @@ def boston(display=False):
 
 def linnerud(display=False):
     """ Return the linnerud data in a nice package (multi-target regression). """
+    import pandas as pd
 
     d = sklearn.datasets.load_linnerud()
     X = pd.DataFrame(d.data, columns=d.feature_names) # pylint: disable=E1101
@@ -63,6 +64,7 @@ def communitiesandcrime(display=False):
     This dataset is from the classic UCI Machine Learning repository:
     https://archive.ics.uci.edu/ml/datasets/Communities+and+Crime+Unnormalized
     """
+    import pandas as pd
 
     raw_data = pd.read_csv(
         cache(github_data_url + "CommViolPredUnnormalizedData.txt"),
@@ -82,6 +84,7 @@ def communitiesandcrime(display=False):
 
 def diabetes(display=False):
     """ Return the diabetes data in a nice package. """
+    import pandas as pd
 
     d = sklearn.datasets.load_diabetes()
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
@@ -90,6 +93,7 @@ def diabetes(display=False):
 
 def iris(display=False):
     """ Return the classic iris data in a nice package. """
+    import pandas as pd
 
     d = sklearn.datasets.load_iris()
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
@@ -101,6 +105,7 @@ def iris(display=False):
 
 def adult(display=False):
     """ Return the Adult census data in a nice package. """
+    import pandas as pd
     dtypes = [
         ("Age", "float32"), ("Workclass", "category"), ("fnlwgt", "float32"),
         ("Education", "category"), ("Education-Num", "float32"), ("Marital Status", "category"),
@@ -141,6 +146,7 @@ def adult(display=False):
 def nhanesi(display=False):
     """ A nicely packaged version of NHANES I data with surivival times as labels.
     """
+    import pandas as pd
     X = pd.read_csv(cache(github_data_url + "NHANESI_subset_X.csv"))
     y = pd.read_csv(cache(github_data_url + "NHANESI_subset_y.csv"))["y"]
     if display:
@@ -153,6 +159,7 @@ def nhanesi(display=False):
 def cric(display=False):
     """ A nicely packaged version of CRIC data with progression to ESRD within 4 years as the label.
     """
+    import pandas as pd
     X = pd.read_csv(cache(github_data_url + "CRIC_time_4yearESRD_X.csv"))
     y = np.loadtxt(cache(github_data_url + "CRIC_time_4yearESRD_y.csv"))
     if display:
@@ -167,6 +174,7 @@ def corrgroups60(display=False):
     
     A simulated dataset with tight correlations among distinct groups of features.
     """
+    import pandas as pd
 
     # set a constant seed
     old_seed = np.random.seed()
@@ -210,6 +218,7 @@ def corrgroups60(display=False):
 def independentlinear60(display=False):
     """ A simulated dataset with tight correlations among distinct groups of features.
     """
+    import pandas as pd
 
     # set a constant seed
     old_seed = np.random.seed()

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -1,7 +1,8 @@
-from ..common import convert_to_instance, convert_to_model, match_instance_to_data, match_model_to_data, convert_to_instance_with_index, convert_to_link, IdentityLink, convert_to_data, DenseData, SparseData
+from ..common import convert_to_instance, convert_to_model, match_instance_to_data, match_model_to_data, \
+    convert_to_instance_with_index, convert_to_link, IdentityLink, convert_to_data, DenseData, SparseData, \
+    is_pandas
 from scipy.special import binom
 import numpy as np
-import pandas as pd
 import scipy as sp
 import logging
 import copy
@@ -115,7 +116,7 @@ class KernelExplainer(Explainer):
         self.nsamplesRun = 0
 
         # find E_x[f(x)]
-        if isinstance(model_null, (pd.DataFrame, pd.Series)):
+        if is_pandas(model_null):
             model_null = np.squeeze(model_null.values)
         self.fnull = np.sum((model_null.T * self.data.weights).T, 0)
         self.expected_value = self.linkfv(self.fnull)
@@ -251,7 +252,7 @@ class KernelExplainer(Explainer):
             model_out = self.model.f(instance.convert_to_df())
         else:
             model_out = self.model.f(instance.x)
-        if isinstance(model_out, (pd.DataFrame, pd.Series)):
+        if is_pandas(model_out):
             model_out = model_out.values
         self.fx = model_out[0]
 
@@ -513,6 +514,7 @@ class KernelExplainer(Explainer):
         num_to_run = self.nsamplesAdded * self.N - self.nsamplesRun * self.N
         data = self.synth_data[self.nsamplesRun*self.N:self.nsamplesAdded*self.N,:]
         if self.keep_index:
+            import pandas as pd
             index = self.synth_data_index[self.nsamplesRun*self.N:self.nsamplesAdded*self.N]
             index = pd.DataFrame(index, columns=[self.data.index_name])
             data = pd.DataFrame(data, columns=self.data.group_names)
@@ -520,7 +522,7 @@ class KernelExplainer(Explainer):
             if self.keep_index_ordered:
                 data = data.sort_index()
         modelOut = self.model.f(data)
-        if isinstance(modelOut, (pd.DataFrame, pd.Series)):
+        if is_pandas(modelOut):
             modelOut = modelOut.values
         self.y[self.nsamplesRun * self.N:self.nsamplesAdded * self.N, :] = np.reshape(modelOut, (num_to_run, self.D))
 

--- a/shap/explainers/sampling.py
+++ b/shap/explainers/sampling.py
@@ -1,7 +1,6 @@
-from ..common import convert_to_instance, convert_to_model, match_instance_to_data, match_model_to_data, convert_to_instance_with_index, convert_to_link, IdentityLink, convert_to_data, DenseData
+from ..common import convert_to_instance, match_instance_to_data, is_pandas
 from .kernel import KernelExplainer
 import numpy as np
-import pandas as pd
 import logging
 
 log = logging.getLogger('shap')
@@ -44,7 +43,7 @@ class SamplingExplainer(KernelExplainer):
             model_out = self.model.f(instance.convert_to_df())
         else:
             model_out = self.model.f(instance.x)
-        if isinstance(model_out, (pd.DataFrame, pd.Series)):
+        if is_pandas(instance):
             model_out = model_out.values[0]
         self.fx = model_out[0]
 

--- a/shap/plots/colors.py
+++ b/shap/plots/colors.py
@@ -4,9 +4,9 @@
 from __future__ import division
 
 import numpy as np
-import skimage.color
 
 try:
+    import skimage.color
     import matplotlib.pyplot as pl
     import matplotlib
     from matplotlib.colors import LinearSegmentedColormap

--- a/shap/plots/force.py
+++ b/shap/plots/force.py
@@ -7,8 +7,6 @@ import io
 import string
 import json
 import random
-from IPython.core.display import display, HTML
-from IPython import get_ipython
 import base64
 import numpy as np
 import scipy.cluster
@@ -202,6 +200,8 @@ err_msg = """
 
 
 def initjs():
+    from IPython.core.display import display, HTML
+
     bundle_path = os.path.join(os.path.split(__file__)[0], "resources", "bundle.js")
     with io.open(bundle_path, encoding="utf-8") as f:
         bundle_data = f.read()
@@ -305,6 +305,7 @@ def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True, 
 
 try:
     # register the visualize function with IPython
+    from IPython import get_ipython
     ip = get_ipython()
     svg_formatter=ip.display_formatter.formatters['text/html']
     svg_formatter.for_type(Explanation, lambda x: visualize(x).data)
@@ -339,6 +340,7 @@ class SimpleListVisualizer:
         }
 
     def html(self):
+        from IPython.core.display import HTML
         return HTML("""
 <div id='{id}'>{err_msg}</div>
  <script>
@@ -372,6 +374,7 @@ class AdditiveForceVisualizer:
         }
 
     def html(self, label_margin=20):
+        from IPython.core.display import HTML
         self.data["labelMargin"] = label_margin
         return HTML("""
 <div id='{id}'>{err_msg}</div>
@@ -428,6 +431,7 @@ class AdditiveForceArrayVisualizer:
                 }
 
     def html(self):
+        from IPython.core.display import HTML
         return HTML("""
 <div id='{id}'>{err_msg}</div>
  <script>


### PR DESCRIPTION
This PR changes the source code for it to only depend on `['numpy', 'scipy', 'scikit-learn', 'tqdm']`. This is suitable for a production system. It partially addresses #466 and #278, and fully addresses #384.

Note that this does not change `setup.py`, only the source code in `shap/shap`. Consequently, it does not completely solve the problem (it is currently unsolvable), it only helps solving it.

## Rational

Currently, installing shap adds a considerable overhead and a small security concern as it depends on many packages (#466). One way to approach this is to split the `install_requires` in multiple `extra_requires`.

However, as @slundberg pointed out in #508, conda-forge does not support extras, and many users expect `pip install shap` to be installed with plotting functionality, and pip does not support a default extra, see [here](https://github.com/pypa/setuptools/issues/1139)). Thus, changing `install_requires` `setup.py` is not feasible at this point as it breaks backward compatibility and drops support for conda-forge.

Another solution is to create a new repository, `shap-core`, that only contains the explainers, and leave this package for all things combined. However, this adds some maintenance cost that @slundberg would have to be willing to maintain.

The current compromise is for developers that want to use a minimal version of this package to fork this repository, change it, and deploy it from their own fork. 

## Main change

This PR introduces a set of changes to the source code that make this a bit easier: it makes the source code work without `['pandas', 'matplotlib', 'scikit-learn', 'ipython', 'scikit-image']` installed.
I.e. with these changes, the only thing that the fork has to do is to change the `setup.py` for those dependencies not be part of the `install_requires`.
    
This change makes shap depend only on: `['numpy', 'scipy', 'scikit-learn', 'tqdm']`.