### PR TITLE
WiP: [feature] Adds utils.to_dataframe

### DIFF
--- a/shap/utils/__init__.py
+++ b/shap/utils/__init__.py
@@ -3,3 +3,4 @@ from ._general import approximate_interactions, potential_interactions, sample, 
 from ._general import shapley_coefficients, convert_name, format_value, ordinal_str, OpChain
 from ._show_progress import show_progress
 from ._masked_model import MaskedModel, make_masks
+from ._tabular import to_dataframe

--- a/shap/utils/_tabular.py
+++ b/shap/utils/_tabular.py
@@ -1,0 +1,39 @@
+import pandas as pd
+
+def to_dataframe(X, shap_values, type="global"):
+    """ Convert the shap values to a pandas DataFrame.
+
+    Parameters
+    ----------
+
+    X : numpy.array or pandas.DataFrame
+        A matrix of samples (# samples x # features).
+
+    shap_values : numpy.array or list
+        A matrix of shap values (# samples x # features).
+
+    type : str
+        "global" : (default) generate one dataframe for all observations.
+        "local" : generates a list of dataframes.
+
+
+    Returns
+    -------
+    Pandas DataFrame or list of Pandas DataFrame
+        If type == "global", returns a DataFrame (# samples x # shap values) containing
+        the shap values for each feature.
+        If type == "local", returns a list with a DataFrame (# features x # shap values x # values) 
+        for each sample.
+    """
+    if type == "global":
+        return pd.DataFrame(shap_values, columns=X.columns)
+    else:
+        samples = []
+        for i, sv in enumerate(shap_values):
+            df = pd.DataFrame()
+            samples.append(pd.DataFrame({
+                'feature_name': X.columns,
+                'shap_value': sv,
+                'feature_value': X.iloc[i, :].values
+            }))
+        return samples


### PR DESCRIPTION
Hi everyone,
I'm opening this PR as a WiP for discussion.
I have been using this function for a while now inside my projects, because I need a better way to handle the shap_values for local interpretability, eg: saving to a database or displaying on a dashboard.

**How to use**
We generate shap values, like this;
```
import xgboost
import shap

# load JS visualization code to notebook
shap.initjs()

# train XGBoost model
X,y = shap.datasets.boston()
model = xgboost.train({"learning_rate": 0.01}, xgboost.DMatrix(X, label=y), 100)

# explain the model's predictions using SHAP
# (same syntax works for LightGBM, CatBoost, scikit-learn and spark models)
explainer = shap.TreeExplainer(model)
shap_values = explainer.shap_values(X)
```

But, instead of calling force_plot or some other visualization function, we call to_dataframe with type="local" to get a structured dataframe for every sample:
```
>> explanations = shap.utils.to_dataframe(X, shap_values, type='local')
>> explanations[0] # one for each sample
feature_name  shap_value  feature_value
0          CRIM    0.214554        0.00632
1            ZN    0.001347       18.00000
2         INDUS    0.018625        2.31000
3          CHAS    0.000000        0.00000
4           NOX   -0.407199        0.53800
5            RM   -1.161836        6.57500
6           AGE   -0.051294       65.20000
7           DIS   -0.342014        4.09000
8           RAD   -0.040446        1.00000
9           TAX    0.005487      296.00000
10      PTRATIO    0.050437       15.30000
11            B    0.027335      396.90000
12        LSTAT    3.944320        4.98000
```

Calling with type="global":
```
>> shap.utils.to_dataframe(X, shap_values)
         CRIM        ZN     INDUS  CHAS       NOX        RM       AGE       DIS       RAD       TAX   PTRATIO         B     LSTAT
0    0.214554  0.001347  0.018625   0.0 -0.407199 -1.161836 -0.051294 -0.342014 -0.040446  0.005487  0.050437  0.027335  3.944320
1    0.155329 -0.000145  0.015380   0.0  0.202683 -1.421003  0.007839 -0.218202 -0.011172  0.068912  0.067537  0.030773  1.776321
2    0.215071 -0.000197  0.010976   0.0  0.300025  2.662230 -0.048194 -0.195486 -0.004875  0.074755  0.059504  0.040972  4.079880
3    0.198795 -0.000197  0.010976   0.0  0.296236  2.100869 -0.047799 -0.202624 -0.004593  0.078215  0.051829  0.041348  4.501813
4    0.225711 -0.000197  0.010976   0.0  0.296236  2.622418 -0.048483 -0.067217 -0.004875  0.078215  0.049482  0.040972  3.991424
..        ...       ...       ...   ...       ...       ...       ...       ...       ...       ...       ...       ...       ...
501  0.217806 -0.003630  0.017437   0.0  0.064196 -0.255168 -0.033671 -0.029691 -0.170089  0.061408 -0.299804  0.044502  1.350070
502  0.135671 -0.003630  0.017437   0.0  0.077881 -1.770273 -0.017433 -0.063375 -0.170089  0.061408 -0.345686  0.028841  1.554053
503  0.205472 -0.003651  0.010618   0.0  0.182431  1.608566 -0.056352  0.008796 -0.170089  0.032885 -1.108893  0.031912  2.081848
504  0.235165 -0.003630  0.017462   0.0  0.059240 -0.260752 -0.056548 -0.055961 -0.170089  0.032741 -0.285619  0.028463  2.270567
505  0.039219 -0.028915  0.014358   0.0  0.107744 -2.511637 -0.165713 -0.072159 -0.332363  0.061408 -0.344520  0.027025  1.118829

[506 rows x 13 columns]
```

This implementation is just the overall idea.  I don't know if the utils is the right place for it or if the name and arguments are in the right "shap pattern".

Also, I've only tested with TreeExplainer.

What do you think about @slundberg?
If you like these changes, I guess there is still a couple things to do, like:
- [ ] Documentation
- [ ] Examples
- [ ] Tests? 

This should close #1724 