### PR TITLE
Add  envvar flag to inject js scripts with vis

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -372,6 +372,15 @@ class SimpleListVisualizer(BaseVisualizer):
 
     def html(self):
         # assert have_ipython, "IPython must be installed to use this visualizer! Run `pip install ipython` and then restart shap."
+        if os.environ.get("ALWAYS_INJECT_JS_SCRIPTS"):
+            return getjs() + """
+<div id='{id}'></div>
+ <script>
+   SHAP.ReactDom.render(
+    SHAP.React.createElement(SHAP.SimpleListVisualizer, {data}),
+    document.getElementById('{id}')
+  );
+</script>""".format(edata=json.dumps(self.data), id=id_generator())
         return """
 <div id='{id}'>{err_msg}</div>
  <script>
@@ -473,6 +482,15 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
 
     def html(self):
         # assert have_ipython, "IPython must be installed to use this visualizer! Run `pip install ipython` and then restart shap."
+        if os.environ.get("ALWAYS_INJECT_JS_SCRIPTS"):
+            return getjs() + """
+    <div id='{id}'></div>
+     <script>
+      SHAP.ReactDom.render(
+        SHAP.React.createElement(SHAP.AdditiveForceArrayVisualizer, {data}),
+        document.getElementById('{id}')
+      );
+    </script>""".format(data=json.dumps(self.data), id=id_generator())
         return """
 <div id='{id}'>{err_msg}</div>
  <script>

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -380,7 +380,7 @@ class SimpleListVisualizer(BaseVisualizer):
     SHAP.React.createElement(SHAP.SimpleListVisualizer, {data}),
     document.getElementById('{id}')
   );
-</script>""".format(edata=json.dumps(self.data), id=id_generator())
+</script>""".format(data=json.dumps(self.data), id=id_generator())
         return """
 <div id='{id}'>{err_msg}</div>
  <script>


### PR DESCRIPTION
Allows users to set an envvar to enable always returning the Javascript scripts with the visualization instead of relying on initjs() having been run to provide them. 

This helps alleviate an issue encountered where each output was being rendered in an individual iframes, making plots unable to render since they could not access the scripts.