### PR TITLE
Fixed plotting features names+ code cleanup

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -1,4 +1,5 @@
 import warnings
+
 try:
     import matplotlib.pyplot as pl
 except ImportError:
@@ -48,7 +49,8 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     elif isinstance(shap_values, Cohorts):
         cohorts = shap_values.cohorts
     else:
-        assert isinstance(shap_values, dict), "You must pass an Explanation object, Cohorts object, or dictionary to bar plot!"
+        assert isinstance(shap_values,
+                          dict), "You must pass an Explanation object, Cohorts object, or dictionary to bar plot!"
 
     # unpack our list of Explanation objects we need to plot
     cohort_labels = list(cohorts.keys())
@@ -56,8 +58,10 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     for i in range(len(cohort_exps)):
         if len(cohort_exps[i].shape) == 2:
             cohort_exps[i] = cohort_exps[i].abs.mean(0)
-        assert isinstance(cohort_exps[i], Explanation), "The shap_values paramemter must be a Explanation object, Cohorts object, or dictionary of Explanation objects!"
-        assert cohort_exps[i].shape == cohort_exps[0].shape, "When passing several Explanation objects they must all have the same shape!"
+        assert isinstance(cohort_exps[i],
+                          Explanation), "The shap_values paramemter must be a Explanation object, Cohorts object, or dictionary of Explanation objects!"
+        assert cohort_exps[i].shape == cohort_exps[
+            0].shape, "When passing several Explanation objects they must all have the same shape!"
         # TODO: check other attributes for equality? like feature names perhaps? probably clustering as well.
 
     # unpack the Explanation object
@@ -70,7 +74,8 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     else:
         partition_tree = clustering
     if partition_tree is not None:
-        assert partition_tree.shape[1] == 4, "The clustering provided by the Explanation object does not seem to be a partition tree (which is all shap.plots.bar supports)!"
+        assert partition_tree.shape[
+                   1] == 4, "The clustering provided by the Explanation object does not seem to be a partition tree (which is all shap.plots.bar supports)!"
     op_history = cohort_exps[0].op_history
     values = np.array([cohort_exps[i].values for i in range(len(cohort_exps))])
 
@@ -83,37 +88,37 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 
     # TODO: Rather than just show the "1st token", "2nd token", etc. it would be better to show the "Instance 0's 1st but", etc
     if issubclass(type(feature_names), str):
-        feature_names = [ordinal_str(i)+" "+feature_names for i in range(len(values[0]))]
+        feature_names = ["{} {}".format(ordinal_str(i), feature_names)
+                         for i in range(len(values[0]))]
 
     # build our auto xlabel based on the transform history of the Explanation object
     xlabel = "SHAP value"
     for op in op_history:
         if op["name"] == "abs":
-            xlabel = "|"+xlabel+"|"
+            xlabel = "|{}|".format(xlabel)
         elif op["name"] == "__getitem__":
-            pass # no need for slicing to effect our label, it will be used later to find the sizes of cohorts
+            pass  # no need for slicing to effect our label, it will be used later to find the sizes of cohorts
         else:
-            xlabel = str(op["name"])+"("+xlabel+")"
+            xlabel = "{} ({})".format(op["name"], xlabel)
 
     # find how many instances are in each cohort (if they were created from an Explanation object)
     cohort_sizes = []
     for exp in cohort_exps:
         for op in exp.op_history:
-            if op.get("collapsed_instances", False): # see if this if the first op to collapse the instances
+            if op.get("collapsed_instances", False):  # see if this if the first op to collapse the instances
                 cohort_sizes.append(op["prev_shape"][0])
                 break
-    
 
     # unwrap any pandas series
     if str(type(features)) == "<class 'pandas.core.series.Series'>":
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values
-    
+
     # ensure we at least have default feature names
     if feature_names is None:
         feature_names = np.array([labels['FEATURE'] % str(i) for i in range(len(values[0]))])
-    
+
     # determine how many top features we will plot
     if max_display is None:
         max_display = len(feature_names)
@@ -125,7 +130,8 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     orig_inds = [[i] for i in range(len(values[0]))]
     orig_values = values.copy()
     while True:
-        feature_order = np.argsort(np.mean([np.argsort(convert_ordering(order, Explanation(values[i]))) for i in range(values.shape[0])], 0))
+        feature_order = np.argsort(
+            np.mean([np.argsort(convert_ordering(order, Explanation(values[i]))) for i in range(values.shape[0])], 0))
         if partition_tree is not None:
 
             # compute the leaf order if we were to show (and so have the ordering respect) the whole partition tree
@@ -134,14 +140,15 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
             # now relax the requirement to match the parition tree ordering for connections above clustering_cutoff
             dist = scipy.spatial.distance.squareform(scipy.cluster.hierarchy.cophenet(partition_tree))
             feature_order = get_sort_order(dist, clust_order, clustering_cutoff, feature_order)
-        
+
             # if the last feature we can display is connected in a tree the next feature then we can't just cut
             # off the feature ordering, so we need to merge some tree nodes and then try again.
-            if max_display < len(feature_order) and dist[feature_order[max_display-1],feature_order[max_display-2]] <= clustering_cutoff:
-                #values, partition_tree, orig_inds = merge_nodes(values, partition_tree, orig_inds)
+            if max_display < len(feature_order) and dist[
+                feature_order[max_display - 1], feature_order[max_display - 2]] <= clustering_cutoff:
+                # values, partition_tree, orig_inds = merge_nodes(values, partition_tree, orig_inds)
                 partition_tree, ind1, ind2 = merge_nodes(np.abs(values).mean(0), partition_tree)
                 for i in range(len(values)):
-                    values[:,ind1] += values[:,ind2]
+                    values[:, ind1] += values[:, ind2]
                     values = np.delete(values, ind2, 1)
                     orig_inds[ind1] += orig_inds[ind2]
                     del orig_inds[ind2]
@@ -149,31 +156,34 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
                 break
         else:
             break
-    
+
     # here we build our feature names, accounting for the fact that some features might be merged together
     feature_inds = feature_order[:max_display]
     y_pos = np.arange(len(feature_inds), 0, -1)
     feature_names_new = []
-    for pos,inds in enumerate(orig_inds):
+    for pos, inds in enumerate(orig_inds):
         if len(inds) == 1:
             feature_names_new.append(feature_names[inds[0]])
         elif len(inds) <= 2:
             feature_names_new.append(" + ".join([feature_names[i] for i in inds]))
         else:
             max_ind = np.argmax(np.abs(orig_values).mean(0)[inds])
-            feature_names_new.append(feature_names[inds[max_ind]] + " + %d other features" % (len(inds)-1))
+            feature_names_new.append("{} + {} other features".format(feature_names[inds[max_ind]],
+                                                                     len(inds) - 1))
     feature_names = feature_names_new
 
     # see how many individual (vs. grouped at the end) features we are plotting
     if num_features < len(values[0]):
-        num_cut = np.sum([len(orig_inds[feature_order[i]]) for i in range(num_features-1, len(values[0]))])
-        values[:,feature_order[num_features-1]] = np.sum([values[:,feature_order[i]] for i in range(num_features-1, len(values[0]))], 0)
-    
+        num_cut = np.sum([len(orig_inds[feature_order[i]]) for i in range(num_features - 1, len(values[0]))])
+        values[:, feature_order[num_features - 1]] = np.sum(
+            [values[:, feature_order[i]] for i in range(num_features - 1, len(values[0]))], 0)
+
     # build our y-tick labels
     yticklabels = []
     for i in feature_inds:
         if features is not None and show_data:
-            yticklabels.append(format_value(features[i], "%0.03f") + " = " + feature_names[i])
+            yticklabels.append("{} = {}".format(format_value(features[i], "%0.03f"),
+                                                feature_names[i]))
         else:
             yticklabels.append(feature_names[i])
     if num_features < len(values[0]):
@@ -184,7 +194,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     pl.gcf().set_size_inches(8, num_features * row_height * np.sqrt(len(values)) + 1.5)
 
     # if negative values are present then we draw a vertical line to mark 0, otherwise the axis does this for us...
-    negative_values_present = np.sum(values[:,feature_order[:num_features]] < 0) > 0
+    negative_values_present = np.sum(values[:, feature_order[:num_features]] < 0) > 0
     if negative_values_present:
         pl.axvline(0, 0, 1, color="#000000", linestyle="-", linewidth=1, zorder=1)
 
@@ -195,10 +205,11 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     for i in range(len(values)):
         ypos_offset = - ((i - len(values) / 2) * bar_width + bar_width / 2)
         pl.barh(
-            y_pos + ypos_offset, values[i,feature_inds],
+            y_pos + ypos_offset, values[i, feature_inds],
             bar_width, align='center',
-            color=[colors.blue_rgb if values[i,feature_inds[j]] <= 0 else colors.red_rgb for j in range(len(y_pos))],
-            hatch=patterns[i], edgecolor=(1,1,1,0.8), label=f"{cohort_labels[i]} [{cohort_sizes[i] if i < len(cohort_sizes) else None}]"
+            color=[colors.blue_rgb if values[i, feature_inds[j]] <= 0 else colors.red_rgb for j in range(len(y_pos))],
+            hatch=patterns[i], edgecolor=(1, 1, 1, 0.8),
+            label=f"{cohort_labels[i]} [{cohort_sizes[i] if i < len(cohort_sizes) else None}]"
         )
 
     # draw the yticks (the 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks)
@@ -207,32 +218,34 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     xlen = pl.xlim()[1] - pl.xlim()[0]
     fig = pl.gcf()
     ax = pl.gca()
-    #xticks = ax.get_xticks()
+    # xticks = ax.get_xticks()
     bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     width, height = bbox.width, bbox.height
-    bbox_to_xscale = xlen/width
+    bbox_to_xscale = xlen / width
 
     for i in range(len(values)):
         ypos_offset = - ((i - len(values) / 2) * bar_width + bar_width / 2)
         for j in range(len(y_pos)):
             ind = feature_order[j]
-            if values[i,ind] < 0:
+            if values[i, ind] < 0:
                 pl.text(
-                    values[i,ind] - (5/72)*bbox_to_xscale, y_pos[j] + ypos_offset, format_value(values[i,ind], '%+0.02f'),
+                    values[i, ind] - (5 / 72) * bbox_to_xscale, y_pos[j] + ypos_offset,
+                    format_value(values[i, ind], '%+0.02f'),
                     horizontalalignment='right', verticalalignment='center', color=colors.blue_rgb,
                     fontsize=12
                 )
             else:
                 pl.text(
-                    values[i,ind] + (5/72)*bbox_to_xscale, y_pos[j] + ypos_offset, format_value(values[i,ind], '%+0.02f'),
+                    values[i, ind] + (5 / 72) * bbox_to_xscale, y_pos[j] + ypos_offset,
+                    format_value(values[i, ind], '%+0.02f'),
                     horizontalalignment='left', verticalalignment='center', color=colors.red_rgb,
                     fontsize=12
                 )
 
     # put horizontal lines for each feature row
     for i in range(num_features):
-        pl.axhline(i+1, color="#888888", lw=0.5, dashes=(1, 5), zorder=-1)
-    
+        pl.axhline(i + 1, color="#888888", lw=0.5, dashes=(1, 5), zorder=-1)
+
     if features is not None:
         features = list(features)
 
@@ -241,9 +254,9 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
             try:
                 if round(features[i]) == features[i]:
                     features[i] = int(features[i])
-            except:
-                pass # features[i] must not be a number
-    
+            except Exception:
+                pass  # features[i] must not be a number
+
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('none')
     pl.gca().spines['right'].set_visible(False)
@@ -252,14 +265,14 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
         pl.gca().spines['left'].set_visible(False)
     pl.gca().tick_params('x', labelsize=11)
 
-    xmin,xmax = pl.gca().get_xlim()
-    ymin,ymax = pl.gca().get_ylim()
-    
+    xmin, xmax = pl.gca().get_xlim()
+    ymin, ymax = pl.gca().get_ylim()
+
     if negative_values_present:
-        pl.gca().set_xlim(xmin - (xmax-xmin)*0.05, xmax + (xmax-xmin)*0.05)
+        pl.gca().set_xlim(xmin - (xmax - xmin) * 0.05, xmax + (xmax - xmin) * 0.05)
     else:
-        pl.gca().set_xlim(xmin, xmax + (xmax-xmin)*0.05)
-    
+        pl.gca().set_xlim(xmin, xmax + (xmax - xmin) * 0.05)
+
     # if features is None:
     #     pl.xlabel(labels["GLOBAL_VALUE"], fontsize=13)
     # else:
@@ -276,25 +289,26 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 
     # draw a dendrogram if we are given a partition tree
     if partition_tree is not None:
-        
+
         # compute the dendrogram line positions based on our current feature order
         feature_pos = np.argsort(feature_order)
-        ylines,xlines = dendrogram_coords(feature_pos, partition_tree)
-        
+        ylines, xlines = dendrogram_coords(feature_pos, partition_tree)
+
         # plot the distance cut line above which we don't show tree edges
-        xmin,xmax = pl.xlim()
-        xlines_min,xlines_max = np.min(xlines),np.max(xlines)
+        xmin, xmax = pl.xlim()
+        xlines_min, xlines_max = np.min(xlines), np.max(xlines)
         ct_line_pos = (clustering_cutoff / (xlines_max - xlines_min)) * 0.1 * (xmax - xmin) + xmax
         pl.text(
-            ct_line_pos + 0.005 * (xmax - xmin), (ymax - ymin)/2, "Clustering cutoff = " + format_value(clustering_cutoff, '%0.02f'),
+            ct_line_pos + 0.005 * (xmax - xmin), (ymax - ymin) / 2,
+            "Clustering cutoff = " + format_value(clustering_cutoff, '%0.02f'),
             horizontalalignment='left', verticalalignment='center', color="#999999",
             fontsize=12, rotation=-90
         )
         l = pl.axvline(ct_line_pos, color="#dddddd", dashes=(1, 1))
         l.set_clip_on(False)
-        
+
         for (xline, yline) in zip(xlines, ylines):
-            
+
             # normalize the x values to fall between 0 and 1
             xv = (np.array(xline) / (xlines_max - xlines_min))
 
@@ -310,27 +324,26 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
                     )
                     for v in l:
                         v.set_clip_on(False)
-    
+
     if show:
         pl.show()
-
 
 
 # def compute_sort_counts(partition_tree, leaf_values, pos=None):
 #     if pos is None:
 #         pos = partition_tree.shape[0]-1
-    
+
 #     M = partition_tree.shape[0] + 1
-        
+
 #     if pos < 0:
 #         return 1,leaf_values[pos + M]
-    
+
 #     left = int(partition_tree[pos, 0]) - M
 #     right = int(partition_tree[pos, 1]) - M
-    
+
 #     left_val,left_sum = compute_sort_counts(partition_tree, leaf_values, left)
 #     right_val,right_sum = compute_sort_counts(partition_tree, leaf_values, right)
-    
+
 #     if left_sum > right_sum:
 #         left_val = right_val + 1
 #     else:
@@ -341,28 +354,26 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 #     if right >= 0:
 #         partition_tree[right,3] = right_val
 
-    
+
 #     return max(left_val, right_val) + 1, max(left_sum, right_sum)
 
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):
-    
     # unwrap pandas series
     if str(type(features)) == "<class 'pandas.core.series.Series'>":
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values
-        
+
     if feature_names is None:
         feature_names = np.array([labels['FEATURE'] % str(i) for i in range(len(shap_values))])
-    
+
     if max_display is None:
         max_display = 7
     else:
         max_display = min(len(feature_names), max_display)
-        
-    
+
     feature_order = np.argsort(-np.abs(shap_values))
-    
+
     # 
     feature_inds = feature_order[:max_display]
     y_pos = np.arange(len(feature_inds), 0, -1)
@@ -381,11 +392,12 @@ def bar_legacy(shap_values, features=None, feature_names=None, max_display=None,
                 if round(features[i]) == features[i]:
                     features[i] = int(features[i])
             except TypeError:
-                pass # features[i] must not be a number
+                pass  # features[i] must not be a number
     yticklabels = []
     for i in feature_inds:
         if features is not None:
-            yticklabels.append(feature_names[i] + " = " + str(features[i]))
+            yticklabels.append("{} = {}".format(feature_names[i],
+                                                features[i]))
         else:
             yticklabels.append(feature_names[i])
     pl.gca().set_yticklabels(yticklabels)
@@ -393,9 +405,9 @@ def bar_legacy(shap_values, features=None, feature_names=None, max_display=None,
     pl.gca().yaxis.set_ticks_position('none')
     pl.gca().spines['right'].set_visible(False)
     pl.gca().spines['top'].set_visible(False)
-    #pl.gca().spines['left'].set_visible(False)
-    
+    # pl.gca().spines['left'].set_visible(False)
+
     pl.xlabel("SHAP value (impact on model output)")
-    
+
     if show:
         pl.show()

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -6,6 +6,7 @@ from __future__ import division
 import warnings
 import numpy as np
 from scipy.stats import gaussian_kde
+
 try:
     import matplotlib.pyplot as pl
 except ImportError:
@@ -52,7 +53,6 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
         #     out_names = shap_exp.output_names
 
     order = convert_ordering(order, values)
-    
 
     # # deprecation warnings
     # if auto_size_plot is not None:
@@ -97,7 +97,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
                     "provided data matrix."
         if num_features - 1 == features.shape[1]:
             assert False, shape_msg + " Perhaps the extra column in the shap_values matrix is the " \
-                          "constant offset? Of so just pass shap_values[:,:-1]."
+                                      "constant offset? Of so just pass shap_values[:,:-1]."
         else:
             assert num_features == features.shape[1], shape_msg
 
@@ -117,9 +117,10 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
         partition_tree = None
     else:
         partition_tree = clustering
-    
+
     if partition_tree is not None:
-        assert partition_tree.shape[1] == 4, "The clustering provided by the Explanation object does not seem to be a partition tree (which is all shap.plots.bar supports)!"
+        assert partition_tree.shape[
+                   1] == 4, "The clustering provided by the Explanation object does not seem to be a partition tree (which is all shap.plots.bar supports)!"
 
     # plotting SHAP interaction values
     if len(values.shape) == 3:
@@ -134,7 +135,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
                     if c1 == c2:
                         new_feature_names.append(c1)
                     else:
-                        new_feature_names.append(c1 + "* - " + c2)
+                        new_feature_names.append("{}* - {}".format(c1, c2))
 
             return beeswarm(
                 new_values, new_features, new_feature_names,
@@ -149,7 +150,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
         else:
             max_display = min(len(feature_names), max_display)
 
-        interaction_sort_inds = order#np.argsort(-np.abs(values.sum(1)).sum(0))
+        interaction_sort_inds = order  # np.argsort(-np.abs(values.sum(1)).sum(0))
 
         # get plotting limits
         delta = 1.0 / (values.shape[1] ** 2)
@@ -219,14 +220,15 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
             # now relax the requirement to match the parition tree ordering for connections above cluster_threshold
             dist = scipy.spatial.distance.squareform(scipy.cluster.hierarchy.cophenet(partition_tree))
             feature_order = get_sort_order(dist, clust_order, cluster_threshold, feature_order)
-        
+
             # if the last feature we can display is connected in a tree the next feature then we can't just cut
             # off the feature ordering, so we need to merge some tree nodes and then try again.
-            if max_display < len(feature_order) and dist[feature_order[max_display-1],feature_order[max_display-2]] <= cluster_threshold:
-                #values, partition_tree, orig_inds = merge_nodes(values, partition_tree, orig_inds)
+            if max_display < len(feature_order) and dist[
+                feature_order[max_display - 1], feature_order[max_display - 2]] <= cluster_threshold:
+                # values, partition_tree, orig_inds = merge_nodes(values, partition_tree, orig_inds)
                 partition_tree, ind1, ind2 = merge_nodes(np.abs(values), partition_tree)
                 for i in range(len(values)):
-                    values[:,ind1] += values[:,ind2]
+                    values[:, ind1] += values[:, ind2]
                     values = np.delete(values, ind2, 1)
                     orig_inds[ind1] += orig_inds[ind2]
                     del orig_inds[ind2]
@@ -239,26 +241,28 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
     feature_inds = feature_order[:max_display]
     y_pos = np.arange(len(feature_inds), 0, -1)
     feature_names_new = []
-    for pos,inds in enumerate(orig_inds):
+    for pos, inds in enumerate(orig_inds):
         if len(inds) == 1:
             feature_names_new.append(feature_names[inds[0]])
         elif len(inds) <= 2:
             feature_names_new.append(" + ".join([feature_names[i] for i in inds]))
         else:
             max_ind = np.argmax(np.abs(orig_values).mean(0)[inds])
-            feature_names_new.append(feature_names[inds[max_ind]] + " + %d other features" % (len(inds)-1))
+            feature_names_new.append("{} + {} other features".format(feature_names[inds[max_ind]],
+                                                                     len(inds) - 1))
     feature_names = feature_names_new
 
     # see how many individual (vs. grouped at the end) features we are plotting
     if num_features < len(values[0]):
-        num_cut = np.sum([len(orig_inds[feature_order[i]]) for i in range(num_features-1, len(values[0]))])
-        values[:,feature_order[num_features-1]] = np.sum([values[:,feature_order[i]] for i in range(num_features-1, len(values[0]))], 0)
-    
+        num_cut = np.sum([len(orig_inds[feature_order[i]]) for i in range(num_features - 1, len(values[0]))])
+        values[:, feature_order[num_features - 1]] = np.sum(
+            [values[:, feature_order[i]] for i in range(num_features - 1, len(values[0]))], 0)
+
     # build our y-tick labels
     yticklabels = [feature_names[i] for i in feature_inds]
     if num_features < len(values[0]):
-        yticklabels[-1] = "Sum of %d other features" % num_cut
-    
+        yticklabels[-1] = "Sum of {} other features".format(num_cut)
+
     row_height = 0.4
     if plot_size == "auto":
         pl.gcf().set_size_inches(8, len(feature_order) * row_height + 1.5)
@@ -310,7 +314,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
                 if vmin == vmax:
                     vmin = np.min(fvalues)
                     vmax = np.max(fvalues)
-            if vmin > vmax: # fixes rare numerical precision issues
+            if vmin > vmax:  # fixes rare numerical precision issues
                 vmin = vmax
 
             assert features.shape[0] == len(shaps), "Feature and SHAP matrices must have the same number of rows!"
@@ -318,8 +322,8 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
             # plot the nan fvalues in the interaction feature as grey
             nan_mask = np.isnan(fvalues)
             pl.scatter(shaps[nan_mask], pos + ys[nan_mask], color="#777777", vmin=vmin,
-                        vmax=vmax, s=16, alpha=alpha, linewidth=0,
-                        zorder=3, rasterized=len(shaps) > 500)
+                       vmax=vmax, s=16, alpha=alpha, linewidth=0,
+                       zorder=3, rasterized=len(shaps) > 500)
 
             # plot the non-nan fvalues colored by the trimmed feature value
             cvals = fvalues[np.invert(nan_mask)].astype(np.float64)
@@ -328,14 +332,13 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
             cvals[cvals_imp > vmax] = vmax
             cvals[cvals_imp < vmin] = vmin
             pl.scatter(shaps[np.invert(nan_mask)], pos + ys[np.invert(nan_mask)],
-                        cmap=color, vmin=vmin, vmax=vmax, s=16,
-                        c=cvals, alpha=alpha, linewidth=0,
-                        zorder=3, rasterized=len(shaps) > 500)
+                       cmap=color, vmin=vmin, vmax=vmax, s=16,
+                       c=cvals, alpha=alpha, linewidth=0,
+                       zorder=3, rasterized=len(shaps) > 500)
         else:
 
             pl.scatter(shaps, pos + ys, s=16, alpha=alpha, linewidth=0, zorder=3,
-                        color=color if colored_feature else "#777777", rasterized=len(shaps) > 500)
-
+                       color=color if colored_feature else "#777777", rasterized=len(shaps) > 500)
 
     # draw the color bar
     if safe_isinstance(color, "matplotlib.colors.Colormap") and color_bar and features is not None:
