### PR TITLE
fix shap import error on matplotlib with missing backend

### DIFF
--- a/shap/plots/bar.py
+++ b/shap/plots/bar.py
@@ -1,4 +1,9 @@
-import matplotlib.pyplot as pl
+import warnings
+try:
+    import matplotlib.pyplot as pl
+except ImportError:
+    warnings.warn("matplotlib could not be loaded!")
+    pass
 from . import labels
 from . import colors
 import numpy as np

--- a/shap/plots/partial_dependence.py
+++ b/shap/plots/partial_dependence.py
@@ -1,6 +1,11 @@
 import shap
 from ..common import convert_name
-import matplotlib.pyplot as pl
+import warnings
+try:
+    import matplotlib.pyplot as pl
+except ImportError:
+    warnings.warn("matplotlib could not be loaded!")
+    pass
 from mpl_toolkits.mplot3d import Axes3D  
 import numpy as np
 import pandas as pd

--- a/shap/plots/waterfall.py
+++ b/shap/plots/waterfall.py
@@ -1,5 +1,10 @@
 import numpy as np
-import matplotlib.pyplot as pl
+import warnings
+try:
+    import matplotlib.pyplot as pl
+except ImportError:
+    warnings.warn("matplotlib could not be loaded!")
+    pass
 from shap.plots import labels
 from shap.common import safe_isinstance, pretty_num
 from . import colors


### PR DESCRIPTION
fix shap import error on matplotlib with missing backend

to test locally on a non-macos machine (setting to missing macos backend will then force matplotlib to throw error on import):

(sh) PS C:\shap> python
>>> import matplotlib
>>> matplotlib.use('MacOSX')
>>> import shap