### PR TITLE
Prevent unexpected `Warning: unrecognized nn.Module`

### DIFF
--- a/shap/explainers/deep/deep_pytorch.py
+++ b/shap/explainers/deep/deep_pytorch.py
@@ -70,12 +70,13 @@ class PyTorchDeepExplainer(Explainer):
         Recursively for non-container layers
         """
         handles_list = []
-        for child in model.children():
-            if 'nn.modules.container' in str(type(child)):
+        model_children = list(model.children())
+        if model_children:
+            for child in model_children:
                 handles_list.extend(self.add_handles(child, forward_handle, backward_handle))
-            else:
-                handles_list.append(child.register_forward_hook(forward_handle))
-                handles_list.append(child.register_backward_hook(backward_handle))
+        else:  # leaves
+            handles_list.append(model.register_forward_hook(forward_handle))
+            handles_list.append(model.register_backward_hook(backward_handle))
         return handles_list
 
     def remove_attributes(self, model):


### PR DESCRIPTION
In these days, there are many codes or programs where coders define their own custom torch module classes inheriting `nn.Module` to build or customize various of models easily. While doing this, a bunch of nested custom Module structure could appear, such as the one I've written in test codes, but `PyTorchDeepExplainer` could not handle it and showed warning like this: `Warning: unrecognized nn.Module` and return `input_gradient`

So, I tried to fix it by recursion and wrote the test code as well.

Please review the code.

