### PR TITLE
PartitionShap: channel-first partitioning and channel SHAP plots. 

### DIFF
--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -14,7 +14,7 @@ class Image(Masker):
     """ This masks out image regions with blurring or inpainting.
     """
 
-    def __init__(self, mask_value, shape=None):
+    def __init__(self, mask_value, shape=None, partition_scheme=0):
         """ Build a new Image masker with the given masking value.
 
         Parameters
@@ -25,6 +25,11 @@ class Image(Masker):
         shape : None or tuple
             If the mask_value is an auto-generated masker instead of a dataset then the input
             image shape needs to be provided.
+
+        partition_scheme : 0 or 1
+            Selects paritioning scheme. If the partition_scheme is 0, then all row, column
+            splits are performed before channel splits. If the partition_scheme is 1, then
+            all channels are split before splitting rows and columns.
         """
         if shape is None:
             if isinstance(mask_value, str):
@@ -34,6 +39,8 @@ class Image(Masker):
             self.input_shape = shape
 
         self.input_mask_value = mask_value
+
+        self.partition_scheme = partition_scheme
 
         # This is the shape of the masks we expect
         self.shape = (1, np.prod(self.input_shape)) # the (1, ...) is because we only return a single masked sample to average over
@@ -153,23 +160,48 @@ class Image(Masker):
                 lzmin = rzmin = zmin
                 lzmax = rzmax = zmax
 
-                # split the xaxis if it is the largest dimension
-                if xwidth >= ywidth and xwidth > 1:
-                    xmid = xmin + xwidth // 2
-                    lxmax = xmid
-                    rxmin = xmid
+                 # Partition scheme 0: xaxis and yaxis fully partitioned before zaxis
+                 if self.partition_scheme == 0:
 
-                # split the yaxis
-                elif ywidth > 1:
-                    ymid = ymin + ywidth // 2
-                    lymax = ymid
-                    rymin = ymid
+                     # split the xaxis if it is the largest dimension
+                     if xwidth >= ywidth and xwidth > 1:
+                         xmid = xmin + xwidth // 2
+                         lxmax = xmid
+                         rxmin = xmid
 
-                # split the zaxis only when the other ranges are already width 1
-                else:
-                    zmid = zmin + zwidth // 2
-                    lzmax = zmid
-                    rzmin = zmid
+                     # split the yaxis
+                     elif ywidth > 1:
+                         ymid = ymin + ywidth // 2
+                         lymax = ymid
+                         rymin = ymid
+
+                     # split the zaxis only when the other ranges are already width 1
+                     else:
+                         zmid = zmin + zwidth // 2
+                         lzmax = zmid
+                         rzmin = zmid
+
+                 # Partition scheme 1: zaxis partitioned first
+                 if self.partition_scheme == 2:
+
+                     # split the zaxis if it is larger than 1
+                     if zwidth > 1:
+                         zmid = zmin + zwidth // 2
+                         lzmax = zmid
+                         rzmin = zmid
+
+                     # split the xaxis if it is larger than the yaxis
+                     elif xwidth >= ywidth and xwidth > 1:
+                         xmid = xmin + xwidth // 2
+                         lxmax = xmid
+                         rxmin = xmid
+
+                     # split the yaxis
+                     elif ywidth > 1:
+                         ymid = ymin + ywidth // 2
+                         lymax = ymid
+                         rymin = ymid
+
 
                 lsize = (lxmax - lxmin) * (lymax - lymin) * (lzmax - lzmin)
                 rsize = (rxmax - rxmin) * (rymax - rymin) * (rzmax - rzmin)

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -160,47 +160,47 @@ class Image(Masker):
                 lzmin = rzmin = zmin
                 lzmax = rzmax = zmax
 
-                 # Partition scheme 0: xaxis and yaxis fully partitioned before zaxis
-                 if self.partition_scheme == 0:
+                # Partition scheme 0: xaxis and yaxis fully partitioned before zaxis
+                if self.partition_scheme == 0:
 
-                     # split the xaxis if it is the largest dimension
-                     if xwidth >= ywidth and xwidth > 1:
-                         xmid = xmin + xwidth // 2
-                         lxmax = xmid
-                         rxmin = xmid
+                    # split the xaxis if it is the largest dimension
+                    if xwidth >= ywidth and xwidth > 1:
+                        xmid = xmin + xwidth // 2
+                        lxmax = xmid
+                        rxmin = xmid
 
