### PR TITLE
Generalize CUDA compilation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,10 @@ class build_ext(_build_ext):
         print("numpy.get_include()", numpy.get_include())
         self.include_dirs.append(numpy.get_include())
 
+
 def find_in_path(name, path):
-    "Find a file in a search path"
-    # adapted from https://github.com/benfred/implicit/blob/master/cuda_setup.py, which is
-    # in turn adapted from:
+    """Find a file in a search path and return its full path."""
+    # adapted from:
     # http://code.activestate.com/recipes/52224-find-a-file-given-a-search-path/
     for dir in path.split(os.pathsep):
         binpath = os.path.join(dir, name)
@@ -67,9 +67,10 @@ def find_in_path(name, path):
             return os.path.abspath(binpath)
     return None
 
+
 def get_cuda_path():
-    """Returns a tuple with (base_cuda_directory, full_path_to_nvcc_compiler)"""
-    # Inspired by: https://github.com/benfred/implicit/blob/master/cuda_setup.py
+    """Return a tuple with (base_cuda_directory, full_path_to_nvcc_compiler)."""
+    # Inspired by https://github.com/benfred/implicit/blob/master/cuda_setup.py
     nvcc_bin = "nvcc.exe" if sys.platform == "win32" else "nvcc"
 
     if "CUDAHOME" in os.environ:
@@ -81,22 +82,24 @@ def get_cuda_path():
         found_nvcc = find_in_path(nvcc_bin, os.environ["PATH"])
         if found_nvcc is None:
             print(
-                "The nvcc binary could not be located in your $PATH. Either add it to "
-                "your path, or set $CUDAHOME to enable CUDA extensions"
+                "The nvcc binary could not be located in your $PATH. Either " +
+                " add it to your path, or set $CUDAHOME to enable CUDA"
             )
             return None
         cuda_home = os.path.dirname(os.path.dirname(found_nvcc))
     if not os.path.exists(os.path.join(cuda_home, "include")):
-        print("Failed to find cuda include directory, attempting /usr/local/cuda")
+        print("Failed to find cuda include directory, using /usr/local/cuda")
         cuda_home = "/usr/local/cuda"
 
     nvcc = os.path.join(cuda_home, "bin", nvcc_bin)
     if not os.path.exists(nvcc):
-        print("Failed to find nvcc compiler in %s, attempting /usr/local/cuda" % nvcc)
+        print("Failed to find nvcc compiler in %s, trying /usr/local/cuda" %
+              nvcc)
         cuda_home = "/usr/local/cuda"
         nvcc = os.path.join(cuda_home, "bin", nvcc_bin)
 
     return (cuda_home, nvcc)
+
 
 def compile_cuda_module(host_args):
     libname = '_cext_gpu.lib' if sys.platform == 'win32' else 'lib_cext_gpu.a'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import subprocess
 # For mac, ensure extensions are built for macos 10.9 when compiling on a
 # 10.9 system or above, overriding distuitls behavior which is to target
 # the version that python was built for. This may be overridden by setting
-# MACOSX_DEPLOYMENT_TARGET before calling setup.py
+# MACOSX_DEPLOYMENT_TARGET before calling setup.pcuda-comp-generalizey
 if sys.platform == 'darwin':
     if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
         current_system = LooseVersion(platform.mac_ver()[0])
@@ -141,10 +141,10 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True, test_catb
     if with_cuda:
         try:
             cuda_home, nvcc = get_cuda_path()
-            cudart_path = cuda_home + '/lib'
             if sys.platform == 'win32':
-                cudart_path += '/x64'
+                cudart_path = cuda_home + '/lib/x64'
             else:
+                cudart_path = cuda_home + '/lib64'
                 compile_args.append('-fPIC')
 
             lib_dir, lib = compile_cuda_module(compile_args)

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,10 @@ def get_cuda_path():
         cuda_home = "/usr/local/cuda"
 
     nvcc = os.path.join(cuda_home, "bin", nvcc_bin)
