### PR TITLE
Gpu test for pytorch expainer

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -222,7 +222,8 @@ def deeplift_grad(module, grad_input, grad_output):
     # first, check the module is supported
     if module_type in op_handler:
         if op_handler[module_type].__name__ not in ['passthrough', 'linear_1d']:
-            return op_handler[module_type](module, grad_input, grad_output)
+            result = op_handler[module_type](module, grad_input, grad_output)
+            return tuple([grad.to(grad_input[0].device) for grad in result])
     else:
         print('Warning: unrecognized nn.Module: {}'.format(module_type))
         return grad_input

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -130,7 +130,7 @@ def test_tf_keras_linear():
     """Test verifying that a linear model with linear data gives the correct result.
     """
     _skip_if_no_tensorflow()
-    
+
     from tensorflow.keras.models import Model
     from tensorflow.keras.layers import Dense, Input
     from tensorflow.keras.optimizers import SGD
@@ -238,7 +238,7 @@ def test_pytorch_mnist_cnn():
     from torch.nn import functional as F
     import shap
 
-    def run_test(train_loader, test_loader, interim):
+    def run_test(train_loader, test_loader, interim, device):
 
         class Net(nn.Module):
             def __init__(self):
@@ -279,7 +279,7 @@ def test_pytorch_mnist_cnn():
                 data, target = data.to(device), target.to(device)
                 optimizer.zero_grad()
                 output = model(data)
-                loss = F.mse_loss(output, torch.eye(10)[target])
+                loss = F.mse_loss(output, torch.eye(10)[target].to(device))
                 # loss = F.nll_loss(output, target)
                 loss.backward()
                 optimizer.step()
@@ -290,25 +290,32 @@ def test_pytorch_mnist_cnn():
                 if num_examples > cutoff:
                     break
 
-        device = torch.device('cpu')
-        train(model, device, train_loader, optimizer, 1)
+
+        train(model.to(device), device, train_loader, optimizer, 1)
 
         next_x, next_y = next(iter(train_loader))
         np.random.seed(0)
         inds = np.random.choice(next_x.shape[0], 20, replace=False)
         if interim:
-            e = shap.DeepExplainer((model, model.conv_layers[0]), next_x[inds, :, :, :])
+            e = shap.DeepExplainer(
+                (model.to(device), model.conv_layers[0].to(device)), next_x[inds, :, :, :].to(device)
+            )
         else:
-            e = shap.DeepExplainer(model, next_x[inds, :, :, :])
+            e = shap.DeepExplainer(
+                model.to(device), next_x[inds, :, :, :].to(device)
+            )
         test_x, test_y = next(iter(test_loader))
         input_tensor = test_x[:1]
         input_tensor.requires_grad = True
-        shap_values = e.shap_values(input_tensor)
+        shap_values = e.shap_values(input_tensor.to(device))
 
+        model = model.to(device)
         model.eval()
         model.zero_grad()
         with torch.no_grad():
-            diff = (model(test_x[:1]) - model(next_x[inds, :, :, :])).detach().numpy().mean(0)
+            test_outputs = model(test_x[:1].to(device))
+            next_outputs = model(next_x[inds, :].to(device))
+            diff = (test_outputs - next_outputs).detach().cpu().numpy().mean(0)
         sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
         d = np.abs(sums - diff).sum()
         assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (
@@ -333,9 +340,13 @@ def test_pytorch_mnist_cnn():
         batch_size=batch_size, shuffle=True)
 
     print ('Running test on interim layer')
-    run_test(train_loader, test_loader, interim=True)
+    run_test(train_loader, test_loader, interim=True, device="cpu")
+    if torch.cuda.is_available():
+        run_test(train_loader, test_loader, interim=True, device="cuda:0")
     print ('Running test on whole model')
-    run_test(train_loader, test_loader, interim=False)
+    run_test(train_loader, test_loader, interim=False, device="cpu")
+    if torch.cuda.is_available():
+        run_test(train_loader, test_loader, interim=True, device="cuda:0")
     # clean up
     shutil.rmtree(root_dir)
 

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -5,6 +5,8 @@ import nose
 import os
 
 from tests.fixtures import set_seed
+from nose.tools import with_setup
+
 
 # force us to not use any GPUs since running many tests may cause trouble
 os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
