### PR TITLE
changes:

### DIFF
--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -9,7 +9,7 @@ import json
 
 # TODO: we should support text output explanations (from models that output text not numbers), this would require the force
 # the force plot and the coloring to update based on mouseovers (or clicks to make it fixed) of the output text
-def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xmin=None, xmax=None, cmax=None):
+def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xmin=None, xmax=None, cmax=None, mylist=[]):
     """ Plots an explanation of a string of text using coloring and interactive labels.
 
     The output is interactive HTML and you can click on any token to toggle the display of the
@@ -82,7 +82,8 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
                 cmax = cmax_i
         for i in range(len(shap_values)):
             display(HTML("<br/><b>"+ordinal_str(i)+" instance:</b><br/>"))
-            text(shap_values[i], num_starting_labels=num_starting_labels, group_threshold=group_threshold, separator=separator, xmin=xmin, xmax=xmax, cmax=cmax)
+            myhtml = text(shap_values[i], num_starting_labels=num_starting_labels, group_threshold=group_threshold, separator=separator, xmin=xmin, xmax=xmax, cmax=cmax)
+            mylist.append(myhtml)
         return
 
     elif len(shap_values.shape) == 2 and shap_values.output_names is not None:
@@ -165,6 +166,7 @@ def text(shap_values, num_starting_labels=0, group_threshold=1, separator='', xm
              + "</div>"
 
     display(HTML(out))
+    return out
 
 def process_shap_values(tokens, values, group_threshold, separator, clustering = None, return_meta_data  = False):
 


### PR DESCRIPTION
SHAP is an excellent package.
However, currently, for some users not using jupyter but e.g. streamlit, it is difficult to use some of the plots for instance shap.plots.text.

https://shap.readthedocs.io/en/latest/example_notebooks/text_examples/sentiment_analysis/Positive%20vs.%20Negative%20Sentiment%20Classification.html

In order to overcome this difficulty I've made some minimal changes (which are also fully compatible), which I feel might be helpful for the community.

In the shap.plots.text function I have introduced the new argument mylist, which collects the html snippets produced in the text function. It can later be used in different environments e.g. for streamlit, but also in jupyter.

Here's an example based on 
https://shap.readthedocs.io/en/latest/example_notebooks/text_examples/sentiment_analysis/Positive%20vs.%20Negative%20Sentiment%20Classification.html
how it can be used together with streamlit.

```
import transformers
import datasets
import shap
import numpy as np

import streamlit as st
import streamlit.components.v1 as components

dataset = datasets.load_dataset("imdb", split="test")

# shorten the strings to fit into the pipeline model
short_data = [v[:500] for v in dataset["text"][:20]]
classifier = transformers.pipeline('sentiment-analysis', return_all_scores=True)
# define the explainer
explainer = shap.Explainer(classifier)
# explain the predictions of the pipeline on the first two samples
shap_values = explainer(short_data[:2])

mylist = []
shap.plots.text(shap_values[:,:,"POSITIVE"], mylist=mylist)

st.header('SHAP in streamlit')
# st.pyplot(fig)

st.write('')
for shap_html in mylist:
    components.html(shap_html, height=300, scrolling=True)
```

Here's a screenshot:

![image](https://user-images.githubusercontent.com/6077743/119222067-d0087800-baf2-11eb-9782-6d00c12c59aa.png)
