### PR TITLE
Add TreeExplainer support for PyOD IForest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ class build_ext(_build_ext):
         self.include_dirs.append(numpy.get_include())
 
 
-def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catboost=True, test_spark=True):
+def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catboost=True, test_spark=True, test_pyod=True):
     ext_modules = []
     if with_binary:
         compile_args = []
@@ -72,6 +72,8 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catb
         tests_require += ['catboost']
     if test_spark:
         tests_require += ['pyspark']
+    if test_pyod:
+        tests_require += ['pyod']
 
     extras_require = {
         'plots': [

--- a/setup.py
+++ b/setup.py
@@ -151,9 +151,13 @@ def try_run_setup(**kwargs):
             kwargs["with_binary"] = False
             print("WARNING: The C extension could not be compiled, sklearn tree models not supported.")
             try_run_setup(**kwargs)
+        elif "pyod" in str(e).lower():
+            kwargs["test_pyod"] = False
+            print("Couldn't install PyOD for testing!")
+            try_run_setup(**kwargs)
         else:
             print("ERROR: Failed to build!")
 
 # we seem to need this import guard for appveyor
 if __name__ == "__main__":
-    try_run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_spark=True)
+    try_run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_spark=True, test_pyod=True)

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -619,6 +619,11 @@ class TreeEnsemble:
             scaling = 1.0 / len(model.estimators_) # output is average of trees
             self.trees = [IsoTree(e.tree_, f, scaling=scaling, data=data, data_missing=data_missing) for e, f in zip(model.estimators_, model.estimators_features_)]
             self.tree_output = "raw_value"
+        elif safe_isinstance(model, ["pyod.models.iforest.IForest"]):
+            self.dtype = np.float32
+            scaling = 1.0 / len(model.estimators_) # output is average of trees
+            self.trees = [IsoTree(e.tree_, f, scaling=scaling, data=data, data_missing=data_missing) for e, f in zip(model.detector_.estimators_, model.detector_.estimators_features_)]
+            self.tree_output = "raw_value"
         elif safe_isinstance(model, "skopt.learning.forest.RandomForestRegressor"):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -863,6 +863,26 @@ def test_isolation_forest():
             )
         assert np.allclose(iso.score_samples(X), score_from_shap, atol=1e-7)
 
+def test_pyod_isolation_forest():
+    import shap
+    import numpy as np
+    from pyod.models.iforest import IForest
+    from sklearn.ensemble.iforest import _average_path_length
+
+    X,_ = shap.datasets.boston()
+    for max_features in [1.0, 0.75]:
+        iso = IForest(max_features=max_features)
+        iso.fit(X)
+
+        explainer = shap.TreeExplainer(iso)
+        shap_values = explainer.shap_values(X)
+
+        score_from_shap = - 2**(
+            - (np.sum(shap_values, axis=1) + explainer.expected_value) /
+            _average_path_length(np.array([iso.max_samples_]))[0]
+            )
+        assert np.allclose(iso.detector_.score_samples(X), score_from_shap, atol=1e-7)
+
 
 # TODO: this has sometimes failed with strange answers, should run memcheck on this for any memory issues at some point...
 def test_multi_target_extra_trees():


### PR DESCRIPTION
PyOD is a Python toolkit for outlier detection. Internally, a PyOD IForest uses Scikit-learn IsolationForest implementation. 

Shap's TreeExplainer already supports Scikit-learn IsolationForest, I slightly changed the existing code to support PyOD IForest.