@@ -231,7 +233,9 @@ def test_tf_keras_imdb_lstm():
         sess.run(mod.layers[-1].output, feed_dict={mod.layers[0].input: background}).mean(0)
     assert np.allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
-def test_pytorch_mnist_cnn(set_seed):
+
+@with_setup(set_seed)
+def test_pytorch_mnist_cnn():
     """The same test as above, but for pytorch
     """
     _skip_if_no_pytorch()
@@ -355,8 +359,8 @@ def test_pytorch_mnist_cnn(set_seed):
     # clean up
     shutil.rmtree(root_dir)
 
-
-def test_pytorch_single_output(set_seed):
+@with_setup(set_seed)
+def test_pytorch_single_output():
     """Testing single outputs
     """
     _skip_if_no_pytorch()
@@ -433,8 +437,8 @@ def test_pytorch_single_output(set_seed):
         os.environ['CUDA_VISIBLE_DEVICES'] = 0
         run_test(loader, device="cuda:0")
 
-
-def test_pytorch_multiple_inputs(set_seed):
+@with_setup(set_seed)
+def test_pytorch_multiple_inputs():
     _skip_if_no_pytorch()
 
     import torch

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -4,8 +4,11 @@ import numpy as np
 import nose
 import os
 
+from tests.fixtures import set_seed
+
 # force us to not use any GPUs since running many tests may cause trouble
 os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+
 
 def _skip_if_no_tensorflow():
     try:
@@ -19,6 +22,7 @@ def _skip_if_no_pytorch():
         import torch
     except ImportError:
         raise nose.SkipTest('Pytorch not installed.')
