### PR TITLE
When plotting categorical interactions, ensure we don't request more bounds than available color buckets

### DIFF
--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -258,7 +258,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         if categorical_interaction and clow != chigh:
             clow = np.nanmin(cv.astype(np.float))
             chigh = np.nanmax(cv.astype(np.float))
-            bounds = np.linspace(clow, chigh, int(chigh - clow + 2))
+            bounds = np.linspace(clow, chigh, min(int(chigh - clow + 2), cmap.N-1))
             color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
 
     # optionally add jitter to feature values
@@ -606,7 +606,7 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         if categorical_interaction and clow != chigh:
             clow = np.nanmin(cv.astype(np.float))
             chigh = np.nanmax(cv.astype(np.float))
-            bounds = np.linspace(clow, chigh, int(chigh - clow + 2))
+            bounds = np.linspace(clow, chigh, min(int(chigh - clow + 2), cmap.N-1))
             color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
 
     # optionally add jitter to feature values


### PR DESCRIPTION
Due to automatic detection of categorical interactions, certain datasets (specifically, those with extreme outlier values) can cause us to generate a bounds array with more elements than the number of color buckets available to us. This leads to an error from matplotlib saying "ncolors must equal or exceed the number of bins".

This PR caps the number of bounds generated to be at most the number of bins available in the colormap.