### PR TITLE
QoL change. Takes into account default 'objective' param in LightGBM,

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -245,9 +245,10 @@ class TreeExplainer(Explainer):
                 assert not approximate, "approximate=True is not supported for LightGBM models!"
                 phi = self.model.original_model.predict(X, num_iteration=tree_limit, pred_contrib=True)
                 # Note: the data must be joined on the last axis
-                if self.model.original_model.params['objective'] == 'binary':
-                    warnings.warn('LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray')
-                    phi = np.concatenate((0-phi, phi), axis=-1)
+                if self.model.original_model.params.get('objective') is not None:
+                    if self.model.original_model.params['objective'] == 'binary':
+                        warnings.warn('LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray')
+                        phi = np.concatenate((0-phi, phi), axis=-1)
                 if phi.shape[1] != X.shape[1] + 1:
                     try:
                         phi = phi.reshape(X.shape[0], phi.shape[1]//(X.shape[1]+1), X.shape[1]+1)


### PR DESCRIPTION
Hi, I just added a preliminary check to see if the params dictionary for a model in LightGBM has its 'objective' key populated. Since when not defining an objective its default value is 'regression' ( as can be seen here: [https://lightgbm.readthedocs.io/en/latest/Parameters.html#objective](url) ). But this does not create an 'objective' entry in the params dictionary unless explicitly specified. Thus when trying to run TreeExplainer(...).shap_values(...) it throws a KeyError, as seen below:

![shap_keyError](https://user-images.githubusercontent.com/43810946/75134843-cfaae280-56df-11ea-9a42-4555421edb47.png)

This is just a QoL change to avoid that anyone else has to dig into why this happens, and allow a more fluid workflow.

P.S. This is my first PR and first time interacting in the open source environment. If there is something else i should have done, considered, please let me know.