### PR TITLE
PyTorch DeepExplainer improvements

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -101,17 +101,30 @@ class PyTorchDeepExplainer(Explainer):
         X = [x.requires_grad_() for x in inputs]
         outputs = self.model(*X)
         selected = [val for val in outputs[:, idx]]
+        grads = []
         if self.interim:
             interim_inputs = self.layer.target_input
-            grads = [torch.autograd.grad(selected, input,
-                                         retain_graph=True if idx + 1 < len(interim_inputs) else None)[0].cpu().numpy()
-                     for idx, input in enumerate(interim_inputs)]
+            for idx, input in enumerate(interim_inputs):
+                grad = torch.autograd.grad(selected, input,
+                                           retain_graph=True if idx + 1 < len(interim_inputs) else None,
+                                           allow_unused=True)[0]
+                if grad is not None:
+                    grad = grad.cpu().numpy()
+                else:
+                    grad = torch.zeros_like(X[idx]).cpu().numpy()
+                grads.append(grad)
             del self.layer.target_input
             return grads, [i.detach().cpu().numpy() for i in interim_inputs]
         else:
-            grads = [torch.autograd.grad(selected, x,
-                                         retain_graph=True if idx + 1 < len(X) else None)[0].cpu().numpy()
-                     for idx, x in enumerate(X)]
+            for idx, x in enumerate(X):
+                grad = torch.autograd.grad(selected, x,
+                                           retain_graph=True if idx + 1 < len(X) else None,
+                                           allow_unused=True)[0]
+                if grad is not None:
+                    grad = grad.cpu().numpy()
+                else:
+                    grad = torch.zeros_like(X[idx]).cpu().numpy()
+                grads.append(grad)
             return grads
 
     def shap_values(self, X, ranked_outputs=None, output_rank_order="max"):

--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -322,9 +322,6 @@ def maxpool(module, grad_input, grad_output):
     if module.__class__.__name__ == 'MaxPool1d':
         complex_module_gradients.append(grad_input[0])
         grad_input[0] = torch.gather(grad_input[0], -1, indices).unsqueeze(1)
-    # delete the attributes
-    del module.x
-    del module.y
     return tuple(grad_input)
 
 
@@ -343,10 +340,6 @@ def nonlinear_1d(module, grad_input, grad_output):
     grads = [None for _ in grad_input]
     grads[0] = torch.where(torch.abs(delta_in.repeat(dup0)) < 1e-6, grad_input[0],
                            grad_output[0] * (delta_out / delta_in).repeat(dup0))
-
-    # delete the attributes
-    del module.x
-    del module.y
     return tuple(grads)
 
 

--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -322,7 +322,7 @@ def maxpool(module, grad_input, grad_output):
     if module.__class__.__name__ == 'MaxPool1d':
         complex_module_gradients.append(grad_input[0])
         # the grad input that is returned doesn't matter, since it will immediately be
-        # be overridden by the gard in the complex_module_gradient
+        # be overridden by the grad in the complex_module_gradient
         grad_input[0] = torch.ones(org_input_shape)
     return tuple(grad_input)
 

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -418,41 +418,72 @@ def test_pytorch_single_output():
 
 
 def test_pytorch_multiple_inputs():
+    """Testing multiple inputs
+    """
     _skip_if_no_pytorch()
 
     import torch
     from torch import nn
+    from torch.nn import functional as F
+    from torch.utils.data import TensorDataset, DataLoader
+    from sklearn.datasets import load_boston
     import shap
 
