### PR TITLE
Wrap IPython import statement with try-catch to prevent `ModuleNotFoundError`

### DIFF
--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -9,12 +9,10 @@ try:
     import matplotlib.pyplot as pl
 except ImportError:
     warnings.warn("matplotlib could not be loaded!")
-    pass
 try:
     from IPython.core.display import display, HTML
 except ImportError:
     warnings.warn("IPython could not be loaded!")
-    pass
 from . import colors
 from ..utils._legacy import kmeans
 

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -10,9 +10,13 @@ try:
 except ImportError:
     warnings.warn("matplotlib could not be loaded!")
     pass
+try:
+    from IPython.core.display import display, HTML
+except ImportError:
+    warnings.warn("IPython could not be loaded!")
+    pass
 from . import colors
 from ..utils._legacy import kmeans
-from IPython.core.display import display, HTML
 
 # .shape[0] messes up pylint a lot here
 # pylint: disable=unsubscriptable-object


### PR DESCRIPTION
When a user installs shap with `pip install shap`, `ipython` is not installed since it’s an extra dependency. Running `import shap` in this state causes `ModuleNotFoundError: No module named 'IPython'`. To prevent this error, this PR proposes to wrap `from IPython.core.display import display, HTML` with try-catch (the same approach used for `matplotlib`).

Dockerfile to reproduce the error:

```
FROM python:3.7

RUN pip install --quiet shap matplotlib  # requires matplotlib to repro the error
RUN pip freeze

RUN python -c "import shap"
```

`docker build .` with this Dockerfile gave:

```diff
Step 1/4 : FROM python:3.7
 ---> 7fefbebd95b5
Step 2/4 : RUN pip install --quiet shap matplotlib
 ---> Using cache
 ---> 551f07f5cc10
Step 3/4 : RUN pip freeze
 ---> Using cache
 ---> 2328604daf4b
Step 4/4 : RUN python -c "import shap"
 ---> Running in a251c6bb936c
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/shap/__init__.py", line 38, in <module>
    from .plots._beeswarm import summary_legacy as summary_plot
  File "/usr/local/lib/python3.7/site-packages/shap/plots/__init__.py", line 8, in <module>
    from ._image import image, image_to_text
  File "/usr/local/lib/python3.7/site-packages/shap/plots/_image.py", line 15, in <module>
    from IPython.core.display import display, HTML
+ ModuleNotFoundError: No module named 'IPython'
The command '/bin/sh -c python -c "import shap"' returned a non-zero code: 1
```