+
 
 def test_tf_eager():
     """ This is a basic eager example from keras.
@@ -227,7 +231,7 @@ def test_tf_keras_imdb_lstm():
         sess.run(mod.layers[-1].output, feed_dict={mod.layers[0].input: background}).mean(0)
     assert np.allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
-def test_pytorch_mnist_cnn():
+def test_pytorch_mnist_cnn(set_seed):
     """The same test as above, but for pytorch
     """
     _skip_if_no_pytorch()
@@ -342,10 +346,12 @@ def test_pytorch_mnist_cnn():
     print ('Running test on interim layer')
     run_test(train_loader, test_loader, interim=True, device="cpu")
     if torch.cuda.is_available():
+        os.environ['CUDA_VISIBLE_DEVICES'] = 0
         run_test(train_loader, test_loader, interim=True, device="cuda:0")
     print ('Running test on whole model')
     run_test(train_loader, test_loader, interim=False, device="cpu")
     if torch.cuda.is_available():
+        os.environ['CUDA_VISIBLE_DEVICES'] = 0
         run_test(train_loader, test_loader, interim=True, device="cuda:0")
     # clean up
     shutil.rmtree(root_dir)

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -294,7 +294,6 @@ def test_pytorch_mnist_cnn(set_seed):
                 if num_examples > cutoff:
                     break
 
-
         train(model.to(device), device, train_loader, optimizer, 1)
 
         next_x, next_y = next(iter(train_loader))
@@ -357,7 +356,7 @@ def test_pytorch_mnist_cnn(set_seed):
     shutil.rmtree(root_dir)
 
 
-def test_pytorch_single_output():
+def test_pytorch_single_output(set_seed):
     """Testing single outputs
     """
     _skip_if_no_pytorch()
@@ -369,76 +368,85 @@ def test_pytorch_single_output():
     from sklearn.datasets import load_boston
     import shap
 
+    def run_test(loader, device):
+        class Net(nn.Module):
+            def __init__(self, num_features):
+                super(Net, self).__init__()
+                self.linear = nn.Linear(num_features // 2, 2)
+                self.conv1d = nn.Conv1d(1, 1, 1)
+                self.convt1d = nn.ConvTranspose1d(1, 1, 1)
+                self.leaky_relu = nn.LeakyReLU()
+                self.aapool1d = nn.AdaptiveAvgPool1d(output_size=6)
+                self.maxpool2 = nn.MaxPool1d(kernel_size=2)
+
+            def forward(self, X):
+                x = self.aapool1d(self.convt1d(self.conv1d(X.unsqueeze(1)))).squeeze(1)
+                return self.maxpool2(self.linear(self.leaky_relu(x)).unsqueeze(1)).squeeze(1)
+        model = Net(num_features)
+        optimizer = torch.optim.Adam(model.parameters())
+
+        def train(model, device, train_loader, optimizer, epoch):
+            model.train()
+            num_examples = 0
+            for batch_idx, (data, target) in enumerate(train_loader):
+                num_examples += target.shape[0]
+                data, target = data.to(device), target.to(device)
+                optimizer.zero_grad()
+                output = model(data)
+                loss = F.mse_loss(output.squeeze(1), target)
+                loss.backward()
+                optimizer.step()
+                if batch_idx % 2 == 0:
+                    print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                        epoch, batch_idx * len(data), len(train_loader.dataset),
+                               100. * batch_idx / len(train_loader), loss.item()))
+
+        train(model.to(device), device, loader, optimizer, 1)
+
+        next_x, next_y = next(iter(loader))
+        np.random.seed(0)
+        inds = np.random.choice(next_x.shape[0], 20, replace=False)
+        e = shap.DeepExplainer(model.to(device), next_x[inds, :].to(device))
+        test_x, test_y = next(iter(loader))
+        shap_values = e.shap_values(test_x[:1].to(device))
+
+        model = model.to(device)
+        model.eval()
+        model.zero_grad()
+        with torch.no_grad():
+            test_outputs = model(test_x[:1].to(device))
+            next_outputs = model(next_x[inds, :].to(device))
+            diff = (test_outputs - next_outputs).detach().cpu().numpy().mean(0)
+        sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
+        d = np.abs(sums - diff).sum()
+        assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (
+                d / np.abs(diff).sum())
+
     X, y = load_boston(return_X_y=True)
     num_features = X.shape[1]
     data = TensorDataset(torch.tensor(X).float(),
                          torch.tensor(y).float())
     loader = DataLoader(data, batch_size=128)
 
-    class Net(nn.Module):
-        def __init__(self, num_features):
-            super(Net, self).__init__()
-            self.linear = nn.Linear(num_features // 2, 2)
-            self.conv1d = nn.Conv1d(1, 1, 1)
-            self.convt1d = nn.ConvTranspose1d(1, 1, 1)
-            self.leaky_relu = nn.LeakyReLU()
-            self.aapool1d = nn.AdaptiveAvgPool1d(output_size=6)
-            self.maxpool2 = nn.MaxPool1d(kernel_size=2)
-
-        def forward(self, X):
-            x = self.aapool1d(self.convt1d(self.conv1d(X.unsqueeze(1)))).squeeze(1)
-            return self.maxpool2(self.linear(self.leaky_relu(x)).unsqueeze(1)).squeeze(1)
-    model = Net(num_features)
-    optimizer = torch.optim.Adam(model.parameters())
-
-    def train(model, device, train_loader, optimizer, epoch):
-        model.train()
-        num_examples = 0
-        for batch_idx, (data, target) in enumerate(train_loader):
-            num_examples += target.shape[0]
-            data, target = data.to(device), target.to(device)
-            optimizer.zero_grad()
-            output = model(data)
-            loss = F.mse_loss(output.squeeze(1), target)
-            loss.backward()
-            optimizer.step()
-            if batch_idx % 2 == 0:
-                print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
-                    epoch, batch_idx * len(data), len(train_loader.dataset),
-                           100. * batch_idx / len(train_loader), loss.item()))
-
-    device = torch.device('cpu')
-    train(model, device, loader, optimizer, 1)
-
-    next_x, next_y = next(iter(loader))
-    np.random.seed(0)
-    inds = np.random.choice(next_x.shape[0], 20, replace=False)
-    e = shap.DeepExplainer(model, next_x[inds, :])
-    test_x, test_y = next(iter(loader))
-    shap_values = e.shap_values(test_x[:1])
-
-    model.eval()
-    model.zero_grad()
-    with torch.no_grad():
-        diff = (model(test_x[:1]) - model(next_x[inds, :])).detach().numpy().mean(0)
-    sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
-    d = np.abs(sums - diff).sum()
-    assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (
-            d / np.abs(diff).sum())
+    run_test(loader, device="cpu")
+    if torch.cuda.is_available():
+        os.environ['CUDA_VISIBLE_DEVICES'] = 0
+        run_test(loader, device="cuda:0")
 
 
-def test_pytorch_multiple_inputs():
+def test_pytorch_multiple_inputs(set_seed):
     _skip_if_no_pytorch()
 
-    def _run_pytorch_multiple_inputs_test(disconnected):
+    import torch
+    from torch import nn
+    from torch.nn import functional as F
+    from torch.utils.data import TensorDataset, DataLoader
+    from sklearn.datasets import load_boston
+    import shap
+
+    def _run_pytorch_multiple_inputs_test(disconnected, device):
         """Testing multiple inputs
         """
-        import torch
-        from torch import nn
-        from torch.nn import functional as F
-        from torch.utils.data import TensorDataset, DataLoader
-        from sklearn.datasets import load_boston
-        import shap
 
         X, y = load_boston(return_X_y=True)
         num_features = X.shape[1]
@@ -487,25 +495,29 @@ def test_pytorch_multiple_inputs():
                         epoch, batch_idx * len(data), len(train_loader.dataset),
                                100. * batch_idx / len(train_loader), loss.item()))
 
-        device = torch.device('cpu')
-        train(model, device, loader, optimizer, 1)
+        train(model.to(device), device, loader, optimizer, 1)
 
         next_x1, next_x2, next_y = next(iter(loader))
         np.random.seed(0)
         inds = np.random.choice(next_x1.shape[0], 20, replace=False)
-        background = [next_x1[inds, :], next_x2[inds, :]]
-        e = shap.DeepExplainer(model, background)
+        background = [next_x1[inds, :].to(device), next_x2[inds, :].to(device)]
+        e = shap.DeepExplainer(model.to(device), background)
         test_x1, test_x2, test_y = next(iter(loader))
-        shap_x1, shap_x2 = e.shap_values([test_x1[:1], test_x2[:1]])
+        shap_x1, shap_x2 = e.shap_values([test_x1[:1].to(device), test_x2[:1].to(device)])
 
+        model = model.to(device)
         model.eval()
         model.zero_grad()
         with torch.no_grad():
-            diff = (model(test_x1[:1], test_x2[:1]) - model(*background)).detach().numpy().mean(0)
+            test_outputs = model(test_x1[:1].to(device), test_x2[:1].to(device))
+            next_outputs = model(*[b.to(device) for b in background])
+            diff = (test_outputs - next_outputs).detach().cpu().numpy().mean(0)
         sums = np.array([shap_x1[i].sum() + shap_x2[i].sum() for i in range(len(shap_x1))])
         d = np.abs(sums - diff).sum()
         assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (
                 d / np.abs(diff).sum())
 
-    _run_pytorch_multiple_inputs_test(disconnected=True)
-    _run_pytorch_multiple_inputs_test(disconnected=False)
+    _run_pytorch_multiple_inputs_test(disconnected=True, device="cpu")
+    if torch.cuda.is_available():
+        os.environ['CUDA_VISIBLE_DEVICES'] = 0
+        _run_pytorch_multiple_inputs_test(disconnected=False, device="cuda:0")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,4 @@
 import random
-import pytest
 
 import numpy as np
 
@@ -18,7 +17,5 @@ def set_random_seeds(seed_value=42):
 
     torch.backends.cudnn.deterministic = True
 
-
-@pytest.fixture()
 def set_seed():
     set_random_seeds()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,21 @@
+import random
+import torch
+import pytest
+
+import numpy as np
+
+
+def set_random_seeds(seed_value=42):
+    np.random.seed(seed_value)
+    random.seed(seed_value)
+
+    torch.manual_seed(seed_value)
+    torch.cuda.manual_seed(seed_value)
+    torch.cuda.manual_seed_all(seed_value)
+
+    torch.backends.cudnn.deterministic = True
+
+
+@pytest.fixture()
+def set_seed():
+    set_random_seeds()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,4 @@
 import random
-import torch
 import pytest
 
 import numpy as np
@@ -9,6 +8,10 @@ def set_random_seeds(seed_value=42):
     np.random.seed(seed_value)
     random.seed(seed_value)
 
+    from tests.explainers.test_deep import _skip_if_no_pytorch
+    _skip_if_no_pytorch()
+
+    import torch
     torch.manual_seed(seed_value)
     torch.cuda.manual_seed(seed_value)
     torch.cuda.manual_seed_all(seed_value)


### PR DESCRIPTION
1. Since the test code is written only on "cpu", I've written the code for testing on "gpu".
The long-term reason for writing test code for gpu is: I've been writing codes for getting shap using **batch-wise inference inside PytorchExplainer** (Currently, all examples codes in the repo use around 100 samples of data when calculating shap. However, I've checked that the shap results are quite different(no similarity at all) when I'm using 100 samples and 100000 samples. Bottleneck is using cpu is so slow when using all data. So that's why I started to write test code for GPU)


2. I've tested on below environment and passed all `test_deep.py`  on this PR (I guess that CI tool can't run the `test_deep.py` because `pytorch` is not installed. So, I tested it manually)

OS: ubuntu 18.04
Driver Version: 440.33.01 
CUDA Version: 10.2
Python version: 3.7.x
shap version: 0.34.0
torch version: 1.2.0



3. The reason that I've also added commit of setting random seed is when I run test on gpu mode, It showed inconsistent results: On `6878952` commit of my PR, I ran test 2 times in a row and the first trial didn't pass, but the second do. Below is history:
 

```
(base) Chois@computer-gpu1:~/shap$ pytest tests/explainers/test_deep.py::test_pytorch_mnist_cnn -s
====================================== test session starts =======================================
platform linux -- Python 3.7.4, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /home/Chois/shap
collected 1 item

tests/explainers/test_deep.py Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to mnist_data/MNIST/raw/train-images-idx3-ubyte.gz
9920512it [00:02, 3901093.37it/s]
Extracting mnist_data/MNIST/raw/train-images-idx3-ubyte.gz to mnist_data/MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to mnist_data/MNIST/raw/train-labels-idx1-ubyte.gz
32768it [00:00, 52727.96it/s]
Extracting mnist_data/MNIST/raw/train-labels-idx1-ubyte.gz to mnist_data/MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to mnist_data/MNIST/raw/t10k-images-idx3-ubyte.gz
1654784it [00:01, 841926.42it/s]
Extracting mnist_data/MNIST/raw/t10k-images-idx3-ubyte.gz to mnist_data/MNIST/raw
Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to mnist_data/MNIST/raw/t10k-labels-idx1-ubyte.gz
8192it [00:00, 18812.56it/s]
Extracting mnist_data/MNIST/raw/t10k-labels-idx1-ubyte.gz to mnist_data/MNIST/raw
Processing...
Done!
Running test on interim layer
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.091955
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.090444
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.091087
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.091120
Running test on whole model
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.091641
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.090700
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.092222
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.090528
F

============================================ FAILURES ============================================
_____________________________________ test_pytorch_mnist_cnn _____________________________________

    def test_pytorch_mnist_cnn():
        """The same test as above, but for pytorch
        """
        _skip_if_no_pytorch()

        import torch, torchvision
        from torchvision import datasets, transforms
        from torch import nn
        from torch.nn import functional as F
        import shap

        def run_test(train_loader, test_loader, interim, device):

            class Net(nn.Module):
                def __init__(self):
                    super(Net, self).__init__()
                    # Testing several different activations
                    self.conv_layers = nn.Sequential(
                        nn.Conv2d(1, 10, kernel_size=5),
                        nn.MaxPool2d(2),
                        nn.Tanh(),
                        nn.Conv2d(10, 20, kernel_size=5),
                        nn.ConvTranspose2d(20, 20, 1),
                        nn.AdaptiveAvgPool2d(output_size=(4, 4)),
                        nn.Softplus(),
                    )
                    self.fc_layers = nn.Sequential(
                        nn.Linear(320, 50),
                        nn.BatchNorm1d(50),
                        nn.ReLU(),
                        nn.Linear(50, 10),
                        nn.ELU(),
                        nn.Softmax(dim=1)
                    )

                def forward(self, x):
                    x = self.conv_layers(x)
                    x = x.view(-1, 320)
                    x = self.fc_layers(x)
                    return x

            model = Net()
            optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)

            def train(model, device, train_loader, optimizer, epoch, cutoff=2000):
                model.train()
                num_examples = 0
                for batch_idx, (data, target) in enumerate(train_loader):
                    num_examples += target.shape[0]
                    data, target = data.to(device), target.to(device)
                    optimizer.zero_grad()
                    output = model(data)
                    loss = F.mse_loss(output, torch.eye(10)[target].to(device))
                    # loss = F.nll_loss(output, target)
                    loss.backward()
                    optimizer.step()
                    if batch_idx % 10 == 0:
                        print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                            epoch, batch_idx * len(data), len(train_loader.dataset),
                                   100. * batch_idx / len(train_loader), loss.item()))
                    if num_examples > cutoff:
                        break


            train(model.to(device), device, train_loader, optimizer, 1)

            next_x, next_y = next(iter(train_loader))
            np.random.seed(0)
            inds = np.random.choice(next_x.shape[0], 20, replace=False)
            if interim:
                e = shap.DeepExplainer(
                    (model.to(device), model.conv_layers[0].to(device)), next_x[inds, :, :, :].to(device)
                )
            else:
                e = shap.DeepExplainer(
                    model.to(device), next_x[inds, :, :, :].to(device)
                )
            test_x, test_y = next(iter(test_loader))
            input_tensor = test_x[:1]
            input_tensor.requires_grad = True
            shap_values = e.shap_values(input_tensor)

            model = model.to(device)
            model.eval()
            model.zero_grad()
            with torch.no_grad():
                test_outputs = model(test_x[:1].to(device))
                next_outputs = model(next_x[inds, :].to(device))
                diff = (test_outputs - next_outputs).detach().cpu().numpy().mean(0)
            sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
            d = np.abs(sums - diff).sum()
            assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (
                    d / np.abs(diff).sum())

        batch_size = 128
        root_dir = 'mnist_data'

        train_loader = torch.utils.data.DataLoader(
            datasets.MNIST(root_dir, train=True, download=True,
                           transform=transforms.Compose([
                               transforms.ToTensor(),
                               transforms.Normalize((0.1307,), (0.3081,))
                           ])),
            batch_size=batch_size, shuffle=True)
        test_loader = torch.utils.data.DataLoader(
            datasets.MNIST(root_dir, train=False, download=True,
                           transform=transforms.Compose([
                               transforms.ToTensor(),
                               transforms.Normalize((0.1307,), (0.3081,))
                           ])),
            batch_size=batch_size, shuffle=True)

        print ('Running test on interim layer')
        run_test(train_loader, test_loader, interim=True, device="cpu")
        if torch.cuda.is_available():
            run_test(train_loader, test_loader, interim=True, device="cuda:0")
        print ('Running test on whole model')
        run_test(train_loader, test_loader, interim=False, device="cpu")
        if torch.cuda.is_available():
>           run_test(train_loader, test_loader, interim=True, device="cuda:0")

tests/explainers/test_deep.py:321:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

train_loader = <torch.utils.data.dataloader.DataLoader object at 0x7fa2c3718f50>
test_loader = <torch.utils.data.dataloader.DataLoader object at 0x7fa2c13a6c10>, interim = True
device = 'cuda:0'

    def run_test(train_loader, test_loader, interim, device):

        class Net(nn.Module):
            def __init__(self):
                super(Net, self).__init__()
                # Testing several different activations
                self.conv_layers = nn.Sequential(
                    nn.Conv2d(1, 10, kernel_size=5),
                    nn.MaxPool2d(2),
                    nn.Tanh(),
                    nn.Conv2d(10, 20, kernel_size=5),
                    nn.ConvTranspose2d(20, 20, 1),
                    nn.AdaptiveAvgPool2d(output_size=(4, 4)),
                    nn.Softplus(),
                )
                self.fc_layers = nn.Sequential(
                    nn.Linear(320, 50),
                    nn.BatchNorm1d(50),
                    nn.ReLU(),
                    nn.Linear(50, 10),
                    nn.ELU(),
                    nn.Softmax(dim=1)
                )

            def forward(self, x):
                x = self.conv_layers(x)
                x = x.view(-1, 320)
                x = self.fc_layers(x)
                return x

        model = Net()
        optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.5)

        def train(model, device, train_loader, optimizer, epoch, cutoff=2000):
            model.train()
            num_examples = 0
            for batch_idx, (data, target) in enumerate(train_loader):
                num_examples += target.shape[0]
                data, target = data.to(device), target.to(device)
                optimizer.zero_grad()
                output = model(data)
                loss = F.mse_loss(output, torch.eye(10)[target].to(device))
                # loss = F.nll_loss(output, target)
                loss.backward()
                optimizer.step()
                if batch_idx % 10 == 0:
                    print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                        epoch, batch_idx * len(data), len(train_loader.dataset),
                               100. * batch_idx / len(train_loader), loss.item()))
                if num_examples > cutoff:
                    break


        train(model.to(device), device, train_loader, optimizer, 1)

        next_x, next_y = next(iter(train_loader))
        np.random.seed(0)
        inds = np.random.choice(next_x.shape[0], 20, replace=False)
        if interim:
            e = shap.DeepExplainer(
                (model.to(device), model.conv_layers[0].to(device)), next_x[inds, :, :, :].to(device)
            )
        else:
            e = shap.DeepExplainer(
                model.to(device), next_x[inds, :, :, :].to(device)
            )
        test_x, test_y = next(iter(test_loader))
        input_tensor = test_x[:1]
        input_tensor.requires_grad = True
        shap_values = e.shap_values(input_tensor)

        model = model.to(device)
        model.eval()
        model.zero_grad()
        with torch.no_grad():
            test_outputs = model(test_x[:1].to(device))
            next_outputs = model(next_x[inds, :].to(device))
            diff = (test_outputs - next_outputs).detach().cpu().numpy().mean(0)
        sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
        d = np.abs(sums - diff).sum()
>       assert d / np.abs(diff).sum() < 0.001, "Sum of SHAP values does not match difference! %f" % (
                d / np.abs(diff).sum())
E       AssertionError: Sum of SHAP values does not match difference! 0.001130
E       assert (1.365514702511561e-05 / 0.012087966) < 0.001
E        +  where 0.012087966 = <built-in method sum of numpy.ndarray object at 0x7fa322c63f80>()
E        +    where <built-in method sum of numpy.ndarray object at 0x7fa322c63f80> = array([0.00034282, 0.00224469, 0.00011375, 0.00256004, 0.00051804,\n       0.00165695, 0.00027921, 0.00112554, 0.00165977, 0.00158717],\n      dtype=float32).sum
E        +      where array([0.00034282, 0.00224469, 0.00011375, 0.00256004, 0.00051804,\n       0.00165695, 0.00027921, 0.00112554, 0.00165977, 0.00158717],\n      dtype=float32) = <ufunc 'absolute'>(array([ 0.00034282, -0.00224469, -0.00011375, -0.00256004,  0.00051804,\n        0.00165695,  0.00027921, -0.00112554,  0.00165977,  0.00158717],\n      dtype=float32))
E        +        where <ufunc 'absolute'> = np.abs

tests/explainers/test_deep.py:293: AssertionError
======================================== warnings summary ========================================
/home/Chois/miniconda3/lib/python3.7/site-packages/nose/importer.py:12
  /home/Chois/miniconda3/lib/python3.7/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import find_module, load_module, acquire_lock, release_lock

tests/explainers/test_deep.py::test_pytorch_mnist_cnn
  Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
  numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject

tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
  numpy.ufunc size changed, may indicate binary incompatibility. Expected 216, got 192

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================ 1 failed, 13 warnings in 15.12s =================================
(base) Chois@computer-gpu1:~/shap$ pytest tests/explainers/test_deep.py::test_pytorch_mnist_cnn -s
====================================== test session starts =======================================
platform linux -- Python 3.7.4, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /home/Chois/shap
collected 1 item

tests/explainers/test_deep.py Running test on interim layer
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.091529
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.092290
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.090987
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.091052
Running test on whole model
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.092100
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.090334
Train Epoch: 1 [0/60000 (0%)]   Loss: 0.091841
Train Epoch: 1 [1280/60000 (2%)]    Loss: 0.090477
.

======================================== warnings summary ========================================
/home/Chois/miniconda3/lib/python3.7/site-packages/nose/importer.py:12
  /home/Chois/miniconda3/lib/python3.7/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import find_module, load_module, acquire_lock, release_lock

tests/explainers/test_deep.py::test_pytorch_mnist_cnn
  Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
  numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject

tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
tests/explainers/test_deep.py::test_pytorch_mnist_cnn
  numpy.ufunc size changed, may indicate binary incompatibility. Expected 216, got 192

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================= 1 passed, 13 warnings in 8.71s =================================
(base) Chois@computer-gpu1:~/shap$
```


4. If this PR is accepted, I would write tests for `test_gradient` as well