@@ -366,12 +369,12 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
     if show:
         pl.show()
 
+
 def shorten_text(text, length_limit):
     if len(text) > length_limit:
         return text[:length_limit - 3] + "..."
     else:
         return text
-
 
 
 def is_color_map(color):
@@ -381,14 +384,14 @@ def is_color_map(color):
 # TODO: remove unused title argument / use title argument
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
 def summary_legacy(shap_values, features=None, feature_names=None, max_display=None, plot_type=None,
-                 color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
-                 color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,
-                 class_inds=None,
-                 color_bar_label=labels["FEATURE_VALUE"],
-                 cmap=colors.red_blue,
-                 # depreciated
-                 auto_size_plot=None,
-                 use_log_scale=False):
+                   color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
+                   color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,
+                   class_inds=None,
+                   color_bar_label=labels["FEATURE_VALUE"],
+                   cmap=colors.red_blue,
+                   # depreciated
+                   auto_size_plot=None,
+                   use_log_scale=False):
     """Create a SHAP beeswarm plot, colored by feature values when they are provided.
 
     Parameters
@@ -439,11 +442,11 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
     if isinstance(shap_values, list):
         multi_class = True
         if plot_type is None:
-            plot_type = "bar" # default for multi-output explanations
+            plot_type = "bar"  # default for multi-output explanations
         assert plot_type == "bar", "Only plot_type = 'bar' is supported for multi-output explanations!"
     else:
         if plot_type is None:
-            plot_type = "dot" # default for single output explanations
+            plot_type = "dot"  # default for single output explanations
         assert len(shap_values.shape) != 1, "Summary plots need a matrix of shap_values, not a vector."
 
     # default color:
@@ -451,7 +454,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
         if plot_type == 'layered_violin':
             color = "coolwarm"
         elif multi_class:
-            color = lambda i: colors.red_blue_circle(i/len(shap_values))
+            color = lambda i: colors.red_blue_circle(i / len(shap_values))
         else:
             color = colors.blue_rgb
 
@@ -475,7 +478,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
                     "provided data matrix."
         if num_features - 1 == features.shape[1]:
             assert False, shape_msg + " Perhaps the extra column in the shap_values matrix is the " \
-                          "constant offset? Of so just pass shap_values[:,:-1]."
+                                      "constant offset? Of so just pass shap_values[:,:-1]."
         else:
             assert num_features == features.shape[1], shape_msg
 
@@ -498,7 +501,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
                     if c1 == c2:
                         new_feature_names.append(c1)
                     else:
-                        new_feature_names.append(c1 + "* - " + c2)
+                        new_feature_names.append("{}* - {}".format(c1, c2))
 
             return summary_legacy(
                 new_shap_values, new_features, new_feature_names,
@@ -628,7 +631,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
                     if vmin == vmax:
                         vmin = np.min(values)
                         vmax = np.max(values)
-                if vmin > vmax: # fixes rare numerical precision issues
+                if vmin > vmax:  # fixes rare numerical precision issues
                     vmin = vmax
 
                 assert features.shape[0] == len(shaps), "Feature and SHAP matrices must have the same number of rows!"
@@ -726,7 +729,8 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
                 for i in range(len(xs) - 1):
                     if ds[i] > 0.05 or ds[i + 1] > 0.05:
                         pl.fill_between([xs[i], xs[i + 1]], [pos + ds[i], pos + ds[i + 1]],
-                                        [pos - ds[i], pos - ds[i + 1]], color=colors.red_blue_no_bounds(smooth_values[i]),
+                                        [pos - ds[i], pos - ds[i + 1]],
+                                        color=colors.red_blue_no_bounds(smooth_values[i]),
                                         zorder=2)
 
         else:
@@ -810,7 +814,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
 
     elif multi_class and plot_type == "bar":
         if class_names is None:
-            class_names = ["Class "+str(i) for i in range(len(shap_values))]
+            class_names = ["Class " + str(i) for i in range(len(shap_values))]
         feature_inds = feature_order[:max_display]
         y_pos = np.arange(len(feature_inds))
         left_pos = np.zeros(len(feature_inds))

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -20,6 +20,7 @@ from ._labels import labels
 from ..utils._legacy import convert_to_link, LogitLink
 from ..utils import hclust_ordering
 
+
 # .shape[0] messes up pylint a lot here
 # pylint: disable=unsubscriptable-object
 
@@ -44,24 +45,24 @@ def __change_shap_base_value(base_value, new_base_value, shap_values) -> np.ndar
 
 
 def __decision_plot_matplotlib(
-    base_value,
-    cumsum,
-    ascending,
-    feature_display_count,
-    features,
-    feature_names,
-    highlight,
-    plot_color,
-    axis_color,
-    y_demarc_color,
-    xlim,
-    alpha,
-    color_bar,
-    auto_size_plot,
-    title,
-    show,
-    legend_labels,
-    legend_location,
+        base_value,
+        cumsum,
+        ascending,
+        feature_display_count,
+        features,
+        feature_names,
+        highlight,
+        plot_color,
+        axis_color,
+        y_demarc_color,
+        xlim,
+        alpha,
+        color_bar,
+        auto_size_plot,
+        title,
+        show,
+        legend_labels,
+        legend_location,
 ):
     """matplotlib rendering for decision_plot()"""
 
@@ -115,12 +116,16 @@ def __decision_plot_matplotlib(
         y_pos = y_pos + 0.5
         for i in range(feature_display_count):
             v = features[0, i]
-            if isinstance(v, str):
+            if v is None:
+                v = "(None)"
+            elif isinstance(v, bool):
+                v = "(True)" if v else "(False)"
+            elif isinstance(v, str):
                 v = "({})".format(str(v).strip())
             else:
                 v = "({})".format("{0:,.3f}".format(v).rstrip("0").rstrip("."))
             t = ax.text(np.max(cumsum[0, i:(i + 2)]), y_pos[i], "  " + v, fontsize=fontsize,
-                    horizontalalignment="left", verticalalignment="center_baseline", color="#666666")
+                        horizontalalignment="left", verticalalignment="center_baseline", color="#666666")
             bb = inverter.transform_bbox(t.get_window_extent(renderer=renderer))
             if bb.xmax > xlim[1]:
                 t.set_text(v + "  ")
@@ -220,28 +225,28 @@ class DecisionPlotResult:
 
 
 def decision(
-    base_value,
-    shap_values,
-    features=None,
-    feature_names=None,
-    feature_order="importance",
-    feature_display_range=None,
-    highlight=None,
-    link="identity",
-    plot_color=None,
-    axis_color="#333333",
-    y_demarc_color="#333333",
-    alpha=None,
-    color_bar=True,
-    auto_size_plot=True,
-    title=None,
-    xlim=None,
-    show=True,
-    return_objects=False,
-    ignore_warnings=False,
-    new_base_value=None,
-    legend_labels=None,
-    legend_location="best",
+        base_value,
+        shap_values,
+        features=None,
+        feature_names=None,
+        feature_order="importance",
+        feature_display_range=None,
+        highlight=None,
+        link="identity",
+        plot_color=None,
+        axis_color="#333333",
+        y_demarc_color="#333333",
+        alpha=None,
+        color_bar=True,
+        auto_size_plot=True,
+        title=None,
+        xlim=None,
+        show=True,
+        return_objects=False,
+        ignore_warnings=False,
+        new_base_value=None,
+        legend_labels=None,
+        legend_location="best",
 ) -> Union[DecisionPlotResult, None]:
     """Visualize model decisions using cumulative SHAP values.
 
@@ -434,7 +439,7 @@ def decision(
         raise ValueError("The feature_order arg requires 'importance', 'hclust', 'none', or an integer list/array "
                          "of feature indices.")
 
-    if (feature_idx.shape != (feature_count, )) or (not np.issubdtype(feature_idx.dtype, np.integer)):
+    if (feature_idx.shape != (feature_count,)) or (not np.issubdtype(feature_idx.dtype, np.integer)):
         raise ValueError("A list or array has been specified for the feature_order arg. The length must match the "
                          "feature count and the data type must be integer.")
 

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -1,6 +1,7 @@
 import numpy as np
 import sklearn
 import warnings
+
 try:
     import matplotlib.pyplot as pl
     import matplotlib
@@ -10,6 +11,7 @@ except ImportError:
 from ._labels import labels
 from . import colors
 from ..utils import convert_name
+
 
 def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, show=True):
     """ Use the SHAP values as an embedding which we project to 2D for visualization.
@@ -38,18 +40,18 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
         The transparency of the data points (between 0 and 1). This can be useful to the
         show density of the data points when using a large dataset.
     """
-    
+
     if feature_names is None:
         feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1])]
-    
+
     ind = convert_name(ind, shap_values, feature_names)
     if ind == "sum()":
         cvals = shap_values.sum(1)
         fname = "sum(SHAP values)"
     else:
-        cvals = shap_values[:,ind]
+        cvals = shap_values[:, ind]
         fname = feature_names[ind]
-    
+
     # see if we need to compute the embedding
     if type(method) == str and method == "pca":
         pca = sklearn.decomposition.PCA(2)
@@ -60,16 +62,15 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
         print("Unsupported embedding method:", method)
 
     pl.scatter(
-        embedding_values[:,0], embedding_values[:,1], c=cvals,
+        embedding_values[:, 0], embedding_values[:, 1], c=cvals,
         cmap=colors.red_blue, alpha=alpha, linewidth=0
     )
     pl.axis("off")
-    #pl.title(feature_names[ind])
+    # pl.title(feature_names[ind])
     cb = pl.colorbar()
-    cb.set_label("SHAP value for\n"+fname, size=13)
+    cb.set_label("SHAP value for\n{}".format(fname), size=13)
     cb.outline.set_visible(False)
-    
-    
+
     pl.gcf().set_size_inches(7.5, 5)
     bbox = cb.ax.get_window_extent().transformed(pl.gcf().dpi_scale_trans.inverted())
     cb.ax.set_aspect((bbox.height - 0.7) * 10)

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -7,9 +7,11 @@ import io
 import string
 import json
 import random
+
 try:
     from IPython.core.display import display, HTML
     from IPython import get_ipython
+
     have_ipython = True
 except ImportError:
     have_ipython = False
@@ -17,10 +19,11 @@ import base64
 import numpy as np
 import scipy.cluster
 import sys
+
 if sys.version_info[0] >= 3:
     from collections.abc import Sequence
 else:
-    from collections import Sequence # pylint: disable=no-name-in-module
+    from collections import Sequence  # pylint: disable=no-name-in-module
 
 import warnings
 import re
@@ -29,9 +32,11 @@ from ..utils._legacy import convert_to_link, Instance, Model, Data, DenseData, L
 from ..utils import hclust_ordering
 from ..plots._force_matplotlib import draw_additive_plot
 
+
 def force(base_value, shap_values=None, features=None, feature_names=None, out_names=None, link="identity",
-               plot_cmap="RdBu", matplotlib=False, show=True, figsize=(20,3), ordering_keys=None, ordering_keys_time_format=None,
-               text_rotation=0):
+          plot_cmap="RdBu", matplotlib=False, show=True, figsize=(20, 3), ordering_keys=None,
+          ordering_keys_time_format=None,
+          text_rotation=0):
     """ Visualize the given SHAP values with an additive force layout.
     
     Parameters
@@ -82,11 +87,10 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
 
     if (type(base_value) == np.ndarray or type(base_value) == list):
         if type(shap_values) != list or len(shap_values) != len(base_value):
-            raise Exception("In v0.20 force_plot now requires the base value as the first parameter! " \
-                            "Try shap.force_plot(explainer.expected_value, shap_values) or " \
-                            "for multi-output models try " \
+            raise Exception("In v0.20 force_plot now requires the base value as the first parameter! "
+                            "Try shap.force_plot(explainer.expected_value, shap_values) or "
+                            "for multi-output models try "
                             "shap.force_plot(explainer.expected_value[0], shap_values[0]).")
-
 
     assert not type(shap_values) == list, "The shap_values arg looks looks multi output, try shap_values[i]."
 
@@ -147,13 +151,13 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
             Model(None, out_names),
             DenseData(np.zeros((1, len(feature_names))), list(feature_names))
         )
-        
+
         return visualize(e, plot_cmap, matplotlib, figsize=figsize, show=show, text_rotation=text_rotation)
-        
+
     else:
         if matplotlib:
             raise Exception("matplotlib = True is not yet supported for force plots with multiple samples!")
-        
+
         if shap_values.shape[0] > 3000:
             warnings.warn("shap.plots.force is slow for many thousands of rows, try subsampling your data.")
 
@@ -162,7 +166,7 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
             if feature_names is None:
                 feature_names = [labels['FEATURE'] % str(i) for i in range(shap_values.shape[1])]
             if features is None:
-                display_features = ["" for i in range(len(feature_names))]
+                display_features = ["" for _ in range(len(feature_names))]
             else:
                 display_features = features[k, :]
 
@@ -178,15 +182,15 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
                 DenseData(np.ones((1, len(feature_names))), list(feature_names))
             )
             exps.append(e)
-        
+
         return visualize(
-                    exps, 
-                    plot_cmap=plot_cmap, 
-                    ordering_keys=ordering_keys, 
-                    ordering_keys_time_format=ordering_keys_time_format, 
-                    text_rotation=text_rotation
-                )
-            
+            exps,
+            plot_cmap=plot_cmap,
+            ordering_keys=ordering_keys,
+            ordering_keys_time_format=ordering_keys_time_format,
+            text_rotation=text_rotation
+        )
+
 
 class Explanation:
     def __init__(self):
@@ -207,6 +211,7 @@ class AdditiveExplanation(Explanation):
         self.model = model
         assert isinstance(data, Data)
         self.data = data
+
 
 err_msg = """
 <div style='color: #900; text-align: center;'>
@@ -257,10 +262,10 @@ def save_html(out_file, plot, full_html=True):
     if type(out_file) == str:
         out_file = open(out_file, "w", encoding="utf-8")
         internal_open = True
-    
+
     if full_html:
         out_file.write("<html><head><meta http-equiv='content-type' content='text/html'; charset='utf-8'>")
-    
+
     out_file.write("<script>\n")
 
     # dump the js code
@@ -269,12 +274,12 @@ def save_html(out_file, plot, full_html=True):
         bundle_data = f.read()
     out_file.write(bundle_data)
     out_file.write("</script>")
-    
+
     if full_html:
         out_file.write("</head><body>\n")
 
     out_file.write(plot.html())
-    
+
     if full_html:
         out_file.write("</body></html>\n")
 
@@ -283,7 +288,7 @@ def save_html(out_file, plot, full_html=True):
 
 
 def id_generator(size=20, chars=string.ascii_uppercase + string.digits):
-    return "i"+''.join(random.choice(chars) for _ in range(size))
+    return "i" + ''.join(random.choice(chars) for _ in range(size))
 
 
 def ensure_not_numpy(x):
@@ -296,22 +301,26 @@ def ensure_not_numpy(x):
     else:
         return x
 
+
 def verify_valid_cmap(cmap):
     assert (isinstance(cmap, str) or isinstance(cmap, list) or str(type(cmap)).endswith("unicode'>")
-        ),"Plot color map must be string or list! not: " + str(type(cmap))
+            ), "Plot color map must be string or list! not: " + str(type(cmap))
     if isinstance(cmap, list):
         assert (len(cmap) > 1), "Color map must be at least two colors."
         _rgbstring = re.compile(r'#[a-fA-F0-9]{6}$')
         for color in cmap:
-             assert(bool(_rgbstring.match(color))),"Invalid color found in CMAP."
+            assert (bool(_rgbstring.match(color))), "Invalid color found in CMAP."
 
     return cmap
 
-def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True, ordering_keys=None, ordering_keys_time_format=None, text_rotation=0):
+
+def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20, 3), show=True, ordering_keys=None,
+              ordering_keys_time_format=None, text_rotation=0):
     plot_cmap = verify_valid_cmap(plot_cmap)
     if isinstance(e, AdditiveExplanation):
         if matplotlib:
-            return AdditiveForceVisualizer(e, plot_cmap=plot_cmap).matplotlib(figsize=figsize, show=show, text_rotation=text_rotation)
+            return AdditiveForceVisualizer(e, plot_cmap=plot_cmap).matplotlib(figsize=figsize, show=show,
+                                                                              text_rotation=text_rotation)
         else:
             return AdditiveForceVisualizer(e, plot_cmap=plot_cmap)
     elif isinstance(e, Explanation):
@@ -323,12 +332,15 @@ def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True, 
         if matplotlib:
             assert False, "Matplotlib plot is only supported for additive explanations"
         else:
-            return AdditiveForceArrayVisualizer(e, plot_cmap=plot_cmap, ordering_keys=ordering_keys, ordering_keys_time_format=ordering_keys_time_format)
+            return AdditiveForceArrayVisualizer(e, plot_cmap=plot_cmap, ordering_keys=ordering_keys,
+                                                ordering_keys_time_format=ordering_keys_time_format)
     else:
         assert False, "visualize() can only display Explanation objects (or arrays of them)!"
 
+
 class BaseVisualizer:
-    pass 
+    pass
+
 
 class SimpleListVisualizer(BaseVisualizer):
     def __init__(self, e):
@@ -347,7 +359,7 @@ class SimpleListVisualizer(BaseVisualizer):
             "link": str(e.link),
             "featureNames": e.data.group_names,
             "features": features,
-            "plot_cmap":e.plot_cmap.plot_cmap
+            "plot_cmap": e.plot_cmap.plot_cmap
         }
 
     def html(self):