-                     # split the yaxis
-                     elif ywidth > 1:
-                         ymid = ymin + ywidth // 2
-                         lymax = ymid
-                         rymin = ymid
+                    # split the yaxis
+                    elif ywidth > 1:
+                        ymid = ymin + ywidth // 2
+                        lymax = ymid
+                        rymin = ymid
 
-                     # split the zaxis only when the other ranges are already width 1
-                     else:
-                         zmid = zmin + zwidth // 2
-                         lzmax = zmid
-                         rzmin = zmid
+                    # split the zaxis only when the other ranges are already width 1
+                    else:
+                        zmid = zmin + zwidth // 2
+                        lzmax = zmid
+                        rzmin = zmid
 
-                 # Partition scheme 1: zaxis partitioned first
-                 if self.partition_scheme == 2:
+                # Partition scheme 1: zaxis partitioned first
+                if self.partition_scheme == 2:
 
-                     # split the zaxis if it is larger than 1
-                     if zwidth > 1:
-                         zmid = zmin + zwidth // 2
-                         lzmax = zmid
-                         rzmin = zmid
+                    # split the zaxis if it is larger than 1
+                    if zwidth > 1:
+                        zmid = zmin + zwidth // 2
+                        lzmax = zmid
+                        rzmin = zmid
 
-                     # split the xaxis if it is larger than the yaxis
-                     elif xwidth >= ywidth and xwidth > 1:
-                         xmid = xmin + xwidth // 2
-                         lxmax = xmid
-                         rxmin = xmid
+                    # split the xaxis if it is larger than the yaxis
+                    elif xwidth >= ywidth and xwidth > 1:
+                        xmid = xmin + xwidth // 2
+                        lxmax = xmid
+                        rxmin = xmid
 
