### PR TITLE
AdditiveForceVisualizer: Use locally imported lodash filter

### DIFF
--- a/javascript/visualizers/AdditiveForceVisualizer.jsx
+++ b/javascript/visualizers/AdditiveForceVisualizer.jsx
@@ -281,7 +281,7 @@ class AdditiveForceVisualizer extends React.Component {
       });
     blocks.exit().remove();
 
-    let filteredData = _.filter(data, d => {
+    let filteredData = filter(data, d => {
       return (
         scale(Math.abs(d.effect)) > scale(totalEffect) / 50 &&
         scale(Math.abs(d.effect)) > 10


### PR DESCRIPTION
I found a usage of lodash's `filter` which was using the global `_.filter` instead of the imported function `filter`.