### PR TITLE
Pylint tree tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,571 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        invalid-name
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ install:
 - python setup.py develop
 - pip install .[test]
 - pip install tensorflow xgboost matplotlib ipython codecov torch torchvision
-script: python -m pytest .
+script:
+  - python -m pytest tests
+  - pylint tests/explainers/test_tree.py
 after_success:
   - codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
 - python setup.py develop
 - pip install .[test]
-- pip install tensorflow xgboost matplotlib ipython codecov torch torchvision
+- pip install tensorflow xgboost matplotlib ipython codecov torch torchvision pylint
 script:
   - python -m pytest tests
   - pylint tests/explainers/test_tree.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ test_script:
   # Note that you must use the environment variable %PYTHON% to refer to
   # the interpreter you're using - Appveyor does not do anything special
   # to put the Python version you want to use on PATH.
-  - "%PYTHON%\\python.exe -m pytest ."
+  - "%PYTHON%\\python.exe -m pytest tests"
 
 artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --mpl --cov=shap tests --cov-report=term-missing --durations=20
+addopts = --mpl --cov=shap --cov-report=term-missing --durations=20

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --mpl --cov=shap tests --cov-report=term-missing
+addopts = --mpl --cov=shap tests --cov-report=term-missing --durations=20

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1,15 +1,19 @@
-import matplotlib
-matplotlib.use('Agg')
+# pylint: disable=missing-function-docstring,too-many-lines,fixme
+"""Test tree functions."""
+import itertools
+import math
+import pickle
+import numpy as np
+import pandas as pd
+import pytest
+import sklearn
+import sklearn.pipeline
+from sklearn.experimental import enable_hist_gradient_boosting  # pylint: disable=unused-import
+import shap
 
 
 def test_front_page_xgboost():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_front_page_xgboost!")
-        return
-    import shap
-    import numpy as np
+    xgboost = pytest.importorskip('xgboost')
 
     # load JS visualization code to notebook
     shap.initjs()
@@ -35,10 +39,8 @@ def test_front_page_xgboost():
     # summarize the effects of all the features
     shap.summary_plot(shap_values, X, show=False)
 
-def test_front_page_sklearn():
-    import sklearn.ensemble
-    import shap
 
+def test_front_page_sklearn():
     # load JS visualization code to notebook
     shap.initjs()
 
@@ -61,32 +63,33 @@ def test_front_page_sklearn():
         # visualize the training set predictions
         shap.force_plot(explainer.expected_value, shap_values, X)
 
-        # create a SHAP dependence plot to show the effect of a single feature across the whole dataset
+        # create a SHAP dependence plot to show the effect of a single feature across the whole
+        # dataset
         shap.dependence_plot(5, shap_values, X, show=False)
         shap.dependence_plot("RM", shap_values, X, show=False)
 
         # summarize the effects of all the features
         shap.summary_plot(shap_values, X, show=False)
 
+
 def _conditional_expectation(tree, S, x):
     tree_ind = 0
+
     def R(node_ind):
-        
+
         f = tree.features[tree_ind, node_ind]
         lc = tree.children_left[tree_ind, node_ind]
         rc = tree.children_right[tree_ind, node_ind]
         if lc < 0:
             return tree.values[tree_ind, node_ind]
-        elif f in S:
+        if f in S:
             if x[f] <= tree.thresholds[tree_ind, node_ind]:
                 return R(lc)
-            else:
-                return R(rc)
-        else:
-            lw = tree.node_sample_weight[tree_ind, lc]
-            rw = tree.node_sample_weight[tree_ind, rc]
-            return (R(lc) * lw + R(rc) * rw) / (lw + rw)
-    
+            return R(rc)
+        lw = tree.node_sample_weight[tree_ind, lc]
+        rw = tree.node_sample_weight[tree_ind, rc]
+        return (R(lc) * lw + R(rc) * rw) / (lw + rw)
+
     out = 0.0
     l = tree.values.shape[0] if tree.tree_limit is None else tree.tree_limit
     for i in range(l):
@@ -94,31 +97,24 @@ def _conditional_expectation(tree, S, x):
         out += R(0)
     return out
 
-def _brute_force_tree_shap(tree, x):
-    import itertools
-    import math
-    import numpy as np
 
+def _brute_force_tree_shap(tree, x):
     m = len(x)
     phi = np.zeros(m)
     for p in itertools.permutations(list(range(m))):
         for i in range(m):
-            phi[p[i]] += _conditional_expectation(tree, p[:i+1], x) - _conditional_expectation(tree, p[:i], x)
+            phi[p[i]] += _conditional_expectation(tree, p[:i + 1], x) - _conditional_expectation(
+                tree, p[:i], x)
     return phi / math.factorial(m)
 
+
 def test_xgboost_direct():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_xgboost_direct!")
-        return
-    import shap
-    import numpy as np
+    xgboost = pytest.importorskip('xgboost')
 
     N = 100
     M = 4
-    X = np.random.randn(N,M)
-    y = np.random.randn(N)  
+    X = np.random.randn(N, M)
+    y = np.random.randn(N)
 
     model = xgboost.XGBRegressor()
     model.fit(X, y)
@@ -126,16 +122,11 @@ def test_xgboost_direct():
     explainer = shap.TreeExplainer(model)
     shap_values = explainer.shap_values(X)
 
-    assert np.allclose(shap_values[0,:], _brute_force_tree_shap(explainer.model, X[0,:]))
+    assert np.allclose(shap_values[0, :], _brute_force_tree_shap(explainer.model, X[0, :]))
+
 
 def test_xgboost_multiclass():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_xgboost_multiclass!")
-        return
-    import shap
-    import numpy as np
+    xgboost = pytest.importorskip('xgboost')
 
     # train XGBoost model
     X, Y = shap.datasets.iris()
@@ -148,104 +139,86 @@ def test_xgboost_multiclass():
     # ensure plot works for first class
     shap.dependence_plot(0, shap_values[0], X, show=False)
 
-def _validate_shap_values(model, x_test):
-    import shap
-    import numpy as np
 
+def _validate_shap_values(model, x_test):
     # explain the model's predictions using SHAP values
     tree_explainer = shap.TreeExplainer(model)
     shap_values = tree_explainer.shap_values(x_test)
     expected_values = tree_explainer.expected_value
     # validate values sum to the margin prediction of the model plus expected_value
-    assert(np.allclose(np.sum(shap_values, axis=1) + expected_values, model.predict(x_test)))
+    assert np.allclose(np.sum(shap_values, axis=1) + expected_values, model.predict(x_test))
+
 
 def test_xgboost_ranking():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_xgboost_ranking!")
-        return
-    import shap
+    xgboost = pytest.importorskip('xgboost')
 
     # train lightgbm ranker model
-    x_train, y_train, x_test, y_test, q_train, q_test = shap.datasets.rank()
+    x_train, y_train, x_test, _, q_train, _ = shap.datasets.rank()
     params = {'objective': 'rank:pairwise', 'learning_rate': 0.1,
               'gamma': 1.0, 'min_child_weight': 0.1,
-              'max_depth': 4, 'n_estimators': 4}
+              'max_depth': 5, 'n_estimators': 4}
     model = xgboost.sklearn.XGBRanker(**params)
     model.fit(x_train, y_train, q_train.astype(int))
     _validate_shap_values(model, x_test)
 
-def test_xgboost_mixed_types():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_xgboost_mixed_types!")
-        return
-    import shap
-    import numpy as np
 
-    X,y = shap.datasets.boston()
+def test_xgboost_mixed_types():
+    xgboost = pytest.importorskip('xgboost')
+
+    X, y = shap.datasets.boston()
     X["LSTAT"] = X["LSTAT"].astype(np.int64)
     X["B"] = X["B"].astype(np.bool)
     bst = xgboost.train({"learning_rate": 0.01, "silent": 1}, xgboost.DMatrix(X, label=y), 1000)
     shap_values = shap.TreeExplainer(bst).shap_values(X)
     shap.dependence_plot(0, shap_values, X, show=False)
 
