### PR TITLE
setup: Add extras-require

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
-  - "%PYTHON%\\python.exe -m pip install tensorflow keras matplotlib ipython"
+  - "%PYTHON%\\python.exe -m pip install tensorflow==1.14 keras matplotlib ipython"
 
 build: off
 

--- a/setup.py
+++ b/setup.py
@@ -69,19 +69,9 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catb
         tests_require += ['catboost']
 
     extras_require = {
-        'tree': [
-            'xgboost',
-            'lightgbm',
-            'catboost',
-        ],
-        'nnet': [
-            'keras',
-            'tensorflow',
-            'torch',
-            'torchvision',
-        ],
         'plots': [
             'matplotlib',
+            'ipython'
         ],
         'others': [
             'lime',

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,27 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catb
     if test_catboost:
         tests_require += ['catboost']
 
+    extras_require = {
+        'tree': [
+            'xgboost',
+            'lightgbm',
+            'catboost',
+        ],
+        'nnet': [
+            'keras',
+            'tensorflow',
+            'torch',
+            'torchvision',
+        ],
+        'plots': [
+            'matplotlib',
+        ],
+        'others': [
+            'lime',
+        ],
+    }
+    extras_require['all'] = list(set(i for val in extras_require.values() for i in val))
+
     setup(
         name='shap',
         version=find_version("shap", "__init__.py"),
@@ -89,6 +110,7 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catb
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy'],
         install_requires=['numpy', 'scipy', 'scikit-learn', 'pandas', 'tqdm>4.25.0'],
+        extras_require=extras_require,
         test_suite='nose.collector',
         tests_require=tests_require,
         ext_modules=ext_modules,


### PR DESCRIPTION
extras-require lets the user decide on any extra packages they may
want to install. This way users can just request for [all] and all
packages that shap uses internally will be installed in one go.

@slundberg this is somewhat of a follow up for https://github.com/slundberg/shap/issues/823

I understand that most packages are "optional", but in local/analytical environments some folks don't like tracking all dependencies and just want everything to work. So, added a `extras_require` as per setuptools convention to maintain a list of such dependencies.
These can be installed with:

`pip install shap[all]`