### PR TITLE
Automatic wheel building

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,58 @@
+name: Build wheels
+
+on:
+  release:
+    types: [published]
+
+  # Enable manual run
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.9.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: "cp27-* cp35-* pp*"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+          name: bdist_files
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+
+      - name: Build sdist (pep517)
+        run: |
+          python -m pip install pep517
+          python -m pep517.build -s .
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v2
+        with:
+          name: sdist_files
+          path: dist/*.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "oldest-supported-numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
#### Issue
I noticed that macOS and Linux wheels are missing on PyPI which is a problem for users without compilers installed on the computer. I the discussion with @slundberg, I offered to propose the solution to build wheels automatically.

#### Solution
This PR enables automatic wheel building with GH Actions. The solution builds wheels and prepares Python tarball for upload to PyPI.

The procedure with this solution is:
1. Bump version
2. Create a new tag and push it to the repository
3. Go to Releases and draft a new release from the tag. It will trigger GH Actions to start building wheels
4. After around 7 minutes find wheels under Actions. Open the action with the name Release x (x is release version) and find two zips under artifacts. Download them unpack and upload to PyPI. The first zip will contain Python tarball and the second wheels for all OSs.

If you agree with this solution merge it to the repository and create a new release as soon as possible that wheels will be available for all operating systems. I am available for any assistence.