### PR TITLE
Allow users to control features displayed on force plot

### DIFF
--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -337,7 +337,7 @@ def update_axis_limits(ax, total_pos, pos_features, total_neg,
             spine.set_visible(False)
 
 
-def draw_additive_plot(data, figsize, show, text_rotation=0):
+def draw_additive_plot(data, figsize, show, text_rotation=0, min_perc=0.05):
     """Draw additive plot."""
     # Turn off interactive plot
     if show is False:
@@ -383,10 +383,10 @@ def draw_additive_plot(data, figsize, show, text_rotation=0):
     # Add labels
     total_effect = np.abs(total_neg) + total_pos
     fig, ax = draw_labels(fig, ax, out_value, neg_features, 'negative',
-                          offset_text, total_effect, min_perc=0.05, text_rotation=text_rotation)
+                          offset_text, total_effect, min_perc=min_perc, text_rotation=text_rotation)
     
     fig, ax = draw_labels(fig, ax, out_value, pos_features, 'positive',
-                          offset_text, total_effect, min_perc=0.05, text_rotation=text_rotation)
+                          offset_text, total_effect, min_perc=min_perc, text_rotation=text_rotation)
     
     # higher lower legend
     draw_higher_lower_element(out_value, offset_text)


### PR DESCRIPTION
**Description** 
This PR adds an input arg to `force_plot` to allow users control the features that are displayed on the force plots. By default, only features are displayed that their contribution is larger than 5% of the total contribution (see[ this line](https://github.com/slundberg/shap/compare/master...shiva-z:force-plot-features?expand=1#diff-6adb73f48f48b176dd2b8ecec105a40e28571d8c2a6458cec9d646925d5e75f7L386)). This threshold (5%) might be too small and resulting in too many features displayed (Issue #4) or might be too large and resulting in not enough features displayed (issue #1214).

**Example Usage**

```
import sklearn.ensemble
import shap

X, y = shap.datasets.boston()
model = sklearn.ensemble.RandomForestRegressor(n_estimators=100)
model.fit(X, y)

explainer = shap.TreeExplainer(model)
shap_values = explainer.shap_values(X)

shap.force_plot(explainer.expected_value,
                shap_values[0, :], X.iloc[0, :],
                matplotlib=True,
                show=False,
                contribution_threshold=0.1)
```

![image](https://user-images.githubusercontent.com/14043961/99124009-8dec0000-25be-11eb-97eb-24f479cd4ff6.png)
