### PR TITLE
Skip warning if feature_perturbation is manually set to 'tree_path_dependent'

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -109,7 +109,7 @@ class TreeExplainer(Explainer):
             self.data = data.data
         else:
             self.data = data
-        if self.data is None:
+        if self.data is None and feature_perturbation != "tree_path_dependent":
             feature_perturbation = "tree_path_dependent"
             warnings.warn("Setting feature_perturbation = \"tree_path_dependent\" because no background data was given.")
         elif feature_perturbation == "interventional" and self.data.shape[0] > 1000:


### PR DESCRIPTION
Currently I don't believe there is a way to use `feature_perturbation='tree_path_dependent'` without getting the warning message:
`Setting feature_perturbation = "tree_path_dependent" because no background data was given.` 

Context:
I am working on a project that builds a forecasting model using a collection of small random forest & XGB models.
When I run a backtest (aka training the models multiple times at different points in time), I end up training hundreds of small RF/XGB models, each which will separately print out the feature_perturbation warning. This makes it highly inconvenient to search through to find any other warnings/errors.
I'm not aware of any way currently that I can use `feature_perturbation='tree_path_dependent'`  without getting the warning message. For example, I tried providing an empty dataset for the background set (since the if statement causing this warning message is conditioned on data=None), thinking it wouldn't be used since `feature_perturbation='tree_path_dependent'` but that caused an error.

I understand if the current state is intentional, implying that people should use `feature_perturbation='interventional'`, but it would be nice to have some way to avoid the warning.