### PR TITLE
Fixes error with XGBoost 1.1

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -1312,7 +1312,8 @@ class XGBTreeModelLoader(object):
     tree can actually be wrong when feature values land almost on a threshold.
     """
     def __init__(self, xgb_model):
-        self.buf = xgb_model.save_raw()
+        # new in XGBoost 1.1, 'binf' is appended to the buffer
+        self.buf = xgb_model.save_raw().lstrip(b'binf')
         self.pos = 0
 
         # load the model parameters


### PR DESCRIPTION
In the new XGBoost (1.1), `.save_raw()` output is slightly different, which means that `TreeExplainer` doesn't work. See issue #1215. 
The build is currently failing for this reason, with all XGBoost tests failing.

The fix here is to just remove the prefix 'binf' from the model buffer, which as been added in the new version (either intentionally or accidentally - I can't find a PR in XGBoost which mentions this change.)

Fixes #1215, #1212