+    if not os.path.exists(nvcc):
+        print("Failed to find nvcc compiler in %s, attempting /usr/local/cuda" % nvcc)
+        cuda_home = "/usr/local/cuda"
+        nvcc = os.path.join(cuda_home, "bin", nvcc_bin)
 
     return (cuda_home, nvcc)
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ def compile_cuda_module(host_args):
                  "-gencode=arch=compute_75,code=sm_75 " + \
                  "-gencode=arch=compute_75,code=compute_75"
     nvcc_command = "shap/cext/_cext_gpu.cu -lib -o {} -Xcompiler {} -I{} " \
-                   "--std c++17 " \
+                   "--std c++14 " \
                    "--extended-lambda " \
                    "--expt-relaxed-constexpr {}".format(
                        lib_out,

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ def compile_cuda_module(host_args):
                  "-gencode=arch=compute_75,code=compute_75"
     nvcc_command = "shap/cext/_cext_gpu.cu -lib -o {} -Xcompiler {} -I{} " \
                    "--std c++14 " \
-                   "--extended-lambda " \
+                   "--expt-extended-lambda " \
                    "--expt-relaxed-constexpr {}".format(
                        lib_out,
                        ','.join(host_args),

--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -39,6 +39,15 @@ struct ShapSplitCondition {
   }
 };
 
+
+// Inspired by: https://en.cppreference.com/w/cpp/iterator/size
+// Limited implementation of std::size fo arrays
+template <class T, size_t N>
+constexpr size_t array_size(const T (&array)[N]) noexcept
+{
+    return N;
+}
+
 void RecurseTree(
     unsigned pos, const TreeEnsemble &tree,
     std::vector<gpu_treeshap::PathElement<ShapSplitCondition>> *tmp_path,
@@ -195,7 +204,7 @@ inline void dense_tree_path_dependent_gpu(
   thrust::for_each(
       counting, counting + phis.size(), [=] __device__(size_t idx) {
         size_t old_shape[] = {X.NumRows(), num_groups, (X.NumCols() + 1)};
-        size_t old_idx[std::size(old_shape)];
+        size_t old_idx[array_size(old_shape)];
         gpu_treeshap::FlatIdxToTensorIdx(idx, old_shape, old_idx);
         // Define new tensor format, switch num_groups axis to end
         size_t new_shape[] = {X.NumRows(), (X.NumCols() + 1), num_groups};
@@ -246,7 +255,7 @@ dense_tree_independent_gpu(const TreeEnsemble &trees,
   thrust::for_each(
       counting, counting + phis.size(), [=] __device__(size_t idx) {
         size_t old_shape[] = {X.NumRows(), num_groups, (X.NumCols() + 1)};
-        size_t old_idx[std::size(old_shape)];
+        size_t old_idx[array_size(old_shape)];
         gpu_treeshap::FlatIdxToTensorIdx(idx, old_shape, old_idx);
         // Define new tensor format, switch num_groups axis to end
         size_t new_shape[] = {X.NumRows(), (X.NumCols() + 1), num_groups};
@@ -294,7 +303,7 @@ inline void dense_tree_path_dependent_interactions_gpu(
       counting, counting + phis.size(), [=] __device__(size_t idx) {
         size_t old_shape[] = {X.NumRows(), num_groups, (X.NumCols() + 1),
                               (X.NumCols() + 1)};
-        size_t old_idx[std::size(old_shape)];
+        size_t old_idx[array_size(old_shape)];
         gpu_treeshap::FlatIdxToTensorIdx(idx, old_shape, old_idx);
         // Define new tensor format, switch num_groups axis to end
         size_t new_shape[] = {X.NumRows(), (X.NumCols() + 1), (X.NumCols() + 1),


### PR DESCRIPTION
Two related changes:
 * Replaces usage of std::size, which requires C++17 support not available everywhere
 * Finding CUDA can be a little wonky depending on how it was installed. This approach will search CUDAHOME in addition to CUDA_PATH and will fall back to /usr/local/cuda if it can't find nvcc. This helps building within conda env and is generally inspired by what @benfred's `implicit` does.