### PR TITLE
add support for GPBoost

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -836,6 +836,19 @@ class TreeEnsemble:
             self.objective = objective_name_map.get(model.params.get("objective", "regression"), None)
             self.tree_output = tree_output_name_map.get(model.params.get("objective", "regression"), None)
 
+        elif safe_isinstance(model, "gpboost.basic.Booster"):
+            assert_import("gpboost")
+            self.model_type = "gpboost"
+            self.original_model = model
+            tree_info = self.original_model.dump_model()["tree_info"]
+            try:
+                self.trees = [SingleTree(e, data=data, data_missing=data_missing) for e in tree_info]
+            except:
+                self.trees = None # we get here because the cext can't handle categorical splits yet
+
+            self.objective = objective_name_map.get(model.params.get("objective", "regression"), None)
+            self.tree_output = tree_output_name_map.get(model.params.get("objective", "regression"), None)
+
         elif safe_isinstance(model, "lightgbm.sklearn.LGBMRegressor"):
             assert_import("lightgbm")
             self.model_type = "lightgbm"

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -388,6 +388,29 @@ def test_lightgbm():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
+def test_gpboost():
+    try:
+        import gpboost
+    except:
+        print("Skipping test_gpboost!")
+        return
+    import shap
+
+    # train gpboost model
+    X, y = shap.datasets.boston()
+    data_train = gpboost.Dataset(X, y, categorical_feature=[8])
+    model = gpboost.train(params={'objective': 'regression_l2', 'learning_rate': 0.1, 'verbose': 0},
+                          train_set=data_train, num_boost_round=10)
+
+    # explain the model's predictions using SHAP values
+    ex = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    shap_values = ex.shap_values(X)
+
+    predicted = model.predict(X, raw_score=True)
+
+    assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
+        "SHAP values don't sum to model output!"
+
 def test_catboost():
     try:
         import catboost


### PR DESCRIPTION
GPBoost is a library for combining tree-boosting with mixed effects and Gaussian process models (see https://github.com/fabsig/GPBoost). The tree boosting part is handled by a clone of LightGBM. I.e., GPBoost can be handled in shap in exactly the same way as LightGBM.