### PR TITLE
fix: correlation dependent linear shap

### DIFF
--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -78,7 +78,7 @@ class Linear(Explainer):
             else:
                 masker = maskers.Independent({"mean": masker[0], "cov": masker[1]})
 
-        super(Linear, self).__init__(model, masker, link=link, algorithm="linear", **kwargs)
+        super(Linear, self).__init__(model, masker, link=link, **kwargs)
 
         self.nsamples = nsamples
         

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -307,7 +307,6 @@ class Linear(Explainer):
             full_phi = np.zeros(((phi.shape[0], self.M)))
             full_phi[:,self.valid_inds] = phi
             phi = full_phi
-            return full_phi
 
         elif self.feature_perturbation == "interventional":
             if sp.sparse.issparse(X):


### PR DESCRIPTION
This PR fixes two bugs in `shap.explainers._linear.Linear` related to  #1795 

1. `shap.maskers.Independent` was always used regardless even when `feature_perturbation="correlation_dependent"` was provided in the constructor.
2. `explain_row(...)` was returning a numpy array for the `correlation_dependent` feature perturbation method instead of the expected dictionary. This error only surfaced after fixing the first issue.