### PR TITLE
Add docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ---
 <a href="https://travis-ci.org/slundberg/shap"><img src="https://travis-ci.org/slundberg/shap.svg?branch=master"></a>
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/slundberg/shap/master)
+[![Documentation](https://readthedocs.org/projects/shap/badge/?version=latest&style=flat)](https://shap.readthedocs.io/en/latest)
 
 **SHAP (SHapley Additive exPlanations)** is a unified approach to explain the output of any machine learning model. SHAP connects game theory with local explanations, uniting several previous methods [1-7] and representing the only possible consistent and locally accurate additive feature attribution method based on expectations (see our [papers](#citations) for details and citations).
 


### PR DESCRIPTION
I couldn't see whether there was a ref docs page when skimming the README. A badge like this would be handy.