### PR TITLE
Allows retaining original class order in multi-class summary plot

### DIFF
--- a/shap/plots/summary.py
+++ b/shap/plots/summary.py
@@ -18,6 +18,7 @@ from . import colors
 def summary_plot(shap_values, features=None, feature_names=None, max_display=None, plot_type=None,
                  color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
                  color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,
+                 class_inds=None,
                  color_bar_label=labels["FEATURE_VALUE"],
                  # depreciated
                  auto_size_plot=None):
@@ -432,8 +433,11 @@ def summary_plot(shap_values, features=None, feature_names=None, max_display=Non
         y_pos = np.arange(len(feature_inds))
         left_pos = np.zeros(len(feature_inds))
 
-        class_inds = np.argsort([-np.abs(shap_values[i]).mean() for i in range(len(shap_values))])
-        for i,ind in enumerate(class_inds):
+        if class_inds is None:
+            class_inds = np.argsort([-np.abs(shap_values[i]).mean() for i in range(len(shap_values))])
+        elif class_inds == "original":
+            class_inds = range(len(shap_values))
+        for i, ind in enumerate(class_inds):
             global_shap_values = np.abs(shap_values[ind]).mean(0)
             pl.barh(
                 y_pos, global_shap_values[feature_inds], 0.7, left=left_pos, align='center',


### PR DESCRIPTION
I needed the colors used in the multi-class stacked bar summary plot to be consistent across many different scenarios and predictable (I'm using a custom cmap where the colours make sense wrt the classes). This trivial change allows for the order of the stacks per variable to be the same as the original class order (or can be entirely custom by providing an index list in `class_inds`).