-def test_ngboost():
-    try:
-        import ngboost
-    except:
-        print("Skipping test_ngboost!")
-        return
-    import shap
-    import numpy as np
 
-    X,y = shap.datasets.boston()
+def test_ngboost():
+    ngboost = pytest.importorskip('ngboost')
+
+    X, y = shap.datasets.boston()
     model = ngboost.NGBRegressor(n_estimators=20).fit(X, y)
     explainer = shap.TreeExplainer(model, model_output=0)
-    assert np.max(np.abs(explainer.shap_values(X).sum(1) + explainer.expected_value - model.predict(X))) < 1e-5
+    assert np.max(np.abs(
+        explainer.shap_values(X).sum(1) + explainer.expected_value - model.predict(X))) < 1e-5
+
 
 def test_pyspark_classifier_decision_tree():
+    # pylint: disable=bare-except
+    pyspark = pytest.importorskip("pyspark")
     try:
-        import pyspark
-        import sklearn.datasets
-        from pyspark.sql import SparkSession
-        from pyspark import SparkContext, SparkConf
-        from pyspark.ml.feature import VectorAssembler, StringIndexer
-        from pyspark.ml.classification import RandomForestClassifier, DecisionTreeClassifier, GBTClassifier
-        import pandas as pd
-        import pickle
-
-        iris_sk = sklearn.datasets.load_iris()
-        iris = pd.DataFrame(data= np.c_[iris_sk['data'], iris_sk['target']], columns= iris_sk['feature_names'] + ['target'])[:100]
-        spark = SparkSession.builder.config(conf=SparkConf().set("spark.master", "local[*]")).getOrCreate()
+        spark = pyspark.sql.SparkSession.builder.config(
+            conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
     except:
-        print("Skipping test_pyspark_classifier_decision_tree!")
-        return
-    import shap
-    import numpy as np
+        pytest.skip("Could not create pyspark context")
 
-    col = ["sepal_length","sepal_width","petal_length","petal_width","type"]
+    iris_sk = sklearn.datasets.load_iris()
+    iris = pd.DataFrame(data=np.c_[iris_sk['data'], iris_sk['target']],
+                        columns=iris_sk['feature_names'] + ['target'])[:100]
+    col = ["sepal_length", "sepal_width", "petal_length", "petal_width", "type"]
     iris = spark.createDataFrame(iris, col)
-    iris = VectorAssembler(inputCols=col[:-1],outputCol="features").transform(iris)
-    iris = StringIndexer(inputCol="type", outputCol="label").fit(iris).transform(iris)
+    iris = pyspark.ml.feature.VectorAssembler(inputCols=col[:-1], outputCol="features").transform(
+        iris)
+    iris = pyspark.ml.feature.StringIndexer(inputCol="type", outputCol="label").fit(iris).transform(
+        iris)
 
-    classifiers = [GBTClassifier(labelCol="label", featuresCol="features"),
-                   RandomForestClassifier(labelCol="label", featuresCol="features"),
-                   DecisionTreeClassifier(labelCol="label", featuresCol="features")]
+    classifiers = [
+        pyspark.ml.classification.GBTClassifier(labelCol="label", featuresCol="features"),
+        pyspark.ml.classification.RandomForestClassifier(labelCol="label", featuresCol="features"),
+        pyspark.ml.classification.DecisionTreeClassifier(labelCol="label", featuresCol="features")]
     for classifier in classifiers:
         model = classifier.fit(iris)
         explainer = shap.TreeExplainer(model)
-        #Make sure the model can be serializable to run shap values with spark
+        # Make sure the model can be serializable to run shap values with spark
         pickle.dumps(explainer)
-        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100] # pylint: disable=E1101
+        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[  # pylint: disable=E1101
+            :100]
 
         shap_values = explainer.shap_values(X)
         expected_values = explainer.expected_value
 
-        predictions = model.transform(iris).select("rawPrediction")\
-            .rdd.map(lambda x:[float(y) for y in x['rawPrediction']]).toDF(['class0','class1']).toPandas()
+        predictions = model.transform(iris).select("rawPrediction").rdd.map(
+            lambda x: [float(y) for y in x['rawPrediction']]).toDF(['class0', 'class1']).toPandas()
 
         if str(type(model)).endswith("GBTClassificationModel'>"):
             diffs = expected_values + shap_values.sum(1) - predictions.class1
@@ -253,43 +226,48 @@ def test_pyspark_classifier_decision_tree():
         else:
             normalizedPredictions = (predictions.T / predictions.sum(1)).T
             diffs = expected_values[0] + shap_values[0].sum(1) - normalizedPredictions.class0