@@ -398,15 +410,15 @@ class AdditiveForceVisualizer(BaseVisualizer):
     document.getElementById('{id}')
   );
 </script>""".format(err_msg=err_msg, data=json.dumps(self.data), id=id_generator())
-    
+
     def matplotlib(self, figsize, show, text_rotation):
         fig = draw_additive_plot(self.data, figsize=figsize, show=show, text_rotation=text_rotation)
-        
+
         return fig
-    
+
     def _repr_html_(self):
         return self.html()
-        
+
 
 class AdditiveForceArrayVisualizer(BaseVisualizer):
     def __init__(self, arr, plot_cmap="RdBu", ordering_keys=None, ordering_keys_time_format=None):
@@ -421,10 +433,10 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
 
         # make sure that we put the higher predictions first...just for consistency
         if sum(arr[clustOrder[0]].effects) < sum(arr[clustOrder[-1]].effects):
-            np.flipud(clustOrder) # reverse
+            np.flipud(clustOrder)  # reverse
 
         # build the json data
-        clustOrder = np.argsort(clustOrder) # inverse permutation
+        clustOrder = np.argsort(clustOrder)  # inverse permutation
         self.data = {
             "outNames": arr[0].model.out_names,
             "baseValue": ensure_not_numpy(arr[0].base_value),
@@ -435,13 +447,13 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
             "ordering_keys": list(ordering_keys) if hasattr(ordering_keys, '__iter__') else None,
             "ordering_keys_time_format": ordering_keys_time_format,
         }
-        for (ind,e) in enumerate(arr):
+        for (ind, e) in enumerate(arr):
             self.data["explanations"].append({
                 "outValue": ensure_not_numpy(e.out_value),
-                "simIndex": ensure_not_numpy(clustOrder[ind])+1,
+                "simIndex": ensure_not_numpy(clustOrder[ind]) + 1,
                 "features": {}
             })
-            for i in filter(lambda j: e.effects[j] != 0 or e.instance.x[0,j] != 0, range(len(e.data.group_names))):
+            for i in filter(lambda j: e.effects[j] != 0 or e.instance.x[0, j] != 0, range(len(e.data.group_names))):
                 self.data["explanations"][-1]["features"][i] = {
                     "effect": ensure_not_numpy(e.effects[i]),
                     "value": ensure_not_numpy(e.instance.group_display_values[i])

--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+
 try:
     import matplotlib.pyplot as plt
     from matplotlib import lines
@@ -16,14 +17,14 @@ def draw_bars(out_value, features, feature_type, width_separators, width_bar):
     """Draw the bars and separators."""
     rectangle_list = []
     separator_list = []
-    
+
     pre_val = out_value
     for index, features in zip(range(len(features)), features):
         if feature_type == 'positive':
             left_bound = float(features[0])
             right_bound = pre_val
             pre_val = left_bound
-            
+
             separator_indent = np.abs(width_separators)
             separator_pos = left_bound
             colors = ['#FF0D57', '#FFC3D5']
@@ -31,11 +32,11 @@ def draw_bars(out_value, features, feature_type, width_separators, width_bar):
             left_bound = pre_val
             right_bound = float(features[0])
             pre_val = right_bound
-            
+
             separator_indent = - np.abs(width_separators)
             separator_pos = right_bound
             colors = ['#1E88E5', '#D1E6FA']
-        
+
         # Create rectangle
         if index == 0:
             if feature_type == 'positive':
@@ -52,7 +53,7 @@ def draw_bars(out_value, features, feature_type, width_separators, width_bar):
                                     [right_bound, width_bar],
                                     [right_bound + separator_indent, (width_bar / 2)]
                                     ]
-        
+
         else:
             points_rectangle = [[left_bound, 0],
                                 [right_bound, 0],
@@ -69,7 +70,7 @@ def draw_bars(out_value, features, feature_type, width_separators, width_bar):
         points_separator = [[separator_pos, 0],
                             [separator_pos + separator_indent, (width_bar / 2)],
                             [separator_pos, width_bar]]
-        
+
         line = plt.Polygon(points_separator, closed=None, fill=None,
                            edgecolor=colors[1], lw=3)
         separator_list += [line]
@@ -77,10 +78,11 @@ def draw_bars(out_value, features, feature_type, width_separators, width_bar):
     return rectangle_list, separator_list
 
 
-def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_effect=0, min_perc=0.05, text_rotation=0):
+def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_effect=0, min_perc=0.05,
+                text_rotation=0):
     start_text = out_value
     pre_val = out_value
-    
+
     # Define variables specific to positive and negative effect features
     if feature_type == 'positive':
         colors = ['#FF0D57', '#FFC3D5']
@@ -90,7 +92,7 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
         colors = ['#1E88E5', '#D1E6FA']
         alignement = 'left'
         sign = -1
-    
+
     # Draw initial line
     if feature_type == 'positive':
         x, y = np.array([[pre_val, pre_val], [0, -0.18]])
@@ -98,7 +100,7 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
         line.set_clip_on(False)
         ax.add_line(line)
         start_text = pre_val
-    
+
     box_end = out_value
     val = out_value
     for feature in features:
@@ -106,15 +108,20 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
         feature_contribution = np.abs(float(feature[0]) - pre_val) / np.abs(total_effect)
         if feature_contribution < min_perc:
             break
-        
+
         # Compute value for current feature
         val = float(feature[0])
-        
+
         # Draw labels.
-        if feature[1] == "":
-            text = feature[2]
+        feature_val = feature[1]
+        feature_name = feature[2]
+        if feature_val == "" or feature_val is None:
+            text = str(feature_name)
+        elif isinstance(feature_val, bool) or isinstance(feature_val, str):
+            text = "{} = {}".format(feature_name, feature_val)
         else:
-            text = feature[2] + ' = ' + feature[1]
+            text = "{} = {}".format(feature_name,
+                                    "{0:,.3f}".format(feature_val).rstrip("0").rstrip("."))
 
         if text_rotation is not 0:
             va_alignment = 'top'
@@ -128,23 +135,23 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
                                 va=va_alignment,
                                 rotation=text_rotation)
         text_out_val.set_bbox(dict(facecolor='none', edgecolor='none'))
-        
+
         # We need to draw the plot to be able to get the size of the
         # text box
         fig.canvas.draw()
-        box_size = text_out_val.get_bbox_patch().get_extents()\
-                               .transformed(ax.transData.inverted())
+        box_size = text_out_val.get_bbox_patch().get_extents() \
+            .transformed(ax.transData.inverted())
         if feature_type == 'positive':
             box_end_ = box_size.get_points()[0][0]
         else:
             box_end_ = box_size.get_points()[1][0]
-        
+
         # If the feature goes over the side of the plot, we remove that label
         # and stop drawing labels
         if box_end_ > ax.get_xlim()[1]:
             text_out_val.remove()
             break
-        
+
         # Create end line
         if (sign * box_end_) > (sign * val):
             x, y = np.array([[val, val], [0, -0.18]])
@@ -162,44 +169,43 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
             line.set_clip_on(False)
             ax.add_line(line)
             start_text = box_end
-        
+
         # Update previous value
         pre_val = float(feature[0])
-            
-    
+
     # Create line for labels
     extent_shading = [out_value, box_end, 0, -0.31]
     path = [[out_value, 0], [pre_val, 0], [box_end, -0.08],
             [box_end, -0.2], [out_value, -0.2],
             [out_value, 0]]
-    
+
     path = Path(path)
     patch = PathPatch(path, facecolor='none', edgecolor='none')
-    ax.add_patch(patch) 
-    
+    ax.add_patch(patch)
+
     # Extend axis if needed
     lower_lim, upper_lim = ax.get_xlim()
     if (box_end < lower_lim):
         ax.set_xlim(box_end, upper_lim)
-    
+
     if (box_end > upper_lim):
         ax.set_xlim(lower_lim, box_end)
-        
+
     # Create shading
     if feature_type == 'positive':
         colors = np.array([(255, 13, 87), (255, 255, 255)]) / 255.
     else:
         colors = np.array([(30, 136, 229), (255, 255, 255)]) / 255.
-    
+
     cm = matplotlib.colors.LinearSegmentedColormap.from_list('cm', colors)
-    
+
     _, Z2 = np.meshgrid(np.linspace(0, 10), np.linspace(-10, 10))
     im = plt.imshow(Z2, interpolation='quadric', cmap=cm,
                     vmax=0.01, alpha=0.3,
                     origin='lower', extent=extent_shading,
                     clip_path=patch, clip_on=True, aspect='auto')
     im.set_clip_path(patch)
-    
+
     return fig, ax
 
 
@@ -210,16 +216,16 @@ def format_data(data):
                               data['features'][x]['value'],
                               data['featureNames'][x]]
                              for x in data['features'].keys() if data['features'][x]['effect'] < 0])
-    
+
     neg_features = np.array(sorted(neg_features, key=lambda x: float(x[0]), reverse=False))
-    
+
     # Format postive features
     pos_features = np.array([[data['features'][x]['effect'],
                               data['features'][x]['value'],
                               data['featureNames'][x]]
                              for x in data['features'].keys() if data['features'][x]['effect'] >= 0])
     pos_features = np.array(sorted(pos_features, key=lambda x: float(x[0]), reverse=True))
-    
+
     # Define link function
     if data['link'] == 'identity':
         convert_func = lambda x: x
@@ -227,7 +233,7 @@ def format_data(data):
         convert_func = lambda x: 1 / (1 + np.exp(-x))
     else:
         assert False, "ERROR: Unrecognized link function: " + str(data['link'])
-    
+
     # Convert negative feature values to plot values
     neg_val = data['outValue']
     for i in neg_features:
@@ -239,24 +245,24 @@ def format_data(data):
                     np.min(neg_features[:, 0].astype(float))
     else:
         total_neg = 0
-    
+
     # Convert positive feature values to plot values
     pos_val = data['outValue']
     for i in pos_features:
         val = float(i[0])
         pos_val = pos_val - np.abs(val)
         i[0] = convert_func(pos_val)
-        
+
     if len(pos_features) > 0:
         total_pos = np.max(pos_features[:, 0].astype(float)) - \
                     np.min(pos_features[:, 0].astype(float))
     else:
         total_pos = 0
-    
+
     # Convert output value and base value
     data['outValue'] = convert_func(data['outValue'])
     data['baseValue'] = convert_func(data['baseValue'])
-    
+
     return neg_features, total_neg, pos_features, total_pos
 
 
@@ -266,7 +272,7 @@ def draw_output_element(out_name, out_value, ax):
     line = lines.Line2D(x, y, lw=2., color='#F2F2F2')
     line.set_clip_on(False)
     ax.add_line(line)
-    
+
     font0 = FontProperties()
     font = font0.copy()
     font.set_weight('bold')
@@ -275,7 +281,7 @@ def draw_output_element(out_name, out_value, ax):
                             fontsize=14,
                             horizontalalignment='center')
     text_out_val.set_bbox(dict(facecolor='white', edgecolor='white'))
-    
+
     text_out_val = plt.text(out_value, 0.33, out_name,
                             fontsize=12, alpha=0.5,
                             horizontalalignment='center')
@@ -287,7 +293,7 @@ def draw_base_element(base_value, ax):
     line = lines.Line2D(x, y, lw=2., color='#F2F2F2')
     line.set_clip_on(False)
     ax.add_line(line)
-    
+
     text_out_val = plt.text(base_value, 0.33, 'base value',
                             fontsize=12, alpha=0.5,
                             horizontalalignment='center')
@@ -302,11 +308,11 @@ def draw_higher_lower_element(out_value, offset_text):
     plt.text(out_value + offset_text, 0.405, 'lower',
              fontsize=13, color='#1E88E5',
              horizontalalignment='left')
-    
+
     plt.text(out_value, 0.4, r'$\leftarrow$',
              fontsize=13, color='#1E88E5',
              horizontalalignment='center')
-    
+
     plt.text(out_value, 0.425, r'$\rightarrow$',
              fontsize=13, color='#FF0D57',
              horizontalalignment='center')
@@ -317,7 +323,7 @@ def update_axis_limits(ax, total_pos, pos_features, total_neg,
     ax.set_ylim(-0.5, 0.15)
     padding = np.max([np.abs(total_pos) * 0.2,
                       np.abs(total_neg) * 0.2])
-    
+
     if len(pos_features) > 0:
         min_x = min(np.min(pos_features[:, 0].astype(float)), base_value) - padding
     else:
@@ -342,41 +348,41 @@ def draw_additive_plot(data, figsize, show, text_rotation=0):
     # Turn off interactive plot
     if show is False:
         plt.ioff()
-    
+
     # Format data
     neg_features, total_neg, pos_features, total_pos = format_data(data)
-    
+
     # Compute overall metrics
     base_value = data['baseValue']
     out_value = data['outValue']
     offset_text = (np.abs(total_neg) + np.abs(total_pos)) * 0.04
-    
+
     # Define plots
     fig, ax = plt.subplots(figsize=figsize)
-    
+
     # Compute axis limit
     update_axis_limits(ax, total_pos, pos_features, total_neg,
                        neg_features, base_value)
-    
+
     # Define width of bar
     width_bar = 0.1
     width_separators = (ax.get_xlim()[1] - ax.get_xlim()[0]) / 200
-    
+
     # Create bar for negative shap values
     rectangle_list, separator_list = draw_bars(out_value, neg_features, 'negative',
                                                width_separators, width_bar)
     for i in rectangle_list:
         ax.add_patch(i)
-    
+
     for i in separator_list:
         ax.add_patch(i)
-    
+
     # Create bar for positive shap values
     rectangle_list, separator_list = draw_bars(out_value, pos_features, 'positive',
                                                width_separators, width_bar)
     for i in rectangle_list:
         ax.add_patch(i)
-    
+
     for i in separator_list:
         ax.add_patch(i)
 
@@ -384,16 +390,16 @@ def draw_additive_plot(data, figsize, show, text_rotation=0):
     total_effect = np.abs(total_neg) + total_pos
     fig, ax = draw_labels(fig, ax, out_value, neg_features, 'negative',
                           offset_text, total_effect, min_perc=0.05, text_rotation=text_rotation)
-    
+
     fig, ax = draw_labels(fig, ax, out_value, pos_features, 'positive',
                           offset_text, total_effect, min_perc=0.05, text_rotation=text_rotation)
-    
+
     # higher lower legend
     draw_higher_lower_element(out_value, offset_text)
-    
+
     # Add label for base value
     draw_base_element(base_value, ax)
-    
+
     # Add output label
     out_names = data['outNames'][0]
     draw_output_element(out_names, out_value, ax)
@@ -408,4 +414,3 @@ def draw_additive_plot(data, figsize, show, text_rotation=0):
         plt.show()
     else:
         return plt.gcf()
-    

--- a/shap/plots/_group_difference.py
+++ b/shap/plots/_group_difference.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+
 try:
     import matplotlib.pyplot as pl
     import matplotlib
@@ -9,7 +10,7 @@ except ImportError:
 from . import colors
 
 
-def group_difference(shap_values, group_mask, feature_names=None, xlabel=None, xmin=None, xmax=None, 
+def group_difference(shap_values, group_mask, feature_names=None, xlabel=None, xmin=None, xmax=None,
                      max_display=None, sort=True, show=True):
     """ This plots the difference in mean SHAP values between two groups.
     
@@ -28,7 +29,7 @@ def group_difference(shap_values, group_mask, feature_names=None, xlabel=None, x
     feature_names : list
         A list of feature names.
     """
-    
+
     # compute confidence bounds for the group difference value
     vs = []
     gmean = group_mask.mean()
@@ -37,39 +38,39 @@ def group_difference(shap_values, group_mask, feature_names=None, xlabel=None, x
         vs.append(shap_values[r].mean(0) - shap_values[~r].mean(0))
     vs = np.array(vs)
     xerr = np.vstack([np.percentile(vs, 95, axis=0), np.percentile(vs, 5, axis=0)])
-    
+
     # See if we were passed a single model output vector and not a matrix of SHAP values
     if len(shap_values.shape) == 1:
         shap_values = shap_values.reshape(1, -1).T
         if feature_names is None:
             feature_names = [""]
-    
+
     # fill in any missing feature names
     if feature_names is None:
-        feature_names = ["Feature %d" % i for i in range(shap_values.shape[1])]
+        feature_names = ["Feature {}".format(i) for i in range(shap_values.shape[1])]
 
     diff = shap_values[group_mask].mean(0) - shap_values[~group_mask].mean(0)
-    
+
     if sort is True:
         inds = np.argsort(-np.abs(diff)).astype(np.int)
     else:
         inds = np.arange(len(diff))
-    
+
     if max_display is not None:
         inds = inds[:max_display]
     # draw the figure
     figsize = [6.4, 0.2 + 0.9 * len(inds)]
     pl.figure(figsize=figsize)
-    ticks = range(len(inds)-1, -1, -1)
+    ticks = range(len(inds) - 1, -1, -1)
     pl.axvline(0, color="#999999", linewidth=0.5)
     pl.barh(
         ticks, diff[inds], color=colors.blue_rgb,
-        capsize=3, xerr=np.abs(xerr[:,inds])
+        capsize=3, xerr=np.abs(xerr[:, inds])
     )
-    
+
     for i in range(len(inds)):
         pl.axhline(y=i, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
-    
+
     ax = pl.gca()
     ax.set_yticklabels([feature_names[i] for i in inds])
     ax.xaxis.set_ticks_position('bottom')

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 try:
     import matplotlib.pyplot as pl
     import matplotlib
@@ -9,7 +10,8 @@ from .. import Explanation
 from ..utils import OpChain
 from ._utils import convert_ordering, convert_color
 
-def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Explanation.abs.mean(0), 
+
+def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Explanation.abs.mean(0),
             feature_order=None, max_display=10, cmap=colors.red_white_blue, show=True):
     """ Create a heatmap plot of a set of SHAP values.
 
@@ -55,7 +57,7 @@ def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Exp
     elif issubclass(type(feature_order), OpChain):
         feature_order = feature_order.apply(Explanation(values))
     elif not hasattr(feature_order, "__len__"):
-        raise Exception("Unsupported feature_order: %s!" % str(feature_order))
+        raise Exception("Unsupported feature_order: {}!".format(feature_order))
     xlabel = "Instances"
     instance_order = convert_ordering(instance_order, shap_values)
     # if issubclass(type(instance_order), OpChain):
@@ -67,22 +69,22 @@ def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Exp
     #     instance_order_ops = None
 
     feature_names = np.array(shap_values.feature_names)[feature_order]
-    values = shap_values.values[instance_order][:,feature_order]
+    values = shap_values.values[instance_order][:, feature_order]
     feature_values = feature_values[feature_order]
 
     # collapse
     if values.shape[1] > max_display:
         new_values = np.zeros((values.shape[0], max_display))
-        new_values[:, :max_display-1] = values[:, :max_display-1]
-        new_values[:, max_display-1] = values[:, max_display-1:].sum(1)
+        new_values[:, :max_display - 1] = values[:, :max_display - 1]
+        new_values[:, max_display - 1] = values[:, max_display - 1:].sum(1)
         new_feature_values = np.zeros(max_display)
-        new_feature_values[:max_display-1] = feature_values[:max_display-1]
-        new_feature_values[max_display-1] = feature_values[max_display-1:].sum()
+        new_feature_values[:max_display - 1] = feature_values[:max_display - 1]
+        new_feature_values[max_display - 1] = feature_values[max_display - 1:].sum()
         feature_names = list(feature_names[:max_display])
-        feature_names[-1] = "Sum of %d other features" % (values.shape[1] - max_display + 1)
+        feature_names[-1] = "Sum of {} other features".format(values.shape[1] - max_display + 1)
         values = new_values
         feature_values = new_feature_values
-    
+
     # define the plot size
     row_height = 0.5
     pl.gcf().set_size_inches(8, values.shape[1] * row_height + 2.5)
@@ -91,18 +93,17 @@ def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Exp
     vmin = np.nanpercentile(values.flatten(), 1)
     vmax = np.nanpercentile(values.flatten(), 99)
     pl.imshow(
-        values.T, aspect=0.7 * values.shape[0]/values.shape[1], interpolation="nearest", vmin=min(vmin,-vmax), vmax=max(-vmin,vmax),
+        values.T, aspect=0.7 * values.shape[0] / values.shape[1], interpolation="nearest", vmin=min(vmin, -vmax),
+        vmax=max(-vmin, vmax),
         cmap=cmap
     )
     yticks_pos = np.arange(values.shape[1])
     yticks_labels = feature_names
 
     pl.yticks([-1.5] + list(yticks_pos), ["f(x)"] + list(yticks_labels), fontsize=13)
-    
-    pl.ylim(values.shape[1]-0.5, -3)
-    
-    
-    
+
+    pl.ylim(values.shape[1] - 0.5, -3)
+
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('left')
     pl.gca().spines['right'].set_visible(True)
@@ -110,40 +111,38 @@ def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Exp
     pl.gca().spines['bottom'].set_visible(False)
     pl.axhline(-1.5, color="#aaaaaa", linestyle="--", linewidth=0.5)
     fx = values.T.mean(0)
-    pl.plot(-fx/np.abs(fx).max() - 1.5, color="#000000", linewidth=1)
-    #pl.colorbar()
-    pl.gca().spines['left'].set_bounds(values.shape[1]-0.5, -0.5)
-    pl.gca().spines['right'].set_bounds(values.shape[1]-0.5, -0.5)
+    pl.plot(-fx / np.abs(fx).max() - 1.5, color="#000000", linewidth=1)
+    # pl.colorbar()
+    pl.gca().spines['left'].set_bounds(values.shape[1] - 0.5, -0.5)
+    pl.gca().spines['right'].set_bounds(values.shape[1] - 0.5, -0.5)
     b = pl.barh(
-        yticks_pos, (feature_values / np.abs(feature_values).max()) * values.shape[0] / 20, 
+        yticks_pos, (feature_values / np.abs(feature_values).max()) * values.shape[0] / 20,
         0.7, align='center', color="#000000", left=values.shape[0] * 1.0 - 0.5
-        #color=[colors.red_rgb if shap_values[feature_inds[i]] > 0 else colors.blue_rgb for i in range(len(y_pos))]
+        # color=[colors.red_rgb if shap_values[feature_inds[i]] > 0 else colors.blue_rgb for i in range(len(y_pos))]
     )
     for v in b:
         v.set_clip_on(False)
-    pl.xlim(-0.5, values.shape[0]-0.5)
+    pl.xlim(-0.5, values.shape[0] - 0.5)
     pl.xlabel(xlabel)
-    
-    
-    
+
     if True:
         import matplotlib.cm as cm
         m = cm.ScalarMappable(cmap=cmap)
-        m.set_array([min(vmin,-vmax), max(-vmin,vmax)])
-        cb = pl.colorbar(m, ticks=[min(vmin,-vmax), max(-vmin,vmax)], aspect=1000, fraction=0.0090, pad=0.10,
-                        panchor=(0,0.05))
-        #cb.set_ticklabels([min(vmin,-vmax), max(-vmin,vmax)])
+        m.set_array([min(vmin, -vmax), max(-vmin, vmax)])
+        cb = pl.colorbar(m, ticks=[min(vmin, -vmax), max(-vmin, vmax)], aspect=1000, fraction=0.0090, pad=0.10,
+                         panchor=(0, 0.05))
+        # cb.set_ticklabels([min(vmin,-vmax), max(-vmin,vmax)])
         cb.set_label("SHAP value", size=12, labelpad=-10)
         cb.ax.tick_params(labelsize=11, length=0)
         cb.set_alpha(1)
         cb.outline.set_visible(False)
         bbox = cb.ax.get_window_extent().transformed(pl.gcf().dpi_scale_trans.inverted())
         cb.ax.set_aspect((bbox.height - 0.9) * 15)
-        cb.ax.set_anchor((1,0.2))
-        #cb.draw_all()
-        
+        cb.ax.set_anchor((1, 0.2))
+        # cb.draw_all()
+
     for i in [0]:
         pl.gca().get_yticklines()[i].set_visible(False)
-    
+
     if show:
         pl.show()

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+
 try:
     import matplotlib.pyplot as pl
 except ImportError:
@@ -7,6 +8,7 @@ except ImportError:
     pass
 from . import colors
 from ..utils._legacy import kmeans
+
 
 # .shape[0] messes up pylint a lot here
 # pylint: disable=unsubscriptable-object
@@ -77,7 +79,7 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
         fig_size *= width / fig_size[0]
     fig, axes = pl.subplots(nrows=x.shape[0], ncols=len(shap_values) + 1, figsize=fig_size)
     if len(axes.shape) == 1:
-        axes = axes.reshape(1,axes.size)
+        axes = axes.reshape(1, axes.size)
     for row in range(x.shape[0]):
         x_curr = x[row].copy()
 
@@ -86,27 +88,29 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
             x_curr = x_curr.reshape(x_curr.shape[:2])
         if x_curr.max() > 1:
             x_curr /= 255.
-        
+
         # get a grayscale version of the image
         if len(x_curr.shape) == 3 and x_curr.shape[2] == 3:
-            x_curr_gray = (0.2989 * x_curr[:,:,0] + 0.5870 * x_curr[:,:,1] + 0.1140 * x_curr[:,:,2]) # rgb to gray
+            x_curr_gray = (
+                        0.2989 * x_curr[:, :, 0] + 0.5870 * x_curr[:, :, 1] + 0.1140 * x_curr[:, :, 2])  # rgb to gray
             x_curr_disp = x_curr
         elif len(x_curr.shape) == 3:
             x_curr_gray = x_curr.mean(2)
 
             # for non-RGB multi-channel data we show an RGB image where each of the three channels is a scaled k-mean center
-            flat_vals = x_curr.reshape([x_curr.shape[0]*x_curr.shape[1], x_curr.shape[2]]).T
+            flat_vals = x_curr.reshape([x_curr.shape[0] * x_curr.shape[1], x_curr.shape[2]]).T
             flat_vals = (flat_vals.T - flat_vals.mean(1)).T
             means = kmeans(flat_vals, 3, round_values=False).data.T.reshape([x_curr.shape[0], x_curr.shape[1], 3])
-            x_curr_disp = (means - np.percentile(means, 0.5, (0,1))) / (np.percentile(means, 99.5, (0,1)) - np.percentile(means, 1, (0,1)))
+            x_curr_disp = (means - np.percentile(means, 0.5, (0, 1))) / (
+                        np.percentile(means, 99.5, (0, 1)) - np.percentile(means, 1, (0, 1)))
             x_curr_disp[x_curr_disp > 1] = 1
             x_curr_disp[x_curr_disp < 0] = 0
         else:
             x_curr_gray = x_curr
             x_curr_disp = x_curr
 
-        axes[row,0].imshow(x_curr_disp, cmap=pl.get_cmap('gray'))
-        axes[row,0].axis('off')
+        axes[row, 0].imshow(x_curr_disp, cmap=pl.get_cmap('gray'))
+        axes[row, 0].axis('off')
         if len(shap_values[0][row].shape) == 2:
             abs_vals = np.stack([np.abs(shap_values[i]) for i in range(len(shap_values))], 0).flatten()
         else:
@@ -114,16 +118,18 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
         max_val = np.nanpercentile(abs_vals, 99.9)
         for i in range(len(shap_values)):
             if labels is not None:
-                axes[row,i+1].set_title(labels[row,i], **label_kwargs)
+                axes[row, i + 1].set_title(labels[row, i], **label_kwargs)
             sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row].sum(-1)
