### PR TITLE
Enable KernelShap support for string type input

### DIFF
--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -423,6 +423,11 @@ class KernelExplainer(Explainer):
 
         return phi
 
+    def not_equal(self, i, j):
+        if isinstance(i, str):
+            return 0 if i is None or j is None or i == j else 1
+        return 0 if np.isclose(i, j, equal_nan=True) else 1
+
     def varying_groups(self, x):
         if not sp.sparse.issparse(x):
             varying = np.zeros(self.data.groups_size)
@@ -434,7 +439,7 @@ class KernelExplainer(Explainer):
                         varying[i] = False
                         continue
                     x_group = x_group.todense()
-                num_mismatches = np.sum(np.invert(np.isclose(x_group, self.data.data[:, inds], equal_nan=True)))
+                num_mismatches = np.sum(np.frompyfunc(self.not_equal, 2, 1)(x_group, self.data.data[:, inds]))
                 varying[i] = num_mismatches > 0
             varying_indices = np.nonzero(varying)[0]
             return varying_indices

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -423,9 +423,10 @@ class KernelExplainer(Explainer):
 
         return phi
 
-    def not_equal(self, i, j):
-        if isinstance(i, str):
-            return 0 if i is None or j is None or i == j else 1
+    @staticmethod
+    def not_equal(i, j):
+        if isinstance(i, str) or isinstance(j, str):
+            return 0 if i == j else 1
         return 0 if np.isclose(i, j, equal_nan=True) else 1
 
     def varying_groups(self, x):

--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -1312,7 +1312,8 @@ class XGBTreeModelLoader(object):
     tree can actually be wrong when feature values land almost on a threshold.
     """
     def __init__(self, xgb_model):
-        self.buf = xgb_model.save_raw()
+        # new in XGBoost 1.1, 'binf' is appended to the buffer
+        self.buf = xgb_model.save_raw().lstrip(b'binf')
         self.pos = 0
 
         # load the model parameters

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -217,4 +217,5 @@ def test_non_numeric():
     explainer = shap.KernelExplainer(pipeline.predict, X, nsamples=100)
     shap_values = explainer.explain(X[0,:].reshape(1, -1))
     
-    assert np.abs(explainer.expected_value + shap_values.sum(1)[0] - pipeline.predict(X[0,:].reshape(1, -1))[0]) < 1e-4
+    assert np.abs(explainer.expected_value + shap_values.sum(0) - pipeline.predict(X[0,:].reshape(1, -1))[0]) < 1e-4
+    assert shap_values[2] == 0

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -219,3 +219,11 @@ def test_non_numeric():
     
     assert np.abs(explainer.expected_value + shap_values.sum(0) - pipeline.predict(X[0,:].reshape(1, -1))[0]) < 1e-4
     assert shap_values[2] == 0
+
+    # tests for shap.KernelExplainer.not_equal
+    assert shap.KernelExplainer.not_equal(0, 0) == shap.KernelExplainer.not_equal('0', '0')
+    assert shap.KernelExplainer.not_equal(0, 1) == shap.KernelExplainer.not_equal('0', '1')
+    assert shap.KernelExplainer.not_equal(0, np.nan) == shap.KernelExplainer.not_equal('0', np.nan)
+    assert shap.KernelExplainer.not_equal(0, np.nan) == shap.KernelExplainer.not_equal('0', None)
+    assert shap.KernelExplainer.not_equal(np.nan, 0) == shap.KernelExplainer.not_equal(np.nan, '0')
+    assert shap.KernelExplainer.not_equal(np.nan, 0) == shap.KernelExplainer.not_equal(None, '0')

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -198,3 +198,21 @@ def test_linear():
     expected = (x - x.mean(0)) * np.array([1.0, 2.0, 0.0])
 
     np.testing.assert_allclose(expected, phi, rtol=1e-3)
+
+
+def test_non_numeric():
+    import sklearn
+    from sklearn.pipeline import Pipeline
+
+    # create dummy data
+    X = np.array([['A', '0', '0'], ['A', '1', '0'], ['B', '0', '0'], ['B', '1', '0'], ['A', '1', '0']])
+    y = np.array([0, 1, 2, 3, 4])
+
+    # build and train the pipeline
+    pipeline = Pipeline([('oneHotEncoder', sklearn.preprocessing.OneHotEncoder()),
+                     ('linear', sklearn.linear_model.LinearRegression())])
+    pipeline.fit(X, y)
+
+    # use KernelExplainer
+    explainer = shap.KernelExplainer(pipeline.predict, X, nsamples=100)
+    shap_values = explainer.explain(X[0,:].reshape(1, -1))

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -216,3 +216,5 @@ def test_non_numeric():
     # use KernelExplainer
     explainer = shap.KernelExplainer(pipeline.predict, X, nsamples=100)
     shap_values = explainer.explain(X[0,:].reshape(1, -1))
+    
+    assert np.abs(explainer.expected_value + shap_values.sum(1)[0] - pipeline.predict(X[0,:].reshape(1, -1))[0]) < 1e-4


### PR DESCRIPTION
SKLearn pipelines use encoders to support string input e.g. OneHotEncoder and OrdinalEncoder. In some cases it is desired to calculate the shap values in the original input space i.e. before encoding it into numeric values. While there is no theoretical limitation, currently KernelExplainer does not support string type input due to the limitations of a single utility function. The utility function varying_groups() relies on numpy functions that assume numeric input. After fixing it to support string type input, KernelExplainer fully supports string values.

