### PR TITLE
Correct samples per feature calculation in SamplingExplainer

### DIFF
--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -131,7 +131,7 @@ class Sampling(Kernel):
             # optimally allocate samples according to the variance
             if phi_var.sum() == 0:
                 phi_var += 1 # spread samples uniformally if we found no variability
-            phi_var /= phi_var.sum()
+            phi_var /= phi_var.sum(0)[np.newaxis, :]
             nsamples_each2 = (phi_var[self.varyingInds,:].mean(1) * round2_samples).astype(np.int)
             for i in range(len(nsamples_each2)):
                 if nsamples_each2[i] % 2 == 1: nsamples_each2[i] += 1


### PR DESCRIPTION
As reported in #1349 (see there for details), the number of samples drawn by SamplingExplainer does not match that specified by `nsamples` due to an error in the variance normalisation. This small PR corrects that bug.

As I pointed out in the issue, I think that `nsamples` is additionally out by a factor two, as it refers to model evaluations (of which there are two per coalition of features sampled + spliced data point) rather than coalition samples as I would have expected. Happy to add a fix for that to this PR if you think it's worth fixing.

Closes: #1349