### PR TITLE
fix isolation forest when max_features < 1

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -604,7 +604,7 @@ class TreeEnsemble:
         elif safe_isinstance(model, ["sklearn.ensemble.IsolationForest", "sklearn.ensemble.iforest.IsolationForest"]):
             self.dtype = np.float32
             scaling = 1.0 / len(model.estimators_) # output is average of trees
-            self.trees = [IsoTree(e.tree_, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
+            self.trees = [IsoTree(e.tree_, f, scaling=scaling, data=data, data_missing=data_missing) for e, f in zip(model.estimators_, model.estimators_features_)]
             self.tree_output = "raw_value"
         elif safe_isinstance(model, "skopt.learning.forest.RandomForestRegressor"):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
@@ -1336,7 +1336,7 @@ class IsoTree(SingleTree):
     """
     In sklearn the tree of the Isolation Forest does not calculated in a good way.
     """
-    def __init__(self, tree, normalize=False, scaling=1.0, data=None, data_missing=None):
+    def __init__(self, tree, tree_features, normalize=False, scaling=1.0, data=None, data_missing=None):
         super(IsoTree, self).__init__(tree, normalize, scaling, data, data_missing)
         if safe_isinstance(tree, "sklearn.tree._tree.Tree"):
             from sklearn.ensemble.iforest import _average_path_length # pylint: disable=no-name-in-module
@@ -1356,6 +1356,8 @@ class IsoTree(SingleTree):
             if normalize:
                 self.values = (self.values.T / self.values.sum(1)).T
             self.values = self.values * scaling
+            # re-number the features if each tree gets a different set of features
+            self.features = np.where(self.features >= 0, tree_features[self.features], self.features)
 
 
 def get_xgboost_json(model):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -842,24 +842,27 @@ def test_multi_target_random_forest():
     phi = np.hstack((shap_values, np.repeat(expected_values, X_test.shape[0]).reshape(-1, 1)))
     assert np.allclose(phi.sum(1), predicted.flatten(order="F"), atol=1e-4)
 
+
 def test_isolation_forest():
     import shap
     import numpy as np
     from sklearn.ensemble import IsolationForest
-    from sklearn.ensemble._iforest import _average_path_length
+    from sklearn.ensemble.iforest import _average_path_length
 
     X,_ = shap.datasets.boston()
-    iso = IsolationForest(contamination='auto')
-    iso.fit(X)
+    for max_features in [1.0, 0.75]:
+        iso = IsolationForest(max_features=max_features)
+        iso.fit(X)
 
-    explainer = shap.TreeExplainer(iso)
-    shap_values = explainer.shap_values(X)
+        explainer = shap.TreeExplainer(iso)
+        shap_values = explainer.shap_values(X)
 
-    score_from_shap = - 2**(
-        - (np.sum(shap_values, axis=1) + explainer.expected_value) /
-        _average_path_length(np.array([iso.max_samples_]))[0]
-        )
-    assert np.allclose(iso.score_samples(X), score_from_shap, atol=1e-7)
+        score_from_shap = - 2**(
+            - (np.sum(shap_values, axis=1) + explainer.expected_value) /
+            _average_path_length(np.array([iso.max_samples_]))[0]
+            )
+        assert np.allclose(iso.score_samples(X), score_from_shap, atol=1e-7)
+
 
 # TODO: this has sometimes failed with strange answers, should run memcheck on this for any memory issues at some point...
 def test_multi_target_extra_trees():


### PR DESCRIPTION
fix #1389 

Issue is caused by each tree gets a different set of features when max_features < 1, the solution is to re-number the feature indexes with the attribute "estimators_features_".

Also updated the test to include this case.