### PR TITLE
Update dead link to API examples for docs

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -88,7 +88,7 @@ class Tree(Explainer):
 
         Examples
         --------
-        See `Tree explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/Tree.html>`_
+        See `API examples <https://shap.readthedocs.io/en/latest/api_examples.html>`_
         """
         if feature_names is not None:
             self.data_feature_names=feature_names


### PR DESCRIPTION
As the docs are updated the old link doesn't work anymore. Until further development, I would suggest to just link to the API examples.

![image](https://user-images.githubusercontent.com/22077628/110837710-e0ee6f00-82a1-11eb-9bcb-a2bcd95ec6d4.png)