-                     # split the yaxis
-                     elif ywidth > 1:
-                         ymid = ymin + ywidth // 2
-                         lymax = ymid
-                         rymin = ymid
+                    # split the yaxis
+                    elif ywidth > 1:
+                        ymid = ymin + ywidth // 2
+                        lymax = ymid
+                        rymin = ymid
 
 
                 lsize = (lxmax - lxmin) * (lymax - lymin) * (lzmax - lzmin)

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -33,8 +33,10 @@ class Image(Masker):
         """
         if shape is None:
             if isinstance(mask_value, str):
-                raise TypeError("When the mask_value is a string the shape parameter must be given!")
-            self.input_shape = mask_value.shape # the (1,) is because we only return a single masked sample to average over
+                raise TypeError(
+                    "When the mask_value is a string the shape parameter must be given!")
+            # the (1,) is because we only return a single masked sample to average over
+            self.input_shape = mask_value.shape
         else:
             self.input_shape = shape
 
@@ -43,7 +45,8 @@ class Image(Masker):
         self.partition_scheme = partition_scheme
 
         # This is the shape of the masks we expect
-        self.shape = (1, np.prod(self.input_shape)) # the (1, ...) is because we only return a single masked sample to average over
+        # the (1, ...) is because we only return a single masked sample to average over
+        self.shape = (1, np.prod(self.input_shape))
 
         self.blur_kernel = None
         self._blur_value_cache = None
@@ -66,8 +69,8 @@ class Image(Masker):
 
     def __call__(self, mask, x):
         if np.prod(x.shape) != np.prod(self.input_shape):
-            raise Exception("The length of the image to be masked must match the shape given in the " + \
-                            "ImageMasker contructor: "+" * ".join([str(i) for i in x.shape])+ \
+            raise Exception("The length of the image to be masked must match the shape given in the " +
+                            "ImageMasker contructor: "+" * ".join([str(i) for i in x.shape]) +
                             " != "+" * ".join([str(i) for i in self.input_shape]))
 
         # unwrap single element lists (which are how single input models look in multi-input format)
@@ -86,7 +89,8 @@ class Image(Masker):
         if isinstance(self.mask_value, str):
             if self.blur_kernel is not None:
                 if self.last_xid != id(x):
-                    self._blur_value_cache = cv2.blur(x.reshape(self.input_shape), self.blur_kernel).flatten()
+                    self._blur_value_cache = cv2.blur(
+                        x.reshape(self.input_shape), self.blur_kernel).flatten()
                     self.last_xid = id(x)
                 out = x.copy()
                 out[~mask] = self._blur_value_cache[~mask]
@@ -143,7 +147,12 @@ class Image(Masker):
 
             # make sure we line up with a flattened indexing scheme
             if ind < 0:
-                assert -ind - 1 == xmin * total_ywidth * total_zwidth + ymin * total_zwidth + zmin
+                assert -ind - 1 == xmin * total_ywidth * \
+                    total_zwidth + ymin * total_zwidth + zmin
+
+            # make sure the partition scheme is supported
+            nschemes = [0, 1]
+            assert self.partition_scheme in nschemes
 
             xwidth = xmax - xmin
             ywidth = ymax - ymin
@@ -182,7 +191,7 @@ class Image(Masker):
                         rzmin = zmid
 
                 # Partition scheme 1: zaxis partitioned first
-                if self.partition_scheme == 2:
+                if self.partition_scheme == 1:
 
                     # split the zaxis if it is larger than 1
                     if zwidth > 1:
@@ -202,12 +211,13 @@ class Image(Masker):
                         lymax = ymid
                         rymin = ymid
 
-
                 lsize = (lxmax - lxmin) * (lymax - lymin) * (lzmax - lzmin)
                 rsize = (rxmax - rxmin) * (rymax - rymin) * (rzmax - rzmin)
 
-                q.put((-lsize, lxmin, lxmax, lymin, lymax, lzmin, lzmax, ind, True))
-                q.put((-rsize, rxmin, rxmax, rymin, rymax, rzmin, rzmax, ind, False))
+                q.put((-lsize, lxmin, lxmax, lymin,
+                       lymax, lzmin, lzmax, ind, True))
+                q.put((-rsize, rxmin, rxmax, rymin,
+                       rymax, rzmin, rzmax, ind, False))
 
             ind -= 1
 

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -47,6 +47,8 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
     show : bool
         Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
         to be customized further after it has been created.
+    plotchannels : None or list
+        List of image channel indices to plot separately. If None, will sum all bands for a single plot.
     """
 
     # support passing an explanation object

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -85,7 +85,7 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
 
     # plot our explanations
     x = pixel_values
-    fig_size = np.array([3 * (len(shap_values) + 1), 2.5 * (x.shape[0] + nchannels)])
+    fig_size = np.array([3 * (len(shap_values) + 1), 2.5 * (x.shape[0] + ((nchannels - 1) * 3))])
     if fig_size[0] > width:
         fig_size *= width / fig_size[0]
     fig, axes = pl.subplots(nrows=x.shape[0] * nchannels, ncols=len(shap_values) + 1, figsize=fig_size)

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -21,131 +21,131 @@ from ..utils._legacy import kmeans
 
 
 
- def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hspace=0.2, labelpad=None, show=True, plotchannels=[0]):
-     """ Plots SHAP values for image inputs.
+def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hspace=0.2, labelpad=None, show=True, plotchannels=[0]):
+    """ Plots SHAP values for image inputs.
 
