### PR TITLE
fix conversion warning

### DIFF
--- a/shap/plots/colors/_colorconv.py
+++ b/shap/plots/colors/_colorconv.py
@@ -795,7 +795,10 @@ def convert(image, dtype, force_copy=False, uniform=False):
     """
     image = np.asarray(image)
     dtypeobj_in = image.dtype
-    dtypeobj_out = np.dtype(dtype)
+    if dtype is np.floating:
+        dtypeobj_out = np.dtype("float64")
+    else:
+        dtypeobj_out = np.dtype(dtype)
     dtype_in = dtypeobj_in.type
     dtype_out = dtypeobj_out.type
     kind_in = dtypeobj_in.kind


### PR DESCRIPTION
Following from https://github.com/scikit-image/scikit-image/pull/4731
Fix warning 
```
Converting `np.inexact` or `np.floating` to a dtype is deprecated. The current result is `float64` which is not strictly correct.
```