### PR TITLE
handle categorical features colors

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -80,10 +80,13 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
             color = colors.blue_rgb
     color = convert_color(color)
 
+    idx2cat = None
     # convert from a DataFrame or other types
     if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
         if feature_names is None:
             feature_names = features.columns
+        # feature index to category flag
+        idx2cat = features.dtypes.astype(str).isin(["object", "category"]).tolist()
         features = features.values
     elif isinstance(features, list):
         if feature_names is None:
@@ -283,7 +286,10 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
         shaps = shaps[inds]
         colored_feature = True
         try:
-            fvalues = np.array(fvalues, dtype=np.float64)  # make sure this can be numeric
+            if idx2cat is not None and idx2cat[i]: # check categorical feature
+                colored_feature = False
+            else:
+                fvalues = np.array(fvalues, dtype=np.float64)  # make sure this can be numeric
         except:
             colored_feature = False
         N = len(shaps)
@@ -458,10 +464,13 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
         else:
             color = colors.blue_rgb
 
+    idx2cat = None
     # convert from a DataFrame or other types
     if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
         if feature_names is None:
             feature_names = features.columns
+        # feature index to category flag
+        idx2cat = features.dtypes.astype(str).isin(["object", "category"]).tolist()
         features = features.values
     elif isinstance(features, list):
         if feature_names is None:
@@ -601,7 +610,10 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
             shaps = shaps[inds]
             colored_feature = True
             try:
-                values = np.array(values, dtype=np.float64)  # make sure this can be numeric
+                if idx2cat is not None and idx2cat[i]: # check categorical feature
+                    colored_feature = False
+                else:
+                    values = np.array(values, dtype=np.float64)  # make sure this can be numeric
             except:
                 colored_feature = False
             N = len(shaps)

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -51,7 +51,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
         if sp.sparse.issparse(features):
             features = features.toarray()
         feature_names = shap_exp.feature_names
-        # if out_names is None: # TODO: waiting for slicer support of this
+        # if out_names is None: # TODO: waiting for slicer support
         #     out_names = shap_exp.output_names
 
     order = convert_ordering(order, values)

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -91,10 +91,13 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
         else:
             color = colors.blue_rgb
 
+    idx2cat = None
     # convert from a DataFrame or other types
     if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
         if feature_names is None:
             feature_names = features.columns
+        # feature index to category flag
+        idx2cat = features.dtypes.astype(str).isin(["object", "category"]).tolist()
         features = features.values
     elif isinstance(features, list):
         if feature_names is None:
@@ -234,7 +237,10 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
             shaps = shaps[inds]
             colored_feature = True
             try:
-                values = np.array(values, dtype=np.float64)  # make sure this can be numeric
+                if idx2cat is not None and idx2cat[i]: # check categorical feature
+                    colored_feature = False
+                else:
+                    values = np.array(values, dtype=np.float64)  # make sure this can be numeric
             except:
                 colored_feature = False
             N = len(shaps)


### PR DESCRIPTION
Small fix in order to handle categorical features mapped as integer in `shap.summary_plot`.
For example features defined as
``` python
pd.Series([0, 1, 2]).astype("category")
```