### PR TITLE
changed uses of equality to 'is' for None, True, and False

### DIFF
--- a/shap/common.py
+++ b/shap/common.py
@@ -120,7 +120,7 @@ class SparseData(Data):
 
 class DenseData(Data):
     def __init__(self, data, group_names, *args):
-        self.groups = args[0] if len(args) > 0 and args[0] != None else [np.array([i]) for i in range(len(group_names))]
+        self.groups = args[0] if len(args) > 0 and args[0] is not None else [np.array([i]) for i in range(len(group_names))]
 
         l = sum(len(g) for g in self.groups)
         num_samples = data.shape[0]

--- a/shap/explainers/deep/deep_tf.py
+++ b/shap/explainers/deep/deep_tf.py
@@ -484,7 +484,7 @@ def softmax(explainer, op, *grads):
     # remove the names we just added
     for op in [evals.op, rsum.op, div.op, in0_centered.op]:
         for t in op.outputs:
-            if explainer.between_tensors[t.name] == False:
+            if explainer.between_tensors[t.name] is False:
                 del explainer.between_tensors[t.name]
 
     # rescale to account for our shift by in0_max (which we did for numerical stability)
@@ -590,7 +590,7 @@ def nonlinearity_1d_handler(input_ind, explainer, op, *grads):
     xin0, rin0 = tf.split(op_inputs[input_ind], 2)
     xout, rout = tf.split(op.outputs[input_ind], 2)
     delta_in0 = xin0 - rin0
-    if delta_in0.shape == None:
+    if delta_in0.shape is None:
         dup0 = [2, 1]
     else:
         dup0 = [2] + [1 for i in delta_in0.shape[1:]]

--- a/shap/plots/force_matplotlib.py
+++ b/shap/plots/force_matplotlib.py
@@ -340,7 +340,7 @@ def update_axis_limits(ax, total_pos, pos_features, total_neg,
 def draw_additive_plot(data, figsize, show, text_rotation=0):
     """Draw additive plot."""
     # Turn off interactive plot
-    if show == False:
+    if show is False:
         plt.ioff()
     
     # Format data


### PR DESCRIPTION
Thanks for this great project!

In this PR, I'd like to propose a small change for safety. When comparing a value to `None`, `False`, or `True`, using `is` is preferred to `==`if you want to strictly check that something is one of those builtins.

For example:

```
>>> 1 == True
True
>>> 1 is True
False
```

Thanks for your time and consideration.