-            axes[row,i+1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
-            im = axes[row,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
-            axes[row,i+1].axis('off')
+            axes[row, i + 1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15,
+                                    extent=(-1, sv.shape[1], sv.shape[0], -1))
+            im = axes[row, i + 1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
+            axes[row, i + 1].axis('off')
     if hspace == 'auto':
         fig.tight_layout()
     else:
         fig.subplots_adjust(hspace=hspace)
-    cb = fig.colorbar(im, ax=np.ravel(axes).tolist(), label="SHAP value", orientation="horizontal", aspect=fig_size[0]/aspect)
+    cb = fig.colorbar(im, ax=np.ravel(axes).tolist(), label="SHAP value", orientation="horizontal",
+                      aspect=fig_size[0] / aspect)
     cb.outline.set_visible(False)
     if show:
         pl.show()

--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy
 import warnings
+
 try:
     import matplotlib.pyplot as pl
     import matplotlib
@@ -13,9 +14,10 @@ from . import colors
 
 def truncate_text(text, max_len):
     if len(text) > max_len:
-        return text[:int(max_len/2)-2] + "..." + text[-int(max_len/2)+1:]
+        return text[:int(max_len / 2) - 2] + "..." + text[-int(max_len / 2) + 1:]
     else:
         return text
+
 
 def monitoring(ind, shap_values, features, feature_names=None, show=True):
     """ Create a SHAP monitoring plot.
@@ -40,7 +42,7 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     feature_names : list
         Names of the features (length # features)
     """
-    
+
     if str(type(features)).endswith("'pandas.core.frame.DataFrame'>"):
         if feature_names is None:
             feature_names = features.columns
@@ -50,25 +52,25 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
 
     if feature_names is None:
         feature_names = np.array([labels['FEATURE'] % str(i) for i in range(num_features)])
-        
-    pl.figure(figsize=(10,3))
-    ys = shap_values[:,ind]
-    xs = np.arange(len(ys))#np.linspace(0, 12*2, len(ys))
-    
+
+    pl.figure(figsize=(10, 3))
+    ys = shap_values[:, ind]
+    xs = np.arange(len(ys))  # np.linspace(0, 12*2, len(ys))
+
     pvals = []
     inc = 50
-    for i in range(inc, len(ys)-inc, inc):
-        #stat, pval = scipy.stats.mannwhitneyu(v[:i], v[i:], alternative="two-sided")
+    for i in range(inc, len(ys) - inc, inc):
+        # stat, pval = scipy.stats.mannwhitneyu(v[:i], v[i:], alternative="two-sided")
         _, pval = scipy.stats.ttest_ind(ys[:i], ys[i:])
         pvals.append(pval)
     min_pval = np.min(pvals)
-    min_pval_ind = np.argmin(pvals)*inc + inc
-    
+    min_pval_ind = np.argmin(pvals) * inc + inc
+
     if min_pval < 0.05 / shap_values.shape[1]:
         pl.axvline(min_pval_ind, linestyle="dashed", color="#666666", alpha=0.2)
-        
-    pl.scatter(xs, ys, s=10, c=features[:,ind], cmap=colors.red_blue)
-    
+
+    pl.scatter(xs, ys, s=10, c=features[:, ind], cmap=colors.red_blue)
+
     pl.xlabel("Sample index")
     pl.ylabel(truncate_text(feature_names[ind], 30) + "\nSHAP value", size=13)
     pl.gca().xaxis.set_ticks_position('bottom')

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 import numpy as np
 import warnings
+
 try:
     import matplotlib.pyplot as pl
     import matplotlib
@@ -72,10 +73,12 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
 
     """
 
-    assert str(type(shap_values)).endswith("Explanation'>"), "The shap_values paramemter must be a shap.Explanation object!"
+    assert str(type(shap_values)).endswith(
+        "Explanation'>"), "The shap_values paramemter must be a shap.Explanation object!"
     if len(shap_values.shape) != 1:
-        raise Exception("The passed Explanation object has multiple columns, please pass a single feature column to shap.plots.dependence like: shap_values[:,column]")
-    
+        raise Exception(
+            "The passed Explanation object has multiple columns, please pass a single feature column to shap.plots.dependence like: shap_values[:,column]")
+
     # this unpacks the explanation object for the code that was written earlier
     feature_names = [shap_values.feature_names]
     ind = 0
@@ -100,34 +103,34 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
     # wrap np.arrays as Explanations
     if isinstance(color, np.ndarray):
         color = Explanation(values=color, base_values=None, data=color)
-    
+
     # TODO: This stacking could be avoided if we use the new shap.utils.potential_interactions function
     if str(type(color)).endswith("Explanation'>"):
         shap_values2 = color
         if issubclass(type(shap_values2.feature_names), (str, int)):
             feature_names.append(shap_values2.feature_names)
-            shap_values_arr = np.hstack([shap_values_arr, shap_values2.values.reshape(-1, len(feature_names)-1)])
-            features = np.hstack([features, shap_values2.data.reshape(-1, len(feature_names)-1)])
+            shap_values_arr = np.hstack([shap_values_arr, shap_values2.values.reshape(-1, len(feature_names) - 1)])
+            features = np.hstack([features, shap_values2.data.reshape(-1, len(feature_names) - 1)])
             if shap_values2.display_data is None:
-                display_features = np.hstack([display_features, shap_values2.data.reshape(-1, len(feature_names)-1)])
+                display_features = np.hstack([display_features, shap_values2.data.reshape(-1, len(feature_names) - 1)])
             else:
-                display_features = np.hstack([display_features, shap_values2.display_data.reshape(-1, len(feature_names)-1)])
+                display_features = np.hstack(
+                    [display_features, shap_values2.display_data.reshape(-1, len(feature_names) - 1)])
         else:
             feature_names2 = np.array(shap_values2.feature_names)
             mask = ~(feature_names[0] == feature_names2)
             feature_names.extend(feature_names2[mask])
-            shap_values_arr = np.hstack([shap_values_arr, shap_values2.values[:,mask]])
-            features = np.hstack([features, shap_values2.data[:,mask]])
+            shap_values_arr = np.hstack([shap_values_arr, shap_values2.values[:, mask]])
+            features = np.hstack([features, shap_values2.data[:, mask]])
             if shap_values2.display_data is None:
-                display_features = np.hstack([display_features, shap_values2.data[:,mask]])
+                display_features = np.hstack([display_features, shap_values2.data[:, mask]])
             else:
-                display_features = np.hstack([display_features, shap_values2.display_data[:,mask]])
+                display_features = np.hstack([display_features, shap_values2.display_data[:, mask]])
         color = None
         interaction_index = "auto"
 
-
     if type(shap_values_arr) is list:
-        raise TypeError("The passed shap_values_arr are a list not an array! If you have a list of explanations try " \
+        raise TypeError("The passed shap_values_arr are a list not an array! If you have a list of explanations try "
                         "passing shap_values_arr[0] instead to explain the first output class of a multi-output model.")
 
     # convert from DataFrames if we got any
@@ -148,23 +151,23 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
     ind = convert_name(ind, shap_values_arr, feature_names)
 
     # pick jitter for categorical features
-    vals = np.sort(np.unique(features[:,ind]))
+    vals = np.sort(np.unique(features[:, ind]))
     min_dist = np.inf
-    for i in range(1,len(vals)):
-        d = vals[i] - vals[i-1]
-        if d > 1e-8 and d < min_dist:
+    for i in range(1, len(vals)):
+        d = vals[i] - vals[i - 1]
+        if 1e-8 < d < min_dist:
             min_dist = d
-    num_points_per_value = len(features[:,ind]) / len(vals)
+    num_points_per_value = len(features[:, ind]) / len(vals)
     if num_points_per_value < 10:
-        #categorical = False
+        # categorical = False
         if x_jitter == "auto":
             x_jitter = 0
     elif num_points_per_value < 100:
-        #categorical = True
+        # categorical = True
         if x_jitter == "auto":
             x_jitter = min_dist * 0.1
     else:
-        #categorical = True
+        # categorical = True
         if x_jitter == "auto":
             x_jitter = min_dist * 0.2
 
@@ -217,18 +220,19 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         "'shap_values_arr' must have the same number of columns as 'features'!"
 
     # get both the raw and display feature values
-    oinds = np.arange(shap_values_arr.shape[0]) # we randomize the ordering so plotting overlaps are not related to data ordering
+    oinds = np.arange(
+        shap_values_arr.shape[0])  # we randomize the ordering so plotting overlaps are not related to data ordering
     np.random.shuffle(oinds)
     xv = encode_array_if_needed(features[oinds, ind])
     xd = display_features[oinds, ind]
-    
+
     s = shap_values_arr[oinds, ind]
     if type(xd[0]) == str:
         name_map = {}
         for i in range(len(xv)):
             name_map[xd[i]] = xv[i]
         xnames = list(name_map.keys())
-    
+
     # allow a single feature name to be passed alone
     if type(feature_names) == str:
         feature_names = [feature_names]
@@ -259,7 +263,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
             clow = np.nanmin(cv.astype(np.float))
             chigh = np.nanmax(cv.astype(np.float))
             bounds = np.linspace(clow, chigh, int(chigh - clow + 2))
-            color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
+            color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N - 1)
 
     # optionally add jitter to feature values
     xv_no_jitter = xv.copy()
@@ -269,13 +273,12 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         if isinstance(xvals[0], float):
             xvals = xvals.astype(np.float)
             xvals = xvals[~np.isnan(xvals)]
-        xvals = np.unique(xvals) # returns a sorted array
+        xvals = np.unique(xvals)  # returns a sorted array
         if len(xvals) >= 2:
             smallest_diff = np.min(np.diff(xvals))
             jitter_amount = x_jitter * smallest_diff
-            xv += (np.random.random_sample(size = len(xv))*jitter_amount) - (jitter_amount/2)
+            xv += (np.random.random_sample(size=len(xv)) * jitter_amount) - (jitter_amount / 2)
 
-    
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     xv_nan = np.isnan(xv)
     xv_notnan = np.invert(xv_nan)
@@ -326,9 +329,9 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
             xmax = np.nanpercentile(xv, float(xmax[11:-1]))
 
         if xmin is None or xmin == np.nanmin(xv):
-            xmin = np.nanmin(xv) - (xmax - np.nanmin(xv))/20
+            xmin = np.nanmin(xv) - (xmax - np.nanmin(xv)) / 20
         if xmax is None or xmax == np.nanmax(xv):
-            xmax = np.nanmax(xv) + (np.nanmax(xv) - xmin)/20
+            xmax = np.nanmax(xv) + (np.nanmax(xv) - xmin) / 20
 
         ax.set_xlim(xmin, xmax)
 
@@ -339,9 +342,9 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         #     ymax = np.nanpercentile(xv, float(ymax[11:-1]))
 
         if ymin is None or ymin == np.nanmin(xv):
-            ymin = np.nanmin(xv) - (ymax - np.nanmin(xv))/20
+            ymin = np.nanmin(xv) - (ymax - np.nanmin(xv)) / 20
         if ymax is None or ymax == np.nanmax(xv):
-            ymax = np.nanmax(xv) + (np.nanmax(xv) - ymin)/20
+            ymax = np.nanmax(xv) + (np.nanmax(xv) - ymin) / 20
 
         ax.set_ylim(ymin, ymax)
 
@@ -364,18 +367,18 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
     # the histogram of the data
     if hist:
         ax2 = ax.twinx()
-        #n, bins, patches = 
+        # n, bins, patches =
         xlim = ax.get_xlim()
         xvals = np.unique(xv_no_jitter)
 
         if len(xvals) / len(xv_no_jitter) < 0.2 and len(xvals) < 75 and np.max(xvals) < 75 and np.min(xvals) >= 0:
             np.sort(xvals)
             bin_edges = []
-            for i in range(int(np.max(xvals)+1)):
-                bin_edges.append(i-0.5)
+            for i in range(int(np.max(xvals) + 1)):
+                bin_edges.append(i - 0.5)
 
-                #bin_edges.append((xvals[i] + xvals[i+1])/2)
-            bin_edges.append(int(np.max(xvals))+0.5)
+                # bin_edges.append((xvals[i] + xvals[i+1])/2)
+            bin_edges.append(int(np.max(xvals)) + 0.5)
 
             lim = np.floor(np.min(xvals) - 0.5) + 0.5, np.ceil(np.max(xvals) + 0.5) - 0.5
             ax.set_xlim(lim)
@@ -388,9 +391,10 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
                 bin_edges = 10
             else:
                 bin_edges = 5
-        
-        ax2.hist(xv[~np.isnan(xv)], bin_edges, density=False, facecolor='#000000', alpha=0.1, range=(xlim[0], xlim[1]), zorder=-1)
-        ax2.set_ylim(0,len(xv))
+
+        ax2.hist(xv[~np.isnan(xv)], bin_edges, density=False, facecolor='#000000', alpha=0.1, range=(xlim[0], xlim[1]),
+                 zorder=-1)
+        ax2.set_ylim(0, len(xv))
 
         ax2.xaxis.set_ticks_position('bottom')
         ax2.yaxis.set_ticks_position('left')
@@ -418,11 +422,9 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         ax.set_xticks([name_map[n] for n in xnames])
         ax.set_xticklabels(xnames, dict(rotation='vertical', fontsize=11))
     if show:
-        with warnings.catch_warnings(): # ignore expected matplotlib warnings
+        with warnings.catch_warnings():  # ignore expected matplotlib warnings
             warnings.simplefilter("ignore", RuntimeWarning)
             pl.show()
-
-
 
 
 def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, display_features=None,
@@ -489,7 +491,7 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         cmap = colors.red_blue
 
     if type(shap_values) is list:
-        raise TypeError("The passed shap_values are a list not an array! If you have a list of explanations try " \
+        raise TypeError("The passed shap_values are a list not an array! If you have a list of explanations try "
                         "passing shap_values[0] instead to explain the first output class of a multi-output model.")
 
     # convert from DataFrames if we got any
@@ -564,9 +566,10 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         "'shap_values' must have the same number of columns as 'features'!"
 
     # get both the raw and display feature values
-    oinds = np.arange(shap_values.shape[0]) # we randomize the ordering so plotting overlaps are not related to data ordering
+    oinds = np.arange(
+        shap_values.shape[0])  # we randomize the ordering so plotting overlaps are not related to data ordering
     np.random.shuffle(oinds)
-    
+
     xv = encode_array_if_needed(features[oinds, ind])
 
     xd = display_features[oinds, ind]
@@ -607,7 +610,7 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
             clow = np.nanmin(cv.astype(np.float))
             chigh = np.nanmax(cv.astype(np.float))
             bounds = np.linspace(clow, chigh, int(chigh - clow + 2))
-            color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
+            color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N - 1)
 
     # optionally add jitter to feature values
     if x_jitter > 0:
@@ -616,11 +619,11 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         if isinstance(xvals[0], float):
             xvals = xvals.astype(np.float)
             xvals = xvals[~np.isnan(xvals)]
-        xvals = np.unique(xvals) # returns a sorted array
+        xvals = np.unique(xvals)  # returns a sorted array
         if len(xvals) >= 2:
             smallest_diff = np.min(np.diff(xvals))
             jitter_amount = x_jitter * smallest_diff
-            xv += (np.random.random_sample(size = len(xv))*jitter_amount) - (jitter_amount/2)
+            xv += (np.random.random_sample(size=len(xv)) * jitter_amount) - (jitter_amount / 2)
 
     # the actual scatter plot, TODO: adapt the dot_size to the number of data points?
     xv_nan = np.isnan(xv)
@@ -673,9 +676,9 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
             xmax = np.nanpercentile(xv, float(xmax[11:-1]))
 
         if xmin is None or xmin == np.nanmin(xv):
-            xmin = np.nanmin(xv) - (xmax - np.nanmin(xv))/20
+            xmin = np.nanmin(xv) - (xmax - np.nanmin(xv)) / 20
         if xmax is None or xmax == np.nanmax(xv):
-            xmax = np.nanmax(xv) + (np.nanmax(xv) - xmin)/20
+            xmax = np.nanmax(xv) + (np.nanmax(xv) - xmin) / 20
 
         ax.set_xlim(xmin, xmax)
 
@@ -711,6 +714,6 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         ax.set_xticks([name_map[n] for n in xnames])
         ax.set_xticklabels(xnames, dict(rotation='vertical', fontsize=11))
     if show:
-        with warnings.catch_warnings(): # ignore expected matplotlib warnings
+        with warnings.catch_warnings():  # ignore expected matplotlib warnings
             warnings.simplefilter("ignore", RuntimeWarning)
             pl.show()

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -17,9 +17,6 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
     """
     from IPython.core.display import display, HTML
 
-
-
-
     def values_min_max(values, base_values):
         """ Used to pick our axis limits.
         """
@@ -37,9 +34,9 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
     if len(shap_values.shape) == 2 and shap_values.output_names is None:
         tokens, values, group_sizes = process_shap_values(shap_values[0], group_threshold, separator)
         xmin, xmax, cmax = values_min_max(values, shap_values[0].base_values)
-        for i in range(1,len(shap_values)):
+        for i in range(1, len(shap_values)):
             tokens, values, group_sizes = process_shap_values(shap_values[i], group_threshold, separator)
-            xmin_i,xmax_i,cmax_i = values_min_max(values, shap_values[i].base_values)
+            xmin_i, xmax_i, cmax_i = values_min_max(values, shap_values[i].base_values)
             if xmin_i < xmin:
                 xmin = xmin_i
             if xmax_i > xmax:
@@ -47,20 +44,20 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
             if cmax_i > cmax:
                 cmax = cmax_i
         for i in range(len(shap_values)):
-            display(HTML("<br/><b>"+ordinal_str(i)+" instance:</b><br/>"))
-            text(shap_values[i], num_starting_labels=num_starting_labels, group_threshold=group_threshold, separator=separator, xmin=xmin, xmax=xmax, cmax=cmax)
+            display(HTML("<br/><b>{} instance:</b><br/>".format(ordinal_str(i))))
+            text(shap_values[i], num_starting_labels=num_starting_labels, group_threshold=group_threshold,
+                 separator=separator, xmin=xmin, xmax=xmax, cmax=cmax)
         return
-    
+
     elif len(shap_values.shape) == 2 and shap_values.output_names is not None:
         text_to_text(shap_values)
         return
     elif len(shap_values.shape) == 3:
         for i in range(len(shap_values)):
-            display(HTML("<br/><b>"+ordinal_str(i)+" instance:</b><br/>"))
+            display(HTML("<br/><b>{} instance:</b><br/>".format(ordinal_str(i))))
             text(shap_values[i])
         return
 
-    
     # set any unset bounds
     xmin_new, xmax_new, cmax_new = values_min_max(shap_values.values, shap_values.base_values)
     if xmin is None:
@@ -69,10 +66,9 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
         xmax = xmax_new
     if cmax is None:
         cmax = cmax_new
-    
 
     tokens, values, group_sizes = process_shap_values(shap_values, group_threshold, separator)
-    
+
     # build out HTML output one word one at a time
     top_inds = np.argsort(-np.abs(values))[:num_starting_labels]
     maxv = values.max()
@@ -81,58 +77,59 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
     # ev_str = str(shap_values.base_values)
     # vsum_str = str(values.sum())
     # fx_str = str(shap_values.base_values + values.sum())
-    
+
     uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
     encoded_tokens = [t.replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '') for t in tokens]
-    out += svg_force_plot(values, shap_values.base_values, shap_values.base_values + values.sum(), encoded_tokens, uuid, xmin, xmax)
-    
+    out += svg_force_plot(values, shap_values.base_values, shap_values.base_values + values.sum(), encoded_tokens, uuid,
+                          xmin, xmax)
+
     for i in range(len(tokens)):
         scaled_value = 0.5 + 0.5 * values[i] / cmax
         color = colors.red_transparent_blue(scaled_value)
-        color = (color[0]*255, color[1]*255, color[2]*255, color[3])
-        
+        color = (color[0] * 255, color[1] * 255, color[2] * 255, color[3])
+
         # display the labels for the most important words
         label_display = "none"
         wrapper_display = "inline"
         if i in top_inds:
             label_display = "block"
             wrapper_display = "inline-block"
-        
+
         # create the value_label string
         value_label = ""
         if group_sizes[i] == 1:
             value_label = str(values[i].round(3))
         else:
             value_label = str(values[i].round(3)) + " / " + str(group_sizes[i])
-        
+
         # the HTML for this token
         out += "<div style='display: " + wrapper_display + "; text-align: center;'>" \
-             + "<div style='display: " + label_display + "; color: #999; padding-top: 0px; font-size: 12px;'>" \
-             + value_label \
-             + "</div>" \
-             + f"<div id='_tp_{uuid}_ind_{i}'" \
-             +   "style='display: inline; background: rgba" + str(color) + "; border-radius: 3px; padding: 0px'" \
-             +   "onclick=\"if (this.previousSibling.style.display == 'none') {" \
-             +       "this.previousSibling.style.display = 'block';" \
-             +       "this.parentNode.style.display = 'inline-block';" \
-             +     "} else {" \
-             +       "this.previousSibling.style.display = 'none';" \
-             +       "this.parentNode.style.display = 'inline';" \
-             +     "}" \
-             +   "\"" \
-             +   f"onmouseover=\"document.getElementById('_fb_{uuid}_ind_{i}').style.opacity = 1; document.getElementById('_fs_{uuid}_ind_{i}').style.opacity = 1;" \
-             +   "\"" \
-             +   f"onmouseout=\"document.getElementById('_fb_{uuid}_ind_{i}').style.opacity = 0; document.getElementById('_fs_{uuid}_ind_{i}').style.opacity = 0;" \
-             +   "\"" \
-             + ">" \
-             + tokens[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '') \
-             + "</div>" \
-             + "</div>"
+               + "<div style='display: " + label_display + "; color: #999; padding-top: 0px; font-size: 12px;'>" \
+               + value_label \
+               + "</div>" \
+               + f"<div id='_tp_{uuid}_ind_{i}'" \
+               + "style='display: inline; background: rgba" + str(color) + "; border-radius: 3px; padding: 0px'" \
+               + "onclick=\"if (this.previousSibling.style.display == 'none') {" \
+               + "this.previousSibling.style.display = 'block';" \
+               + "this.parentNode.style.display = 'inline-block';" \
+               + "} else {" \
+               + "this.previousSibling.style.display = 'none';" \
+               + "this.parentNode.style.display = 'inline';" \
+               + "}" \
+               + "\"" \
+               + f"onmouseover=\"document.getElementById('_fb_{uuid}_ind_{i}').style.opacity = 1; document.getElementById('_fs_{uuid}_ind_{i}').style.opacity = 1;" \
+               + "\"" \
+               + f"onmouseout=\"document.getElementById('_fb_{uuid}_ind_{i}').style.opacity = 0; document.getElementById('_fs_{uuid}_ind_{i}').style.opacity = 0;" \
+               + "\"" \
+               + ">" \
+               + tokens[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '') \
+               + "</div>" \
+               + "</div>"
 
     display(HTML(out))
 
-def process_shap_values(shap_values, group_threshold, separator):
 
+def process_shap_values(shap_values, group_threshold, separator):
     # unpack the Explanation object
     tokens = shap_values.data
     clustering = getattr(shap_values, "clustering", None)
@@ -145,13 +142,13 @@ def process_shap_values(shap_values, group_threshold, separator):
     # shap_values and tokens to get the groups we want to display
     M = len(tokens)
     if len(values) != M:
-        
+
         # make sure we were given a partition tree
         if clustering is None:
-            raise ValueError("The length of the attribution values must match the number of " + \
-                             "tokens if shap_values.clustering is None! When passing hierarchical " + \
+            raise ValueError("The length of the attribution values must match the number of "
+                             "tokens if shap_values.clustering is None! When passing hierarchical "
                              "attributions the clustering is also required.")
-        
+
         # compute the groups, lower_values, and max_values
         groups = [[i] for i in range(M)]
         lower_values = np.zeros(len(values))
@@ -159,29 +156,30 @@ def process_shap_values(shap_values, group_threshold, separator):
         max_values = np.zeros(len(values))
         max_values[:M] = np.abs(values[:M])
         for i in range(clustering.shape[0]):
-            li = int(clustering[i,0])
-            ri = int(clustering[i,1])
+            li = int(clustering[i, 0])
+            ri = int(clustering[i, 1])
             groups.append(groups[li] + groups[ri])
-            lower_values[M+i] = lower_values[li] + lower_values[ri] + values[M+i]
-            max_values[i+M] = max(abs(values[M+i]) / len(groups[M+i]), max_values[li], max_values[ri])
-    
+            lower_values[M + i] = lower_values[li] + lower_values[ri] + values[M + i]
+            max_values[i + M] = max(abs(values[M + i]) / len(groups[M + i]), max_values[li], max_values[ri])
+
         # compute the upper_values
         upper_values = np.zeros(len(values))
+
         def lower_credit(upper_values, clustering, i, value=0):
             if i < M:
                 upper_values[i] = value
                 return
-            li = int(clustering[i-M,0])
-            ri = int(clustering[i-M,1])
+            li = int(clustering[i - M, 0])
+            ri = int(clustering[i - M, 1])
             upper_values[i] = value
             value += values[i]
-#             lower_credit(upper_values, clustering, li, value * len(groups[li]) / (len(groups[li]) + len(groups[ri])))
-#             lower_credit(upper_values, clustering, ri, value * len(groups[ri]) / (len(groups[li]) + len(groups[ri])))
+            #             lower_credit(upper_values, clustering, li, value * len(groups[li]) / (len(groups[li]) + len(groups[ri])))
+            #             lower_credit(upper_values, clustering, ri, value * len(groups[ri]) / (len(groups[li]) + len(groups[ri])))
             lower_credit(upper_values, clustering, li, value * 0.5)
             lower_credit(upper_values, clustering, ri, value * 0.5)
 
         lower_credit(upper_values, clustering, len(values) - 1)
-        
+
         # the group_values comes from the dividends above them and below them
         group_values = lower_values + upper_values
 
@@ -189,50 +187,52 @@ def process_shap_values(shap_values, group_threshold, separator):
         new_tokens = []
         new_values = []
         group_sizes = []
+
         def merge_tokens(new_tokens, new_values, group_sizes, i):
-            
+
             # return at the leaves
-            if i < M and i >= 0:
+            if M > i >= 0:
                 new_tokens.append(tokens[i])
                 new_values.append(group_values[i])
                 group_sizes.append(1)
             else:
 
                 # compute the dividend at internal nodes
-                li = int(clustering[i-M,0])
-                ri = int(clustering[i-M,1])
+                li = int(clustering[i - M, 0])
+                ri = int(clustering[i - M, 1])
                 dv = abs(values[i]) / len(groups[i])
-                
+
                 # if the interaction level is too high then just treat this whole group as one token
                 if dv > group_threshold * max(max_values[li], max_values[ri]):
-                    new_tokens.append(separator.join([tokens[g] for g in groups[li]]) + separator + separator.join([tokens[g] for g in groups[ri]]))
+                    new_tokens.append(separator.join([tokens[g] for g in groups[li]]) + separator + separator.join(
+                        [tokens[g] for g in groups[ri]]))
                     new_values.append(group_values[i])
                     group_sizes.append(len(groups[i]))
                 # if interaction level is not too high we recurse
                 else:
                     merge_tokens(new_tokens, new_values, group_sizes, li)
                     merge_tokens(new_tokens, new_values, group_sizes, ri)
+
         merge_tokens(new_tokens, new_values, group_sizes, len(group_values) - 1)
-        
+
         # replance the incoming parameters with the grouped versions
         tokens = np.array(new_tokens)
         values = np.array(new_values)
         group_sizes = np.array(group_sizes)
-        M = len(tokens) 
+        M = len(tokens)
     else:
         group_sizes = np.ones(M)
 
     return tokens, values, group_sizes
 
-def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
-    
 
+def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
     def xpos(xval):
-        return 100 * (xval - xmin)  / (xmax - xmin)
+        return 100 * (xval - xmin) / (xmax - xmin)
 
     s = ''
     s += '<svg width="100%" height="80px">'
-    
+
     ### x-axis marks ###
 
     # draw x axis line
@@ -241,37 +241,41 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
     # draw base value
     def draw_tick_mark(xval, label=None, bold=False):
         s = ""
-        s += '<line x1="%f%%" y1="33" x2="%f%%" y2="37" style="stroke:rgb(150,150,150);stroke-width:1" />' % ((xpos(xval),) * 2)
+        s += '<line x1="%f%%" y1="33" x2="%f%%" y2="37" style="stroke:rgb(150,150,150);stroke-width:1" />' % (
+                    (xpos(xval),) * 2)
         if not bold:
-            s += '<text x="%f%%" y="27" font-size="12px" fill="rgb(120,120,120)" dominant-baseline="bottom" text-anchor="middle">%f</text>' % (xpos(xval),xval)
+            s += '<text x="%f%%" y="27" font-size="12px" fill="rgb(120,120,120)" dominant-baseline="bottom" text-anchor="middle">%f</text>' % (
+            xpos(xval), xval)
         else:
-            s += '<text x="%f%%" y="27" font-size="13px" style="stroke:#ffffff;stroke-width:8px;" font-weight="bold" fill="rgb(255,255,255)" dominant-baseline="bottom" text-anchor="middle">%f</text>' % (xpos(xval),xval)
-            s += '<text x="%f%%" y="27" font-size="13px" font-weight="bold" fill="rgb(0,0,0)" dominant-baseline="bottom" text-anchor="middle">%f</text>' % (xpos(xval),xval)
+            s += '<text x="%f%%" y="27" font-size="13px" style="stroke:#ffffff;stroke-width:8px;" font-weight="bold" fill="rgb(255,255,255)" dominant-baseline="bottom" text-anchor="middle">%f</text>' % (
+            xpos(xval), xval)
+            s += '<text x="%f%%" y="27" font-size="13px" font-weight="bold" fill="rgb(0,0,0)" dominant-baseline="bottom" text-anchor="middle">%f</text>' % (
+            xpos(xval), xval)
         if label is not None:
-            s += '<text x="%f%%" y="10" font-size="12px" fill="rgb(120,120,120)" dominant-baseline="bottom" text-anchor="middle">%s</text>' % (xpos(xval), label)
+            s += '<text x="%f%%" y="10" font-size="12px" fill="rgb(120,120,120)" dominant-baseline="bottom" text-anchor="middle">%s</text>' % (
+            xpos(xval), label)
         return s
 
     s += draw_tick_mark(base_values, label="base value")
     tick_interval = (xmax - xmin) / 7
     side_buffer = (xmax - xmin) / 14
-    for i in range(1,10):
+    for i in range(1, 10):
         pos = base_values - i * tick_interval
         if pos < xmin + side_buffer:
             break
         s += draw_tick_mark(pos)
-    for i in range(1,10):
+    for i in range(1, 10):
         pos = base_values + i * tick_interval
         if pos > xmax - side_buffer:
             break
         s += draw_tick_mark(pos)
     s += draw_tick_mark(fx, bold=True, label="f(x)")
-    
-    
+
     ### Positive value marks ###
-    
+
     red = tuple(colors.red_rgb * 255)
     light_red = (255, 195, 213)
-    
+
     # draw base red bar
     x = fx - values[values > 0].sum()
     w = 100 * values[values > 0].sum() / (xmax - xmin)
@@ -281,52 +285,52 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
     pos = fx
     last_pos = pos
     inds = [i for i in np.argsort(-np.abs(values)) if values[i] > 0]
-    for i,ind in enumerate(inds):
+    for i, ind in enumerate(inds):
         v = values[ind]
         pos -= v
-        
+
         # a line under the bar to animate
         s += f'<line x1="{xpos(pos)}%" x2="{xpos(last_pos)}%" y1="60" y2="60" id="_fb_{uuid}_ind_{ind}" style="stroke:rgb{red};stroke-width:2; opacity: 0"/>'
-        
+
         # the text label cropped and centered
-        s += f'<text x="{(xpos(last_pos) + xpos(pos))/2}%" y="71" font-size="12px" id="_fs_{uuid}_ind_{ind}" fill="rgb{red}" style="opacity: 0" dominant-baseline="middle" text-anchor="middle">{values[ind].round(3)}</text>'
-        
+        s += f'<text x="{(xpos(last_pos) + xpos(pos)) / 2}%" y="71" font-size="12px" id="_fs_{uuid}_ind_{ind}" fill="rgb{red}" style="opacity: 0" dominant-baseline="middle" text-anchor="middle">{values[ind].round(3)}</text>'
+
         # the text label cropped and centered
         s += f'<svg x="{xpos(pos)}%" y="40" height="20" width="{xpos(last_pos) - xpos(pos)}%">'
         s += f'  <svg x="0" y="0" width="100%" height="100%">'
         s += f'    <text x="50%" y="9" font-size="12px" fill="rgb(255,255,255)" dominant-baseline="middle" text-anchor="middle">{tokens[ind].strip()}</text>'
         s += f'  </svg>'
         s += f'</svg>'
-        
+
         last_pos = pos
-    
+
     # draw the divider padding (which covers the text near the dividers)
     pos = fx
-    for i,ind in enumerate(inds):
+    for i, ind in enumerate(inds):
         v = values[ind]
         pos -= v
-        
+
         if i != 0:
             for j in range(4):
-                s += f'<g transform="translate({2*j-8},0)">'
+                s += f'<g transform="translate({2 * j - 8},0)">'
                 s += f'  <svg x="{xpos(last_pos)}%" y="40" height="18" overflow="visible" width="30">'
                 s += f'    <path d="M 0 -9 l 6 18 L 0 25" fill="none" style="stroke:rgb{red};stroke-width:2" />'
                 s += f'  </svg>'
                 s += f'</g>'
-            
+
         if i + 1 != len(inds):
             for j in range(4):
-                s += f'<g transform="translate({2*j-0},0)">'
+                s += f'<g transform="translate({2 * j - 0},0)">'
                 s += f'  <svg x="{xpos(pos)}%" y="40" height="18" overflow="visible" width="30">'
                 s += f'    <path d="M 0 -9 l 6 18 L 0 25" fill="none" style="stroke:rgb{red};stroke-width:2" />'
                 s += f'  </svg>'
                 s += f'</g>'
-        
+
         last_pos = pos
-    
+
     # center padding
     s += f'<rect transform="translate(-8,0)" x="{xpos(fx)}%" y="40" width="8" height="18" style="fill:rgb{red}"/>'
-        
+
     # cover up a notch at the end of the red bar
     pos = fx - values[values > 0].sum()
     s += f'<g transform="translate(-11.5,0)">'
@@ -335,14 +339,13 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
     s += f'  </svg>'
     s += f'</g>'
 
-
     # draw the light red divider lines and a rect to handle mouseover events
     pos = fx
     last_pos = pos
-    for i,ind in enumerate(inds):
+    for i, ind in enumerate(inds):
         v = values[ind]
         pos -= v
-        
+
         # divider line
         if i + 1 != len(inds):
             s += f'<g transform="translate(-1.5,0)">'
@@ -350,7 +353,7 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
             s += f'    <path d="M 0 -9 l 6 18 L 0 25" fill="none" style="stroke:rgb{light_red};stroke-width:2" />'
             s += f'  </svg>'
             s += f'</g>'
-        
+
         # mouse over rectangle
         s += f'<rect x="{xpos(pos)}%" y="40" height="20" width="{xpos(last_pos) - xpos(pos)}%"'
         s += f'      onmouseover="'
@@ -363,15 +366,14 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
         s += f'document.getElementById(\'_fs_{uuid}_ind_{ind}\').style.opacity = 0;'
         s += f'document.getElementById(\'_fb_{uuid}_ind_{ind}\').style.opacity = 0;'
         s += f'" style="fill:rgb(0,0,0,0)" />'
-        
+
         last_pos = pos
-        
-    
+
     ### Negative value marks ###
-    
+
     blue = tuple(colors.blue_rgb * 255)
     light_blue = (208, 230, 250)
-    
+
     # draw base blue bar
     w = 100 * -values[values < 0].sum() / (xmax - xmin)
     s += f'<rect x="{xpos(fx)}%" width="{w}%" y="40" height="18" style="fill:rgb{blue}; stroke-width:0; stroke:rgb(0,0,0)" />'
@@ -380,52 +382,52 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
     pos = fx
     last_pos = pos
     inds = [i for i in np.argsort(-np.abs(values)) if values[i] < 0]
-    for i,ind in enumerate(inds):
+    for i, ind in enumerate(inds):
         v = values[ind]
         pos -= v
-        
+
         # a line under the bar to animate
         s += f'<line x1="{xpos(last_pos)}%" x2="{xpos(pos)}%" y1="60" y2="60" id="_fb_{uuid}_ind_{ind}" style="stroke:rgb{blue};stroke-width:2; opacity: 0"/>'
-        
+
         # the value text
-        s += f'<text x="{(xpos(last_pos) + xpos(pos))/2}%" y="71" font-size="12px" fill="rgb{blue}" id="_fs_{uuid}_ind_{ind}" style="opacity: 0" dominant-baseline="middle" text-anchor="middle">{values[ind].round(3)}</text>'
-        
+        s += f'<text x="{(xpos(last_pos) + xpos(pos)) / 2}%" y="71" font-size="12px" fill="rgb{blue}" id="_fs_{uuid}_ind_{ind}" style="opacity: 0" dominant-baseline="middle" text-anchor="middle">{values[ind].round(3)}</text>'
+
         # the text label cropped and centered
         s += f'<svg x="{xpos(last_pos)}%" y="40" height="20" width="{xpos(pos) - xpos(last_pos)}%">'
         s += f'  <svg x="0" y="0" width="100%" height="100%">'
         s += f'    <text x="50%" y="9" font-size="12px" fill="rgb(255,255,255)" dominant-baseline="middle" text-anchor="middle">{tokens[ind].strip()}</text>'
         s += f'  </svg>'
         s += f'</svg>'
-        
+
         last_pos = pos
-    
+
     # draw the divider padding (which covers the text near the dividers)
     pos = fx
-    for i,ind in enumerate(inds):
+    for i, ind in enumerate(inds):
         v = values[ind]
         pos -= v
-        
+
         if i != 0:
             for j in range(4):
-                s += f'<g transform="translate({-2*j+2},0)">'
+                s += f'<g transform="translate({-2 * j + 2},0)">'
                 s += f'  <svg x="{xpos(last_pos)}%" y="40" height="18" overflow="visible" width="30">'
                 s += f'    <path d="M 8 -9 l -6 18 L 8 25" fill="none" style="stroke:rgb{blue};stroke-width:2" />'
                 s += f'  </svg>'
                 s += f'</g>'
-            
+
         if i + 1 != len(inds):
             for j in range(4):
-                s += f'<g transform="translate(-{2*j+8},0)">'
+                s += f'<g transform="translate(-{2 * j + 8},0)">'
                 s += f'  <svg x="{xpos(pos)}%" y="40" height="18" overflow="visible" width="30">'
                 s += f'    <path d="M 8 -9 l -6 18 L 8 25" fill="none" style="stroke:rgb{blue};stroke-width:2" />'
                 s += f'  </svg>'
                 s += f'</g>'
-        
+
         last_pos = pos
-    
+
     # center padding
     s += f'<rect transform="translate(0,0)" x="{xpos(fx)}%" y="40" width="8" height="18" style="fill:rgb{blue}"/>'
-    
+
     # cover up a notch at the end of the blue bar
     pos = fx - values[values < 0].sum()
     s += f'<g transform="translate(-6.0,0)">'
@@ -437,7 +439,7 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
     # draw the light blue divider lines and a rect to handle mouseover events
     pos = fx
     last_pos = pos
-    for i,ind in enumerate(inds):
+    for i, ind in enumerate(inds):
         v = values[ind]
         pos -= v
 
@@ -448,7 +450,7 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
             s += f'    <path d="M 8 -9 l -6 18 L 8 25" fill="none" style="stroke:rgb{light_blue};stroke-width:2" />'
             s += f'  </svg>'
             s += f'</g>'
-            
+
         # mouse over rectangle
         s += f'<rect x="{xpos(last_pos)}%" y="40" height="20" width="{xpos(pos) - xpos(last_pos)}%"'
         s += f'      onmouseover="'
@@ -461,11 +463,11 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax):
         s += f'document.getElementById(\'_fs_{uuid}_ind_{ind}\').style.opacity = 0;'
         s += f'document.getElementById(\'_fb_{uuid}_ind_{ind}\').style.opacity = 0;'
         s += f'" style="fill:rgb(0,0,0,0)" />'
-        
+
         last_pos = pos
 
     s += '</svg>'
-    
+
     return s
 
 
@@ -475,18 +477,18 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
     The output is interactive HTML and you can click on any token to toggle the display of the
     SHAP value assigned to that token.
     """
-    
+
     # See if we got hierarchical input data. If we did then we need to reprocess the 
     # shap_values and tokens to get the groups we want to display
     M = len(tokens)
     if len(shap_values) != M:
-        
+
         # make sure we were given a partition tree
         if partition_tree is None:
-            raise ValueError("The length of the attribution values must match the number of " + \
-                             "tokens if partition_tree is None! When passing hierarchical " + \
+            raise ValueError("The length of the attribution values must match the number of "
+                             "tokens if partition_tree is None! When passing hierarchical "
                              "attributions the partition_tree is also required.")
-        
+
         # compute the groups, lower_values, and max_values
         groups = [[i] for i in range(M)]
         lower_values = np.zeros(len(shap_values))
@@ -494,29 +496,30 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
         max_values = np.zeros(len(shap_values))
         max_values[:M] = np.abs(shap_values[:M])
         for i in range(partition_tree.shape[0]):
-            li = partition_tree[i,0]
-            ri = partition_tree[i,1]
+            li = partition_tree[i, 0]
+            ri = partition_tree[i, 1]
             groups.append(groups[li] + groups[ri])
-            lower_values[M+i] = lower_values[li] + lower_values[ri] + shap_values[M+i]
-            max_values[i+M] = max(abs(shap_values[M+i]) / len(groups[M+i]), max_values[li], max_values[ri])
-    
+            lower_values[M + i] = lower_values[li] + lower_values[ri] + shap_values[M + i]
+            max_values[i + M] = max(abs(shap_values[M + i]) / len(groups[M + i]), max_values[li], max_values[ri])
+
         # compute the upper_values
         upper_values = np.zeros(len(shap_values))
+
         def lower_credit(upper_values, partition_tree, i, value=0):
             if i < M:
                 upper_values[i] = value
                 return
-            li = partition_tree[i-M,0]
-            ri = partition_tree[i-M,1]
+            li = partition_tree[i - M, 0]
+            ri = partition_tree[i - M, 1]
             upper_values[i] = value
             value += shap_values[i]
-#             lower_credit(upper_values, partition_tree, li, value * len(groups[li]) / (len(groups[li]) + len(groups[ri])))
-#             lower_credit(upper_values, partition_tree, ri, value * len(groups[ri]) / (len(groups[li]) + len(groups[ri])))
+            #             lower_credit(upper_values, partition_tree, li, value * len(groups[li]) / (len(groups[li]) + len(groups[ri])))
+            #             lower_credit(upper_values, partition_tree, ri, value * len(groups[ri]) / (len(groups[li]) + len(groups[ri])))
             lower_credit(upper_values, partition_tree, li, value * 0.5)
             lower_credit(upper_values, partition_tree, ri, value * 0.5)
 
         lower_credit(upper_values, partition_tree, len(shap_values) - 1)
-        
+
         # the group_values comes from the dividends above them and below them
         group_values = lower_values + upper_values
 
@@ -524,8 +527,9 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
         new_tokens = []
         new_shap_values = []
         group_sizes = []
+
         def merge_tokens(new_tokens, new_values, group_sizes, i):
-            
+
             # return at the leaves
             if i < M and i >= 0:
                 new_tokens.append(tokens[i])
@@ -534,29 +538,31 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
             else:
 
                 # compute the dividend at internal nodes
-                li = partition_tree[i-M,0]
-                ri = partition_tree[i-M,1]
+                li = partition_tree[i - M, 0]
+                ri = partition_tree[i - M, 1]
                 dv = abs(shap_values[i]) / len(groups[i])
-                
+
                 # if the interaction level is too high then just treat this whole group as one token
                 if dv > group_threshold * max(max_values[li], max_values[ri]):
-                    new_tokens.append(separator.join([tokens[g] for g in groups[li]]) + separator + separator.join([tokens[g] for g in groups[ri]]))
+                    new_tokens.append(separator.join([tokens[g] for g in groups[li]]) + separator + separator.join(
+                        [tokens[g] for g in groups[ri]]))
                     new_values.append(group_values[i] / len(groups[i]))
                     group_sizes.append(len(groups[i]))
                 # if interaction level is not too high we recurse
                 else:
                     merge_tokens(new_tokens, new_values, group_sizes, li)
                     merge_tokens(new_tokens, new_values, group_sizes, ri)
+
         merge_tokens(new_tokens, new_shap_values, group_sizes, len(group_values) - 1)
-        
+
         # replance the incoming parameters with the grouped versions
         tokens = np.array(new_tokens)
         shap_values = np.array(new_shap_values)
         group_sizes = np.array(group_sizes)
-        M = len(tokens) 
+        M = len(tokens)
     else:
         group_sizes = np.ones(M)
-    
+
     # build out HTML output one word one at a time
     top_inds = np.argsort(-np.abs(shap_values))[:num_starting_labels]
     maxv = shap_values.max()
@@ -565,54 +571,54 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
     for i in range(M):
         scaled_value = 0.5 + 0.5 * shap_values[i] / max(abs(maxv), abs(minv))
         color = colors.red_transparent_blue(scaled_value)
-        color = (color[0]*255, color[1]*255, color[2]*255, color[3])
-        
+        color = (color[0] * 255, color[1] * 255, color[2] * 255, color[3])
+
         # display the labels for the most important words
         label_display = "none"
         wrapper_display = "inline"
         if i in top_inds:
             label_display = "block"
             wrapper_display = "inline-block"
-        
+
         # create the value_label string
         value_label = ""
         if group_sizes[i] == 1:
             value_label = str(shap_values[i].round(3))
         else:
             value_label = str((shap_values[i] * group_sizes[i]).round(3)) + " / " + str(group_sizes[i])
-        
+
         # the HTML for this token
         out += "<div style='display: " + wrapper_display + "; text-align: center;'>" \
-             + "<div style='display: " + label_display + "; color: #999; padding-top: 0px; font-size: 12px;'>" \
-             + value_label \
-             + "</div>" \
-             + "<div " \
-             +   "style='display: inline; background: rgba" + str(color) + "; border-radius: 3px; padding: 0px'" \
-             +   "onclick=\"if (this.previousSibling.style.display == 'none') {" \
-             +       "this.previousSibling.style.display = 'block';" \
-             +       "this.parentNode.style.display = 'inline-block';" \
-             +     "} else {" \
-             +       "this.previousSibling.style.display = 'none';" \
-             +       "this.parentNode.style.display = 'inline';" \
-             +     "}" \
-             +   "\"" \
-             + ">" \
-             + tokens[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '') \
-             + "</div>" \
-             + "</div>"
+               + "<div style='display: " + label_display + "; color: #999; padding-top: 0px; font-size: 12px;'>" \
+               + value_label \
+               + "</div>" \
+               + "<div " \
+               + "style='display: inline; background: rgba" + str(color) + "; border-radius: 3px; padding: 0px'" \
+               + "onclick=\"if (this.previousSibling.style.display == 'none') {" \
+               + "this.previousSibling.style.display = 'block';" \
+               + "this.parentNode.style.display = 'inline-block';" \
+               + "} else {" \
+               + "this.previousSibling.style.display = 'none';" \
+               + "this.parentNode.style.display = 'inline';" \
+               + "}" \
+               + "\"" \
+               + ">" \
+               + tokens[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '') \
+               + "</div>" \
+               + "</div>"
 
     from IPython.core.display import display, HTML
     return display(HTML(out))
 
-def text_to_text(shap_values):                
-    
+
+def text_to_text(shap_values):
     from IPython.core.display import display, HTML
     # unique ID added to HTML elements and function to avoid collision of differnent instances
     uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
-    
+
     saliency_plot_markup = saliency_plot(shap_values)
     heatmap_markup = heatmap(shap_values)
-    
+
     html = f"""
     <html>
     <div id="{uuid}_viz_container">
@@ -636,7 +642,6 @@ def text_to_text(shap_values):
     </html>
     """
 
-
     javascript = f"""
     <script>
         function selectVizType_{uuid}(selectObject) {{
@@ -658,53 +663,55 @@ def text_to_text(shap_values):
         }}
     </script>
     """
-    
+
     display(HTML(javascript + html))
 
+
 def saliency_plot(shap_values):
-    
     uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
-    
+
     # generate background colors of saliency plot
-    
+
     def get_colors(shap_values):
         input_colors = []
         for row_index in range(shap_values.values.shape[0]):
             input_colors_row = []
             for col_index in range(shap_values.values.shape[1]):
-                cmax = max(abs(shap_values.values[:,col_index].min()), abs(shap_values.values[:,col_index].max()))
-                scaled_value = 0.5 + 0.5 * shap_values.values[row_index,col_index] / cmax
+                cmax = max(abs(shap_values.values[:, col_index].min()), abs(shap_values.values[:, col_index].max()))
+                scaled_value = 0.5 + 0.5 * shap_values.values[row_index, col_index] / cmax
                 color = colors.red_transparent_blue(scaled_value)
-                color = 'rgba'+str((color[0]*255, color[1]*255, color[2]*255, color[3]))
+                color = 'rgba' + str((color[0] * 255, color[1] * 255, color[2] * 255, color[3]))
                 input_colors_row.append(color)
             input_colors.append(input_colors_row)
-        
+
         return input_colors
-    
-    
+
     model_input = shap_values.data
     model_output = shap_values.output_names
-    
+
     input_colors = get_colors(shap_values)
-    
+
     out = '<table border = "1" cellpadding = "5" cellspacing = "5" style="overflow-x:scroll;display:block;">'
-    
+
     # add top row containing input tokens
     out += '<tr>'
     out += '<th></th>'
     for j in range(model_input.shape[0]):
-        out += '<th>' + model_input[j].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁', '') + '</th>'
+        out += '<th>' + model_input[j].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁',
+                                                                                                            '') + '</th>'
     out += '</tr>'
-    
+
     for row_index in range(model_output.shape[0]):
         out += '<tr>'
-        out += '<th>' + model_output[row_index].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁', '') + '</th>'
+        out += '<th>' + model_output[row_index].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace(
+            '▁', '') + '</th>'
         for col_index in range(model_input.shape[0]):
-            out += '<th style="background:' + input_colors[col_index][row_index]+ '">' + str(round(shap_values.values[col_index][row_index],3)) + '</th>'
+            out += '<th style="background:' + input_colors[col_index][row_index] + '">' + str(
+                round(shap_values.values[col_index][row_index], 3)) + '</th>'
         out += '</tr>'
-            
+
     out += '</table>'
-            
+
     saliency_plot_html = f"""
         <div id="{uuid}_saliency_plot" class="{uuid}_viz_content">
             <div style="margin:5px;font-family:sans-serif;font-weight:bold;">
@@ -719,101 +726,102 @@ def saliency_plot(shap_values):
     """
     return saliency_plot_html
 
+
 def heatmap(shap_values):
-    
     uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
-    
-    def get_color(shap_value,cmax):
+
+    def get_color(shap_value, cmax):
         scaled_value = 0.5 + 0.5 * shap_value / cmax
         color = colors.red_transparent_blue(scaled_value)
-        color = (color[0]*255, color[1]*255, color[2]*255, color[3])
+        color = (color[0] * 255, color[1] * 255, color[2] * 255, color[3])
         return color
-    
-    
+
     # unpack input tokens and output tokens
     model_input = shap_values.data
     model_output = shap_values.output_names
-    
+
     # generate dictionary containing precomputed backgroud colors and shap values which are addresable by html token ids
     colors_dict = {}
     shap_values_dict = {}
-    
+
     for col_index in range(model_output.shape[0]):
         color_values = {}
-        cmax = max(abs(shap_values.values[:,col_index].min()), abs(shap_values.values[:,col_index].max()))
+        cmax = max(abs(shap_values.values[:, col_index].min()), abs(shap_values.values[:, col_index].max()))
         for row_index in range(model_input.shape[0]):
-            color_values[uuid+'_flat_token_input_'+str(row_index)] = 'rgba' + str(get_color(shap_values.values[row_index][col_index],cmax))
-        colors_dict[uuid+'_flat_token_output_'+str(col_index)] = color_values
-    
-    
+            color_values[uuid + '_flat_token_input_' + str(row_index)] = 'rgba' + str(
+                get_color(shap_values.values[row_index][col_index], cmax))
+        colors_dict[uuid + '_flat_token_output_' + str(col_index)] = color_values
+
     for row_index in range(model_input.shape[0]):
         color_values = {}
-        cmax = max(abs(shap_values.values[row_index,:].min()), abs(shap_values.values[row_index,:].max()))
+        cmax = max(abs(shap_values.values[row_index, :].min()), abs(shap_values.values[row_index, :].max()))
         for col_index in range(model_output.shape[0]):
-            color_values[uuid+'_flat_token_output_'+str(col_index)] = 'rgba' + str(get_color(shap_values.values[row_index][col_index],cmax))
-        colors_dict[uuid+'_flat_token_input_'+str(row_index)] = color_values
-        
+            color_values[uuid + '_flat_token_output_' + str(col_index)] = 'rgba' + str(
+                get_color(shap_values.values[row_index][col_index], cmax))
+        colors_dict[uuid + '_flat_token_input_' + str(row_index)] = color_values
+
     for col_index in range(model_output.shape[0]):
         shap_values_list = {}
         for row_index in range(model_input.shape[0]):
-            shap_values_list[uuid+'_flat_value_label_input_'+str(row_index)] = shap_values.values[row_index][col_index]
-        shap_values_dict[uuid+'_flat_token_output_'+str(col_index)] = shap_values_list
-    
+            shap_values_list[uuid + '_flat_value_label_input_' + str(row_index)] = shap_values.values[row_index][
+                col_index]
+        shap_values_dict[uuid + '_flat_token_output_' + str(col_index)] = shap_values_list
+
     for row_index in range(model_input.shape[0]):
         shap_values_list = {}
         for col_index in range(model_output.shape[0]):
-            shap_values_list[uuid+'_flat_value_label_output_'+str(col_index)] = shap_values.values[row_index][col_index]
-        shap_values_dict[uuid+'_flat_token_input_'+str(row_index)] = shap_values_list
-    
+            shap_values_list[uuid + '_flat_value_label_output_' + str(col_index)] = shap_values.values[row_index][
+                col_index]
+        shap_values_dict[uuid + '_flat_token_input_' + str(row_index)] = shap_values_list
+
     # convert python disctionary into json to be inserted into the runtime javascript environment
     colors_json = json.dumps(colors_dict)
     shap_values_json = json.dumps(shap_values_dict)
-    
-    
+
     javascript_values = "<script> " \
-            + f"colors_{uuid} = " + colors_json + "\n" \
-            + f" shap_values_{uuid} = " + shap_values_json + "\n"\
-            +  "</script> \n "
-    
-    
+                        + f"colors_{uuid} = " + colors_json + "\n" \
+                        + f" shap_values_{uuid} = " + shap_values_json + "\n" \
+                        + "</script> \n "
+
     # generates the input token html elements
     # each element contains the label value (initially hidden) and the token text
     input_text_html = ''
 
     for i in range(model_input.shape[0]):
         input_text_html += "<div style='display:inline; text-align:center;'>" \
-                + f"<div id='{uuid}_flat_value_label_input_"+ str(i) +"'" \
-                + "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>" \
-                + "</div>" \
-                + f"<div id='{uuid}_flat_token_input_"+ str(i) +"'" \
-                + "style='display: inline; background:white; border-radius: 3px; padding: 0px;cursor: default;'" \
-                + f"onmouseover=\"onMouseHoverFlat_{uuid}(this.id)\" " \
-                + f"onmouseout=\"onMouseOutFlat_{uuid}(this.id)\" " \
-                + f"onclick=\"onMouseClickFlat_{uuid}(this.id)\" " \
-                + ">" \
-                + model_input[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁', '') \
-                + " </div>" \
-                + "</div>"
-        
-        
+                           + f"<div id='{uuid}_flat_value_label_input_" + str(i) + "'" \
+                           + "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>" \
+                           + "</div>" \
+                           + f"<div id='{uuid}_flat_token_input_" + str(i) + "'" \
+                           + "style='display: inline; background:white; border-radius: 3px; padding: 0px;cursor: default;'" \
+                           + f"onmouseover=\"onMouseHoverFlat_{uuid}(this.id)\" " \
+                           + f"onmouseout=\"onMouseOutFlat_{uuid}(this.id)\" " \
+                           + f"onclick=\"onMouseClickFlat_{uuid}(this.id)\" " \
+                           + ">" \
+                           + model_input[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁',
+                                                                                                                 '') \
+                           + " </div>" \
+                           + "</div>"
+
     # generates the output token html elements
     output_text_html = ''
 
     for i in range(model_output.shape[0]):
         output_text_html += "<div style='display:inline; text-align:center;'>" \
-                + f"<div id='{uuid}_flat_value_label_output_"+ str(i) +"'" \
-                + "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>" \
-                + "</div>" \
-                + f"<div id='{uuid}_flat_token_output_"+ str(i) +"'" \
-                + "style='display: inline; background:white; border-radius: 3px; padding: 0px;cursor: default;'" \
-                + f"onmouseover=\"onMouseHoverFlat_{uuid}(this.id)\" " \
-                + f"onmouseout=\"onMouseOutFlat_{uuid}(this.id)\" " \
-                + f"onclick=\"onMouseClickFlat_{uuid}(this.id)\" " \
-                + ">" \
-                + model_output[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁', '') \
-                + " </div>" \
-                + "</div>"
-    
+                            + f"<div id='{uuid}_flat_value_label_output_" + str(i) + "'" \
+                            + "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>" \
+                            + "</div>" \
+                            + f"<div id='{uuid}_flat_token_output_" + str(i) + "'" \
+                            + "style='display: inline; background:white; border-radius: 3px; padding: 0px;cursor: default;'" \
+                            + f"onmouseover=\"onMouseHoverFlat_{uuid}(this.id)\" " \
+                            + f"onmouseout=\"onMouseOutFlat_{uuid}(this.id)\" " \
+                            + f"onclick=\"onMouseClickFlat_{uuid}(this.id)\" " \
+                            + ">" \
+                            + model_output[i].replace("<", "&lt;").replace(">", "&gt;").replace(' ##', '').replace('▁',
+                                                                                                                   '') \
+                            + " </div>" \
+                            + "</div>"
+
     heatmap_html = f"""
         <div id="{uuid}_heatmap" class="{uuid}_viz_content">
           <div id="{uuid}_heatmap_header" style="padding:15px;margin:5px;font-family:sans-serif;font-weight:bold;">
@@ -848,7 +856,7 @@ def heatmap(shap_values):
           </div>
         </div>
     """
-    
+
     heatmap_javascript = f"""
         <script>
             function selectAlignment_{uuid}(selectObject) {{
@@ -945,5 +953,5 @@ def heatmap(shap_values):
             }}
         </script>
     """
-    
+
     return heatmap_html + heatmap_javascript + javascript_values

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -9,13 +9,14 @@ def convert_color(color):
         color = pl.get_cmap(color)
     except:
         pass
-    
+
     if color == "shap_red":
         color = colors.red_rgb
     elif color == "shap_blue":
         color = colors.blue_rgb
-    
+
     return color
+
 
 def convert_ordering(ordering, shap_values):
     if issubclass(type(ordering), OpChain):
@@ -31,49 +32,46 @@ def convert_ordering(ordering, shap_values):
 def get_sort_order(dist, clust_order, cluster_threshold, feature_order):
     """ Returns a sorted order of the values where we respect the clustering order when dist[i,j] < cluster_threshold
     """
-    
-    #feature_imp = np.abs(values)
+
+    # feature_imp = np.abs(values)
 
     # if partition_tree is not None:
     #     new_tree = fill_internal_max_values(partition_tree, shap_values)
     #     clust_order = sort_inds(new_tree, np.abs(shap_values))
     clust_inds = np.argsort(clust_order)
 
-    feature_order = feature_order.copy()#order.apply(Explanation(shap_values))
+    feature_order = feature_order.copy()  # order.apply(Explanation(shap_values))
     # print("feature_order", feature_order)
-    for i in range(len(feature_order)-1):
+    for i in range(len(feature_order) - 1):
         ind1 = feature_order[i]
-        next_ind = feature_order[i+1]
+        next_ind = feature_order[i + 1]
         next_ind_pos = i + 1
-        for j in range(i+1,len(feature_order)):
+        for j in range(i + 1, len(feature_order)):
             ind2 = feature_order[j]
 
-            
-            
-            #if feature_imp[ind] > 
+            # if feature_imp[ind] >
             # if ind1 == 2:
             #     print(ind1, ind2, dist[ind1,ind2])
-            if dist[ind1,ind2] <= cluster_threshold:
-                
+            if dist[ind1, ind2] <= cluster_threshold:
+
                 # if ind1 == 2:
                 #     print(clust_inds)
                 #     print(ind1, ind2, next_ind, dist[ind1,ind2], clust_inds[ind2], clust_inds[next_ind])
-                if dist[ind1,next_ind] > cluster_threshold or clust_inds[ind2] < clust_inds[next_ind]:
+                if dist[ind1, next_ind] > cluster_threshold or clust_inds[ind2] < clust_inds[next_ind]:
                     next_ind = ind2
                     next_ind_pos = j
             # print("next_ind", next_ind)
             # print("next_ind_pos", next_ind_pos)
-        
-        # insert the next_ind next
-        for j in range(next_ind_pos, i+1, -1):
-            #print("j", j)
-            feature_order[j] = feature_order[j-1]
-        feature_order[i+1] = next_ind
-        #print(feature_order)
 
-        
-    
+        # insert the next_ind next
+        for j in range(next_ind_pos, i + 1, -1):
+            # print("j", j)
+            feature_order[j] = feature_order[j - 1]
+        feature_order[i + 1] = next_ind
+        # print(feature_order)
+
     return feature_order
+
 
 def merge_nodes(values, partition_tree):
     """ This merges the two clustered leaf nodes with the smallest total value.
@@ -83,50 +81,50 @@ def merge_nodes(values, partition_tree):
     ptind = 0
     min_val = np.inf
     for i in range(partition_tree.shape[0]):
-        ind1 = int(partition_tree[i,0])
-        ind2 = int(partition_tree[i,1])
+        ind1 = int(partition_tree[i, 0])
+        ind2 = int(partition_tree[i, 1])
         if ind1 < M and ind2 < M:
             val = np.abs(values[ind1]) + np.abs(values[ind2])
             if val < min_val:
                 min_val = val
                 ptind = i
-                #print("ptind", ptind, min_val)
+                # print("ptind", ptind, min_val)
 
-    ind1 = int(partition_tree[ptind,0])
-    ind2 = int(partition_tree[ptind,1])
+    ind1 = int(partition_tree[ptind, 0])
+    ind2 = int(partition_tree[ptind, 1])
     if ind1 > ind2:
         tmp = ind1
         ind1 = ind2
         ind2 = tmp
-    
+
     partition_tree_new = partition_tree.copy()
     for i in range(partition_tree_new.shape[0]):
-        i0 = int(partition_tree_new[i,0])
-        i1 = int(partition_tree_new[i,1])
+        i0 = int(partition_tree_new[i, 0])
+        i1 = int(partition_tree_new[i, 1])
         if i0 == ind2:
-            partition_tree_new[i,0] = ind1
+            partition_tree_new[i, 0] = ind1
         elif i0 > ind2:
-            partition_tree_new[i,0] -= 1
+            partition_tree_new[i, 0] -= 1
             if i0 == ptind + M:
-                partition_tree_new[i,0] = ind1
+                partition_tree_new[i, 0] = ind1
             elif i0 > ptind + M:
-                partition_tree_new[i,0] -= 1
+                partition_tree_new[i, 0] -= 1
 
-            
         if i1 == ind2:
-            partition_tree_new[i,1] = ind1
+            partition_tree_new[i, 1] = ind1
         elif i1 > ind2:
-            partition_tree_new[i,1] -= 1
+            partition_tree_new[i, 1] -= 1
             if i1 == ptind + M:
-                partition_tree_new[i,1] = ind1
+                partition_tree_new[i, 1] = ind1
             elif i1 > ptind + M:
-                partition_tree_new[i,1] -= 1
+                partition_tree_new[i, 1] -= 1
     partition_tree_new = np.delete(partition_tree_new, ptind, axis=0)
 
     # update the counts to be correct
     fill_counts(partition_tree_new)
-    
+
     return partition_tree_new, ind1, ind2
+
 
 def dendrogram_coords(leaf_positions, partition_tree):
     """ Returns the x and y coords of the lines of a dendrogram where the leaf order is given.
@@ -134,30 +132,33 @@ def dendrogram_coords(leaf_positions, partition_tree):
     Note that scipy can compute these coords as well, but it does not allow you to easily specify
     a specific leaf order, hence this reimplementation.
     """
-    
+
     xout = []
     yout = []
-    _dendrogram_coords_rec(partition_tree.shape[0]-1, leaf_positions, partition_tree, xout, yout)
-    
+    _dendrogram_coords_rec(partition_tree.shape[0] - 1, leaf_positions, partition_tree, xout, yout)
+
     return np.array(xout), np.array(yout)
+
+
 def _dendrogram_coords_rec(pos, leaf_positions, partition_tree, xout, yout):
     M = partition_tree.shape[0] + 1
-    
+
     if pos < 0:
         return leaf_positions[pos + M], 0
-    
+
     left = int(partition_tree[pos, 0]) - M
     right = int(partition_tree[pos, 1]) - M
-    
+
     x_left, y_left = _dendrogram_coords_rec(left, leaf_positions, partition_tree, xout, yout)
     x_right, y_right = _dendrogram_coords_rec(right, leaf_positions, partition_tree, xout, yout)
-    
+
     y_curr = partition_tree[pos, 2]
-    
+
     xout.append([x_left, x_left, x_right, x_right])
     yout.append([y_left, y_curr, y_curr, y_right])
-    
+
     return (x_left + x_right) / 2, y_curr
+
 
 def fill_internal_max_values(partition_tree, leaf_values):
     """ This fills the forth column of the partition tree matrix with the max leaf value in that cluster.
@@ -166,20 +167,21 @@ def fill_internal_max_values(partition_tree, leaf_values):
     new_tree = partition_tree.copy()
     for i in range(new_tree.shape[0]):
         val = 0
-        if new_tree[i,0] < M:
-            ind = int(new_tree[i,0])
+        if new_tree[i, 0] < M:
+            ind = int(new_tree[i, 0])
             val = max(val, np.abs(leaf_values[ind]))
         else:
-            ind = int(new_tree[i,0])-M
-            val = max(val, np.abs(new_tree[ind,3])) # / partition_tree[ind,2])
-        if new_tree[i,1] < M:
-            ind = int(new_tree[i,1])
+            ind = int(new_tree[i, 0]) - M
+            val = max(val, np.abs(new_tree[ind, 3]))  # / partition_tree[ind,2])
+        if new_tree[i, 1] < M:
+            ind = int(new_tree[i, 1])
             val = max(val, np.abs(leaf_values[ind]))
         else:
-            ind = int(new_tree[i,1])-M
-            val = max(val, np.abs(new_tree[ind,3])) # / partition_tree[ind,2])
-        new_tree[i,3] = val
+            ind = int(new_tree[i, 1]) - M
+            val = max(val, np.abs(new_tree[ind, 3]))  # / partition_tree[ind,2])
+        new_tree[i, 3] = val
     return new_tree
+
 
 def fill_counts(partition_tree):
     """ This updates the 
@@ -187,47 +189,47 @@ def fill_counts(partition_tree):
     M = partition_tree.shape[0] + 1
     for i in range(partition_tree.shape[0]):
         val = 0
-        if partition_tree[i,0] < M:
-            ind = int(partition_tree[i,0])
+        if partition_tree[i, 0] < M:
+            ind = int(partition_tree[i, 0])
             val += 1
         else:
-            ind = int(partition_tree[i,0])-M
-            val += partition_tree[ind,3]
-        if partition_tree[i,1] < M:
-            ind = int(partition_tree[i,1])
+            ind = int(partition_tree[i, 0]) - M
+            val += partition_tree[ind, 3]
+        if partition_tree[i, 1] < M:
+            ind = int(partition_tree[i, 1])
             val += 1
         else:
-            ind = int(partition_tree[i,1])-M
-            val += partition_tree[ind,3]
-        partition_tree[i,3] = val
+            ind = int(partition_tree[i, 1]) - M
+            val += partition_tree[ind, 3]
+        partition_tree[i, 3] = val
+
 
 def sort_inds(partition_tree, leaf_values, pos=None, inds=None):
     if inds is None:
         inds = []
-    
+
     if pos is None:
         partition_tree = fill_internal_max_values(partition_tree, leaf_values)
-        pos = partition_tree.shape[0]-1
-    
+        pos = partition_tree.shape[0] - 1
+
     M = partition_tree.shape[0] + 1
-        
+
     if pos < 0:
         inds.append(pos + M)
         return
-    
+
     left = int(partition_tree[pos, 0]) - M
     right = int(partition_tree[pos, 1]) - M
-    
-    
-    left_val = partition_tree[left,3] if left >= 0 else leaf_values[left + M]
-    right_val = partition_tree[right,3] if right >= 0 else leaf_values[right + M]
-    
+
+    left_val = partition_tree[left, 3] if left >= 0 else leaf_values[left + M]
+    right_val = partition_tree[right, 3] if right >= 0 else leaf_values[right + M]
+
     if left_val < right_val:
         tmp = right
         right = left
         left = tmp
-    
+
     sort_inds(partition_tree, leaf_values, left, inds)
     sort_inds(partition_tree, leaf_values, right, inds)
-    
+
     return inds

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -6,6 +6,7 @@ from __future__ import division
 import warnings
 import numpy as np
 from scipy.stats import gaussian_kde
+
 try:
     import matplotlib.pyplot as pl
 except ImportError:
@@ -14,17 +15,18 @@ except ImportError:
 from ._labels import labels
 from . import colors
 
+
 # TODO: remove unused title argument / use title argument
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
 def violin(shap_values, features=None, feature_names=None, max_display=None, plot_type="violin",
-                 color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
-                 color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,
-                 class_inds=None,
-                 color_bar_label=labels["FEATURE_VALUE"],
-                 cmap=colors.red_blue,
-                 # depreciated
-                 auto_size_plot=None,
-                 use_log_scale=False):
+           color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
+           color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,
+           class_inds=None,
+           color_bar_label=labels["FEATURE_VALUE"],
+           cmap=colors.red_blue,
+           # depreciated
+           auto_size_plot=None,
+           use_log_scale=False):
     """Create a SHAP beeswarm plot, colored by feature values when they are provided.
 
     Parameters
@@ -75,11 +77,11 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
     if isinstance(shap_values, list):
         multi_class = True
         if plot_type is None:
-            plot_type = "bar" # default for multi-output explanations
+            plot_type = "bar"  # default for multi-output explanations
         assert plot_type == "bar", "Only plot_type = 'bar' is supported for multi-output explanations!"
     else:
         if plot_type is None:
-            plot_type = "dot" # default for single output explanations
+            plot_type = "dot"  # default for single output explanations
         assert len(shap_values.shape) != 1, "Summary plots need a matrix of shap_values, not a vector."
 
     # default color:
@@ -87,7 +89,7 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
         if plot_type == 'layered_violin':
             color = "coolwarm"
         elif multi_class:
-            color = lambda i: colors.red_blue_circle(i/len(shap_values))
+            color = lambda i: colors.red_blue_circle(i / len(shap_values))
         else:
             color = colors.blue_rgb
 
@@ -111,7 +113,7 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
                     "provided data matrix."
         if num_features - 1 == features.shape[1]:
             assert False, shape_msg + " Perhaps the extra column in the shap_values matrix is the " \
-                          "constant offset? Of so just pass shap_values[:,:-1]."
+                                      "constant offset? Of so just pass shap_values[:,:-1]."
         else:
             assert num_features == features.shape[1], shape_msg
 
@@ -134,7 +136,7 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
                     if c1 == c2:
                         new_feature_names.append(c1)
                     else:
-                        new_feature_names.append(c1 + "* - " + c2)
+                        new_feature_names.append("{}* - ".format(c1, c2))
 
             return summary(
                 new_shap_values, new_features, new_feature_names,
@@ -341,7 +343,8 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
                 for i in range(len(xs) - 1):
                     if ds[i] > 0.05 or ds[i + 1] > 0.05:
                         pl.fill_between([xs[i], xs[i + 1]], [pos + ds[i], pos + ds[i + 1]],
-                                        [pos - ds[i], pos - ds[i + 1]], color=colors.red_blue_no_bounds(smooth_values[i]),
+                                        [pos - ds[i], pos - ds[i + 1]],
+                                        color=colors.red_blue_no_bounds(smooth_values[i]),
                                         zorder=2)
 
         else:
@@ -425,7 +428,7 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
 
     elif multi_class and plot_type == "bar":
         if class_names is None:
-            class_names = ["Class "+str(i) for i in range(len(shap_values))]
+            class_names = ["Class {}".format(i) for i in range(len(shap_values))]
         feature_inds = feature_order[:max_display]
         y_pos = np.arange(len(feature_inds))
         left_pos = np.zeros(len(feature_inds))
@@ -479,6 +482,7 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
     if show:
         pl.show()
 
+
 def _trim_crange(values, nan_mask):
     """Trim the color range, but prevent the color range from collapsing."""
     # Get vmin and vmax as 5. and 95. percentiles
@@ -491,7 +495,7 @@ def _trim_crange(values, nan_mask):
             vmin = np.min(values)
             vmax = np.max(values)
 
-    if vmin > vmax: # fixes rare numerical precision issues
+    if vmin > vmax:  # fixes rare numerical precision issues
         vmin = vmax
 
     # Get color values depnding on value range

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -1,5 +1,6 @@
 import numpy as np
 import warnings
+
 try:
     import matplotlib.pyplot as pl
     import matplotlib
@@ -37,10 +38,9 @@ def waterfall(shap_values, max_display=10, show=True):
         Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
         to be customized further after it has been created.
     """
-    
 
     base_values = shap_values.base_values
-    
+
     features = shap_values.data
     feature_names = shap_values.feature_names
     lower_bounds = getattr(shap_values, "lower_bounds", None)
@@ -49,16 +49,17 @@ def waterfall(shap_values, max_display=10, show=True):
 
     # make sure we only have a single output to explain
     if (type(base_values) == np.ndarray and len(base_values) > 0) or type(base_values) == list:
-        raise Exception("waterfall_plot requires a scalar base_values of the model output as the first " \
-                        "parameter, but you have passed an array as the first parameter! " \
-                        "Try shap.waterfall_plot(explainer.base_values[0], values[0], X[0]) or " \
-                        "for multi-output models try " \
+        raise Exception("waterfall_plot requires a scalar base_values of the model output as the first "
+                        "parameter, but you have passed an array as the first parameter! "
+                        "Try shap.waterfall_plot(explainer.base_values[0], values[0], X[0]) or "
+                        "for multi-output models try "
                         "shap.waterfall_plot(explainer.base_values[0], values[0][0], X[0]).")
 
     # make sure we only have a single explanation to plot
     if len(values.shape) == 2:
-        raise Exception("The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
-    
+        raise Exception(
+            "The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
+
     # unwrap pandas series
     if safe_isinstance(features, "pandas.core.series.Series"):
         if feature_names is None:
@@ -68,7 +69,7 @@ def waterfall(shap_values, max_display=10, show=True):
     # fallback feature names
     if feature_names is None:
         feature_names = np.array([labels['FEATURE'] % str(i) for i in range(len(values))])
-    
+
     # init variables we use for tracking the plot locations
     num_features = min(max_display, len(values))
     row_height = 0.5
@@ -85,8 +86,8 @@ def waterfall(shap_values, max_display=10, show=True):
     neg_low = []
     neg_high = []
     loc = base_values + values.sum()
-    yticklabels = ["" for i in range(num_features + 1)]
-    
+    yticklabels = ["" for _ in range(num_features + 1)]
+
     # size the plot based on how many features we are plotting
     pl.gcf().set_size_inches(8, num_features * row_height + 1.5)
 
@@ -115,15 +116,17 @@ def waterfall(shap_values, max_display=10, show=True):
                 neg_high.append(upper_bounds[order[i]])
             neg_lefts.append(loc)
         if num_individual != num_features or i + 4 < num_individual:
-            pl.plot([loc, loc], [rng[i] -1 - 0.4, rng[i] + 0.4], color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
+            pl.plot([loc, loc], [rng[i] - 1 - 0.4, rng[i] + 0.4], color="#bbbbbb", linestyle="--", linewidth=0.5,
+                    zorder=-1)
         if features is None:
             yticklabels[rng[i]] = feature_names[order[i]]
         else:
-            yticklabels[rng[i]] = format_value(features[order[i]], "%0.03f") + " = " + feature_names[order[i]] 
-    
-    # add a last grouped feature to represent the impact of all the features we didn't show
+            yticklabels[rng[i]] = "{} = {}".format(format_value(features[order[i]], "%0.03f"),
+                                                   feature_names[order[i]])
+
+            # add a last grouped feature to represent the impact of all the features we didn't show
     if num_features < len(values):
-        yticklabels[0] = "%d other features" % (len(values) - num_features + 1)
+        yticklabels[0] = "{} other features".format(len(values) - num_features + 1)
         remaining_impact = base_values - loc
         if remaining_impact < 0:
             pos_inds.append(0)
@@ -136,15 +139,18 @@ def waterfall(shap_values, max_display=10, show=True):
             neg_lefts.append(loc + remaining_impact)
             c = colors.blue_rgb
 
-    points = pos_lefts + list(np.array(pos_lefts) + np.array(pos_widths)) + neg_lefts + list(np.array(neg_lefts) + np.array(neg_widths))
+    points = pos_lefts + list(np.array(pos_lefts) + np.array(pos_widths)) + neg_lefts + list(
+        np.array(neg_lefts) + np.array(neg_widths))
     dataw = np.max(points) - np.min(points)
-    
+
     # draw invisible bars just for sizing the axes
-    label_padding = np.array([0.1*dataw if w < 1 else 0 for w in pos_widths])
-    pl.barh(pos_inds, np.array(pos_widths) + label_padding + 0.02*dataw, left=np.array(pos_lefts) - 0.01*dataw, color=colors.red_rgb, alpha=0)
-    label_padding = np.array([-0.1*dataw  if -w < 1 else 0 for w in neg_widths])
-    pl.barh(neg_inds, np.array(neg_widths) + label_padding - 0.02*dataw, left=np.array(neg_lefts) + 0.01*dataw, color=colors.blue_rgb, alpha=0)
-    
+    label_padding = np.array([0.1 * dataw if w < 1 else 0 for w in pos_widths])
+    pl.barh(pos_inds, np.array(pos_widths) + label_padding + 0.02 * dataw, left=np.array(pos_lefts) - 0.01 * dataw,
+            color=colors.red_rgb, alpha=0)
+    label_padding = np.array([-0.1 * dataw if -w < 1 else 0 for w in neg_widths])
+    pl.barh(neg_inds, np.array(neg_widths) + label_padding - 0.02 * dataw, left=np.array(neg_lefts) + 0.01 * dataw,
+            color=colors.blue_rgb, alpha=0)
+
     # define variable we need for plotting the arrows
     head_length = 0.08
     bar_width = 0.8
@@ -154,51 +160,51 @@ def waterfall(shap_values, max_display=10, show=True):
     xticks = ax.get_xticks()
     bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     width, height = bbox.width, bbox.height
-    bbox_to_xscale = xlen/width
+    bbox_to_xscale = xlen / width
     hl_scaled = bbox_to_xscale * head_length
     renderer = fig.canvas.get_renderer()
-    
+
     # draw the positive arrows
     for i in range(len(pos_inds)):
         dist = pos_widths[i]
         arrow_obj = pl.arrow(
-            pos_lefts[i], pos_inds[i], max(dist-hl_scaled, 0.000001), 0,
+            pos_lefts[i], pos_inds[i], max(dist - hl_scaled, 0.000001), 0,
             head_length=min(dist, hl_scaled),
             color=colors.red_rgb, width=bar_width,
             head_width=bar_width
         )
-        
+
         if pos_low is not None and i < len(pos_low):
             pl.errorbar(
-                pos_lefts[i] + pos_widths[i], pos_inds[i], 
+                pos_lefts[i] + pos_widths[i], pos_inds[i],
                 xerr=np.array([[pos_widths[i] - pos_low[i]], [pos_high[i] - pos_widths[i]]]),
                 ecolor=colors.light_red_rgb
             )
 
         txt_obj = pl.text(
-            pos_lefts[i] + 0.5*dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
+            pos_lefts[i] + 0.5 * dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
             horizontalalignment='center', verticalalignment='center', color="white",
             fontsize=12
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
-        
+
         # if the text overflows the arrow then draw it after the arrow
-        if text_bbox.width > arrow_bbox.width: 
+        if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
-            
+
             txt_obj = pl.text(
-                pos_lefts[i] + (5/72)*bbox_to_xscale + dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
+                pos_lefts[i] + (5 / 72) * bbox_to_xscale + dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
                 horizontalalignment='left', verticalalignment='center', color=colors.red_rgb,
                 fontsize=12
             )
-    
+
     # draw the negative arrows
     for i in range(len(neg_inds)):
         dist = neg_widths[i]
-        
+
         arrow_obj = pl.arrow(
-            neg_lefts[i], neg_inds[i], -max(-dist-hl_scaled, 0.000001), 0,
+            neg_lefts[i], neg_inds[i], -max(-dist - hl_scaled, 0.000001), 0,
             head_length=min(-dist, hl_scaled),
             color=colors.blue_rgb, width=bar_width,
             head_width=bar_width
@@ -206,42 +212,43 @@ def waterfall(shap_values, max_display=10, show=True):
 
         if neg_low is not None and i < len(neg_low):
             pl.errorbar(
-                neg_lefts[i] + neg_widths[i], neg_inds[i], 
+                neg_lefts[i] + neg_widths[i], neg_inds[i],
                 xerr=np.array([[neg_widths[i] - neg_low[i]], [neg_high[i] - neg_widths[i]]]),
                 ecolor=colors.light_blue_rgb
             )
-        
+
         txt_obj = pl.text(
-            neg_lefts[i] + 0.5*dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
+            neg_lefts[i] + 0.5 * dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
             horizontalalignment='center', verticalalignment='center', color="white",
             fontsize=12
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
-        
+
         # if the text overflows the arrow then draw it after the arrow
-        if text_bbox.width > arrow_bbox.width: 
+        if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
-            
+
             txt_obj = pl.text(
-                neg_lefts[i] - (5/72)*bbox_to_xscale + dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
+                neg_lefts[i] - (5 / 72) * bbox_to_xscale + dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
                 horizontalalignment='right', verticalalignment='center', color=colors.blue_rgb,
                 fontsize=12
             )
 
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
-    ytick_pos = list(range(num_features)) + list(np.arange(num_features)+1e-8) # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
+    ytick_pos = list(range(num_features)) + list(
+        np.arange(num_features) + 1e-8)  # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     pl.yticks(ytick_pos, yticklabels[:-1] + [l.split('=')[-1] for l in yticklabels[:-1]], fontsize=13)
-    
+
     # put horizontal lines for each feature row
     for i in range(num_features):
         pl.axhline(i, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
-    
+
     # mark the prior expected value and the model prediction
-    pl.axvline(base_values, 0, 1/num_features, color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
+    pl.axvline(base_values, 0, 1 / num_features, color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
     fx = base_values + values.sum()
     pl.axvline(fx, 0, 1, color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
-    
+
     # clean up the main axis
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('none')
@@ -249,26 +256,30 @@ def waterfall(shap_values, max_display=10, show=True):
     pl.gca().spines['top'].set_visible(False)
     pl.gca().spines['left'].set_visible(False)
     ax.tick_params(labelsize=13)
-    #pl.xlabel("\nModel output", fontsize=12)
+    # pl.xlabel("\nModel output", fontsize=12)
 
     # draw the E[f(X)] tick mark
-    xmin,xmax = ax.get_xlim()
-    ax2=ax.twiny()
-    ax2.set_xlim(xmin,xmax)
-    ax2.set_xticks([base_values, base_values+1e-8]) # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
-    ax2.set_xticklabels(["\n$E[f(X)]$","\n$ = "+format_value(base_values, "%0.03f")+"$"], fontsize=12, ha="left")
+    xmin, xmax = ax.get_xlim()
+    ax2 = ax.twiny()
+    ax2.set_xlim(xmin, xmax)
+    ax2.set_xticks(
+        [base_values, base_values + 1e-8])  # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
+    ax2.set_xticklabels(["\n$E[f(X)]$", "\n$ = " + format_value(base_values, "%0.03f") + "$"], fontsize=12, ha="left")
     ax2.spines['right'].set_visible(False)
     ax2.spines['top'].set_visible(False)
     ax2.spines['left'].set_visible(False)
 
     # draw the f(x) tick mark
-    ax3=ax2.twiny()
-    ax3.set_xlim(xmin,xmax)
-    ax3.set_xticks([base_values + values.sum(), base_values + values.sum() + 1e-8]) # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
-    ax3.set_xticklabels(["$f(x)$","$ = "+format_value(fx, "%0.03f")+"$"], fontsize=12, ha="left")
+    ax3 = ax2.twiny()
+    ax3.set_xlim(xmin, xmax)
+    ax3.set_xticks([base_values + values.sum(),
+                    base_values + values.sum() + 1e-8])  # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
+    ax3.set_xticklabels(["$f(x)$", "$ = " + format_value(fx, "%0.03f") + "$"], fontsize=12, ha="left")
     tick_labels = ax3.xaxis.get_majorticklabels()
-    tick_labels[0].set_transform(tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-10/72., 0, fig.dpi_scale_trans))
-    tick_labels[1].set_transform(tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(12/72., 0, fig.dpi_scale_trans))
+    tick_labels[0].set_transform(
+        tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-10 / 72., 0, fig.dpi_scale_trans))
+    tick_labels[1].set_transform(
+        tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(12 / 72., 0, fig.dpi_scale_trans))
     tick_labels[1].set_color("#999999")
     ax3.spines['right'].set_visible(False)
     ax3.spines['top'].set_visible(False)
@@ -276,9 +287,12 @@ def waterfall(shap_values, max_display=10, show=True):
 
     # adjust the position of the E[f(X)] = x.xx label
     tick_labels = ax2.xaxis.get_majorticklabels()
-    tick_labels[0].set_transform(tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-20/72., 0, fig.dpi_scale_trans))
-    tick_labels[1].set_transform(tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(22/72., -1/72., fig.dpi_scale_trans))
-    
+    tick_labels[0].set_transform(
+        tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-20 / 72., 0, fig.dpi_scale_trans))
+    tick_labels[1].set_transform(
+        tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(22 / 72., -1 / 72.,
+                                                                                 fig.dpi_scale_trans))
+
     tick_labels[1].set_color("#999999")
 
     # color the y tick labels that have the feature values as gray
@@ -286,10 +300,9 @@ def waterfall(shap_values, max_display=10, show=True):
     tick_labels = ax.yaxis.get_majorticklabels()
     for i in range(num_features):
         tick_labels[i].set_color("#999999")
-    
+
     if show:
         pl.show()
-
 
 
 def waterfall_legacy(expected_value, shap_values=None, features=None, feature_names=None, max_display=10, show=True):
@@ -325,7 +338,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
         Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
         to be customized further after it has been created.
     """
-    
+
     # support passing an explanation object
     upper_bounds = None
     lower_bounds = None
@@ -340,16 +353,17 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
     # make sure we only have a single output to explain
     if (type(expected_value) == np.ndarray and len(expected_value) > 0) or type(expected_value) == list:
-        raise Exception("waterfall_plot requires a scalar expected_value of the model output as the first " \
-                        "parameter, but you have passed an array as the first parameter! " \
-                        "Try shap.waterfall_plot(explainer.expected_value[0], shap_values[0], X[0]) or " \
-                        "for multi-output models try " \
+        raise Exception("waterfall_plot requires a scalar expected_value of the model output as the first "
+                        "parameter, but you have passed an array as the first parameter! "
+                        "Try shap.waterfall_plot(explainer.expected_value[0], shap_values[0], X[0]) or "
+                        "for multi-output models try "
                         "shap.waterfall_plot(explainer.expected_value[0], shap_values[0][0], X[0]).")
 
     # make sure we only have a single explanation to plot
     if len(shap_values.shape) == 2:
-        raise Exception("The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
-    
+        raise Exception(
+            "The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
+
     # unwrap pandas series
     if safe_isinstance(features, "pandas.core.series.Series"):
         if feature_names is None:
@@ -359,7 +373,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     # fallback feature names
     if feature_names is None:
         feature_names = np.array([labels['FEATURE'] % str(i) for i in range(len(shap_values))])
-    
+
     # init variables we use for tracking the plot locations
     num_features = min(max_display, len(shap_values))
     row_height = 0.5
@@ -377,7 +391,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     neg_high = []
     loc = expected_value + shap_values.sum()
     yticklabels = ["" for i in range(num_features + 1)]
-    
+
     # size the plot based on how many features we are plotting
     pl.gcf().set_size_inches(8, num_features * row_height + 1.5)
 
@@ -406,15 +420,17 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
                 neg_high.append(upper_bounds[order[i]])
             neg_lefts.append(loc)
         if num_individual != num_features or i + 4 < num_individual:
-            pl.plot([loc, loc], [rng[i] -1 - 0.4, rng[i] + 0.4], color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
+            pl.plot([loc, loc], [rng[i] - 1 - 0.4, rng[i] + 0.4], color="#bbbbbb", linestyle="--", linewidth=0.5,
+                    zorder=-1)
         if features is None:
             yticklabels[rng[i]] = feature_names[order[i]]
         else:
-            yticklabels[rng[i]] = format_value(features[order[i]], "%0.03f") + " = " + feature_names[order[i]] 
-    
-    # add a last grouped feature to represent the impact of all the features we didn't show
+            yticklabels[rng[i]] = "{} = {}".format(format_value(features[order[i]], "%0.03f"),
+                                                   feature_names[order[i]])
+
+            # add a last grouped feature to represent the impact of all the features we didn't show
     if num_features < len(shap_values):
-        yticklabels[0] = "%d other features" % (len(shap_values) - num_features + 1)
+        yticklabels[0] = "{} other features".format(len(shap_values) - num_features + 1)
         remaining_impact = expected_value - loc
         if remaining_impact < 0:
             pos_inds.append(0)
@@ -427,15 +443,18 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             neg_lefts.append(loc + remaining_impact)
             c = colors.blue_rgb
 
-    points = pos_lefts + list(np.array(pos_lefts) + np.array(pos_widths)) + neg_lefts + list(np.array(neg_lefts) + np.array(neg_widths))
+    points = pos_lefts + list(np.array(pos_lefts) + np.array(pos_widths)) + neg_lefts + list(
+        np.array(neg_lefts) + np.array(neg_widths))
     dataw = np.max(points) - np.min(points)
-    
+
     # draw invisible bars just for sizing the axes
-    label_padding = np.array([0.1*dataw if w < 1 else 0 for w in pos_widths])
-    pl.barh(pos_inds, np.array(pos_widths) + label_padding + 0.02*dataw, left=np.array(pos_lefts) - 0.01*dataw, color=colors.red_rgb, alpha=0)
-    label_padding = np.array([-0.1*dataw  if -w < 1 else 0 for w in neg_widths])
-    pl.barh(neg_inds, np.array(neg_widths) + label_padding - 0.02*dataw, left=np.array(neg_lefts) + 0.01*dataw, color=colors.blue_rgb, alpha=0)
-    
+    label_padding = np.array([0.1 * dataw if w < 1 else 0 for w in pos_widths])
+    pl.barh(pos_inds, np.array(pos_widths) + label_padding + 0.02 * dataw, left=np.array(pos_lefts) - 0.01 * dataw,
+            color=colors.red_rgb, alpha=0)
+    label_padding = np.array([-0.1 * dataw if -w < 1 else 0 for w in neg_widths])
+    pl.barh(neg_inds, np.array(neg_widths) + label_padding - 0.02 * dataw, left=np.array(neg_lefts) + 0.01 * dataw,
+            color=colors.blue_rgb, alpha=0)
+
     # define variable we need for plotting the arrows
     head_length = 0.08
     bar_width = 0.8
@@ -445,51 +464,51 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     xticks = ax.get_xticks()
     bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     width, height = bbox.width, bbox.height
-    bbox_to_xscale = xlen/width
+    bbox_to_xscale = xlen / width
     hl_scaled = bbox_to_xscale * head_length
     renderer = fig.canvas.get_renderer()
-    
+
     # draw the positive arrows
     for i in range(len(pos_inds)):
         dist = pos_widths[i]
         arrow_obj = pl.arrow(
-            pos_lefts[i], pos_inds[i], max(dist-hl_scaled, 0.000001), 0,
+            pos_lefts[i], pos_inds[i], max(dist - hl_scaled, 0.000001), 0,
             head_length=min(dist, hl_scaled),
             color=colors.red_rgb, width=bar_width,
             head_width=bar_width
         )
-        
+
         if pos_low is not None and i < len(pos_low):
             pl.errorbar(
-                pos_lefts[i] + pos_widths[i], pos_inds[i], 
+                pos_lefts[i] + pos_widths[i], pos_inds[i],
                 xerr=np.array([[pos_widths[i] - pos_low[i]], [pos_high[i] - pos_widths[i]]]),
                 ecolor=colors.light_red_rgb
             )
 
         txt_obj = pl.text(
-            pos_lefts[i] + 0.5*dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
+            pos_lefts[i] + 0.5 * dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
             horizontalalignment='center', verticalalignment='center', color="white",
             fontsize=12
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
-        
+
         # if the text overflows the arrow then draw it after the arrow
-        if text_bbox.width > arrow_bbox.width: 
+        if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
-            
+
             txt_obj = pl.text(
-                pos_lefts[i] + (5/72)*bbox_to_xscale + dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
+                pos_lefts[i] + (5 / 72) * bbox_to_xscale + dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
                 horizontalalignment='left', verticalalignment='center', color=colors.red_rgb,
                 fontsize=12
             )
-    
+
     # draw the negative arrows
     for i in range(len(neg_inds)):
         dist = neg_widths[i]
-        
+
         arrow_obj = pl.arrow(
-            neg_lefts[i], neg_inds[i], -max(-dist-hl_scaled, 0.000001), 0,
+            neg_lefts[i], neg_inds[i], -max(-dist - hl_scaled, 0.000001), 0,
             head_length=min(-dist, hl_scaled),
             color=colors.blue_rgb, width=bar_width,
             head_width=bar_width
@@ -497,41 +516,42 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
         if neg_low is not None and i < len(neg_low):
             pl.errorbar(
-                neg_lefts[i] + neg_widths[i], neg_inds[i], 
+                neg_lefts[i] + neg_widths[i], neg_inds[i],
                 xerr=np.array([[neg_widths[i] - neg_low[i]], [neg_high[i] - neg_widths[i]]]),
                 ecolor=colors.light_blue_rgb
             )
-        
+
         txt_obj = pl.text(
-            neg_lefts[i] + 0.5*dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
+            neg_lefts[i] + 0.5 * dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
             horizontalalignment='center', verticalalignment='center', color="white",
             fontsize=12
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
-        
+
         # if the text overflows the arrow then draw it after the arrow
-        if text_bbox.width > arrow_bbox.width: 
+        if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
-            
+
             txt_obj = pl.text(
-                neg_lefts[i] - (5/72)*bbox_to_xscale + dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
+                neg_lefts[i] - (5 / 72) * bbox_to_xscale + dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
                 horizontalalignment='right', verticalalignment='center', color=colors.blue_rgb,
                 fontsize=12
             )
 
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
-    pl.yticks(list(range(num_features))*2, yticklabels[:-1] + [l.split('=')[-1] for l in yticklabels[:-1]], fontsize=13)
-    
+    pl.yticks(list(range(num_features)) * 2, yticklabels[:-1] + [l.split('=')[-1] for l in yticklabels[:-1]],
+              fontsize=13)
+
     # put horizontal lines for each feature row
     for i in range(num_features):
         pl.axhline(i, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
-    
+
     # mark the prior expected value and the model prediction
-    pl.axvline(expected_value, 0, 1/num_features, color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
+    pl.axvline(expected_value, 0, 1 / num_features, color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
     fx = expected_value + shap_values.sum()
     pl.axvline(fx, 0, 1, color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1)
-    
+
     # clean up the main axis
     pl.gca().xaxis.set_ticks_position('bottom')
     pl.gca().yaxis.set_ticks_position('none')
@@ -539,26 +559,29 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     pl.gca().spines['top'].set_visible(False)
     pl.gca().spines['left'].set_visible(False)
     ax.tick_params(labelsize=13)
-    #pl.xlabel("\nModel output", fontsize=12)
+    # pl.xlabel("\nModel output", fontsize=12)
 
     # draw the E[f(X)] tick mark
-    xmin,xmax = ax.get_xlim()
-    ax2=ax.twiny()
-    ax2.set_xlim(xmin,xmax)
+    xmin, xmax = ax.get_xlim()
+    ax2 = ax.twiny()
+    ax2.set_xlim(xmin, xmax)
     ax2.set_xticks([expected_value, expected_value])
-    ax2.set_xticklabels(["\n$E[f(X)]$","\n$ = "+format_value(expected_value, "%0.03f")+"$"], fontsize=12, ha="left")
+    ax2.set_xticklabels(["\n$E[f(X)]$", "\n$ = " + format_value(expected_value, "%0.03f") + "$"], fontsize=12,
+                        ha="left")
     ax2.spines['right'].set_visible(False)
     ax2.spines['top'].set_visible(False)
     ax2.spines['left'].set_visible(False)
 
     # draw the f(x) tick mark
-    ax3=ax2.twiny()
-    ax3.set_xlim(xmin,xmax)
+    ax3 = ax2.twiny()
+    ax3.set_xlim(xmin, xmax)
     ax3.set_xticks([expected_value + shap_values.sum()] * 2)
-    ax3.set_xticklabels(["$f(x)$","$ = "+format_value(fx, "%0.03f")+"$"], fontsize=12, ha="left")
+    ax3.set_xticklabels(["$f(x)$", "$ = " + format_value(fx, "%0.03f") + "$"], fontsize=12, ha="left")
     tick_labels = ax3.xaxis.get_majorticklabels()
-    tick_labels[0].set_transform(tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-10/72., 0, fig.dpi_scale_trans))
-    tick_labels[1].set_transform(tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(12/72., 0, fig.dpi_scale_trans))
+    tick_labels[0].set_transform(
+        tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-10 / 72., 0, fig.dpi_scale_trans))
+    tick_labels[1].set_transform(
+        tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(12 / 72., 0, fig.dpi_scale_trans))
     tick_labels[1].set_color("#999999")
     ax3.spines['right'].set_visible(False)
     ax3.spines['top'].set_visible(False)
@@ -566,8 +589,11 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
     # adjust the position of the E[f(X)] = x.xx label
     tick_labels = ax2.xaxis.get_majorticklabels()
-    tick_labels[0].set_transform(tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-20/72., 0, fig.dpi_scale_trans))
-    tick_labels[1].set_transform(tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(22/72., -1/72., fig.dpi_scale_trans))
+    tick_labels[0].set_transform(
+        tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-20 / 72., 0, fig.dpi_scale_trans))
+    tick_labels[1].set_transform(
+        tick_labels[1].get_transform() + matplotlib.transforms.ScaledTranslation(22 / 72., -1 / 72.,
+                                                                                 fig.dpi_scale_trans))
     tick_labels[1].set_color("#999999")
 
     # color the y tick labels that have the feature values as gray
@@ -575,6 +601,6 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     tick_labels = ax.yaxis.get_majorticklabels()
     for i in range(num_features):
         tick_labels[i].set_color("#999999")
-    
+
     if show:
         pl.show()


### PR DESCRIPTION
1) Code cleanup - a small reformatting for PEP-8 with PyCharm's help in files for plotting, nothing major
2) Replaced a lot of `%` string formatting with `.format()` - string formatting with `%` is discouraged and may be deprecated and removed in the forseeable future. Therefore I changed the `%` formatting to `.format()` where possible; since `.format()` is also extensively used, this also makes code more uniform. It should also be noted that f-strings for formatting are used, which requires Python 3.6+, which should be explicitly stated in the documentation. This is the most desirable form in many cases, I can also replace `.format()` with f-strings, if this is an official decision to transition to 3.6+.
3) Fixed plotting features names - formatting was off or not working for types other than string and numbers; for example, for None values (e.g. from XGBoost) in decision plot errors were thrown, while booleans were displayed as 0.0 or 1.0. For force plots, booleans were not displayed at all. I fixed that with a `is None` and `isinstance()` checks. This should greatly increase user experience for tree-based models like XGBoost, which often use those values.