### PR TITLE
Fix for  CatBoostClassifier TreeExplainer with evaluation and early stopping

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -1192,7 +1192,7 @@ class CatBoostTreeModelLoader:
         self.loaded_cb_model = json.load(open("cb_model.json", "r"))
 
         # load the CatBoost oblivious trees specific parameters
-        self.num_trees = self.num_trees = len(self.loaded_cb_model['oblivious_trees'])
+        self.num_trees = len(self.loaded_cb_model['oblivious_trees'])
         self.max_depth = self.loaded_cb_model['model_info']['params']['tree_learner_options']['depth']
 
     def get_trees(self, data=None, data_missing=None):

--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -1192,7 +1192,7 @@ class CatBoostTreeModelLoader:
         self.loaded_cb_model = json.load(open("cb_model.json", "r"))
 
         # load the CatBoost oblivious trees specific parameters
-        self.num_trees = self.loaded_cb_model['model_info']['params']['boosting_options']['iterations']
+        self.num_trees = self.num_trees = len(self.loaded_cb_model['oblivious_trees'])
         self.max_depth = self.loaded_cb_model['model_info']['params']['tree_learner_options']['depth']
 
     def get_trees(self, data=None, data_missing=None):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -326,6 +326,7 @@ def test_lightgbm():
 def test_catboost():
     try:
         import catboost
+        from catboost.datasets import amazon
     except:
         print("Skipping test_catboost!")
         return
@@ -346,6 +347,22 @@ def test_catboost():
 
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-6, \
         "SHAP values don't sum to model output!"
+    
+    train_df, _ = amazon()
+    ix = 100
+    X_train = train_df.drop('ACTION', axis=1)[:ix]
+    y_train = train_df.ACTION[:ix]
+    X_val = train_df.drop('ACTION', axis=1)[ix:ix+20]
+    y_val = train_df.ACTION[ix:ix+20]
+    model = catboost.CatBoostClassifier(iterations=100, learning_rate=0.5, random_seed=12)
+    model.fit(
+        X_train,
+        y_train,
+        eval_set=(X_val, y_val),        
+        verbose=False,
+        plot=False
+    )
+    shap.TreeExplainer(model)
 
 def test_lightgbm_constant_prediction():
     # note: this test used to fail with lightgbm 2.2.1 with error:


### PR DESCRIPTION
Fix for get_trees() method of CatBoostTreeModelLoader tree explainer (causes issue #745).
The number of trees is not always equal to the number of iterations. In cases when there is early stopping, and/or evaluation set is used, then the number of trees is equal to model.tree_count_ or just the size of the model['oblivious_trees'] list in the model's json file dict.