### PR TITLE
Update tree.py

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -692,7 +692,7 @@ class TreeEnsemble:
             self.objective = objective_name_map.get(model.criterion, None)
         elif "pyspark.ml" in str(type(model)):
             assert_import("pyspark")
-            self.original_model = model
+            #self.original_model = model
             self.model_type = "pyspark"
             # model._java_obj.getImpurity() can be gini, entropy or variance.
             self.objective = objective_name_map.get(model._java_obj.getImpurity(), None)


### PR DESCRIPTION
commented out self.original_model = model in case of pyspark model

After a talk on ISSUE #884, I created this pull request. Please @QuentinAmbard review it and accept if you think it's reasonable.

:)