### PR TITLE
Enabling identification of econml trees and generalized random forests

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -623,7 +623,8 @@ class TreeEnsemble:
             self.trees = [SingleTree(t, data=data, data_missing=data_missing) for t in model["trees"]]
         elif type(model) is list and type(model[0]) == SingleTree: # old-style direct-load format
             self.trees = model
-        elif safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor"]):
+        elif safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor",
+                                     "econml.grf._base_grf.BaseGRF"]):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -665,7 +666,8 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "raw_value"
-        elif safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor"]):
+        elif safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor",
+                                     "econml.grf._base_grftree.GRFTree"]):
             self.internal_dtype = model.tree_.value.dtype.type
             self.input_dtype = np.float32
             self.trees = [SingleTree(model.tree_, data=data, data_missing=data_missing)]
@@ -1124,7 +1126,7 @@ class SingleTree:
     def __init__(self, tree, normalize=False, scaling=1.0, data=None, data_missing=None):
         assert_import("cext")
 
-        if safe_isinstance(tree, "sklearn.tree._tree.Tree"):
+        if safe_isinstance(tree, ["sklearn.tree._tree.Tree", "econml.tree._tree.Tree"]):
             self.children_left = tree.children_left.astype(np.int32)
             self.children_right = tree.children_right.astype(np.int32)
             self.children_default = self.children_left # missing values not supported in sklearn

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -623,8 +623,7 @@ class TreeEnsemble:
             self.trees = [SingleTree(t, data=data, data_missing=data_missing) for t in model["trees"]]
         elif type(model) is list and type(model[0]) == SingleTree: # old-style direct-load format
             self.trees = model
-        elif safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor",
-                                     "econml.grf._base_grf.BaseGRF"]):
+        elif safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor", "econml.grf._base_grf.BaseGRF"]):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -666,8 +665,7 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "raw_value"
-        elif safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor",
-                                     "econml.grf._base_grftree.GRFTree"]):
+        elif safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor", "econml.grf._base_grftree.GRFTree"]):
             self.internal_dtype = model.tree_.value.dtype.type
             self.input_dtype = np.float32
             self.trees = [SingleTree(model.tree_, data=data, data_missing=data_missing)]

--- a/shap/explainers/other/_treegain.py
+++ b/shap/explainers/other/_treegain.py
@@ -19,6 +19,8 @@ class TreeGain(Explainer):
             pass
         elif str(type(model)).endswith("xgboost.sklearn.XGBClassifier'>"):
             pass
+        elif str(type(model)).endswith("econml.grf._base_grftree.GRFTree'>"):
+            pass
         else:
             raise Exception("The passed model is not yet supported by TreeGainExplainer: " + str(type(model)))
         assert hasattr(model, "feature_importances_"), "The passed model does not have a feature_importances_ attribute!"

--- a/shap/explainers/other/_treegain.py
+++ b/shap/explainers/other/_treegain.py
@@ -19,8 +19,6 @@ class TreeGain(Explainer):
             pass
         elif str(type(model)).endswith("xgboost.sklearn.XGBClassifier'>"):
             pass
-        elif str(type(model)).endswith("econml.grf._base_grftree.GRFTree'>"):
-            pass
         else:
             raise Exception("The passed model is not yet supported by TreeGainExplainer: " + str(type(model)))
         assert hasattr(model, "feature_importances_"), "The passed model does not have a feature_importances_ attribute!"


### PR DESCRIPTION
Enabling identification of econml trees and generalized random forests by TreeExplainer and handled identically to sklearn.tree._tree.Tree, sklearn.tree.DecisionTreeRegressor, sklearn.ensemble.RandomForestRegressor