### PR TITLE
Remove unused imports from the JSX visualizers

### DIFF
--- a/javascript/visualizers/AdditiveForceArrayVisualizer.jsx
+++ b/javascript/visualizers/AdditiveForceArrayVisualizer.jsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { select, selectAll, mouse } from "d3-selection";
+import { select, mouse } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
-import { extent } from "d3-array";
 import { format } from "d3-format";
 import { timeFormat, timeParse } from "d3-time-format";
 import { axisBottom, axisLeft } from "d3-axis";
@@ -11,7 +10,6 @@ import {
   sortBy,
   min,
   max,
-  copy,
   map,
   each,
   sum,

--- a/javascript/visualizers/AdditiveForceVisualizer.jsx
+++ b/javascript/visualizers/AdditiveForceVisualizer.jsx
@@ -1,15 +1,12 @@
 import React from "react";
-import { select, selectAll } from "d3-selection";
+import { select } from "d3-selection";
 import { scaleLinear } from "d3-scale";
-import { extent } from "d3-array";
 import { format } from "d3-format";
 import { axisBottom } from "d3-axis";
 import { line } from "d3-shape";
 import { hsl } from "d3-color";
 import {
   sortBy,
-  max,
-  copy,
   map,
   each,
   sum,

--- a/javascript/visualizers/SimpleListVisualizer.jsx
+++ b/javascript/visualizers/SimpleListVisualizer.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { scaleLinear } from "d3-scale";
-import { extent } from "d3-array";
 import { format } from "d3-format";
-import { sortBy, reverse, max, range, copy, map, size } from "lodash";
+import { sortBy, reverse, max, map } from "lodash";
 import colors from "../color-set";
 
 class SimpleListVisualizer extends React.Component {


### PR DESCRIPTION
With the help of ESLint's [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars) I was able to identify unused imports.
To keep the code clean and understandable, I recommend to remove these imports.