### PR TITLE
Remove unused variables from the JSX visualizers

### DIFF
--- a/javascript/visualizers/AdditiveForceArrayVisualizer.jsx
+++ b/javascript/visualizers/AdditiveForceArrayVisualizer.jsx
@@ -151,7 +151,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
     this.ylabel.node().onchange = () => this.internalDraw();
 
     this.svg.on("mousemove", x => this.mouseMoved(x));
-    this.svg.on("click", x => alert("This original index of the sample you clicked is " + this.nearestExpIndex));
+    this.svg.on("click", () => alert("This original index of the sample you clicked is " + this.nearestExpIndex));
 
     this.svg.on("mouseout", x => this.mouseOut(x));
 
@@ -176,7 +176,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
     this.hoverGroup2.attr("display", "none");
   }
 
-  mouseMoved(event) {
+  mouseMoved() {
     let i, nearestExp;
 
     this.hoverLine.attr("display", "");
@@ -228,8 +228,6 @@ class AdditiveForceArrayVisualizer extends React.Component {
         .attr("x", this.leftOffset - 6)
         .attr("y", nearestExp.joinPointy)
         .text(this.ytickFormat(this.invLinkFunction(nearestExp.joinPoint)));
-
-      let P = this.props.featureNames.length;
 
       let posFeatures = [];
       let lastPos, pos;
@@ -402,7 +400,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
     if (this.props.ordering_keys != null)  {
       options.unshift("sample order by key");
     }
-    
+
     let xLabelOptions = this.xlabel.selectAll("option").data(options);
     xLabelOptions
       .enter()
@@ -454,7 +452,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
 
 
     // Set scaleTime if time ticks provided for original ordering
-    let isTimeScale = ((xsort === "sample order by key") && 
+    let isTimeScale = ((xsort === "sample order by key") &&
 		       (this.props.ordering_keys_time_format != null));
     if (isTimeScale)  {
 	    this.xscale = scaleTime();
@@ -496,7 +494,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
 
       // Build explanations where effects are averaged when the x values are identical
       explanations = [];
-      let laste, copye, e;
+      let laste, copye;
       for (let i = 0; i < explanations2.length; ++i) {
         let e = explanations2[i];
         if (
@@ -614,7 +612,6 @@ class AdditiveForceArrayVisualizer extends React.Component {
       let data2 = explanations[ind].features;
       //console.log(length(data2))
 
-      let totalEffect = sum(map(data2, x => Math.abs(x.effect)));
       let totalNegEffects =
         sum(map(filter(data2, x => x.effect < 0), x => -x.effect)) || 0;
 
@@ -705,7 +702,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
       })
       .attr("fill", "none")
       .attr("stroke-width", 1)
-      .attr("stroke", d => this.colors[0].brighter(1.2));
+      .attr("stroke", () => this.colors[0].brighter(1.2));
     dividersPos.exit().remove();
 
     let dividersNeg = this.mainGroup
@@ -725,7 +722,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
       })
       .attr("fill", "none")
       .attr("stroke-width", 1)
-      .attr("stroke", d => this.colors[1].brighter(1.5));
+      .attr("stroke", () => this.colors[1].brighter(1.5));
     dividersNeg.exit().remove();
 
     let boxBounds = function(es, ind, starti, endi, featType) {
@@ -762,7 +759,6 @@ class AdditiveForceArrayVisualizer extends React.Component {
       for (let ind of this.currUsedFeatures) {
         let starti = 0,
           endi = 0,
-          i,
           boxWidth = 0,
           hbounds = { top: 0, bottom: 0 };
         let newHbounds;

--- a/javascript/visualizers/AdditiveForceVisualizer.jsx
+++ b/javascript/visualizers/AdditiveForceVisualizer.jsx
@@ -56,11 +56,11 @@ class AdditiveForceVisualizer extends React.Component {
       .attr("stroke-width", "4")
       .attr("stroke-linejoin", "round")
       .text("")
-      .on("mouseover", d => {
+      .on("mouseover", () => {
         this.hoverLabel.attr("opacity", 1);
         this.hoverLabelBacking.attr("opacity", 1);
       })
-      .on("mouseout", d => {
+      .on("mouseout", () => {
         this.hoverLabel.attr("opacity", 0);
         this.hoverLabelBacking.attr("opacity", 0);
       });
@@ -71,11 +71,11 @@ class AdditiveForceVisualizer extends React.Component {
       .attr("font-size", 12)
       .attr("fill", "#0f0")
       .text("")
-      .on("mouseover", d => {
+      .on("mouseover", () => {
         this.hoverLabel.attr("opacity", 1);
         this.hoverLabelBacking.attr("opacity", 1);
       })
-      .on("mouseout", d => {
+      .on("mouseout", () => {
         this.hoverLabel.attr("opacity", 0);
         this.hoverLabelBacking.attr("opacity", 0);
       });
@@ -275,7 +275,7 @@ class AdditiveForceVisualizer extends React.Component {
             .text(getLabel(d));
         }
       })
-      .on("mouseout", d => {
+      .on("mouseout", () => {
         this.hoverLabel.attr("opacity", 0);
         this.hoverLabelBacking.attr("opacity", 0);
       });
@@ -297,7 +297,7 @@ class AdditiveForceVisualizer extends React.Component {
       .append("text")
       .attr("class", "force-bar-labels")
       .attr("font-size", "12px")
-      .attr("y", d => 48 + topOffset)
+      .attr("y", 48 + topOffset)
       .merge(labels)
       .text(d => {
         if (d.value !== undefined && d.value !== null && d.value !== "") {
@@ -309,7 +309,7 @@ class AdditiveForceVisualizer extends React.Component {
         } else return d.name;
       })
       .attr("fill", d => (d.effect > 0 ? this.colors[0] : this.colors[1]))
-      .attr("stroke", function(d, i) {
+      .attr("stroke", function(d) {
         d.textWidth = Math.max(
           this.getComputedTextLength(),
           scale(Math.abs(d.effect)) - 10


### PR DESCRIPTION
With the help of ESLint's [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars) I was able to identify unused variables.
To keep the code clean and understandable, I recommend to remove these declarations.