### PR TITLE
Draw colorbar on individual axes when doing dependence_plot

### DIFF
--- a/shap/plots/dependence.py
+++ b/shap/plots/dependence.py
@@ -225,10 +225,10 @@ def dependence_plot(ind, shap_values, features, feature_names=None, display_feat
             if len(tick_positions) == 2:
                 tick_positions[0] -= 0.25
                 tick_positions[1] += 0.25
-            cb = pl.colorbar(p, ticks=tick_positions)
+            cb = pl.colorbar(p, ticks=tick_positions, ax=ax)
             cb.set_ticklabels(cnames)
         else:
-            cb = pl.colorbar(p)
+            cb = pl.colorbar(p, ax=ax)
 
         cb.set_label(feature_names[interaction_index], size=13)
         cb.ax.tick_params(labelsize=11)


### PR DESCRIPTION
When using dependence plot with a subplot, the colorbar is currently drawn in the right part of the figure rather than the individual axes.

Examples of before/after using the below code:

```python
fig, axs = plt.subplots(1, 2, figsize=(20,8))
shap.dependence_plot("DateDaysAgo-1", shap_values, X, ax=axs[0], show=False)
shap.dependence_plot("CouponRate", shap_values, X, ax=axs[1], show=False)
```

Before PF:
![Before PR](https://user-images.githubusercontent.com/655289/69229868-8e59e280-0b86-11ea-9ec4-7abf9701e9fa.png)
After PR:
![After PR](https://user-images.githubusercontent.com/655289/69229869-8ef27900-0b86-11ea-81b4-5246a8c903ab.png)
