### PR TITLE
Add python 3 trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,10 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True):
         test_suite='nose.collector',
         tests_require=tests_require,
         ext_modules=ext_modules,
+        classifiers=[
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.6',
+        ],
         zip_safe=False
         # python_requires='>3.0' we will add this at some point
     )


### PR DESCRIPTION
Clearly identify this project as supporting python 3.
This is useful for utility programs like [caniusepython3](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3).