-     Parameters
-     ----------
-     shap_values : [numpy.array]
-         List of arrays of SHAP values. Each array has the shap (# samples x width x height x channels), and the
-         length of the list is equal to the number of model outputs that are being explained.
+    Parameters
+    ----------
+    shap_values : [numpy.array]
+        List of arrays of SHAP values. Each array has the shap (# samples x width x height x channels), and the
+        length of the list is equal to the number of model outputs that are being explained.
 
-     pixel_values : numpy.array
-         Matrix of pixel values (# samples x width x height x channels) for each image. It should be the same
-         shape as each array in the shap_values list of arrays.
+    pixel_values : numpy.array
+        Matrix of pixel values (# samples x width x height x channels) for each image. It should be the same
+        shape as each array in the shap_values list of arrays.
 
-     labels : list
-         List of names for each of the model outputs that are being explained. This list should be the same length
-         as the shap_values list.
+    labels : list
+        List of names for each of the model outputs that are being explained. This list should be the same length
+        as the shap_values list.
 
-     width : float
-         The width of the produced matplotlib plot.
+    width : float
+        The width of the produced matplotlib plot.
 
-     labelpad : float
-         How much padding to use around the model output labels.
+    labelpad : float
+        How much padding to use around the model output labels.
 
-     show : bool
-         Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
-         to be customized further after it has been created.
-     """
+    show : bool
+        Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
+        to be customized further after it has been created.
+    """
 
-     # support passing an explanation object
-     if str(type(shap_values)).endswith("Explanation'>"):
-         shap_exp = shap_values
-         feature_names = [shap_exp.feature_names]
-         ind = 0
-         if len(shap_exp.base_values.shape) == 2:
-             shap_values = [shap_exp.values[..., i] for i in range(shap_exp.values.shape[-1])]
-         else:
-             raise Exception("Number of outputs needs to have support added!! (probably a simple fix)")
-         if pixel_values is None:
-             pixel_values = shap_exp.data
-         if labels is None:
-             labels = shap_exp.output_names
+    # support passing an explanation object
+    if str(type(shap_values)).endswith("Explanation'>"):
+        shap_exp = shap_values
+        feature_names = [shap_exp.feature_names]
+        ind = 0
+        if len(shap_exp.base_values.shape) == 2:
+            shap_values = [shap_exp.values[..., i] for i in range(shap_exp.values.shape[-1])]
+        else:
+            raise Exception("Number of outputs needs to have support added!! (probably a simple fix)")
+        if pixel_values is None:
+            pixel_values = shap_exp.data
+        if labels is None:
+            labels = shap_exp.output_names
 
-     multi_output = True
-     if type(shap_values) != list:
-         multi_output = False
-         shap_values = [shap_values]
+    multi_output = True
+    if type(shap_values) != list:
+        multi_output = False
+        shap_values = [shap_values]
 
-     # make sure the number of channels to plot is <= number of channels present
-     nchannels = min(shap_values[0].shape[-1], len(plotchannels))
-     plotchannels = plotchannels[:nchannels]
+    # make sure the number of channels to plot is <= number of channels present
+    nchannels = min(shap_values[0].shape[-1], len(plotchannels))
+    plotchannels = plotchannels[:nchannels]
 
-     # make sure labels
-     if labels is not None:
-         labels = np.array(labels)
-         assert labels.shape[0] == shap_values[0].shape[0], "Labels must have same row count as shap_values arrays!"
-         if multi_output:
-             assert labels.shape[1] == len(shap_values), "Labels must have a column for each output in shap_values!"
-         else:
-             assert len(labels.shape) == 1, "Labels must be a vector for single output shap_values."
+    # make sure labels
+    if labels is not None:
+        labels = np.array(labels)
+        assert labels.shape[0] == shap_values[0].shape[0], "Labels must have same row count as shap_values arrays!"
+        if multi_output:
+            assert labels.shape[1] == len(shap_values), "Labels must have a column for each output in shap_values!"
+        else:
+            assert len(labels.shape) == 1, "Labels must be a vector for single output shap_values."
 
-     label_kwargs = {} if labelpad is None else {'pad': labelpad}
+    label_kwargs = {} if labelpad is None else {'pad': labelpad}
 
-     # plot our explanations
-     x = pixel_values
-     fig_size = np.array([3 * (len(shap_values) + 1), 2.5 * (x.shape[0] + nchannels)])
-     if fig_size[0] > width:
-         fig_size *= width / fig_size[0]
-     fig, axes = pl.subplots(nrows=x.shape[0] * nchannels, ncols=len(shap_values) + 1, figsize=fig_size)
-     if len(axes.shape) == 1:
-         axes = axes.reshape(1,axes.size)
-     for row in range(x.shape[0]):
-         x_curr = x[row].copy()
+    # plot our explanations
+    x = pixel_values
+    fig_size = np.array([3 * (len(shap_values) + 1), 2.5 * (x.shape[0] + nchannels)])
+    if fig_size[0] > width:
+        fig_size *= width / fig_size[0]
+    fig, axes = pl.subplots(nrows=x.shape[0] * nchannels, ncols=len(shap_values) + 1, figsize=fig_size)
+    if len(axes.shape) == 1:
+        axes = axes.reshape(1,axes.size)
+    for row in range(x.shape[0]):
+        x_curr = x[row].copy()
 
-         # make sure we have a 2D array for grayscale
-         if len(x_curr.shape) == 3 and x_curr.shape[2] == 1:
-             x_curr = x_curr.reshape(x_curr.shape[:2])
-         if x_curr.max() > 1:
-             x_curr /= 255.
+        # make sure we have a 2D array for grayscale
+        if len(x_curr.shape) == 3 and x_curr.shape[2] == 1:
+            x_curr = x_curr.reshape(x_curr.shape[:2])
+        if x_curr.max() > 1:
+            x_curr /= 255.
 
-         # get a grayscale version of the image
-         if len(x_curr.shape) == 3 and x_curr.shape[2] == 3:
-             x_curr_gray = (0.2989 * x_curr[:,:,0] + 0.5870 * x_curr[:,:,1] + 0.1140 * x_curr[:,:,2]) # rgb to gray
-             x_curr_disp = x_curr
-         elif len(x_curr.shape) == 3:
-             x_curr_gray = x_curr.mean(2)
+        # get a grayscale version of the image
+        if len(x_curr.shape) == 3 and x_curr.shape[2] == 3:
+            x_curr_gray = (0.2989 * x_curr[:,:,0] + 0.5870 * x_curr[:,:,1] + 0.1140 * x_curr[:,:,2]) # rgb to gray
+            x_curr_disp = x_curr
+        elif len(x_curr.shape) == 3:
+            x_curr_gray = x_curr.mean(2)
 
-             # for non-RGB multi-channel data we show an RGB image where each of the three channels is a scaled k-mean center
-             flat_vals = x_curr.reshape([x_curr.shape[0]*x_curr.shape[1], x_curr.shape[2]]).T
-             flat_vals = (flat_vals.T - flat_vals.mean(1)).T
-             means = kmeans(flat_vals, 3, round_values=False).data.T.reshape([x_curr.shape[0], x_curr.shape[1], 3])
-             x_curr_disp = (means - np.percentile(means, 0.5, (0,1))) / (np.percentile(means, 99.5, (0,1)) - np.percentile(means, 1, (0,1)))
-             x_curr_disp[x_curr_disp > 1] = 1
-             x_curr_disp[x_curr_disp < 0] = 0
-         else:
-             x_curr_gray = x_curr
-             x_curr_disp = x_curr
+            # for non-RGB multi-channel data we show an RGB image where each of the three channels is a scaled k-mean center
+            flat_vals = x_curr.reshape([x_curr.shape[0]*x_curr.shape[1], x_curr.shape[2]]).T
+            flat_vals = (flat_vals.T - flat_vals.mean(1)).T
+            means = kmeans(flat_vals, 3, round_values=False).data.T.reshape([x_curr.shape[0], x_curr.shape[1], 3])
+            x_curr_disp = (means - np.percentile(means, 0.5, (0,1))) / (np.percentile(means, 99.5, (0,1)) - np.percentile(means, 1, (0,1)))
+            x_curr_disp[x_curr_disp > 1] = 1
+            x_curr_disp[x_curr_disp < 0] = 0
+        else:
+            x_curr_gray = x_curr
+            x_curr_disp = x_curr
 
-         axes[row*nchannels,0].imshow(x_curr_disp, cmap=pl.get_cmap('gray'))
-         axes[row*nchannels,0].axis('off')
-         for c in range(1, nchannels):
-             axes[row*nchannels+c, 0].set_visible(False)
+        axes[row*nchannels,0].imshow(x_curr_disp, cmap=pl.get_cmap('gray'))
+        axes[row*nchannels,0].axis('off')
+        for c in range(1, nchannels):
+            axes[row*nchannels+c, 0].set_visible(False)
 
-         if len(shap_values[0][row].shape) == 2:
-             abs_vals = np.stack([np.abs(shap_values[i]) for i in range(len(shap_values))], 0).flatten()
-         else:
-             abs_vals = np.stack([np.abs(shap_values[i].sum(-1)) for i in range(len(shap_values))], 0).flatten()
-         max_val = np.nanpercentile(abs_vals, 99.9)
-         for i in range(len(shap_values)):
-             if labels is not None:
-                 axes[row*nchannels,i+1].set_title(labels[row,i], **label_kwargs)
+        if len(shap_values[0][row].shape) == 2:
+            abs_vals = np.stack([np.abs(shap_values[i]) for i in range(len(shap_values))], 0).flatten()
+        else:
+            abs_vals = np.stack([np.abs(shap_values[i].sum(-1)) for i in range(len(shap_values))], 0).flatten()
+        max_val = np.nanpercentile(abs_vals, 99.9)
+        for i in range(len(shap_values)):
+            if labels is not None:
+                axes[row*nchannels,i+1].set_title(labels[row,i], **label_kwargs)
 
-             for c in range(nchannels):
-                 sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row][..., plotchannels[c]]
-                 axes[row*nchannels+c,i+1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
-                 im = axes[row*nchannels+c,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
-                 axes[row*nchannels+c,i+1].axis('off')
+            for c in range(nchannels):
+                sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row][..., plotchannels[c]]
+                axes[row*nchannels+c,i+1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
+                im = axes[row*nchannels+c,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
+                axes[row*nchannels+c,i+1].axis('off')
 
-     if hspace == 'auto':
-         fig.tight_layout()
-     else:
-         fig.subplots_adjust(hspace=hspace)
-     cb = fig.colorbar(im, ax=np.ravel(axes).tolist(), label="SHAP value", orientation="horizontal", aspect=fig_size[0]/aspect)
-     cb.outline.set_visible(False)
-     if show:
-         pl.show()
+    if hspace == 'auto':
+        fig.tight_layout()
+    else:
+        fig.subplots_adjust(hspace=hspace)
+    cb = fig.colorbar(im, ax=np.ravel(axes).tolist(), label="SHAP value", orientation="horizontal", aspect=fig_size[0]/aspect)
+    cb.outline.set_visible(False)
+    if show:
+        pl.show()
 
 
 def image_to_text(shap_values):

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -69,8 +69,11 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
         shap_values = [shap_values]
 
     # make sure the number of channels to plot is <= number of channels present
-    nchannels = min(shap_values[0].shape[-1], len(plotchannels))
-    plotchannels = plotchannels[:nchannels]
+    if plotchannels is not None:
+        nchannels = min(shap_values[0].shape[-1], len(plotchannels))
+        plotchannels = plotchannels[:nchannels]
+    else:
+        nchannels = 1
 
     # make sure labels
     if labels is not None:
@@ -132,11 +135,17 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
             if labels is not None:
                 axes[row*nchannels,i+1].set_title(labels[row,i], **label_kwargs)
 
-            for c in range(nchannels):
-                sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row][..., plotchannels[c]]
-                axes[row*nchannels+c,i+1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
-                im = axes[row*nchannels+c,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
-                axes[row*nchannels+c,i+1].axis('off')
+            if plotchannels is not None:
+                for c in range(nchannels):
+                    sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row][..., plotchannels[c]]
+                    axes[row*nchannels+c,i+1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
+                    im = axes[row*nchannels+c,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
+                    axes[row*nchannels+c,i+1].axis('off')
+            else:
+                sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row].sum(-1)
+                axes[row,i+1].imshow(x_curr_gray, cmap=pl.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
+                im = axes[row,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
+                axes[row,i+1].axis('off')
 
     if hspace == 'auto':
         fig.tight_layout()


### PR DESCRIPTION
There are a few of us interested in using SHAP to explore the channel-wise contributions. For example, for multispectral satellite imagery or 3D CNNs where the channels are time, temperatures, etc.

To help with initial explorations, I added support for `shap/plots/_image.py` to display requested channels. For example, if I want to see all RGB bands I can send in [0, 1, 2]. By default, it will sum the channels as before. 

I also added a second partition scheme where the channels are split before the the rows and columns. I suspect it will take some time to figure out the best partition schemes and masking methods for these various problems, but hopefully this will be useful for exploring. Again, its an optional parameter that will not affect existing code. 

Here is a quick demo: https://github.com/ekrell/shap_multiband/blob/main/MultiChannel_PartitionSHAP_Demo.ipynb  