### PR TITLE
Several bug fixes to call SHAP from EconML

### DIFF
--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -319,10 +319,10 @@ class Linear(Explainer):
                 #     return [np.array(X - self.mean) * self.coef[i] for i in range(self.coef.shape[0])]
 
         return {
-            "values": phi,
+            "values": phi.T,
             "expected_values": self.expected_value,
             "mask_shapes": (X.shape[1:],),
-            "main_effects": phi,
+            "main_effects": phi.T,
             "clustering": None
         }
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -86,7 +86,7 @@ class Tree(Explainer):
     --------
     See :ref:`Tree Explainer Examples <tree_explainer_examples>`
     """
-    def __init__(self, model, data = None, model_output="raw", feature_perturbation="interventional",feature_names=None, **deprecated_options):
+    def __init__(self, model, data = None, model_output="raw", feature_perturbation="interventional", feature_names=None, **deprecated_options):
         
         if feature_names is not None:
             self.data_feature_names=feature_names

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -86,13 +86,15 @@ class Tree(Explainer):
     --------
     See :ref:`Tree Explainer Examples <tree_explainer_examples>`
     """
-    def __init__(self, model, data = None, model_output="raw", feature_perturbation="interventional", **deprecated_options):
-
-        if safe_isinstance(data, "pandas.core.frame.DataFrame"):
+    def __init__(self, model, data = None, model_output="raw", feature_perturbation="interventional",feature_names=None, **deprecated_options):
+        
+        if feature_names is not None:
+            self.data_feature_names=feature_names
+        elif safe_isinstance(data, "pandas.core.frame.DataFrame"):
             self.data_feature_names = list(data.columns)
 
         masker = data
-        super(Tree, self).__init__(model, masker)
+        super(Tree, self).__init__(model, masker,feature_names=feature_names)
 
         if type(self.masker) is maskers.Independent:
             data = self.masker.data

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -94,7 +94,7 @@ class Tree(Explainer):
             self.data_feature_names = list(data.columns)
 
         masker = data
-        super(Tree, self).__init__(model, masker,feature_names=feature_names)
+        super(Tree, self).__init__(model, masker, feature_names=feature_names)
 
         if type(self.masker) is maskers.Independent:
             data = self.masker.data

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -425,7 +425,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
     # support passing an explanation object
     if str(type(shap_values)).endswith("Explanation'>"):
         shap_exp = shap_values
-        base_value = shap_exp.base_value
+        base_value = shap_exp.base_values
         shap_values = shap_exp.values
         if features is None:
             features = shap_exp.data


### PR DESCRIPTION
- the `explain_row()` method under linear explainer should return the values of shape (dx,dy) in multiple outcome, it will be in line with other explainers

- add extra argument to allow feature names being passed through

- fix variable name typo in beeswarm plot 