### PR TITLE
add sklearn.ensemble._gb.GradientBoostingClassifier to the list

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -671,7 +671,7 @@ class TreeEnsemble:
             self.trees = list(itertools.chain.from_iterable(output_trees))
             self.objective = objective_name_map.get(model.loss, None)
             self.tree_output = "log_odds"
-        elif safe_isinstance(model, ["sklearn.ensemble.GradientBoostingClassifier", "sklearn.ensemble.gradient_boosting.GradientBoostingClassifier"]):
+        elif safe_isinstance(model, ["sklearn.ensemble.GradientBoostingClassifier","sklearn.ensemble._gb.GradientBoostingClassifier", "sklearn.ensemble.gradient_boosting.GradientBoostingClassifier"]):
             self.input_dtype = np.float32
 
             # TODO: deal with estimators for each class


### PR DESCRIPTION
In scikit-learn, the GradientBoostingClassifier is now under _gb.py file. 
Without this change, the tree explainer will not be able to read GradientBoostingClassifier. 