### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,7 @@ An implementation of Kernel SHAP, a model agnostic method to estimate SHAP value
 
 These notebooks comprehensively demonstrate how to use specific functions and objects. 
 
-- [`shap.decision_plot` and `shap.multioutput_decision_plot`](https://slundberg.github.io/shap/notebooks/plots
-/decision_plot.html)
+- [`shap.decision_plot` and `shap.multioutput_decision_plot`](https://slundberg.github.io/shap/notebooks/plots/decision_plot.html)
 
 - [`shap.dependence_plot`](https://slundberg.github.io/shap/notebooks/plots/dependence_plot.html)
 


### PR DESCRIPTION
Line-break in README.md broke the link to the `decision_plot` documentation and displayed markdown code. Normally, I wouldn't submit such a small change, but it affects the project's main page.