### PR TITLE
Handle missing IPython import

### DIFF
--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -12,7 +12,13 @@ except ImportError:
     pass
 from . import colors
 from ..utils._legacy import kmeans
-from IPython.core.display import display, HTML
+
+try:
+    from IPython.core.display import display, HTML
+except ImportError:
+    warnings.warn("IPython could not be loaded!")
+    pass
+
 
 # .shape[0] messes up pylint a lot here
 # pylint: disable=unsubscriptable-object


### PR DESCRIPTION
Resolve issue #1757 .

## Why 
When installing `matplotlib` and `shap` without installing IPython the following error will be raised when importing shap  
```sh
$ shap python -c "import shap"                                                                                                                                                          <aws:hunters>
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/roi/Dev/shap/shap/__init__.py", line 38, in <module>
    from .plots._beeswarm import summary_legacy as summary_plot
  File "/Users/roi/Dev/shap/shap/plots/__init__.py", line 8, in <module>
    from ._image import image, image_to_text
  File "/Users/roi/Dev/shap/shap/plots/_image.py", line 17, in <module>
    from IPython.core.display import display, HTML
ModuleNotFoundError: No module named 'IPython'
```

## How 
Add an except on `ImportError` when importing `IPython`. 