-    batch_size = 10
-    x1 = torch.ones(batch_size, 3)
-    x2 = torch.ones(batch_size, 4)
-
-    background = [torch.zeros(batch_size, 3), torch.zeros(batch_size, 4)]
+    X, y = load_boston(return_X_y=True)
+    num_features = X.shape[1]
+    x1 = X[:, num_features // 2:]
+    x2 = X[:, :num_features // 2]
+    data = TensorDataset(torch.tensor(x1).float(),
+                         torch.tensor(x2).float(),
+                         torch.tensor(y).float())
+    loader = DataLoader(data, batch_size=128)
 
     class Net(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.linear = nn.Linear(7, 2)
-            self.others = nn.Sequential(
+        def __init__(self, num_features):
+            super(Net, self).__init__()
+            self.linear = nn.Linear(num_features, 2)
+            self.output = nn.Sequential(
                 nn.MaxPool1d(2),
-                nn.ReLU())
+                nn.ReLU()
+            )
 
         def forward(self, x1, x2):
-            x = self.linear(torch.cat((x1, x2), dim=-1))
-            x = x.unsqueeze(1)
-            return self.others(x)
+            x = self.linear(torch.cat((x1, x2), dim=-1)).unsqueeze(1)
+            return self.output(x).squeeze(1)
+    model = Net(num_features)
+    optimizer = torch.optim.Adam(model.parameters())
 
-    model = Net()
+    def train(model, device, train_loader, optimizer, epoch):
+        model.train()
+        num_examples = 0
+        for batch_idx, (data1, data2, target) in enumerate(train_loader):
+            num_examples += target.shape[0]
+            data1, data2, target = data1.to(device), data2.to(device), target.to(device)
+            optimizer.zero_grad()
+            output = model(data1, data2)
+            loss = F.mse_loss(output.squeeze(1), target)
+            loss.backward()
+            optimizer.step()
+            if batch_idx % 2 == 0:
+                print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                    epoch, batch_idx * len(data), len(train_loader.dataset),
+                           100. * batch_idx / len(train_loader), loss.item()))
 
+    device = torch.device('cpu')
+    train(model, device, loader, optimizer, 1)
+
+    next_x1, next_x2, next_y = next(iter(loader))
+    np.random.seed(0)
+    inds = np.random.choice(next_x1.shape[0], 20, replace=False)
+    background = [next_x1[inds, :], next_x2[inds, :]]
     e = shap.DeepExplainer(model, background)
-    shap_x1, shap_x2 = e.shap_values([x1, x2])
+    test_x1, test_x2, test_y = next(iter(loader))
+    shap_x1, shap_x2 = e.shap_values([test_x1[:1], test_x2[:1]])
 
     model.eval()
     model.zero_grad()
     with torch.no_grad():
-        diff = (model(x1, x2) - model(*background)).detach().numpy().mean(0)
-
+        diff = (model(test_x1[:1], test_x2[:1]) - model(*background)).detach().numpy().mean(0)
     sums = np.array([shap_x1[i].sum() + shap_x2[i].sum() for i in range(len(shap_x1))])
     d = np.abs(sums - diff).sum()
     assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -433,10 +433,15 @@ def test_pytorch_multiple_inputs():
     class Net(nn.Module):
         def __init__(self):
             super().__init__()
-            self.linear = nn.Linear(7, 1)
+            self.linear = nn.Linear(7, 2)
+            self.others = nn.Sequential(
+                nn.MaxPool1d(2),
+                nn.ReLU())
 
         def forward(self, x1, x2):
-            return self.linear(torch.cat((x1, x2), dim=-1))
+            x = self.linear(torch.cat((x1, x2), dim=-1))
+            x = x.unsqueeze(1)
+            return self.others(x)
 
     model = Net()
 


### PR DESCRIPTION
Fixes two issues identified by @florianst, in #728 and #516 

1) The DeepExplainer was deleting the saved `y` and `x` attributes - this is okay for single inputs, since they are no longer necessary, but was preventing the gradient from being calculated for subsequent inputs in the multi-input case. The solution was to not delete those attributes.

2) The maxpool1d gradient output shape was still problematic. Since the returned gradient is overridden by one which is registered on the tensor, this was replaced by a tensor of ones so that the correct shape could be guaranteed.

In addition, shap values for unused inputs can be calculated. This is useful if a model only conditionally considers a certain input:

```python
# in an nn.Module
def forward(x, x2):
    if self.use_x2:
        x = torch.cat((x1, x2), dim=-1)
    ...
    return x
````
The shap value for an unused input (i.e. the case where `use_x2 == False`) is 0.
       
This PR closes #728 
