### PR TITLE
Updates to the PyTorch explainers

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -139,7 +139,7 @@ class PyTorchDeepExplainer(Explainer):
         else:
             assert type(X) == list, "Expected a list of model inputs!"
 
-        X = [x.to(self.device) for x in X]
+        X = [x.detach().to(self.device) for x in X]
 
         if ranked_outputs is not None and self.multi_output:
             with torch.no_grad():

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -310,7 +310,9 @@ def test_pytorch_mnist_cnn():
         else:
             e = shap.DeepExplainer(model, next_x[inds, :, :, :])
         test_x, test_y = next(iter(test_loader))
-        shap_values = e.shap_values(test_x[:1])
+        input_tensor = test_x[:1]
+        input_tensor.requires_grad = True
+        shap_values = e.shap_values(input_tensor)
 
         model.eval()
         model.zero_grad()


### PR DESCRIPTION
Two updates:

1. Previously, if the input tensor passed to the explainer has `requires_grad == True`, then the DeepExplainer throws the following RunTime error:
```
Can't call numpy() on Variable that requires grad. Use var.detach().numpy() instead.
```
This is fixed by ensuring all tensors are detached when they are passed to the explainer.

2. ~The PyTorch gradient explainer is updated to handle `return_variances`.~ This is fixed in #873 