-            assert np.max(np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output for class0!"+model
+            assert np.max(
+                np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output for class0!" + model
             diffs = expected_values[1] + shap_values[1].sum(1) - normalizedPredictions.class1
-            assert np.max(np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output for class1!"+model
-            assert (np.abs(expected_values - normalizedPredictions.mean()) < 1e-1).all(), "Bad expected_value!"+model
+            assert np.max(
+                np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output for class1!" + model
+            assert (np.abs(
+                expected_values - normalizedPredictions.mean()) < 1e-1).all(), \
+                "Bad expected_value!" + model
     spark.stop()
 
-def test_pyspark_regression_decision_tree():
-    try:
-        import pyspark
-        import sklearn.datasets
-        from pyspark.sql import SparkSession
-        from pyspark import SparkContext, SparkConf
-        from pyspark.ml.feature import VectorAssembler, StringIndexer
-        from pyspark.ml.regression import DecisionTreeRegressor, GBTRegressor, RandomForestRegressor
-        import pandas as pd
 
-        iris_sk = sklearn.datasets.load_iris()
-        iris = pd.DataFrame(data= np.c_[iris_sk['data'], iris_sk['target']], columns= iris_sk['feature_names'] + ['target'])[:100]
-        spark = SparkSession.builder.config(conf=SparkConf().set("spark.master", "local[*]")).getOrCreate()
+def test_pyspark_regression_decision_tree():
+    # pylint: disable=bare-except
+    pyspark = pytest.importorskip("pyspark")
+    try:
+        spark = pyspark.sql.SparkSession.builder.config(
+            conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
     except:
-        print("Skipping test_pyspark_regression_decision_tree!")
-        return
-    import shap
-    import numpy as np
+        pytest.skip("Could not create pyspark context")
+
+    iris_sk = sklearn.datasets.load_iris()
+    iris = pd.DataFrame(data=np.c_[iris_sk['data'], iris_sk['target']],
+                        columns=iris_sk['feature_names'] + ['target'])[:100]
 
     # Simple regressor: try to predict sepal length based on the other features
-    col = ["sepal_length","sepal_width","petal_length","petal_width","type"]
+    col = ["sepal_length", "sepal_width", "petal_length", "petal_width", "type"]
     iris = spark.createDataFrame(iris, col).drop("type")
-    iris = VectorAssembler(inputCols=col[1:-1],outputCol="features").transform(iris)
+    iris = pyspark.ml.feature.VectorAssembler(inputCols=col[1:-1], outputCol="features").transform(
+        iris)
 
-    regressors = [GBTRegressor(labelCol="sepal_length", featuresCol="features"),
-                  RandomForestRegressor(labelCol="sepal_length", featuresCol="features"),
-                  DecisionTreeRegressor(labelCol="sepal_length", featuresCol="features")]
+    regressors = [
+        pyspark.ml.classification.GBTRegressor(labelCol="sepal_length", featuresCol="features"),
+        pyspark.ml.classification.RandomForestRegressor(labelCol="sepal_length",
+                                                        featuresCol="features"),
+        pyspark.ml.classification.DecisionTreeRegressor(labelCol="sepal_length",
+                                                        featuresCol="features")]
     for regressor in regressors:
         model = regressor.fit(iris)
         explainer = shap.TreeExplainer(model)
-        X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop('sepal length (cm)', 1)[:100] # pylint: disable=E1101
+        X = pd.DataFrame(
+            data=iris_sk.data, columns=iris_sk.feature_names).drop(  # pylint: disable=E1101
+                'sepal length (cm)', 1)[:100]
 
         shap_values = explainer.shap_values(X)
         expected_values = explainer.expected_value
@@ -301,53 +279,48 @@ def test_pyspark_regression_decision_tree():
         assert (np.abs(expected_values - predictions.mean()) < 1e-1).all(), "Bad expected_value!"
     spark.stop()
 
-def test_sklearn_random_forest_multiclass():
-    import shap
-    from sklearn.ensemble import RandomForestClassifier
-    import numpy as np
 
+def test_sklearn_random_forest_multiclass():
     X, y = shap.datasets.iris()
     y[y == 2] = 1
-    model = RandomForestClassifier(n_estimators=100, max_depth=None, min_samples_split=2, random_state=0)
+    model = sklearn.ensemble.RandomForestClassifier(n_estimators=100, max_depth=None,
+                                                    min_samples_split=2,
+                                                    random_state=0)
     model.fit(X, y)
 
     explainer = shap.TreeExplainer(model)
     shap_values = explainer.shap_values(X)
 
-    assert np.abs(shap_values[0][0,0] - 0.05) < 1e-3
-    assert np.abs(shap_values[1][0,0] + 0.05) < 1e-3
+    assert np.abs(shap_values[0][0, 0] - 0.05) < 1e-3
+    assert np.abs(shap_values[1][0, 0] + 0.05) < 1e-3
+
 
 def create_binary_newsgroups_data():
-    from sklearn.datasets import fetch_20newsgroups
-
     categories = ['alt.atheism', 'soc.religion.christian']
-    newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
-    newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
+    newsgroups_train = sklearn.datasets.fetch_20newsgroups(subset='train', categories=categories)
+    newsgroups_test = sklearn.datasets.fetch_20newsgroups(subset='test', categories=categories)
     class_names = ['atheism', 'christian']
     return newsgroups_train, newsgroups_test, class_names
 
+
 def create_random_forest_vectorizer():
-    from sklearn.feature_extraction.text import CountVectorizer
-    from sklearn.pipeline import Pipeline
-    from sklearn.ensemble import RandomForestClassifier
-    from sklearn.base import TransformerMixin
+    # pylint: disable=unused-argument,no-self-use,missing-class-docstring
+    vectorizer = sklearn.feature_extraction.text.CountVectorizer(lowercase=False, min_df=0.0,
+                                                                 binary=True)
 
-    vectorizer = CountVectorizer(lowercase=False, min_df=0.0, binary=True)
-
-    class DenseTransformer(TransformerMixin):
+    class DenseTransformer(sklearn.base.TransformerMixin):
         def fit(self, X, y=None, **fit_params):
             return self
+
         def transform(self, X, y=None, **fit_params):
             return X.toarray()
 
-    rf = RandomForestClassifier(n_estimators=10, random_state=777)
-    return Pipeline([('vectorizer', vectorizer), ('to_dense', DenseTransformer()), ('rf', rf)])
+    rf = sklearn.ensemble.RandomForestClassifier(n_estimators=10, random_state=777)
+    return sklearn.pipeline.Pipeline(
+        [('vectorizer', vectorizer), ('to_dense', DenseTransformer()), ('rf', rf)])
+
 
 def test_sklearn_random_forest_newsgroups():
-    import shap
-    import numpy as np
-    #from sklearn.ensemble import RandomForestClassifier
-
     # note: this test used to fail in native TreeExplainer code due to memory corruption
     newsgroups_train, newsgroups_test, _ = create_binary_newsgroups_data()
     pipeline = create_random_forest_vectorizer()
@@ -364,29 +337,21 @@ def test_sklearn_random_forest_newsgroups():
     dense_row = densifier.transform(vec_row)
     explainer.shap_values(dense_row)
 
-def test_sklearn_decision_tree_multiclass():
-    import shap
-    from sklearn.tree import DecisionTreeClassifier
-    import numpy as np
 
+def test_sklearn_decision_tree_multiclass():
     X, y = shap.datasets.iris()
     y[y == 2] = 1
-    model = DecisionTreeClassifier(max_depth=None, min_samples_split=2, random_state=0)
+    model = sklearn.tree.DecisionTreeClassifier(max_depth=None, min_samples_split=2, random_state=0)
     model.fit(X, y)
 
     explainer = shap.TreeExplainer(model)
     shap_values = explainer.shap_values(X)
-    assert np.abs(shap_values[0][0,0] - 0.05) < 1e-1
-    assert np.abs(shap_values[1][0,0] + 0.05) < 1e-1
+    assert np.abs(shap_values[0][0, 0] - 0.05) < 1e-1
+    assert np.abs(shap_values[1][0, 0] + 0.05) < 1e-1
+
 
 def test_lightgbm():
-    try:
-        import lightgbm
-    except:
-        print("Skipping test_lightgbm!")
-        return
-    import shap
-    import numpy as np
+    lightgbm = pytest.importorskip("lightgbm")
 
     # train lightgbm model
     X, y = shap.datasets.boston()
@@ -402,14 +367,9 @@ def test_lightgbm():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_gpboost():
-    try:
-        import gpboost
-    except:
-        print("Skipping test_gpboost!")
-        return
-    import shap
 
+def test_gpboost():
+    gpboost = pytest.importorskip("gpboost")
     # train gpboost model
     X, y = shap.datasets.boston()
     data_train = gpboost.Dataset(X, y, categorical_feature=[8])
@@ -425,17 +385,9 @@ def test_gpboost():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_catboost():
-    try:
-        import catboost
-        from sklearn.datasets import load_breast_cancer
-        from catboost.datasets import amazon
-    except:
-        print("Skipping test_catboost!")
-        return
-    import shap
-    import numpy as np
 
+def test_catboost():
+    catboost = pytest.importorskip("catboost")
     # train catboost model
     X, y = shap.datasets.boston()
     X["RAD"] = X["RAD"].astype(np.int)
@@ -452,7 +404,7 @@ def test_catboost():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to modThisel output!"
 
-    X, y = load_breast_cancer(return_X_y=True)
+    X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
     model = catboost.CatBoostClassifier(iterations=10, learning_rate=0.5, random_seed=12)
     model.fit(
         X,
@@ -467,21 +419,12 @@ def test_catboost():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_catboost_categorical():
-    try:
-        import catboost
-        from catboost.datasets import amazon
-    except:
-        print("Skipping test_catboost!")
-        return
-    import shap
-    import pandas as pd
-    from sklearn.datasets import load_boston
-    import numpy as np
 
-    bunch = load_boston()
-    X, y = load_boston(True)
-    X = pd.DataFrame(X, columns=bunch.feature_names) # pylint: disable=no-member
+def test_catboost_categorical():
+    catboost = pytest.importorskip("catboost")
+    bunch = sklearn.datasets.load_boston()
+    X, y = sklearn.datasets.load_boston(return_X_y=True)
+    X = pd.DataFrame(X, columns=bunch.feature_names)  # pylint: disable=no-member
     X['CHAS'] = X['CHAS'].astype(str)
 
     model = catboost.CatBoostRegressor(100, cat_features=['CHAS'], verbose=False)
@@ -495,20 +438,14 @@ def test_catboost_categorical():
     assert np.abs(shap_values.sum(1) + explainer.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
+
 def test_lightgbm_constant_prediction():
     # note: this test used to fail with lightgbm 2.2.1 with error:
     # ValueError: zero-size array to reduction operation maximum which has no identity
     # on TreeExplainer when trying to compute max nodes:
     # max_nodes = np.max([len(t.values) for t in self.trees])
     # The test does not fail with latest lightgbm 2.2.3 however
-    try:
-        import lightgbm
-    except:
-        print("Skipping test_lightgbm_constant_prediction!")
-        return
-    import shap
-    import numpy as np
-
+    lightgbm = pytest.importorskip("lightgbm")
     # train lightgbm model with a constant value for y
     X, y = shap.datasets.boston()
     # use the mean for all values
@@ -520,19 +457,14 @@ def test_lightgbm_constant_prediction():
     # explain the model's predictions using SHAP values
     shap.TreeExplainer(model).shap_values(X)
 
+
 def test_lightgbm_constant_multiclass():
     # note: this test used to fail with lightgbm 2.2.1 with error:
     # ValueError: zero-size array to reduction operation maximum which has no identity
     # on TreeExplainer when trying to compute max nodes:
     # max_nodes = np.max([len(t.values) for t in self.trees])
     # The test does not fail with latest lightgbm 2.2.3 however
-    try:
-        import lightgbm
-    except:
-        print("Skipping test_lightgbm_constant_multiclass!")
-        return
-    import shap
-    import numpy as np
+    lightgbm = pytest.importorskip("lightgbm")
 
     # train lightgbm model
     X, Y = shap.datasets.iris()
@@ -543,15 +475,9 @@ def test_lightgbm_constant_multiclass():
     # explain the model's predictions using SHAP values
     shap.TreeExplainer(model).shap_values(X)
 
-def test_lightgbm_multiclass():
-    try:
-        import lightgbm
-    except:
-        print("Skipping test_lightgbm_multiclass!")
-        return
-    import shap
-    import numpy as np
 
+def test_lightgbm_multiclass():
+    lightgbm = pytest.importorskip("lightgbm")
     # train lightgbm model
     X, Y = shap.datasets.iris()
     model = lightgbm.sklearn.LGBMClassifier()
@@ -563,17 +489,13 @@ def test_lightgbm_multiclass():
     # ensure plot works for first class
     shap.dependence_plot(0, shap_values[0], X, show=False)
 
-def test_lightgbm_binary():
-    try:
-        import lightgbm
-    except:
-        print("Skipping test_lightgbm_binary!")
-        return
-    import shap
-    from sklearn.model_selection import train_test_split
 
+def test_lightgbm_binary():
+    lightgbm = pytest.importorskip("lightgbm")
     # train lightgbm model
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
     model = lightgbm.sklearn.LGBMClassifier()
     model.fit(X_train, Y_train)
 
@@ -587,14 +509,15 @@ def test_lightgbm_binary():
     # ensure plot works for first class
     shap.dependence_plot(0, shap_values[0], X_test, show=False)
 
+
 # def test_lightgbm_ranking():
 #     try:
 #         import lightgbm
 #     except:
 #         print("Skipping test_lightgbm_ranking!")
 #         return
-#     import shap
-#     import numpy as np
+#
+#
 
 #     # train lightgbm ranker model
 #     x_train, y_train, x_test, y_test, q_train, q_test = shap.datasets.rank()
@@ -607,37 +530,29 @@ def test_lightgbm_binary():
 # TODO: Test tree_limit argument
 
 def test_sklearn_interaction():
-    import sklearn
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import RandomForestClassifier
-    import numpy as np
-    import shap
-
     # train a simple sklean RF model on the iris dataset
     X, _ = shap.datasets.iris()
-    X_train,_,Y_train,_ = train_test_split(*shap.datasets.iris(), test_size=0.2, random_state=0)
-    rforest = RandomForestClassifier(n_estimators=100, max_depth=None, min_samples_split=2, random_state=0)
+    X_train, _, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.iris(),
+                                                                      test_size=0.2, random_state=0)
+    rforest = sklearn.ensemble.RandomForestClassifier(n_estimators=100, max_depth=None,
+                                                      min_samples_split=2,
+                                                      random_state=0)
     model = rforest.fit(X_train, Y_train)
 
     # verify symmetry of the interaction values (this typically breaks if anything is wrong)
     interaction_vals = shap.TreeExplainer(model).shap_interaction_values(X)
-    for i in range(len(interaction_vals)):
-        for j in range(len(interaction_vals[i])):
-            for k in range(len(interaction_vals[i][j])):
-                for l in range(len(interaction_vals[i][j][k])):
+    for i, _ in enumerate(interaction_vals):
+        for j, _ in enumerate(interaction_vals[i]):
+            for k, _ in enumerate(interaction_vals[i][j]):
+                for l, _ in enumerate(interaction_vals[i][j][k]):
                     assert abs(interaction_vals[i][j][k][l] - interaction_vals[i][j][l][k]) < 1e-4
 
     # ensure the interaction plot works
     shap.summary_plot(interaction_vals[0], X, show=False)
 
+
 def test_lightgbm_interaction():
-    try:
-        import lightgbm
-    except:
-        print("Skipping test_lightgbm_interaction!")
-        return
-    import shap
-    import numpy as np
+    lightgbm = pytest.importorskip("lightgbm")
 
     # train XGBoost model
     X, y = shap.datasets.boston()
@@ -646,35 +561,30 @@ def test_lightgbm_interaction():
 
     # verify symmetry of the interaction values (this typically breaks if anything is wrong)
     interaction_vals = shap.TreeExplainer(model).shap_interaction_values(X)
-    for j in range(len(interaction_vals)):
-        for k in range(len(interaction_vals[j])):
-            for l in range(len(interaction_vals[j][k])):
+    for j, _ in enumerate(interaction_vals):
+        for k, _ in enumerate(interaction_vals[j]):
+            for l, _ in enumerate(interaction_vals[j][k]):
                 assert abs(interaction_vals[j][k][l] - interaction_vals[j][l][k]) < 1e-4
 
-def test_sum_match_random_forest():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import RandomForestClassifier
 
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = RandomForestClassifier(random_state=202, n_estimators=10, max_depth=10)
+def test_sum_match_random_forest():
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.RandomForestClassifier(random_state=202, n_estimators=10, max_depth=10)
     clf.fit(X_train, Y_train)
     predicted = clf.predict_proba(X_test)
     ex = shap.TreeExplainer(clf)
     shap_values = ex.shap_values(X_test)
-    assert np.abs(shap_values[0].sum(1) + ex.expected_value[0] - predicted[:,0]).max() < 1e-4, \
+    assert np.abs(shap_values[0].sum(1) + ex.expected_value[0] - predicted[:, 0]).max() < 1e-4, \
         "SHAP values don't sum to model output!"
-    
-def test_sum_match_extra_trees():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import ExtraTreesRegressor
-    import sklearn
 
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = ExtraTreesRegressor(random_state=202, n_estimators=10, max_depth=10)
+
+def test_sum_match_extra_trees():
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.ExtraTreesRegressor(random_state=202, n_estimators=10, max_depth=10)
     clf.fit(X_train, Y_train)
     predicted = clf.predict(X_test)
     ex = shap.TreeExplainer(clf)
@@ -682,31 +592,26 @@ def test_sum_match_extra_trees():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_single_row_random_forest():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import RandomForestClassifier
-    import sklearn
 
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = RandomForestClassifier(random_state=202, n_estimators=10, max_depth=10)
+def test_single_row_random_forest():
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.RandomForestClassifier(random_state=202, n_estimators=10, max_depth=10)
     clf.fit(X_train, Y_train)
     predicted = clf.predict_proba(X_test)
     ex = shap.TreeExplainer(clf)
-    shap_values = ex.shap_values(X_test.iloc[0,:])
-    assert np.abs(shap_values[0].sum() + ex.expected_value[0] - predicted[0,0]) < 1e-4, \
+    shap_values = ex.shap_values(X_test.iloc[0, :])
+    assert np.abs(shap_values[0].sum() + ex.expected_value[0] - predicted[0, 0]) < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_sum_match_gradient_boosting_classifier():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import GradientBoostingClassifier
-    import sklearn
 
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = GradientBoostingClassifier(random_state=202, n_estimators=10, max_depth=10)
+def test_sum_match_gradient_boosting_classifier():
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.GradientBoostingClassifier(random_state=202, n_estimators=10,
+                                                      max_depth=10)
     clf.fit(X_train, Y_train)
 
     # Use decision function to get prediction before it is mapped to a probability
@@ -723,77 +628,64 @@ def test_sum_match_gradient_boosting_classifier():
     assert np.abs(initial_ex_value - ex.expected_value) < 1e-4, "Inital expected value is wrong!"
 
     # check SHAP interaction values
-    shap_interaction_values = ex.shap_interaction_values(X_test.iloc[:10,:])
-    assert np.abs(shap_interaction_values.sum(1).sum(1) + ex.expected_value - predicted[:10]).max() < 1e-4, \
+    shap_interaction_values = ex.shap_interaction_values(X_test.iloc[:10, :])
+    assert np.abs(
+        shap_interaction_values.sum(1).sum(1) + ex.expected_value - predicted[:10]).max() < 1e-4, \
         "SHAP interaction values don't sum to model output!"
 
-def test_single_row_gradient_boosting_classifier():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import GradientBoostingClassifier
-    import sklearn
 
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = GradientBoostingClassifier(random_state=202, n_estimators=10, max_depth=10)
+def test_single_row_gradient_boosting_classifier():
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.GradientBoostingClassifier(random_state=202, n_estimators=10,
+                                                      max_depth=10)
     clf.fit(X_train, Y_train)
     predicted = clf.decision_function(X_test)
     ex = shap.TreeExplainer(clf)
-    shap_values = ex.shap_values(X_test.iloc[0,:])
+    shap_values = ex.shap_values(X_test.iloc[0, :])
     assert np.abs(shap_values.sum() + ex.expected_value - predicted[0]) < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_HistGradientBoostingRegressor():
-    from sklearn.experimental import enable_hist_gradient_boosting
-    from sklearn.ensemble import HistGradientBoostingRegressor
-    import numpy as np
-    import shap
 
+def test_HistGradientBoostingRegressor():
     # train a tree-based model
     X, y = shap.datasets.diabetes()
-    model = HistGradientBoostingRegressor(max_iter=1000, max_depth=6).fit(X, y)
+    model = sklearn.ensemble.HistGradientBoostingRegressor(max_iter=1000, max_depth=6).fit(X, y)
     explainer = shap.TreeExplainer(model)
     shap_values = explainer.shap_values(X)
     assert np.max(np.abs(shap_values.sum(1) + explainer.expected_value - model.predict(X))) < 1e-4
 
-def test_HistGradientBoostingClassifier_proba():
-    from sklearn.experimental import enable_hist_gradient_boosting
-    from sklearn.ensemble import HistGradientBoostingClassifier
-    import numpy as np
-    import shap
 
+def test_HistGradientBoostingClassifier_proba():
     # train a tree-based model
     X, y = shap.datasets.adult()
-    model = HistGradientBoostingClassifier(max_iter=10, max_depth=6).fit(X, y)
+    model = sklearn.ensemble.HistGradientBoostingClassifier(max_iter=10, max_depth=6).fit(X, y)
     explainer = shap.TreeExplainer(model, shap.sample(X, 10), model_output="predict_proba")
     shap_values = explainer.shap_values(X)
-    assert np.max(np.abs(shap_values[0].sum(1) + explainer.expected_value[0] - model.predict_proba(X)[:,0])) < 1e-4
+    assert np.max(np.abs(
+        shap_values[0].sum(1) + explainer.expected_value[0] - model.predict_proba(X)[:, 0])) < 1e-4
+
 
 def test_HistGradientBoostingClassifier_multidim():
-    from sklearn.experimental import enable_hist_gradient_boosting
-    from sklearn.ensemble import HistGradientBoostingClassifier
-    import numpy as np
-    import shap
-
     # train a tree-based model
     X, y = shap.datasets.adult()
     X = X[:100]
     y = y[:100]
     y = np.random.randint(0, 3, len(y))
-    model = HistGradientBoostingClassifier(max_iter=10, max_depth=6).fit(X, y)
+    model = sklearn.ensemble.HistGradientBoostingClassifier(max_iter=10, max_depth=6).fit(X, y)
     explainer = shap.TreeExplainer(model, shap.sample(X, 10), model_output="raw")
     shap_values = explainer.shap_values(X)
-    assert np.max(np.abs(shap_values[0].sum(1) + explainer.expected_value[0] - model.decision_function(X)[:,0])) < 1e-4
+    assert np.max(np.abs(shap_values[0].sum(1) +
+                         explainer.expected_value[0] - model.decision_function(X)[:, 0])) < 1e-4
+
 
 def test_sum_match_gradient_boosting_regressor():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import GradientBoostingRegressor
-    import sklearn
-
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = GradientBoostingRegressor(random_state=202, n_estimators=10, max_depth=10)
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.GradientBoostingRegressor(random_state=202, n_estimators=10,
+                                                     max_depth=10)
     clf.fit(X_train, Y_train)
 
     predicted = clf.predict(X_test)
@@ -802,100 +694,83 @@ def test_sum_match_gradient_boosting_regressor():
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"
 
-def test_single_row_gradient_boosting_regressor():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import GradientBoostingRegressor
-    import sklearn
 
-    X_train,X_test,Y_train,_ = train_test_split(*shap.datasets.adult(), test_size=0.2, random_state=0)
-    clf = GradientBoostingRegressor(random_state=202, n_estimators=10, max_depth=10)
+def test_single_row_gradient_boosting_regressor():
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(),
+                                                                           test_size=0.2,
+                                                                           random_state=0)
+    clf = sklearn.ensemble.GradientBoostingRegressor(random_state=202, n_estimators=10,
+                                                     max_depth=10)
     clf.fit(X_train, Y_train)
-    
+
     predicted = clf.predict(X_test)
     ex = shap.TreeExplainer(clf)
-    shap_values = ex.shap_values(X_test.iloc[0,:])
+    shap_values = ex.shap_values(X_test.iloc[0, :])
     assert np.abs(shap_values.sum() + ex.expected_value - predicted[0]) < 1e-4, \
         "SHAP values don't sum to model output!"
 
 
 def test_multi_target_random_forest():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import RandomForestRegressor
-
-    X_train, X_test, Y_train, _ = train_test_split(*shap.datasets.linnerud(), test_size=0.2, random_state=0)
-    est = RandomForestRegressor(random_state=202, n_estimators=10, max_depth=10)
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(
+        *shap.datasets.linnerud(), test_size=0.2,
+        random_state=0)
+    est = sklearn.ensemble.RandomForestRegressor(random_state=202, n_estimators=10, max_depth=10)
     est.fit(X_train, Y_train)
     predicted = est.predict(X_test)
 
     explainer = shap.TreeExplainer(est)
     expected_values = np.asarray(explainer.expected_value)
-    assert len(expected_values) == est.n_outputs_, "Length of expected_values doesn't match n_outputs_"
-    shap_values = np.asarray(explainer.shap_values(X_test)).reshape(est.n_outputs_ * X_test.shape[0], X_test.shape[1])
+    assert len(
+        expected_values) == est.n_outputs_, "Length of expected_values doesn't match n_outputs_"
+    shap_values = np.asarray(explainer.shap_values(X_test)).reshape(
+        est.n_outputs_ * X_test.shape[0], X_test.shape[1])
     phi = np.hstack((shap_values, np.repeat(expected_values, X_test.shape[0]).reshape(-1, 1)))
     assert np.allclose(phi.sum(1), predicted.flatten(order="F"), atol=1e-4)
 
 
 def test_isolation_forest():
-    import shap
-    import numpy as np
-    from sklearn.ensemble import IsolationForest
-    from sklearn.ensemble.iforest import _average_path_length
-
-    X,_ = shap.datasets.boston()
+    X, _ = shap.datasets.boston()
     for max_features in [1.0, 0.75]:
-        iso = IsolationForest(max_features=max_features)
+        iso = sklearn.ensemble.IsolationForest(max_features=max_features)
         iso.fit(X)
 
         explainer = shap.TreeExplainer(iso)
         shap_values = explainer.shap_values(X)
 
-        score_from_shap = - 2**(
-            - (np.sum(shap_values, axis=1) + explainer.expected_value) /
-            _average_path_length(np.array([iso.max_samples_]))[0]
-            )
+        l = sklearn.ensemble.iforest._average_path_length(  # pylint: disable=protected-access
+            np.array([iso.max_samples_]))[0]
+        score_from_shap = - 2 ** (- (np.sum(shap_values, axis=1) + explainer.expected_value) / l)
         assert np.allclose(iso.score_samples(X), score_from_shap, atol=1e-7)
 
 
-# TODO: this has sometimes failed with strange answers, should run memcheck on this for any memory issues at some point...
+# TODO: this has sometimes failed with strange answers, should run memcheck on this for any
+#  memory issues at some point...
 def test_multi_target_extra_trees():
-    import shap
-    import numpy as np
-    from sklearn.model_selection import train_test_split
-    from sklearn.ensemble import ExtraTreesRegressor
-
-    X_train, X_test, Y_train, _ = train_test_split(*shap.datasets.linnerud(), test_size=0.2, random_state=0)
-    est = ExtraTreesRegressor(random_state=202, n_estimators=10, max_depth=10)
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(
+        *shap.datasets.linnerud(), test_size=0.2,
+        random_state=0)
+    est = sklearn.ensemble.ExtraTreesRegressor(random_state=202, n_estimators=10, max_depth=10)
     est.fit(X_train, Y_train)
     predicted = est.predict(X_test)
 
     explainer = shap.TreeExplainer(est)
     expected_values = np.asarray(explainer.expected_value)
-    assert len(expected_values) == est.n_outputs_, "Length of expected_values doesn't match n_outputs_"
-    shap_values = np.asarray(explainer.shap_values(X_test)).reshape(est.n_outputs_ * X_test.shape[0], X_test.shape[1])
+    assert len(
+        expected_values) == est.n_outputs_, "Length of expected_values doesn't match n_outputs_"
+    shap_values = np.asarray(explainer.shap_values(X_test)).reshape(
+        est.n_outputs_ * X_test.shape[0], X_test.shape[1])
     phi = np.hstack((shap_values, np.repeat(expected_values, X_test.shape[0]).reshape(-1, 1)))
     assert np.allclose(phi.sum(1), predicted.flatten(order="F"), atol=1e-4)
 
 
 def test_provided_background_tree_path_dependent():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_provided_background_tree_path_dependent!")
-        return
-
-    from sklearn.model_selection import train_test_split
-    import numpy as np
-    import shap
+    xgboost = pytest.importorskip("xgboost")
     np.random.seed(10)
 
-    X,y = shap.datasets.iris()
+    X, y = shap.datasets.iris()
     X = X[:100]
     y = y[:100]
-    train_x, test_x, train_y, _ = train_test_split(X, y, random_state=1)
+    train_x, test_x, train_y, _ = sklearn.model_selection.train_test_split(X, y, random_state=1)
     feature_names = ["a", "b", "c", "d"]
     dtrain = xgboost.DMatrix(train_x, label=train_y, feature_names=feature_names)
     dtest = xgboost.DMatrix(test_x, feature_names=feature_names)
@@ -912,26 +787,23 @@ def test_provided_background_tree_path_dependent():
     bst = xgboost.train(params=params, dtrain=dtrain, num_boost_round=100)
 
     explainer = shap.TreeExplainer(bst, test_x, feature_perturbation="tree_path_dependent")
-    diffs = explainer.expected_value + explainer.shap_values(test_x).sum(1) - bst.predict(dtest, output_margin=True)
+    diffs = explainer.expected_value + \
+            explainer.shap_values(test_x).sum(1) - bst.predict(dtest, output_margin=True)
     assert np.max(np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output!"
-    assert np.abs(explainer.expected_value - bst.predict(dtest, output_margin=True).mean()) < 1e-6, "Bad expected_value!"
+    assert np.abs(explainer.expected_value - bst.predict(dtest,
+                                                         output_margin=True).mean()) < 1e-6, \
+        "Bad expected_value!"
+
 
 def test_provided_background_independent():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_provided_background_independent!")
-        return
+    xgboost = pytest.importorskip("xgboost")
 
-    from sklearn.model_selection import train_test_split
-    import numpy as np
-    import shap
     np.random.seed(10)
 
-    X,y = shap.datasets.iris()
+    X, y = shap.datasets.iris()
     X = X[:100]
     y = y[:100]
-    train_x, test_x, train_y, _ = train_test_split(X, y, random_state=1)
+    train_x, test_x, train_y, _ = sklearn.model_selection.train_test_split(X, y, random_state=1)
     feature_names = ["a", "b", "c", "d"]
     dtrain = xgboost.DMatrix(train_x, label=train_y, feature_names=feature_names)
     dtest = xgboost.DMatrix(test_x, feature_names=feature_names)
@@ -948,26 +820,23 @@ def test_provided_background_independent():
     bst = xgboost.train(params=params, dtrain=dtrain, num_boost_round=100)
 
     explainer = shap.TreeExplainer(bst, test_x, feature_perturbation="interventional")
-    diffs = explainer.expected_value + explainer.shap_values(test_x).sum(1) - bst.predict(dtest, output_margin=True)
+    diffs = explainer.expected_value + \
+            explainer.shap_values(test_x).sum(1) - bst.predict(dtest, output_margin=True)
     assert np.max(np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output!"
-    assert np.abs(explainer.expected_value - bst.predict(dtest, output_margin=True).mean()) < 1e-4, "Bad expected_value!"
+    assert np.abs(explainer.expected_value - bst.predict(dtest,
+                                                         output_margin=True).mean()) < 1e-4, \
+        "Bad expected_value!"
+
 
 def test_provided_background_independent_prob_output():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_provided_background_independent_prob_output!")
-        return
+    xgboost = pytest.importorskip("xgboost")
 
-    from sklearn.model_selection import train_test_split
-    import numpy as np
-    import shap
     np.random.seed(10)
 
-    X,y = shap.datasets.iris()
+    X, y = shap.datasets.iris()
     X = X[:100]
     y = y[:100]
-    train_x, test_x, train_y, _ = train_test_split(X, y, random_state=1)
+    train_x, test_x, train_y, _ = sklearn.model_selection.train_test_split(X, y, random_state=1)
     feature_names = ["a", "b", "c", "d"]
     dtrain = xgboost.DMatrix(train_x, label=train_y, feature_names=feature_names)
     dtest = xgboost.DMatrix(test_x, feature_names=feature_names)
@@ -984,91 +853,84 @@ def test_provided_background_independent_prob_output():
 
         bst = xgboost.train(params=params, dtrain=dtrain, num_boost_round=100)
 
-        explainer = shap.TreeExplainer(bst, test_x, feature_perturbation="interventional", model_output="probability")
+        explainer = shap.TreeExplainer(bst, test_x, feature_perturbation="interventional",
+                                       model_output="probability")
         diffs = explainer.expected_value + explainer.shap_values(test_x).sum(1) - bst.predict(dtest)
         assert np.max(np.abs(diffs)) < 1e-4, "SHAP values don't sum to model output!"
-        assert np.abs(explainer.expected_value - bst.predict(dtest).mean()) < 1e-4, "Bad expected_value!"
+        assert np.abs(
+            explainer.expected_value - bst.predict(dtest).mean()) < 1e-4, "Bad expected_value!"
+
 
 def test_single_tree_compare_with_kernel_shap():
     """ Compare with Kernel SHAP, which makes the same independence assumptions
-    as Independent Tree SHAP.  Namely, they both assume independence between the 
+    as Independent Tree SHAP.  Namely, they both assume independence between the
     set being conditioned on, and the remainder set.
     """
-    try:
-        import xgboost
-    except:
-        print("Skipping test_single_tree_compare_with_kernel_shap!")
-        return
-    import numpy as np
-    import shap
+    xgboost = pytest.importorskip("xgboost")
     np.random.seed(10)
 
     n = 100
-    X = np.random.normal(size=(n,7))
-    b = np.array([-2,1,3,5,2,20,-5])
-    y = np.matmul(X,b)
-    max_depth = 6
+    X = np.random.normal(size=(n, 7))
+    y = np.matmul(X, [-2, 1, 3, 5, 2, 20, -5])
 
     # train a model with single tree
     Xd = xgboost.DMatrix(X, label=y)
-    model = xgboost.train({'eta':1, 
-                       'max_depth':max_depth, 
-                       'base_score': 0, 
-                       "lambda": 0}, 
-                      Xd, 1)
+    model = xgboost.train({'eta': 1,
+                           'max_depth': 6,
+                           'base_score': 0,
+                           "lambda": 0},
+                          Xd, 1)
     ypred = model.predict(Xd)
 
     # Compare for five random samples
     for _ in range(5):
-        x_ind = np.random.choice(X.shape[1]); x = X[x_ind:x_ind+1,:]
+        x_ind = np.random.choice(X.shape[1])
+        x = X[x_ind:x_ind + 1, :]
 
         expl = shap.TreeExplainer(model, X, feature_perturbation="interventional")
-        f = lambda inp : model.predict(xgboost.DMatrix(inp))
+        f = lambda inp: model.predict(xgboost.DMatrix(inp))
         expl_kern = shap.KernelExplainer(f, X)
 
         itshap = expl.shap_values(x)
         kshap = expl_kern.shap_values(x, nsamples=150)
-        assert np.allclose(itshap,kshap), \
-        "Kernel SHAP doesn't match Independent Tree SHAP!"
+        assert np.allclose(itshap, kshap), \
+            "Kernel SHAP doesn't match Independent Tree SHAP!"
         assert np.allclose(itshap.sum() + expl.expected_value, ypred[x_ind]), \
-        "SHAP values don't sum to model output!"    
+            "SHAP values don't sum to model output!"
+
 
 def test_several_trees():
     """ Make sure Independent Tree SHAP sums up to the correct value for
     larger models (20 trees).
-    """    
-    try:
-        import xgboost
-    except:
-        print("Skipping test_several_trees!")
-        return
-    import shap
-    import numpy as np
+    """
+    xgboost = pytest.importorskip("xgboost")
     np.random.seed(10)
 
     n = 1000
-    X = np.random.normal(size=(n,7))
-    b = np.array([-2,1,3,5,2,20,-5])
-    y = np.matmul(X,b)
+    X = np.random.normal(size=(n, 7))
+    b = np.array([-2, 1, 3, 5, 2, 20, -5])
+    y = np.matmul(X, b)
     max_depth = 6
 
     # train a model with single tree
     Xd = xgboost.DMatrix(X, label=y)
-    model = xgboost.train({'eta':1, 
-                       'max_depth':max_depth, 
-                       'base_score': 0, 
-                       "lambda": 0}, 
-                      Xd, 20)
+    model = xgboost.train({'eta': 1,
+                           'max_depth': max_depth,
+                           'base_score': 0,
+                           "lambda": 0},
+                          Xd, 20)
     ypred = model.predict(Xd)
 
     # Compare for five random samples
     for _ in range(5):
-        x_ind = np.random.choice(X.shape[1]); x = X[x_ind:x_ind+1,:]
+        x_ind = np.random.choice(X.shape[1])
+        x = X[x_ind:x_ind + 1, :]
         expl = shap.TreeExplainer(model, X, feature_perturbation="interventional")
         itshap = expl.shap_values(x)
         assert np.allclose(itshap.sum() + expl.expected_value, ypred[x_ind]), \
-        "SHAP values don't sum to model output!"
-        
+            "SHAP values don't sum to model output!"
+
+
 def test_single_tree_nonlinear_transformations():
     """ Make sure Independent Tree SHAP single trees with non-linear
     transformations.
@@ -1083,76 +945,64 @@ def test_single_tree_nonlinear_transformations():
     # def mse(yt,yp):
     #     return(np.square(yt-yp))
 
-    try:
-        import xgboost
-    except:
-        print("Skipping test_several_trees!")
-        return
-    import shap
-    import numpy as np
+    xgboost = pytest.importorskip("xgboost")
     np.random.seed(10)
 
     n = 100
-    X = np.random.normal(size=(n,7))
-    b = np.array([-2,1,3,5,2,20,-5])
-    y = np.matmul(X,b)
+    X = np.random.normal(size=(n, 7))
+    y = np.matmul(X, [-2, 1, 3, 5, 2, 20, -5])
     y = y + abs(min(y))
-    y = np.random.binomial(n=1,p=y/max(y))
-    max_depth = 6
+    y = np.random.binomial(n=1, p=y / max(y))
 
     # train a model with single tree
     Xd = xgboost.DMatrix(X, label=y)
-    model = xgboost.train({'eta':1, 
-                       'max_depth':max_depth, 
-                       'base_score': y.mean(), 
-                       "lambda": 0,
-                       "objective": "binary:logistic"}, 
-                      Xd, 1)
-    pred = model.predict(Xd,output_margin=True) # In margin space (log odds)
-    trans_pred = model.predict(Xd) # In probability space
+    model = xgboost.train({'eta': 1,
+                           'max_depth': 6,
+                           'base_score': y.mean(),
+                           "lambda": 0,
+                           "objective": "binary:logistic"},
+                          Xd, 1)
+    pred = model.predict(Xd, output_margin=True)  # In margin space (log odds)
+    trans_pred = model.predict(Xd)  # In probability space
 
     expl = shap.TreeExplainer(model, X, feature_perturbation="interventional")
-    f = lambda inp : model.predict(xgboost.DMatrix(inp), output_margin=True)
+    f = lambda inp: model.predict(xgboost.DMatrix(inp), output_margin=True)
     expl_kern = shap.KernelExplainer(f, X)
 
-    x_ind = 0; x = X[x_ind:x_ind+1,:]
+    x_ind = 0
+    x = X[x_ind:x_ind + 1, :]
     itshap = expl.shap_values(x)
     kshap = expl_kern.shap_values(x, nsamples=300)
     assert np.allclose(itshap.sum() + expl.expected_value, pred[x_ind]), \
-    "SHAP values don't sum to model output on explaining margin!"
+        "SHAP values don't sum to model output on explaining margin!"
     assert np.allclose(itshap, kshap), \
-    "Independent Tree SHAP doesn't match Kernel SHAP on explaining margin!"
+        "Independent Tree SHAP doesn't match Kernel SHAP on explaining margin!"
 
     model.set_attr(objective="binary:logistic")
-    expl = shap.TreeExplainer(model, X, feature_perturbation="interventional", model_output="probability")
+    expl = shap.TreeExplainer(model, X, feature_perturbation="interventional",
+                              model_output="probability")
     itshap = expl.shap_values(x)
     assert np.allclose(itshap.sum() + expl.expected_value, trans_pred[x_ind]), \
-    "SHAP values don't sum to model output on explaining logistic!"
+        "SHAP values don't sum to model output on explaining logistic!"
 
-    # expl = shap.TreeExplainer(model, X, feature_perturbation="interventional", model_output="logloss")
+    # expl = shap.TreeExplainer(model, X, feature_perturbation="interventional",
+    # model_output="logloss")
     # itshap = expl.shap_values(x,y=y[x_ind])
     # margin_pred = model.predict(xgb.DMatrix(x),output_margin=True)
     # currpred = log_loss(y[x_ind],sigmoid(margin_pred))
     # assert np.allclose(itshap.sum(), currpred - expl.expected_value), \
     # "SHAP values don't sum to model output on explaining logloss!"
 
-def test_xgboost_classifier_independent_margin():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_several_trees!")
-        return
-    import numpy as np
-    import shap
 
+def test_xgboost_classifier_independent_margin():
+    xgboost = pytest.importorskip("xgboost")
     # train XGBoost model
     np.random.seed(10)
     n = 1000
-    X = np.random.normal(size=(n,7))
-    b = np.array([-2,1,3,5,2,20,-5])
-    y = np.matmul(X,b)
+    X = np.random.normal(size=(n, 7))
+    y = np.matmul(X, [-2, 1, 3, 5, 2, 20, -5])
     y = y + abs(min(y))
-    y = np.random.binomial(n=1,p=y/max(y))
+    y = np.random.binomial(n=1, p=y / max(y))
 
     model = xgboost.XGBClassifier(n_estimators=10, max_depth=5)
     model.fit(X, y)
@@ -1165,40 +1015,36 @@ def test_xgboost_classifier_independent_margin():
 
 
 def test_xgboost_classifier_independent_probability():
-    try:
-        import xgboost
-    except:
-        print("Skipping test_several_trees!")
-        return
-    import shap
-    import numpy as np
+    xgboost = pytest.importorskip("xgboost")
 
     # train XGBoost model
     np.random.seed(10)
     n = 1000
-    X = np.random.normal(size=(n,7))
-    b = np.array([-2,1,3,5,2,20,-5])
-    y = np.matmul(X,b)
+    X = np.random.normal(size=(n, 7))
+    b = np.array([-2, 1, 3, 5, 2, 20, -5])
+    y = np.matmul(X, b)
     y = y + abs(min(y))
-    y = np.random.binomial(n=1,p=y/max(y))
+    y = np.random.binomial(n=1, p=y / max(y))
 
     model = xgboost.XGBClassifier(n_estimators=10, max_depth=5)
     model.fit(X, y)
 
     # explain the model's predictions using SHAP values
-    e = shap.TreeExplainer(model, X, feature_perturbation="interventional", model_output="probability")
+    e = shap.TreeExplainer(model, X, feature_perturbation="interventional",
+                           model_output="probability")
     shap_values = e.shap_values(X)
 
-    assert np.allclose(shap_values.sum(1) + e.expected_value, model.predict_proba(X)[:,1])
+    assert np.allclose(shap_values.sum(1) + e.expected_value, model.predict_proba(X)[:, 1])
+
 
 # def test_front_page_xgboost_global_path_dependent():
 #     try:
-#         import xgboost
+#         xgboost = pytest.importorskip("xgboost")
 #     except:
 #         print("Skipping test_front_page_xgboost!")
 #         return
-#     import shap
-#     import numpy as np
+#
+#
 
 #     # train XGBoost model
 #     X, y = shap.datasets.boston()
@@ -1212,37 +1058,34 @@ def test_xgboost_classifier_independent_probability():
 #     assert np.allclose(shap_values.sum(1) + explainer.expected_value, model.predict(X))
 
 def test_skopt_rf_et():
-    try:
-        import skopt
-        import pandas as pd
-    except:
-        print("Skipping test_skopt_rf_et!")
-        return
-    import shap
-    import numpy as np
+    skopt = pytest.importorskip("skopt")
 
     # Define an objective function for skopt to optimise.
     def objective_function(x):
-        return x[0]**2 - x[1]**2 + x[1]*x[0]
+        return x[0] ** 2 - x[1] ** 2 + x[1] * x[0]
 
     # Uneven bounds to prevent "objective has been evaluated" warnings.
     problem_bounds = [(-1e6, 3e6), (-1e6, 3e6)]
 
     # Don't worry about "objective has been evaluated" warnings.
-    result_et = skopt.forest_minimize(objective_function, problem_bounds, n_calls = 100, base_estimator = "ET")
-    result_rf = skopt.forest_minimize(objective_function, problem_bounds, n_calls = 100, base_estimator = "RF")
+    result_et = skopt.forest_minimize(objective_function, problem_bounds, n_calls=100,
+                                      base_estimator="ET")
+    result_rf = skopt.forest_minimize(objective_function, problem_bounds, n_calls=100,
+                                      base_estimator="RF")
 
-    et_df = pd.DataFrame(result_et.x_iters, columns = ["X0", "X1"])
+    et_df = pd.DataFrame(result_et.x_iters, columns=["X0", "X1"])
 
     # Explain the model's predictions.
     explainer_et = shap.TreeExplainer(result_et.models[-1], et_df)
     shap_values_et = explainer_et.shap_values(et_df)
 
-    rf_df = pd.DataFrame(result_rf.x_iters, columns = ["X0", "X1"])
+    rf_df = pd.DataFrame(result_rf.x_iters, columns=["X0", "X1"])
 
     # Explain the model's predictions (Random forest).
     explainer_rf = shap.TreeExplainer(result_rf.models[-1], rf_df)
     shap_values_rf = explainer_rf.shap_values(rf_df)
 
-    assert np.allclose(shap_values_et.sum(1) + explainer_et.expected_value, result_et.models[-1].predict(et_df))
-    assert np.allclose(shap_values_rf.sum(1) + explainer_rf.expected_value, result_rf.models[-1].predict(rf_df))
+    assert np.allclose(shap_values_et.sum(1) + explainer_et.expected_value,
+                       result_et.models[-1].predict(et_df))
+    assert np.allclose(shap_values_rf.sum(1) + explainer_rf.expected_value,
+                       result_rf.models[-1].predict(rf_df))

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -186,6 +186,7 @@ def test_ngboost():
 def test_pyspark_classifier_decision_tree():
     # pylint: disable=bare-except
     pyspark = pytest.importorskip("pyspark")
+    pytest.importorskip("pyspark.ml")
     try:
         spark = pyspark.sql.SparkSession.builder.config(
             conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
@@ -240,6 +241,7 @@ def test_pyspark_classifier_decision_tree():
 def test_pyspark_regression_decision_tree():
     # pylint: disable=bare-except
     pyspark = pytest.importorskip("pyspark")
+    pytest.importorskip("pyspark.ml")
     try:
         spark = pyspark.sql.SparkSession.builder.config(
             conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
@@ -257,17 +259,17 @@ def test_pyspark_regression_decision_tree():
         iris)
 
     regressors = [
-        pyspark.ml.classification.GBTRegressor(labelCol="sepal_length", featuresCol="features"),
-        pyspark.ml.classification.RandomForestRegressor(labelCol="sepal_length",
+        pyspark.ml.regression.GBTRegressor(labelCol="sepal_length", featuresCol="features"),
+        pyspark.ml.regression.RandomForestRegressor(labelCol="sepal_length",
                                                         featuresCol="features"),
-        pyspark.ml.classification.DecisionTreeRegressor(labelCol="sepal_length",
+        pyspark.ml.regression.DecisionTreeRegressor(labelCol="sepal_length",
                                                         featuresCol="features")]
     for regressor in regressors:
         model = regressor.fit(iris)
         explainer = shap.TreeExplainer(model)
         X = pd.DataFrame(
             data=iris_sk.data, columns=iris_sk.feature_names).drop(  # pylint: disable=E1101
-                'sepal length (cm)', 1)[:100]
+            'sepal length (cm)', 1)[:100]
 
         shap_values = explainer.shap_values(X)
         expected_values = explainer.expected_value


### PR DESCRIPTION
- Remove tests path from pytest.ini so we can run individual tests instead of running all tests every time 

- Reduce the duration of a few longer running tree tests

- Add .pylintrc and lint tests/explainers/test_tree.py

- Tests that fail optional imports now get marked as skipped instead of succeeded

- If pyspark cluster cannot be instantiated, mark as skipped instead of succeeded