### PR TITLE
fix edge case where background data is dense and evaluation data is sparse

### DIFF
--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -178,6 +178,11 @@ def test_kernel_sparse_vs_dense_multirow_background():
 
     assert(np.allclose(shap_values, sparse_shap_values, rtol=1e-05, atol=1e-05))
 
+    # Use sparse evaluation examples with dense background
+    sparse_sv_dense_bg = explainer.shap_values(X_sparse_test)
+    assert(np.allclose(shap_values, sparse_sv_dense_bg, rtol=1e-05, atol=1e-05))
+
+
 def test_linear():
     """tests that a linear model on the KernelExplainer gives the right result"""
 


### PR DESCRIPTION
follow-up bug fix for https://github.com/slundberg/shap/issues/569 and https://github.com/slundberg/shap/issues/138
There is an edge case where the background data is dense and the test data is sparse.  In this case, we convert the test data to dense prior to setting it on the background when generating samples.