### PR TITLE
Fixed kernel explainer expected value with single value output

### DIFF
--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -118,7 +118,6 @@ class KernelExplainer(Explainer):
         if isinstance(model_null, (pd.DataFrame, pd.Series)):
             model_null = np.squeeze(model_null.values)
         self.fnull = np.sum((model_null.T * self.data.weights).T, 0)
-        self.expected_value = self.linkfv(self.fnull)
 
         # see if we have a vector output
         self.vector_out = True
@@ -128,6 +127,8 @@ class KernelExplainer(Explainer):
             self.D = 1
         else:
             self.D = self.fnull.shape[0]
+        self.expected_value = self.linkfv(self.fnull)
+        
 
     def shap_values(self, X, **kwargs):
         """ Estimate the SHAP values for a set of samples.

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -118,16 +118,17 @@ class KernelExplainer(Explainer):
         if isinstance(model_null, (pd.DataFrame, pd.Series)):
             model_null = np.squeeze(model_null.values)
         self.fnull = np.sum((model_null.T * self.data.weights).T, 0)
-
+        self.expected_value = self.linkfv(self.fnull)
+        
         # see if we have a vector output
         self.vector_out = True
         if len(self.fnull.shape) == 0:
             self.vector_out = False
             self.fnull = np.array([self.fnull])
             self.D = 1
+            self.expected_value = float(self.expected_value)
         else:
             self.D = self.fnull.shape[0]
-        self.expected_value = self.linkfv(self.fnull)
         
 
     def shap_values(self, X, **kwargs):


### PR DESCRIPTION
The expected_value of kernel explainer is dependent to fnull but it is initialized before the change of fnull w.r.t. single value output predict function. 

Example to show the unexpected case:

```python
import pandas as pd
import shap

def predict(X):
    return X.sum(axis=1)

X = pd.DataFrame({(1,), (2,)})

explainer = shap.KernelExplainer(predict, X)
```
explainer.expected_value is `array(1.5)` while the correct value should be `array([1.5])`. So I moved the initialization of expected_value to the end of the init function to fix it.