### PR TITLE
Handle 1d output tensor

### DIFF
--- a/shap/explainers/gradient.py
+++ b/shap/explainers/gradient.py
@@ -358,7 +358,7 @@ class _PyTorchGradientExplainer(Explainer):
 
         multi_output = False
         outputs = self.model(*self.model_inputs)
-        if outputs.shape[1] > 1:
+        if len(outputs.shape) > 1 and outputs.shape[1] > 1:
             multi_output = True
         self.multi_output = multi_output
 


### PR DESCRIPTION
Don't crash on 
```
  File "/usr/local/lib/python3.7/site-packages/shap/explainers/gradient.py", line 73, in __init__
    self.explainer = _PyTorchGradientExplainer(model, data, batch_size, local_smoothing)
  File "/usr/local/lib/python3.7/site-packages/shap/explainers/gradient.py", line 361, in __init__
    if outputs.shape[1] > 1:
IndexError: tuple index out of range
```
when the output tensor from the pytorch model is one-dimensional.