### PR TITLE
Add LogLink for decision plot's link parameter

### DIFF
--- a/shap/common.py
+++ b/shap/common.py
@@ -81,7 +81,7 @@ def convert_to_model(val):
 
 def match_model_to_data(model, data):
     assert isinstance(model, Model), "model must be of type Model!"
-    
+
     try:
         if isinstance(data, DenseDataWithIndex):
             out_val = model.f(data.convert_to_df())
@@ -96,7 +96,7 @@ def match_model_to_data(model, data):
             model.out_names = ["output value"]
         else:
             model.out_names = ["output value "+str(i) for i in range(out_val.shape[0])]
-    
+
     return out_val
 
 
@@ -208,6 +208,19 @@ class LogitLink(Link):
         return 1/(1+np.exp(-x))
 
 
+class LogLink(Link):
+    def __str__(self):
+        return "log"
+
+    @staticmethod
+    def f(x):
+        return np.log(x)
+
+    @staticmethod
+    def finv(x):
+        return np.exp(x)
+
+
 def convert_to_link(val):
     if isinstance(val, Link):
         return val
@@ -215,6 +228,8 @@ def convert_to_link(val):
         return IdentityLink()
     elif val == "logit":
         return LogitLink()
+    elif val == "log":
+        return LogLink()
     else:
         assert False, "Passed link object must be a subclass of iml.Link"
 
@@ -222,17 +237,17 @@ def convert_to_link(val):
 def hclust_ordering(X, metric="sqeuclidean"):
     """ A leaf ordering is under-defined, this picks the ordering that keeps nearby samples similar.
     """
-    
+
     # compute a hierarchical clustering
     D = sp.spatial.distance.pdist(X, metric)
     cluster_matrix = sp.cluster.hierarchy.complete(D)
-    
+
     # merge clusters, rotating them to make the end points match as best we can
     sets = [[i] for i in range(X.shape[0])]
     for i in range(cluster_matrix.shape[0]):
         s1 = sets[int(cluster_matrix[i,0])]
         s2 = sets[int(cluster_matrix[i,1])]
-        
+
         # compute distances between the end points of the lists
         d_s1_s2 = pdist(np.vstack([X[s1[-1],:], X[s2[0],:]]), metric)[0]
         d_s2_s1 = pdist(np.vstack([X[s1[0],:], X[s2[-1],:]]), metric)[0]
@@ -250,7 +265,7 @@ def hclust_ordering(X, metric="sqeuclidean"):
             sets.append(list(reversed(s1)) + s2)
         else:
             sets.append(s1 + list(reversed(s2)))
-    
+
     return sets[-1]
 
 
@@ -264,7 +279,7 @@ def convert_name(ind, shap_values, feature_names):
 
             # we allow the sum of all the SHAP values to be specified with "sum()"
             # assuming here that the calling method can deal with this case
-            elif ind == "sum()": 
+            elif ind == "sum()":
                 return "sum()"
             else:
                 raise ValueError("Could not find feature named: " + ind)
@@ -358,7 +373,7 @@ def safe_isinstance(obj, class_path_str):
         class_path_strs = class_path_str
     else:
         class_path_strs = ['']
-    
+
     # try each module path in order
     for class_path_str in class_path_strs:
         if "." not in class_path_str:
@@ -382,7 +397,7 @@ def safe_isinstance(obj, class_path_str):
         _class = getattr(module, class_name, None)
         if _class is None:
             continue
-        
+
         return isinstance(obj, _class)
 
     return False

--- a/shap/plots/decision.py
+++ b/shap/plots/decision.py
@@ -16,7 +16,7 @@ except ImportError:
     pass
 
 from . import colors, labels
-from ..common import convert_to_link, hclust_ordering, LogitLink
+from ..common import convert_to_link, hclust_ordering, LogitLink, LogLink
 
 
 def __change_shap_base_value(base_value, new_base_value, shap_values) -> np.ndarray:
@@ -277,7 +277,7 @@ def decision_plot(
         example, list of integer indices, or a bool array.
 
     link : str
-        Use "identity" or "logit" to specify the transformation used for the x-axis. The "logit" link transforms
+        Use "identity", "logit" or "log" to specify the transformation used for the x-axis. The "logit" link transforms
         log-odds into probabilities.
 
     plot_color : str or matplotlib.colors.ColorMap
@@ -285,23 +285,23 @@ def decision_plot(
 
     axis_color : str or int
         Color used to draw plot axes.
-        
+
     y_demarc_color : str or int
         Color used to draw feature demarcation lines on the y-axis.
-        
+
     alpha : float
         Alpha blending value in [0, 1] used to draw plot lines.
-        
+
     color_bar : bool
         Whether to draw the color bar.
-        
+
     auto_size_plot : bool
-        Whether to automatically size the matplotlib plot to fit the number of features displayed. If `False`, 
+        Whether to automatically size the matplotlib plot to fit the number of features displayed. If `False`,
         specify the plot size using matplotlib before calling this function.
-        
+
     title : str
         Title of the plot.
-        
+
     xlim: tuple[float, float]
         The extents of the x-axis (e.g. (-1.0, 1.0)). If not specified, the limits are determined by the
         maximum/minimum predictions centered around base_value when link='identity'. When link='logit', the
@@ -314,7 +314,7 @@ def decision_plot(
     return_objects : bool
         Whether to return a DecisionPlotResult object containing various plotting features. This can be used to
         generate multiple decision plots using the same feature ordering and scale.
-        
+
     ignore_warnings : bool
         Plotting many data points or too many features at a time may be slow, or may create very large plots. Set
         this argument to `True` to override hard-coded limits that prevent plotting large amounts of data.
@@ -497,6 +497,11 @@ def decision_plot(
     create_xlim = xlim is None
     link = convert_to_link(link)
     base_value_saved = base_value
+
+    if isinstance(link, LogLink):
+        base_value = link.finv(base_value)
+        cumsum = link.finv(cumsum)
+
     if isinstance(link, LogitLink):
         base_value = link.finv(base_value)
         cumsum = link.finv(cumsum)


### PR DESCRIPTION
Very minor change to add a Log link function to decision plots.

Our models had their targets pre transformed using logarithms so the explainer.shap_values function couldn't pick on that from the models objective.

I added this link function to be able to apply the inverse transform, and show exponentiated targets at the decision plot level.