### PR TITLE
fixed linear shap explainer shape for classifiers to be list of ndarray

### DIFF
--- a/shap/explainers/linear.py
+++ b/shap/explainers/linear.py
@@ -57,13 +57,8 @@ class LinearExplainer(Explainer):
 
         # sklearn style model
         elif hasattr(model, "coef_") and hasattr(model, "intercept_"):
-            # work around for multi-class with a single class
-            if len(model.coef_.shape) > 1 and model.coef_.shape[0] == 1:
-                self.coef = model.coef_[0]
-                self.intercept = model.intercept_[0]
-            else:
-                self.coef = model.coef_
-                self.intercept = model.intercept_
+            self.coef = model.coef_
+            self.intercept = model.intercept_
         else:
             raise Exception("An unknown model type was passed: " + str(type(model)))
 
@@ -86,7 +81,6 @@ class LinearExplainer(Explainer):
                 self.mean = np.array(np.mean(data, 0)).flatten() # assumes it is an array
                 if feature_dependence == "correlation":
                     self.cov = np.cov(data, rowvar=False)
-        #print(self.coef, self.mean.flatten(), self.intercept)
         # Note: mean can be numpy.matrixlib.defmatrix.matrix or numpy.matrix type depending on numpy version
         if sp.sparse.issparse(self.mean) or str(type(self.mean)).endswith("matrix'>"):
             # accept both sparse and dense coef

--- a/tests/explainers/test_linear.py
+++ b/tests/explainers/test_linear.py
@@ -122,4 +122,4 @@ def test_sparse():
     # explain the model's predictions using SHAP values
     explainer = shap.LinearExplainer(model, X)
     shap_values = explainer.shap_values(X)
-    assert np.max(np.abs(expit(explainer.expected_value + shap_values.sum(1)) - model.predict_proba(X)[:, 1])) < 1e-6
+    assert np.max(np.abs(expit(explainer.expected_value + shap_values[0].sum(1)) - model.predict_proba(X)[:, 1])) < 1e-6


### PR DESCRIPTION
follow-up to discussion on https://github.com/slundberg/shap/pull/645 , specifically:
https://github.com/slundberg/shap/pull/645#discussion_r293589975 
was the workaround needed for anything in particular?  I validated the tests pass with the multi-class workaround removed.