### PR TITLE
#866 spark regressor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ shap/_cext.so
 /data/CRIC*
 /docs/artwork/local
 /shap/_cext*
+.idea

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ pip install shap
 conda install -c conda-forge shap
 </pre>
 
-## Tree ensemble example with TreeExplainer (XGBoost/LightGBM/CatBoost/scikit-learn models)
+## Tree ensemble example with TreeExplainer (XGBoost/LightGBM/CatBoost/scikit-learn/pyspark models)
 
-While SHAP values can explain the output of any machine learning model, we have developed a high-speed exact algorithm for tree ensemble methods ([Tree SHAP arXiv paper](https://arxiv.org/abs/1802.03888)). Fast C++ implementations are supported for *XGBoost*, *LightGBM*, *CatBoost*, and *scikit-learn* tree models:
+While SHAP values can explain the output of any machine learning model, we have developed a high-speed exact algorithm for tree ensemble methods ([Tree SHAP arXiv paper](https://arxiv.org/abs/1802.03888)). Fast C++ implementations are supported for *XGBoost*, *LightGBM*, *CatBoost*, *scikit-learn* and *pyspark* tree models:
 
 ```python
 import xgboost
@@ -38,7 +38,7 @@ X,y = shap.datasets.boston()
 model = xgboost.train({"learning_rate": 0.01}, xgboost.DMatrix(X, label=y), 100)
 
 # explain the model's predictions using SHAP values
-# (same syntax works for LightGBM, CatBoost, and scikit-learn models)
+# (same syntax works for LightGBM, CatBoost, scikit-learn and spark models)
 explainer = shap.TreeExplainer(model)
 shap_values = explainer.shap_values(X)
 
@@ -61,7 +61,7 @@ X,y = shap.datasets.boston()
 
 model = xgboost.train({"learning_rate": 0.01}, xgboost.DMatrix(X, label=y), 100)
 # explain the model's predictions using SHAP values
-# (same syntax works for LightGBM, CatBoost, and scikit-learn models)
+# (same syntax works for LightGBM, CatBoost, scikit-learn and spark models)
 explainer = shap.TreeExplainer(model)
 shap_values = explainer.shap_values(X)
 # visualize the first prediction's explanation using matplotlib (no javascript needed)

--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -496,7 +496,7 @@ class TreeEnsemble:
             assert_import("pyspark")
             self.original_model = model
             self.model_type = "pyspark"
-            #model._java_obj.getImpurity() can be gini, entropy or variance.
+            # model._java_obj.getImpurity() can be gini, entropy or variance.
             self.objective = objective_name_map.get(model._java_obj.getImpurity(), None)
             if "Classification" in str(type(model)):
                 normalize = True
@@ -504,17 +504,18 @@ class TreeEnsemble:
             else:
                 normalize = False
                 self.tree_output = "raw_value"
-            #Spark Random forest, create 1 weighted (avg) tree per sub-model
+            # Spark Random forest, create 1 weighted (avg) tree per sub-model
             if str(type(model)).endswith("pyspark.ml.classification.RandomForestClassificationModel'>") \
                     or str(type(model)).endswith("pyspark.ml.regression.RandomForestRegressionModel'>"):
-                sum_weight = sum(model.treeWeights) # output is average of trees
+                sum_weight = sum(model.treeWeights)  # output is average of trees
                 self.trees = [Tree(tree, normalize=normalize, scaling=model.treeWeights[i]/sum_weight) for i, tree in enumerate(model.trees)]
-            #Spark GBT, create 1 weighted (learning rate) tree per sub-model
+            # Spark GBT, create 1 weighted (learning rate) tree per sub-model
             elif str(type(model)).endswith("pyspark.ml.classification.GBTClassificationModel'>") \
                     or str(type(model)).endswith("pyspark.ml.regression.GBTRegressionModel'>"):
-                self.objective = "squared_error" #GBT subtree use the variance
+                self.objective = "squared_error" # GBT subtree use the variance
+                self.tree_output = "raw_value"
                 self.trees = [Tree(tree, normalize=False, scaling=model.treeWeights[i]) for i, tree in enumerate(model.trees)]
-            #Spark Basic model (single tree)
+            # Spark Basic model (single tree)
             elif str(type(model)).endswith("pyspark.ml.classification.DecisionTreeClassificationModel'>") \
                     or str(type(model)).endswith("pyspark.ml.regression.DecisionTreeRegressionModel'>"):
                 self.trees = [Tree(model, normalize=normalize, scaling=1)]

--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -43,7 +43,7 @@ class TreeExplainer(Explainer):
     Parameters
     ----------
     model : model object
-        The tree based machine learning model that we want to explain. XGBoost, LightGBM, CatBoost,
+        The tree based machine learning model that we want to explain. XGBoost, LightGBM, CatBoost, Pyspark
         and most tree-based scikit-learn models are supported.
 
     data : numpy.array or pandas.DataFrame

--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -386,6 +386,7 @@ class TreeEnsemble:
         # we use names like keras
         objective_name_map = {
             "mse": "squared_error",
+            "variance": "squared_error",
             "friedman_mse": "squared_error",
             "reg:linear": "squared_error",
             "regression": "squared_error",
@@ -490,28 +491,35 @@ class TreeEnsemble:
 
             self.trees = [Tree(e.tree_, scaling=model.learning_rate, data=data, data_missing=data_missing) for e in model.estimators_[:,0]]
             self.objective = objective_name_map.get(model.criterion, None)
-        elif str(type(model)).endswith("pyspark.ml.classification.RandomForestClassificationModel'>") \
-                or str(type(model)).endswith("pyspark.ml.classification.GBTClassificationModel'>"):
+
+        elif "pyspark.ml" in str(type(model)):
             assert_import("pyspark")
             self.original_model = model
             self.model_type = "pyspark"
-            self.trees = [Tree(tree, scaling=model.treeWeights[i]) for i, tree in enumerate(model.trees)]
-            if model._java_obj.getImpurity() == 'variance':
-                assert False, "Unsupported objective: variance"
-            self.objective = objective_name_map.get(model._java_obj.getImpurity(), None)
-            self.tree_output = "raw_value"
-        elif str(type(model)).endswith("pyspark.ml.classification.DecisionTreeClassificationModel'>"):
-            assert_import("pyspark")
-            self.original_model = model
-            self.model_type = "pyspark"
-            self.trees = [Tree(model, scaling=1)]
             #model._java_obj.getImpurity() can be gini, entropy or variance.
-            if model._java_obj.getImpurity() == 'variance':
-                #TODO handle variance as loss?
-                assert False, "Unsupported objective: variance"
             self.objective = objective_name_map.get(model._java_obj.getImpurity(), None)
-            #TODO base_offset?
-            self.tree_output = "raw_value"
+            if "Classification" in str(type(model)):
+                normalize = True
+                self.tree_output = "probability"
+            else:
+                normalize = False
+                self.tree_output = "raw_value"
+            #Spark Random forest, create 1 weighted (avg) tree per sub-model
+            if str(type(model)).endswith("pyspark.ml.classification.RandomForestClassificationModel'>") \
+                    or str(type(model)).endswith("pyspark.ml.regression.RandomForestRegressionModel'>"):
+                sum_weight = sum(model.treeWeights) # output is average of trees
+                self.trees = [Tree(tree, normalize=normalize, scaling=model.treeWeights[i]/sum_weight) for i, tree in enumerate(model.trees)]
+            #Spark GBT, create 1 weighted (learning rate) tree per sub-model
+            elif str(type(model)).endswith("pyspark.ml.classification.GBTClassificationModel'>") \
+                    or str(type(model)).endswith("pyspark.ml.regression.GBTRegressionModel'>"):
+                self.objective = "squared_error" #GBT subtree use the variance
+                self.trees = [Tree(tree, normalize=False, scaling=model.treeWeights[i]) for i, tree in enumerate(model.trees)]
+            #Spark Basic model (single tree)
+            elif str(type(model)).endswith("pyspark.ml.classification.DecisionTreeClassificationModel'>") \
+                    or str(type(model)).endswith("pyspark.ml.regression.DecisionTreeRegressionModel'>"):
+                self.trees = [Tree(model, normalize=normalize, scaling=1)]
+            else:
+                assert False, "Unsupported Spark model type: " + str(type(model))
         elif str(type(model)).endswith("xgboost.core.Booster'>"):
             assert_import("xgboost")
             self.original_model = model
@@ -786,7 +794,8 @@ class Tree:
             self.values = tree["value"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
-        elif str(type(tree)).endswith("pyspark.ml.classification.DecisionTreeClassificationModel'>"):
+        elif str(type(tree)).endswith("pyspark.ml.classification.DecisionTreeClassificationModel'>") \
+                or str(type(tree)).endswith("pyspark.ml.regression.DecisionTreeRegressionModel'>"):
             #model._java_obj.numNodes() doesn't give leaves, need to recompute the size
             def getNumNodes(node, size):
                 size = size + 1
@@ -806,7 +815,10 @@ class Tree:
             self.node_sample_weight = np.full(num_nodes, -2, dtype=np.float64)
             def buildTree(index, node):
                 index = index + 1
-                self.values[index] = [e for e in node.impurityStats().stats()] #NDarray(numLabel): 1 per label: number of item for each label which went through this node
+                if tree._java_obj.getImpurity() == 'variance':
+                    self.values[index] = [node.prediction()] #prediction for the node
+                else:
+                    self.values[index] = [e for e in node.impurityStats().stats()] #for gini: NDarray(numLabel): 1 per label: number of item for each label which went through this node
                 self.node_sample_weight[index] = node.impurityStats().count() #weighted count of element trough this node
 
                 if node.subtreeDepth() == 0:
@@ -828,6 +840,8 @@ class Tree:
             #default Not supported with mlib? (TODO)
             self.children_default = self.children_left
             self.values = np.asarray(self.values)
+            if normalize:
+                self.values = (self.values.T / self.values.sum(1)).T
             self.values = self.values * scaling
 
         elif type(tree) == dict and 'tree_structure' in tree:

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -265,7 +265,7 @@ def test_pyspark_regression_decision_tree():
     # validate values sum to the margin prediction of the model plus expected_value
     test = model.transform(iris).toPandas()
     predictions = model.transform(iris).select("prediction").toPandas()
-    diffs = expected_values + shap_values.sum() - predictions
+    diffs = expected_values + shap_values.sum(1) - predictions["prediction"]
     assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
     assert (np.abs(expected_values - predictions.mean()) < 1e-6).all(), "Bad expected_value!"
     spark.stop()

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -187,17 +187,17 @@ def test_xgboost_mixed_types():
     shap_values = shap.TreeExplainer(bst).shap_values(X)
     shap.dependence_plot(0, shap_values, X, show=False)
 
-def test_pyspark_decision_tree():
+def test_pyspark_classifier_decision_tree():
     try:
         import pyspark
         import sklearn.datasets
         from pyspark.sql import SparkSession
         from pyspark import SparkContext, SparkConf
         from pyspark.ml.feature import VectorAssembler, StringIndexer
-        from pyspark.ml.classification import DecisionTreeClassifier
+        from pyspark.ml.classification import RandomForestClassifier, DecisionTreeClassifier, GBTClassifier
         import pandas as pd
     except:
-        print("Skipping test_pyspark_decision_tree!")
+        print("Skipping test_pyspark_classifier_decision_tree!")
         return
     import shap
 
@@ -210,7 +210,51 @@ def test_pyspark_decision_tree():
     iris = VectorAssembler(inputCols=col[:-1],outputCol="features").transform(iris)
     iris = StringIndexer(inputCol="type", outputCol="label").fit(iris).transform(iris)
 
-    dt = DecisionTreeClassifier(labelCol="label", featuresCol="features")
+    classifiers = [RandomForestClassifier(labelCol="label", featuresCol="features"),
+                   #TODO GBTClassifier doesn't work as it use regressionTree, which are broken
+                   #GBTClassifier(labelCol="label", featuresCol="features"),
+                   DecisionTreeClassifier(labelCol="label", featuresCol="features")]
+    for classifier in classifiers:
+        model = classifier.fit(iris)
+        explainer = shap.TreeExplainer(model)
+        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100] # pylint: disable=E1101
+
+        shap_values = explainer.shap_values(X)
+        expected_values = explainer.expected_value
+
+        predictions = model.transform(iris).select("rawPrediction")\
+            .rdd.map(lambda x:[float(y) for y in x['rawPrediction']]).toDF(['class0','class1']).toPandas()
+        normalizedPredictions = (predictions.T / predictions.sum(1)).T
+        diffs = expected_values[0] + shap_values[0].sum(1) - normalizedPredictions.class0
+        assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
+        diffs = expected_values[1] + shap_values[1].sum(1) - normalizedPredictions.class1
+        assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class1!"
+        assert (np.abs(expected_values - normalizedPredictions.mean()) < 1e-2).all(), "Bad expected_value!"
+    spark.stop()
+
+def test_pyspark_regression_decision_tree():
+    try:
+        import pyspark
+        import sklearn.datasets
+        from pyspark.sql import SparkSession
+        from pyspark import SparkContext, SparkConf
+        from pyspark.ml.feature import VectorAssembler, StringIndexer
+        from pyspark.ml.regression import DecisionTreeRegressor
+        import pandas as pd
+    except:
+        print("Skipping test_pyspark_regression_decision_tree!")
+        return
+    import shap
+
+    iris_sk = sklearn.datasets.load_iris()
+    iris = pd.DataFrame(data= np.c_[iris_sk['data'], iris_sk['target']], columns= iris_sk['feature_names'] + ['target'])[:100]
+    spark = SparkSession.builder.config(conf=SparkConf().set("spark.master", "local[*]")).getOrCreate()
+
+    col = ["sepal_length","sepal_width","petal_length","petal_width","type"]
+    iris = spark.createDataFrame(iris, col)
+    iris = VectorAssembler(inputCols=col[1:],outputCol="features").transform(iris)
+
+    dt = DecisionTreeRegressor(labelCol="sepal_length", featuresCol="features")
     model = dt.fit(iris)
     explainer = shap.TreeExplainer(model)
     X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100] # pylint: disable=E1101
@@ -219,14 +263,14 @@ def test_pyspark_decision_tree():
     expected_values = explainer.expected_value
 
     # validate values sum to the margin prediction of the model plus expected_value
-    predictions = model.transform(iris).select("rawPrediction")\
-        .rdd.map(lambda x:[float(y) for y in x['rawPrediction']]).toDF(['class0','class1']).toPandas()
-    diffs = expected_values[0] + shap_values[0].sum(1) - predictions.class0
+    test = model.transform(iris).toPandas()
+    predictions = model.transform(iris).select("prediction").toPandas()
+    diffs = expected_values + shap_values.sum() - predictions
     assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
-    diffs = expected_values[1] + shap_values[1].sum(1) - predictions.class1
-    assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class1!"
     assert (np.abs(expected_values - predictions.mean()) < 1e-6).all(), "Bad expected_value!"
     spark.stop()
+
+test_pyspark_regression_decision_tree()
 
 def test_sklearn_random_forest_multiclass():
     import shap
@@ -797,6 +841,8 @@ def test_xgboost_classifier_independent_margin():
     shap_values = e.shap_values(X)
 
     assert np.allclose(shap_values.sum(1) + e.expected_value, model.predict(X, output_margin=True))
+
+test_xgboost_classifier_independent_margin()
 
 def test_xgboost_classifier_independent_probability():
     try:

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -210,9 +210,8 @@ def test_pyspark_classifier_decision_tree():
     iris = VectorAssembler(inputCols=col[:-1],outputCol="features").transform(iris)
     iris = StringIndexer(inputCol="type", outputCol="label").fit(iris).transform(iris)
 
-    classifiers = [RandomForestClassifier(labelCol="label", featuresCol="features"),
-                   #TODO GBTClassifier doesn't work as it use regressionTree, which are broken
-                   #GBTClassifier(labelCol="label", featuresCol="features"),
+    classifiers = [GBTClassifier(labelCol="label", featuresCol="features"),
+                   RandomForestClassifier(labelCol="label", featuresCol="features"),
                    DecisionTreeClassifier(labelCol="label", featuresCol="features")]
     for classifier in classifiers:
         model = classifier.fit(iris)
@@ -224,12 +223,17 @@ def test_pyspark_classifier_decision_tree():
 
         predictions = model.transform(iris).select("rawPrediction")\
             .rdd.map(lambda x:[float(y) for y in x['rawPrediction']]).toDF(['class0','class1']).toPandas()
-        normalizedPredictions = (predictions.T / predictions.sum(1)).T
-        diffs = expected_values[0] + shap_values[0].sum(1) - normalizedPredictions.class0
-        assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
-        diffs = expected_values[1] + shap_values[1].sum(1) - normalizedPredictions.class1
-        assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class1!"
-        assert (np.abs(expected_values - normalizedPredictions.mean()) < 1e-2).all(), "Bad expected_value!"
+
+        if str(type(model)).endswith("GBTClassificationModel'>"):
+            diffs = expected_values + shap_values.sum(1) - predictions.class1
+            assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
+        else:
+            normalizedPredictions = (predictions.T / predictions.sum(1)).T
+            diffs = expected_values[0] + shap_values[0].sum(1) - normalizedPredictions.class0
+            assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
+            diffs = expected_values[1] + shap_values[1].sum(1) - normalizedPredictions.class1
+            assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class1!"
+            assert (np.abs(expected_values - normalizedPredictions.mean()) < 1e-2).all(), "Bad expected_value!"
     spark.stop()
 
 def test_pyspark_regression_decision_tree():
@@ -239,7 +243,7 @@ def test_pyspark_regression_decision_tree():
         from pyspark.sql import SparkSession
         from pyspark import SparkContext, SparkConf
         from pyspark.ml.feature import VectorAssembler, StringIndexer
-        from pyspark.ml.regression import DecisionTreeRegressor
+        from pyspark.ml.regression import DecisionTreeRegressor, GBTRegressor, RandomForestRegressor
         import pandas as pd
     except:
         print("Skipping test_pyspark_regression_decision_tree!")
@@ -250,27 +254,28 @@ def test_pyspark_regression_decision_tree():
     iris = pd.DataFrame(data= np.c_[iris_sk['data'], iris_sk['target']], columns= iris_sk['feature_names'] + ['target'])[:100]
     spark = SparkSession.builder.config(conf=SparkConf().set("spark.master", "local[*]")).getOrCreate()
 
+    # Simple regressor: try to predict sepal length based on the other features
     col = ["sepal_length","sepal_width","petal_length","petal_width","type"]
-    iris = spark.createDataFrame(iris, col)
-    iris = VectorAssembler(inputCols=col[1:],outputCol="features").transform(iris)
+    iris = spark.createDataFrame(iris, col).drop("type")
+    iris = VectorAssembler(inputCols=col[1:-1],outputCol="features").transform(iris)
 
-    dt = DecisionTreeRegressor(labelCol="sepal_length", featuresCol="features")
-    model = dt.fit(iris)
-    explainer = shap.TreeExplainer(model)
-    X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100] # pylint: disable=E1101
+    regressors = [GBTRegressor(labelCol="sepal_length", featuresCol="features"),
+                  RandomForestRegressor(labelCol="sepal_length", featuresCol="features"),
+                  DecisionTreeRegressor(labelCol="sepal_length", featuresCol="features")]
+    for regressor in regressors:
+        model = regressor.fit(iris)
+        explainer = shap.TreeExplainer(model)
+        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop('sepal length (cm)', 1)[:100] # pylint: disable=E1101
 
-    shap_values = explainer.shap_values(X)
-    expected_values = explainer.expected_value
+        shap_values = explainer.shap_values(X)
+        expected_values = explainer.expected_value
 
-    # validate values sum to the margin prediction of the model plus expected_value
-    test = model.transform(iris).toPandas()
-    predictions = model.transform(iris).select("prediction").toPandas()
-    diffs = expected_values + shap_values.sum(1) - predictions["prediction"]
-    assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
-    assert (np.abs(expected_values - predictions.mean()) < 1e-6).all(), "Bad expected_value!"
+        # validate values sum to the margin prediction of the model plus expected_value
+        predictions = model.transform(iris).select("prediction").toPandas()
+        diffs = expected_values + shap_values.sum(1) - predictions["prediction"]
+        assert np.max(np.abs(diffs)) < 1e-6, "SHAP values don't sum to model output for class0!"
+        assert (np.abs(expected_values - predictions.mean()) < 1e-1).all(), "Bad expected_value!"
     spark.stop()
-
-test_pyspark_regression_decision_tree()
 
 def test_sklearn_random_forest_multiclass():
     import shap
@@ -842,7 +847,6 @@ def test_xgboost_classifier_independent_margin():
 
     assert np.allclose(shap_values.sum(1) + e.expected_value, model.predict(X, output_margin=True))
 
-test_xgboost_classifier_independent_margin()
 
 def test_xgboost_classifier_independent_probability():
     try:


### PR DESCRIPTION
This pull request add support for pyspark Decision Trees Regressor in the explainer (previous implementation was only working Classifier).

The following algorithms are now supported and tested in test_tree.py:
- GBTClassifier
- RandomForestClassifier
- DecisionTreeClassifier
- GBTRegressor
- RandomForestRegressor
- DecisionTreeRegressor

pyspark explainer bug correction:
- Fix a bug with GBTClassifier

Limitations:
- As previously, categorical split aren't supported
- As previously, the .predict() function doesn't support prediction with spark

See #866 for more details 