### PR TITLE
Use pseudo-inverse instead of inverse for non-singluar matrices in linear regression

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -568,7 +568,18 @@ class Kernel(Explainer):
 
         # solve a weighted least squares equation to estimate phi
         tmp = np.transpose(np.transpose(etmp) * np.transpose(self.kernelWeights))
-        tmp2 = np.linalg.inv(np.dot(np.transpose(tmp), etmp))
+        etmp_dot = np.dot(np.transpose(tmp), etmp)
+        try:
+            tmp2 = np.linalg.inv(etmp_dot)
+        except np.linalg.LinAlgError:
+            tmp2 = np.linalg.pinv(etmp_dot)
+            warnings.warn(
+                "Linear regression equation is singular, Moore-Penrose pseudoinverse is used instead of the regular inverse.\n"
+                "To use regular inverse do one of the following:\n"
+                "1) turn up the number of samples,\n"
+                "2) turn up the L1 regularization with num_features(N) where N is less than the number of samples,\n"
+                "3) group features together to reduce the number of inputs that need to be explained."
+            )
         w = np.dot(tmp2, np.dot(np.transpose(tmp), eyAdj2))
         log.debug("np.sum(w) = {0}".format(np.sum(w)))
         log.debug("self.link(self.fx) - self.link(self.fnull) = {0}".format(


### PR DESCRIPTION
Fixes https://github.com/slundberg/shap/issues/240

With this PR I changed the use of inverse to pseudoinverse in cases when a non-singular matrix appears in the linear regression equation. This is kind of approximation for the inverse in cases when it is not possible to compute the inverse. This way we avoid the problem when code fails because the result of the computation is not invertible since it is not nice that error appears just because the result of some computation is not appropriate.

I know that pseudoinverse is not the ideal solution but it is the best I can imagine in these cases and users get warned that it happened so they can do one of the proposed solutions to avoid this. **As far as I know also other Python-based implementations of the linear regression use pseudoinverse instead of the inverse.**