### PR TITLE
Make package compatible with IBM zOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,11 @@ class build_ext(_build_ext):
 def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catboost=True, test_spark=True):
     ext_modules = []
     if with_binary:
+        compile_args = []
+        if sys.platform == 'zos':
+            compile_args.append('-qlonglong')
         ext_modules.append(
-            Extension('shap._cext', sources=['shap/_cext.cc'])
+            Extension('shap._cext', sources=['shap/_cext.cc'], extra_compile_args=compile_args)
         )
 
     tests_require = ['nose']

--- a/shap/tree_shap.h
+++ b/shap/tree_shap.h
@@ -13,6 +13,8 @@
 #include <ctime>
 #if defined(_WIN32) || defined(WIN32)
     #include <malloc.h>
+#elif defined(__MVS__)
+    #include <stdlib.h>
 #else
     #include <alloca.h>
 #endif


### PR DESCRIPTION
Not sure if the stdlib include is necessary but alloca.h is not available on zOS.

An additional compile option is needed for the xlC compiler to enable long long type.