### PR TITLE
Add .detach() to make deep explainer work with PyTorch 1.7

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -195,7 +195,7 @@ class PyTorchDeep(Explainer):
                         phis[l][j] = (sample_phis[l][self.data[l].shape[0]:] * (x[l] - data[l])).mean(0)
                 else:
                     for l in range(len(X)):
-                        phis[l][j] = (torch.from_numpy(sample_phis[l][self.data[l].shape[0]:]).to(self.device) * (X[l][j: j + 1] - self.data[l])).cpu().numpy().mean(0)
+                        phis[l][j] = (torch.from_numpy(sample_phis[l][self.data[l].shape[0]:]).to(self.device) * (X[l][j: j + 1] - self.data[l])).cpu().detach().numpy().mean(0)
             output_phis.append(phis[0] if not self.multi_input else phis)
         # cleanup; remove all gradient handles
         for handle in handles:


### PR DESCRIPTION
I used python3.7 with the following packages:

torchvision==0.8.1
torch==1.7.0
shap==0.36.0

With this code:
"""
import shap
import torch
import torchvision
from torch.autograd import Variable
from PIL import Image

model = torch.load('./model.pth')
model.eval()

loader = torchvision.transforms.Compose([
    torchvision.transforms.Resize(size = (224,224)),
    torchvision.transforms.ToTensor(),
    torchvision.transforms.Normalize(mean =[0.485,0.456,0.406],
                                     std=[0.229,0.224,0.225]),
])


def image_loader(image_name):
    """load image, returns cuda tensor"""
    image = Image.open(image_name).convert('RGB')
    image = loader(image).float()
    image = Variable(image, requires_grad=True)
    image = image.unsqueeze(0)
    return image


image = image_loader('./COVID-19 (36).png')

e = shap.DeepExplainer(model, image)
shap_values = e.shap_values(image)
"""

Returning the following error:

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-1-448fec2c27df> in <module>
----> 1 import codecs, os;__pyfile = codecs.open('''/tmp/py4330hko''', encoding='''utf-8''');__code = __pyfile.read().encode('''utf-8''');__pyfile.close();os.remove('''/tmp/py4330hko''');exec(compile(__code, '''/home/users/azarnyhd/work/test_shapley/shapley_for_covid19.py''', 'exec'));

~/work/test_shapley/shapley_for_covid19.py in <module>
     28 
     29 e = shap.DeepExplainer(model, image)
---> 30 shap_values = e.shap_values(image)

anaconda3/lib/python3.7/site-packages/shap/explainers/_deep/__init__.py in shap_values(self, X, ranked_outputs, output_rank_order, check_additivity)
    117         were chosen as "top".
    118         """
--> 119         return self.explainer.shap_values(X, ranked_outputs, output_rank_order, check_additivity=check_additivity)

anaconda3/lib/python3.7/site-packages/shap/explainers/_deep/deep_pytorch.py in shap_values(self, X, ranked_outputs, output_rank_order, check_additivity)
    196                 else:
    197                     for l in range(len(X)):
--> 198                         phis[l][j] = (torch.from_numpy(sample_phis[l][self.data[l].shape[0]:]).to(self.device) * (X[l][j: j + 1] - self.data[l])).cpu().numpy().mean(0)
    199             output_phis.append(phis[0] if not self.multi_input else phis)
    200         # cleanup; remove all gradient handles

RuntimeError: Can't call numpy() on Tensor that requires grad. Use tensor.detach().numpy() instead.

Model could be found here: https://github.com/azarnyx/shapley_covid19/tree/main/data/model
The image: https://github.com/azarnyx/shapley_covid19/tree/main/data/sample_images

This modification fixes the error.