### PR TITLE
Update force.py for fixing an index bug of force_plot()

### DIFF
--- a/shap/plots/force.py
+++ b/shap/plots/force.py
@@ -141,7 +141,7 @@ def force_plot(base_value, shap_values, features=None, feature_names=None, out_n
             warnings.warn("shap.force_plot is slow for many thousands of rows, try subsampling your data.")
 
         exps = []
-        for i in range(shap_values.shape[0]):
+        for k in range(shap_values.shape[0]):
             if feature_names is None:
                 feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1])]
             if features is None:
@@ -152,8 +152,8 @@ def force_plot(base_value, shap_values, features=None, feature_names=None, out_n
             instance = Instance(np.ones((1, len(feature_names))), display_features)
             e = AdditiveExplanation(
                 base_value,
-                np.sum(shap_values[i, :]) + base_value,
-                shap_values[i, :],
+                np.sum(shap_values[k, :]) + base_value,
+                shap_values[k, :],
                 None,
                 instance,
                 link,

--- a/shap/plots/force.py
+++ b/shap/plots/force.py
@@ -147,7 +147,7 @@ def force_plot(base_value, shap_values, features=None, feature_names=None, out_n
             if features is None:
                 display_features = ["" for i in range(len(feature_names))]
             else:
-                display_features = features[i, :]
+                display_features = features[k, :]
 
             instance = Instance(np.ones((1, len(feature_names))), display_features)
             e = AdditiveExplanation(


### PR DESCRIPTION
Hi Thanks for the awesome tool for ML explanation. I encountered a bug when plotting force plots and did a quick fix:

The index "i" is doubly used in the for loop of line 144, causing confusion in subsequent lines. 

The bug was detected when I tried to force plot a shap matrix with 100 rows and 346 features. An IndexError popped up saying "345 is out of the range of 100". This was probably due to that "i" had been used to loop over all features, and been re-used to indexing instances. 

I guess it would be a better to change the index variable of the for loop to avoid the issue.  