### PR TITLE
Make shap explainer serializable with spark models

### DIFF
--- a/shap/explainers/tree.py
+++ b/shap/explainers/tree.py
@@ -692,7 +692,6 @@ class TreeEnsemble:
             self.objective = objective_name_map.get(model.criterion, None)
         elif "pyspark.ml" in str(type(model)):
             assert_import("pyspark")
-            self.original_model = model
             self.model_type = "pyspark"
             # model._java_obj.getImpurity() can be gini, entropy or variance.
             self.objective = objective_name_map.get(model._java_obj.getImpurity(), None)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -207,6 +207,7 @@ def test_pyspark_classifier_decision_tree():
         from pyspark.ml.feature import VectorAssembler, StringIndexer
         from pyspark.ml.classification import RandomForestClassifier, DecisionTreeClassifier, GBTClassifier
         import pandas as pd
+        import pickle
     except:
         print("Skipping test_pyspark_classifier_decision_tree!")
         return
@@ -226,7 +227,9 @@ def test_pyspark_classifier_decision_tree():
                    DecisionTreeClassifier(labelCol="label", featuresCol="features")]
     for classifier in classifiers:
         model = classifier.fit(iris)
+        #Make sure the model can be serializable to run shap values with spark
         explainer = shap.TreeExplainer(model)
+        pickle.dumps(explainer)
         X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100] # pylint: disable=E1101
 
         shap_values = explainer.shap_values(X)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -227,8 +227,8 @@ def test_pyspark_classifier_decision_tree():
                    DecisionTreeClassifier(labelCol="label", featuresCol="features")]
     for classifier in classifiers:
         model = classifier.fit(iris)
-        #Make sure the model can be serializable to run shap values with spark
         explainer = shap.TreeExplainer(model)
+        #Make sure the model can be serializable to run shap values with spark
         pickle.dumps(explainer)
         X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100] # pylint: disable=E1101
 


### PR DESCRIPTION
As discussed in https://github.com/slundberg/shap/issues/884, shap explainer can't be used in a spark UDF as it's not serializable. This is due to the fact that we keep a reference to the original spark model which isn't serializable.

To prevent this, we removed the reference as it's currently not being used 
(Note: something similar to the original model could be required to implement https://github.com/slundberg/shap/issues/1192 ?). 

thanks @guidiandrea for highlighting this 