### PR TITLE
Fixed summation of token attribution for multiclass along the class axis

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -325,7 +325,7 @@ class Explanation(object, metaclass=MetaExplanation):
         if self.feature_names is not None and not is_1d(self.feature_names) and axis == 0:
             new_values = self._flatten_feature_names()
             new_self.feature_names = np.array(list(new_values.keys()))
-            new_self.values = np.array([getattr(np, fname)(v) for v in new_values.values()])
+            new_self.values = np.array([getattr(np, fname)(v,0) for v in new_values.values()])
             new_self.clustering = None
         else:
             new_self.values = getattr(np, fname)(np.array(self.values), **kwargs)


### PR DESCRIPTION
Presently when we run sum on the explanation object for multiclass, it flattens features and creates new_values which are a set of arrays(with len=no. of classes) corresponding to every unique token but doesn't sum across individual dimension and instead produces one overall score as feature contribution for a token. Hence modified that to sum contribution separately for each class so we now have contribution of every token towards each class