### PR TITLE
More explicit error handling

### DIFF
--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -68,6 +68,7 @@ else:
 from . import datasets
 from . import utils
 from . import links
+from . import exceptions
 
 from .actions._optimizer import ActionOptimizer
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -233,7 +233,7 @@ class Explanation(object, metaclass=MetaExplanation):
             cohorts = np.array(cohorts)
             return Cohorts(**{name: self[cohorts == name] for name in np.unique(cohorts)})
         else:
-            raise Exception("The given set of cohort indicators is not recognized! Please give an array or int.")
+            raise TypeError("The given set of cohort indicators is not recognized! Please give an array or int.")
 
     def __repr__(self):
         out = ".values =\n"+self.values.__repr__()
@@ -460,7 +460,7 @@ class Explanation(object, metaclass=MetaExplanation):
         elif axis == 1 or len(self.shape) == 1:
             return group_features(self, grouping)
         else:
-            raise Exception("Only axis = 1 is supported for grouping right now...")
+            raise ValueError("Only axis = 1 is supported for grouping right now...")
 
     # def reshape(self, *args):
     #     return self._numpy_func("reshape", newshape=args)
@@ -498,7 +498,7 @@ class Explanation(object, metaclass=MetaExplanation):
         values = self.values
 
         if len(values.shape) != 2:
-            raise Exception("The hclust order only supports 2D arrays right now!")
+            raise ValueError("The hclust order only supports 2D arrays right now!")
 
         if axis == 1:
             values = values.T

--- a/shap/_serializable.py
+++ b/shap/_serializable.py
@@ -39,7 +39,7 @@ class Serializable():
             return None
 
         if not inspect.isclass(obj_type) or (not issubclass(obj_type, cls) and (obj_type is not cls)):
-            raise Exception(f"Invalid object type loaded from file. {obj_type} is not a subclass of {cls}.")
+            raise TypeError(f"Invalid object type loaded from file. {obj_type} is not a subclass of {cls}.")
 
         # here we call the constructor with all the arguments we have loaded
         constructor_args = obj_type.load(in_file, instantiate=False, **kwargs)

--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -24,7 +24,7 @@ class ActionOptimizer():
                     v._grouped_index = i
                 self.action_groups.append(group)
             else:
-                raise Exception("A passed action was not an Action or list of actions!")
+                raise TypeError("A passed action was not an Action or list of actions!")
         
     def __call__(self, *args, max_evals=10000):
         
@@ -40,7 +40,7 @@ class ActionOptimizer():
             # see if we have exceeded our runtime budget
             nevals += 1
             if nevals > max_evals:
-                raise Exception(f"Failed to find a solution with max_evals={max_evals}! Try reducing the number of actions or increasing max_evals.")
+                raise RuntimeError(f"Failed to find a solution with max_evals={max_evals}! Try reducing the number of actions or increasing max_evals.")
             
             # get the next cheapest set of actions we can do
             cost, actions = q.get()

--- a/shap/benchmark/experiments.py
+++ b/shap/benchmark/experiments.py
@@ -408,12 +408,12 @@ def __run_remote_experiment(experiment, remote, cache_dir="/tmp", python_binary=
     # copy the results back
     subprocess.check_output(["scp", remote+":"+cache_file, cache_file])
 
-    if os.path.isfile(cache_file):
+    try:
         with open(cache_file, "rb") as f:
             #print(cache_id.replace("__", " ") + " ...loaded from remote after %f seconds" % (time.time() - start))
             return pickle.load(f)
-    else:
-        raise Exception("Remote benchmark call finished but no local file was found!")
+    except (FileNotFoundError, IOError) as err:
+        raise FileNotFoundError("Remote benchmark call finished but no local file was found!") from err
 
 def __gen_cache_id(experiment):
     dataset_name, model_name, method_name, metric_name = experiment

--- a/shap/exceptions.py
+++ b/shap/exceptions.py
@@ -1,0 +1,7 @@
+"""Custom exceptions for more verbose error handling"""
+
+class UnsupportedModelError(Exception):
+    """
+    Explainer cannot handle the given model
+    """
+

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -48,8 +48,7 @@ class Additive(Explainer):
                 # self.model(np.zeros(num_features))
                 # self._zero_offset = self.model(np.zeros(num_features))#model.intercept_#outputs[0]
                 # self._input_offsets = np.zeros(num_features) #* self._zero_offset
-                raise Exception("Masker not given and we don't yet support pulling the distribution centering directly from the EBM model!")
-                return
+                raise ValueError("Masker not given and we don't yet support pulling the distribution centering directly from the EBM model!")
 
         # here we need to compute the offsets ourselves because we can't pull them directly from a model we know about
         assert safe_isinstance(self.masker, "shap.maskers.Independent"), "The Additive explainer only supports the Tabular masker at the moment!"
@@ -83,7 +82,7 @@ class Additive(Explainer):
         """
         if safe_isinstance(model, "interpret.glassbox.ExplainableBoostingClassifier"):
             if model.interactions is not 0:
-                raise Exception("Need to add support for interaction effects!")
+                raise NotImplementedError("Need to add support for interaction effects!")
             return True
             
         return False

--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -170,7 +170,7 @@ class TFDeep(Explainer):
             if noutputs is not None:
                 self.phi_symbolics = [None for i in range(noutputs)]
             else:
-                raise Exception("The model output tensor to be explained cannot have a static shape in dim 1 of None!")
+                raise ValueError("The model output tensor to be explained cannot have a static shape in dim 1 of None!")
 
     def _get_model_output(self, model):
         if len(model.layers[-1]._inbound_nodes) == 0:

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -85,7 +85,7 @@ class Exact(Explainer):
 
             # make sure we have enough evals
             if max_evals is not None and max_evals != "auto" and max_evals < 2**len(inds):
-                raise Exception(
+                raise ValueError(
                     f"It takes {2**len(inds)} masked evaluations to run the Exact explainer on this instance, but max_evals={max_evals}!"
                 )
 
@@ -124,14 +124,14 @@ class Exact(Explainer):
                 _compute_grey_code_row_values_st(row_values, mask, inds, outputs, coeff, extended_delta_indexes, MaskedModel.delta_mask_noop_value)
 
             elif interactions > 2:
-                raise Exception("Currently the Exact explainer does not support interactions higher than order 2!")
+                raise ValueError("Currently the Exact explainer does not support interactions higher than order 2!")
 
         # do a partition tree constrained version of Shapley values
         else:
 
             # make sure we have enough evals
             if max_evals is not None and max_evals != "auto" and max_evals < len(fm)**2:
-                raise Exception(
+                raise ValueError(
                     f"It takes {len(fm)**2} masked evaluations to run the Exact explainer on this instance, but max_evals={max_evals}!"
                 )
 

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -9,6 +9,7 @@ from .. import models
 from ..models import Model
 from ..maskers import Masker
 from .._explanation import Explanation
+from ..exceptions import UnsupportedModelError
 from .._serializable import Serializable
 from .. import explainers
 from .._serializable import Serializer, Deserializer
@@ -122,7 +123,7 @@ class Explainer(Serializable):
         if callable(link) and callable(getattr(link, "inverse", None)):
             self.link = link
         else:
-            raise Exception("The passed link function needs to be callable and have a callable .inverse property!")
+            raise AttributeError("The passed link function needs to be callable and have a callable .inverse property!")
 
         # if we are called directly (as opposed to through super()) then we convert ourselves to the subclass
         # that implements the specific algorithm that was chosen
@@ -165,7 +166,7 @@ class Explainer(Serializable):
 
                 # if we get here then we don't know how to handle what was given to us
                 else:
-                    raise Exception("The passed model is not callable and cannot be analyzed directly with the given masker! Model: " + str(model))
+                    raise UnsupportedModelError("The passed model is not callable and cannot be analyzed directly with the given masker! Model: " + str(model))
 
             # build the right subclass
             if algorithm == "exact":
@@ -187,7 +188,7 @@ class Explainer(Serializable):
                 self.__class__ = explainers.Linear
                 explainers.Linear.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, **kwargs)
             else:
-                raise Exception("Unknown algorithm type passed: %s!" % algorithm)
+                raise ValueError("Unknown algorithm type passed: %s!" % algorithm)
 
 
     def __call__(self, *args, max_evals="auto", main_effects=False, error_bounds=False, batch_size="auto",

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -3,6 +3,7 @@ import scipy as sp
 import warnings
 from tqdm.autonotebook import tqdm
 from ._explainer import Explainer
+from ..exceptions import UnsupportedModelError
 from ..utils import safe_isinstance
 from .. import maskers
 from .. import links
@@ -92,7 +93,7 @@ class Linear(Explainer):
         elif issubclass(type(self.masker), maskers.Impute):
             self.feature_perturbation = "correlation_dependent"
         else:
-            raise Exception("The Linear explainer only supports the Independent, Partition, and Impute maskers right now!")
+            raise ValueError("The Linear explainer only supports the Independent, Partition, and Impute maskers right now!")
         data = getattr(self.masker, "data", None)
 
         # convert DataFrame's to numpy arrays
@@ -120,12 +121,12 @@ class Linear(Explainer):
             if safe_isinstance(self.cov, "pandas.core.frame.DataFrame"):
                 self.cov = self.cov.values
         elif data is None:
-            raise Exception("A background data distribution must be provided!")
+            raise ValueError("A background data distribution must be provided!")
         else:
             if sp.sparse.issparse(data):
                 self.mean = np.array(np.mean(data, 0))[0]
                 if self.feature_perturbation != "interventional":
-                    raise Exception("Only feature_perturbation = 'interventional' is supported for sparse data")
+                    raise ValueError("Only feature_perturbation = 'interventional' is supported for sparse data")
             else:
                 self.mean = np.array(np.mean(data, 0)).flatten() # assumes it is an array
                 if self.feature_perturbation == "correlation_dependent":
@@ -173,7 +174,7 @@ class Linear(Explainer):
             if nsamples != 1000:
                 warnings.warn("Setting nsamples has no effect when feature_perturbation = 'interventional'!")
         else:
-            raise Exception("Unknown type of feature_perturbation provided: " + self.feature_perturbation)
+            raise TypeError("Unknown type of feature_perturbation provided: " + self.feature_perturbation)
 
     def _estimate_transforms(self, nsamples):
         """ Uses block matrix inversion identities to quickly estimate transforms.
@@ -261,7 +262,7 @@ class Linear(Explainer):
                 coef = model.coef_
                 intercept = model.intercept_
         else:
-            raise Exception("An unknown model type was passed: " + str(type(model)))
+            raise UnsupportedModelError("An unknown model type was passed: " + str(type(model)))
 
         return coef,intercept
 
@@ -300,7 +301,7 @@ class Linear(Explainer):
 
         if self.feature_perturbation == "correlation_dependent":
             if sp.sparse.issparse(X):
-                raise Exception("Only feature_perturbation = 'interventional' is supported for sparse data")
+                raise TypeError("Only feature_perturbation = 'interventional' is supported for sparse data")
             phi = np.matmul(np.matmul(X[:,self.valid_inds], self.avg_proj.T), self.x_transform.T) - self.mean_transformed
             phi = np.matmul(phi, self.avg_proj)
 
@@ -363,7 +364,7 @@ class Linear(Explainer):
 
         if self.feature_perturbation == "correlation_dependent":
             if sp.sparse.issparse(X):
-                raise Exception("Only feature_perturbation = 'interventional' is supported for sparse data")
+                raise TypeError("Only feature_perturbation = 'interventional' is supported for sparse data")
             phi = np.matmul(np.matmul(X[:,self.valid_inds], self.avg_proj.T), self.x_transform.T) - self.mean_transformed
             phi = np.matmul(phi, self.avg_proj)
 

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -116,7 +116,7 @@ class Partition(Explainer):
             # else:
             fixed_context = None
         elif fixed_context not in [0, 1, None]:
-            raise Exception("Unknown fixed_context value passed (must be 0, 1 or None): %s" %fixed_context)
+            raise ValueError("Unknown fixed_context value passed (must be 0, 1 or None): %s" %fixed_context)
 
         # build a masked version of the model for the current input sample
         fm = MaskedModel(self.model, self.masker, self.link, *row_args)

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -64,7 +64,7 @@ class Permutation(Explainer):
             elif callable(self.masker.clustering):
                 row_clustering = self.masker.clustering(*row_args)
             else:
-                raise Exception("The masker passed has a .clustering attribute that is not yet supported by the Permutation explainer!")
+                raise AttributeError("The masker passed has a .clustering attribute that is not yet supported by the Permutation explainer!")
 
         # loop over many permutations
         inds = fm.varying_inputs()
@@ -108,7 +108,7 @@ class Permutation(Explainer):
                     row_values[ind] += outputs[i+1] - outputs[i]
 
             if npermutations == 0:
-                raise Exception("max_evals is too low for the Permutation explainer, it must be at least 2 * num_features + 1!")
+                raise ValueError("max_evals is too low for the Permutation explainer, it must be at least 2 * num_features + 1!")
 
             expected_value = outputs[0]
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -11,6 +11,7 @@ from ._explainer import Explainer
 from ..utils import assert_import, record_import_error, safe_isinstance
 from ..utils._legacy import DenseData
 from .._explanation import Explanation
+from ..exceptions import UnsupportedModelError
 from .. import maskers
 import warnings
 import pandas as pd
@@ -101,10 +102,10 @@ class Tree(Explainer):
         if type(self.masker) is maskers.Independent:
             data = self.masker.data
         elif masker is not None:
-            raise Exception("Unsupported masker type: %s!" % str(type(self.masker)))
+            raise TypeError("Unsupported masker type: %s!" % str(type(self.masker)))
 
         if getattr(self.masker, "clustering", None) is not None:
-            raise Exception("TreeExplainer does not support clustered data inputs! Please use shap.Explainer or pass an unclustered masker!")
+            raise TypeError("TreeExplainer does not support clustered data inputs! Please use shap.Explainer or pass an unclustered masker!")
 
         # check for deprecated options
         if model_output == "margin":
@@ -122,10 +123,10 @@ class Tree(Explainer):
                 warnings.warn("feature_dependence = \"independent\" has been renamed to feature_perturbation" \
                     " = \"interventional\", you can't supply both options! See GitHub issue #882.")
             if dep_val == "tree_path_dependent" and feature_perturbation == "interventional":
-                raise Exception("The feature_dependence option has been renamed to feature_perturbation! " \
+                raise AttributeError("The feature_dependence option has been renamed to feature_perturbation! " \
                     "Please update the option name before calling TreeExplainer. See GitHub issue #882.")
         if feature_perturbation == "independent":
-            raise Exception("feature_perturbation = \"independent\" is not a valid option value, please use " \
+            raise ValueError("feature_perturbation = \"independent\" is not a valid option value, please use " \
                 "feature_perturbation = \"interventional\" instead. See GitHub issue #882.")
 
 
@@ -160,7 +161,7 @@ class Tree(Explainer):
 
         if self.model.model_output != "raw":
             if self.model.objective is None and self.model.tree_output is None:
-                raise Exception("Model does not have a known objective or output type! When model_output is " \
+                raise AttributeError("Model does not have a known objective or output type! When model_output is " \
                                 "not \"raw\" then we need to know the model's objective or link function.")
 
         # A bug in XGBoost fixed in v0.81 makes XGBClassifier fail to give margin outputs
@@ -175,10 +176,10 @@ class Tree(Explainer):
         elif data is not None:
             try:
                 self.expected_value = self.model.predict(self.data).mean(0)
-            except ValueError:
-                raise Exception("Currently TreeExplainer can only handle models with categorical splits when " \
+            except ValueError as err:
+                raise ValueError("Currently TreeExplainer can only handle models with categorical splits when " \
                                 "feature_perturbation=\"tree_path_dependent\" and no background data is passed. Please try again using " \
-                                "shap.TreeExplainer(model, feature_perturbation=\"tree_path_dependent\").")
+                                "shap.TreeExplainer(model, feature_perturbation=\"tree_path_dependent\").") from err
             if hasattr(self.expected_value, '__len__') and len(self.expected_value) == 1:
                 self.expected_value = self.expected_value[0]
         elif hasattr(self.model, "node_sample_weight"):
@@ -352,7 +353,7 @@ class Tree(Explainer):
                     try:
                         phi = phi.reshape(X.shape[0], phi.shape[1]//(X.shape[1]+1), X.shape[1]+1)
                     except ValueError as e:
-                        raise Exception("This reshape error is often caused by passing a bad data matrix to SHAP. " \
+                        raise ValueError("This reshape error is often caused by passing a bad data matrix to SHAP. " \
                                          "See https://github.com/slundberg/shap/issues/580") from e
 
             elif self.model.model_type == "catboost": # thanks to the CatBoost team for implementing this...
@@ -530,7 +531,7 @@ class Tree(Explainer):
                 err_msg += " This check failed because for one of the samples the sum of the SHAP values" \
                            " was %f, while the model output was %f. If this difference is acceptable" \
                            " you can set check_additivity=False to disable this check." % (sum_val[ind], model_output[ind])
-                raise Exception(err_msg)
+                raise ValueError(err_msg)
 
         if type(phi) is list:
             for i in range(len(phi)):
@@ -735,7 +736,7 @@ class TreeEnsemble:
             import sklearn
             self.base_offset = model._baseline_prediction
             if hasattr(self.base_offset, "__len__") and self.model_output != "raw":
-                raise Exception("Multi-output HistGradientBoostingClassifier models are not yet supported unless model_output=\"raw\". See GitHub issue #1028")
+                raise UnsupportedModelError("Multi-output HistGradientBoostingClassifier models are not yet supported unless model_output=\"raw\". See GitHub issue #1028")
             self.input_dtype = sklearn.ensemble._hist_gradient_boosting.common.X_DTYPE
             self.num_stacked_models = len(model._predictors[0])
             if self.model_output == "predict_proba":
@@ -974,7 +975,7 @@ class TreeEnsemble:
             self.tree_output = "raw_value"
             self.base_offset = model.init_params[param_idx]
         else:
-            raise Exception("Model type not yet supported by TreeExplainer: " + str(type(model)))
+            raise UnsuportedModelError("Model type not yet supported by TreeExplainer: " + str(type(model)))
 
         # build a dense numpy version of all the tree objects
         if self.trees is not None and self.trees:
@@ -1036,7 +1037,7 @@ class TreeEnsemble:
             elif self.tree_output == "probability":
                 transform = "identity"
             else:
-                raise Exception("model_output = \"probability\" is not yet supported when model.tree_output = \"" + self.tree_output + "\"!")
+                raise ValueError("model_output = \"probability\" is not yet supported when model.tree_output = \"" + self.tree_output + "\"!")
         elif self.model_output == "log_loss":
 
             if self.objective == "squared_error":
@@ -1044,9 +1045,9 @@ class TreeEnsemble:
             elif self.objective == "binary_crossentropy":
                 transform = "logistic_nlogloss"
             else:
-                raise Exception("model_output = \"log_loss\" is not yet supported when model.objective = \"" + self.objective + "\"!")
+                raise ValueError("model_output = \"log_loss\" is not yet supported when model.objective = \"" + self.objective + "\"!")
         else:
-            raise Exception("Unrecognized model_output parameter value: %s! If model.%s is a valid function open a github issue to ask that this method be supported. If you want 'predict_proba' just use 'probability' for now." % (str(self.model_output), str(self.model_output)))
+            raise ValueError("Unrecognized model_output parameter value: %s! If model.%s is a valid function open a github issue to ask that this method be supported. If you want 'predict_proba' just use 'probability' for now." % (str(self.model_output), str(self.model_output)))
 
         return transform
 
@@ -1345,7 +1346,7 @@ class SingleTree:
             self.values = values[:,np.newaxis] * scaling
             self.node_sample_weight = node_sample_weight
         else:
-            raise Exception("Unknown input to SingleTree constructor: " + str(tree))
+            raise UnsupportedModelError("Unknown input to SingleTree constructor: " + str(tree))
 
         # Re-compute the number of samples that pass through each node if we are given data
         if data is not None and data_missing is not None:

--- a/shap/explainers/other/_maple.py
+++ b/shap/explainers/other/_maple.py
@@ -1,4 +1,5 @@
 from .._explainer import Explainer
+from ...exceptions import UnsupportedModelError
 import numpy as np
 from sklearn.model_selection import train_test_split
 
@@ -87,7 +88,7 @@ class TreeMaple(Explainer):
         # elif str(type(model)).endswith("xgboost.sklearn.XGBClassifier'>"):
         #     pass
         else:
-            raise Exception("The passed model is not yet supported by TreeMapleExplainer: " + str(type(model)))
+            raise UnsupportedModelError("The passed model is not yet supported by TreeMapleExplainer: " + str(type(model)))
 
         if str(type(data)).endswith("pandas.core.frame.DataFrame'>"):
             data = data.values

--- a/shap/explainers/other/_treegain.py
+++ b/shap/explainers/other/_treegain.py
@@ -1,4 +1,5 @@
 from .._explainer import Explainer
+from ...exceptions import UnsupportedModelError
 import numpy as np
 
 class TreeGain(Explainer):
@@ -20,7 +21,7 @@ class TreeGain(Explainer):
         elif str(type(model)).endswith("xgboost.sklearn.XGBClassifier'>"):
             pass
         else:
-            raise Exception("The passed model is not yet supported by TreeGainExplainer: " + str(type(model)))
+            raise UnsupportedModelError("The passed model is not yet supported by TreeGainExplainer: " + str(type(model)))
         assert hasattr(model, "feature_importances_"), "The passed model does not have a feature_importances_ attribute!"
         self.model = model
 

--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -6,6 +6,7 @@ module which uses a compiled C++ implmentation.
 import numpy as np
 #import numba
 from .explainer import Explainer
+from ..exceptions import UnsupportedModelError
 
 # class TreeExplainer(Explainer):
 #     def __init__(self, model, **kwargs):
@@ -153,7 +154,7 @@ class TreeExplainer:
             self.model_type = "lightgbm"
             self.trees = model
         else:
-            raise Exception("Model type not supported by TreeExplainer: " + str(type(model)))
+            raise UnsupportedModelError("Model type not supported by TreeExplainer: " + str(type(model)))
 
         if self.model_type == "internal":
             # Preallocate space for the unique path data
@@ -227,7 +228,7 @@ class TreeExplainer:
                 tree_limit=0
             return self.trees.predict(X, ntree_limit=tree_limit, pred_interactions=True)
         else:
-            raise Exception("Interaction values not yet supported for model type: " + str(type(X)))
+            raise UnsupportedModelError("Interaction values not yet supported for model type: " + str(type(X)))
 
     def tree_shap(self, tree, x, x_missing, phi, condition=0, condition_feature=0):
 

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -59,7 +59,7 @@ class Image(Masker):
 
     def __call__(self, mask, x):
         if np.prod(x.shape) != np.prod(self.input_shape):
-            raise Exception("The length of the image to be masked must match the shape given in the " + \
+            raise ValueError("The length of the image to be masked must match the shape given in the " + \
                             "ImageMasker contructor: "+" * ".join([str(i) for i in x.shape])+ \
                             " != "+" * ".join([str(i) for i in self.input_shape]))
 

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -70,7 +70,7 @@ class Tabular(Masker):
             elif safe_isinstance(clustering, "numpy.ndarray"):
                 self.clustering = clustering
             else:
-                raise Exception(
+                raise ValueError(
                     "Unknown clustering given! Make sure you pass a distance metric as a string, or a clustering as a numpy.ndarray."
                 )
         else:
@@ -91,7 +91,7 @@ class Tabular(Masker):
 
         # make sure we are given a single sample
         if len(x.shape) != 1 or x.shape[0] != self.data.shape[1]:
-            raise Exception("The input passed for tabular masking does not match the background data shape!")
+            raise ValueError("The input passed for tabular masking does not match the background data shape!")
 
         # if mask is an array of integers then we are doing delta masking
         if np.issubdtype(mask.dtype, np.integer):
@@ -140,7 +140,7 @@ class Tabular(Masker):
 
         # make sure we got valid data
         if x.shape != self.data.shape[1:]:
-            raise Exception(
+            raise ValueError(
                 "The passed data does not match the background shape expected by the masker! The data of shape " + \
                 str(x.shape) + " was passed while the masker expected data of shape " + str(self.data.shape[1:]) + "."
             )

--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -145,7 +145,7 @@ class Text(Masker):
             return out
         if safe_isinstance(self.tokenizer, "transformers.tokenization_utils_fast.PreTrainedTokenizerFast"):
             return self.token_segments(s)
-        raise Exception("Unknown tokenizer type!", self.tokenizer)
+        raise TypeError("Unknown tokenizer type!", self.tokenizer)
 
     def tokenize(self, s):
         """ Calls the underlying tokenizer on the given string.
@@ -154,7 +154,7 @@ class Text(Masker):
             return self.tokenizer.encode_plus(s)
         if safe_isinstance(self.tokenizer, "transformers.tokenization_utils_fast.PreTrainedTokenizerFast"):
             return self.tokenizer.encode_plus(s, return_offsets_mapping=True)
-        raise Exception("Unknown tokenizer type!", self.tokenizer)
+        raise TypeError("Unknown tokenizer type!", self.tokenizer)
 
     def token_segments(self, s):
         """ Returns the substrings associated with each token in the given string.
@@ -179,7 +179,7 @@ class Text(Masker):
             parts = [s[offsets[i][0]:max(offsets[i][1], offsets[i+1][0])] for i in range(len(offsets)-1)]
             parts.append(s[offsets[len(offsets)-1][0]:offsets[len(offsets)-1][1]])
             return parts
-        raise Exception("Unknown tokenizer type!", self.tokenizer)
+        raise TypeError("Unknown tokenizer type!", self.tokenizer)
 
     def clustering(self, s):
         """ Compute the clustering of tokens for the given string.

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -75,7 +75,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     values = np.array([cohort_exps[i].values for i in range(len(cohort_exps))])
 
     if len(values[0]) == 0:
-        raise Exception("The passed Explanation is empty! (so there is nothing to plot)")
+        raise ValueError("The passed Explanation is empty! (so there is nothing to plot)")
 
     # we show the data on auto only when there are no transforms
     if show_data == "auto":

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -92,7 +92,7 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
 
     if (isinstance(base_value, np.ndarray) or type(base_value) == list):
         if not isinstance(shap_values, list) or len(shap_values) != len(base_value):
-            raise Exception("In v0.20 force_plot now requires the base value as the first parameter! " \
+            raise TypeError("In v0.20 force_plot now requires the base value as the first parameter! " \
                             "Try shap.force_plot(explainer.expected_value, shap_values) or " \
                             "for multi-output models try " \
                             "shap.force_plot(explainer.expected_value[0], shap_values[0]).")
@@ -144,7 +144,7 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
             if len(features) == shap_values.shape[1] - 1:
                 msg += " You might be using an old format shap_values array with the base value " \
                        "as the last column. In this case just pass the array without the last column."
-            raise Exception(msg)
+            raise ValueError(msg)
 
         instance = Instance(np.zeros((1, len(feature_names))), features)
         e = AdditiveExplanation(
@@ -168,7 +168,7 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
         
     else:
         if matplotlib:
-            raise Exception("matplotlib = True is not yet supported for force plots with multiple samples!")
+            raise ValueError("matplotlib = True is not yet supported for force plots with multiple samples!")
         
         if shap_values.shape[0] > 3000:
             warnings.warn("shap.plots.force is slow for many thousands of rows, try subsampling your data.")

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -55,7 +55,7 @@ def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Exp
     elif issubclass(type(feature_order), OpChain):
         feature_order = feature_order.apply(Explanation(values))
     elif not hasattr(feature_order, "__len__"):
-        raise Exception("Unsupported feature_order: %s!" % str(feature_order))
+        raise TypeError("Unsupported feature_order: %s!" % str(feature_order))
     xlabel = "Instances"
     instance_order = convert_ordering(instance_order, shap_values)
     # if issubclass(type(instance_order), OpChain):

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -56,7 +56,7 @@ def image(shap_values, pixel_values=None, labels=None, width=20, aspect=0.2, hsp
         if len(shap_exp.base_values.shape) == 2:
             shap_values = [shap_exp.values[..., i] for i in range(shap_exp.values.shape[-1])]
         else:
-            raise Exception("Number of outputs needs to have support added!! (probably a simple fix)")
+            raise NotImplementedError("Number of outputs needs to have support added!! (probably a simple fix)")
         if pixel_values is None:
             pixel_values = shap_exp.data
         if labels is None:

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -107,7 +107,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         return
 
     if len(shap_values.shape) != 1:
-        raise Exception("The passed Explanation object has multiple columns, please pass a single feature column to " + \
+        raise ValueError("The passed Explanation object has multiple columns, please pass a single feature column to " + \
                         "shap.plots.dependence like: shap_values[:,column]")
 
     # this unpacks the explanation object for the code that was written earlier

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -49,7 +49,7 @@ def waterfall(shap_values, max_display=10, show=True):
 
     # make sure we only have a single output to explain
     if (type(base_values) == np.ndarray and len(base_values) > 0) or type(base_values) == list:
-        raise Exception("waterfall_plot requires a scalar base_values of the model output as the first " \
+        raise TypeError("waterfall_plot requires a scalar base_values of the model output as the first " \
                         "parameter, but you have passed an array as the first parameter! " \
                         "Try shap.waterfall_plot(explainer.base_values[0], values[0], X[0]) or " \
                         "for multi-output models try " \
@@ -57,7 +57,7 @@ def waterfall(shap_values, max_display=10, show=True):
 
     # make sure we only have a single explanation to plot
     if len(values.shape) == 2:
-        raise Exception("The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
+        raise ValueError("The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
     
     # unwrap pandas series
     if safe_isinstance(features, "pandas.core.series.Series"):
@@ -340,7 +340,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
     # make sure we only have a single output to explain
     if (type(expected_value) == np.ndarray and len(expected_value) > 0) or type(expected_value) == list:
-        raise Exception("waterfall_plot requires a scalar expected_value of the model output as the first " \
+        raise TypeError("waterfall_plot requires a scalar expected_value of the model output as the first " \
                         "parameter, but you have passed an array as the first parameter! " \
                         "Try shap.waterfall_plot(explainer.expected_value[0], shap_values[0], X[0]) or " \
                         "for multi-output models try " \
@@ -348,7 +348,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
     # make sure we only have a single explanation to plot
     if len(shap_values.shape) == 2:
-        raise Exception("The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
+        raise ValueError("The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
     
     # unwrap pandas series
     if safe_isinstance(features, "pandas.core.series.Series"):

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -161,7 +161,7 @@ def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
                     elif linkage == "average":
                         dist.append((dist_full[i,j] + dist_full[j,i]) / 2)
                     else:
-                        raise Exception("Unsupported linkage type!")
+                        raise ValueError("Unsupported linkage type!")
         dist = np.array(dist)
     
     else:
@@ -185,4 +185,4 @@ def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
     elif linkage == "average":
         return sp.cluster.hierarchy.average(dist)
     else:
-        raise Exception("Unknown linkage: " + str(linkage))
+        raise ValueError("Unknown linkage: " + str(linkage))

--- a/shap/utils/_keras.py
+++ b/shap/utils/_keras.py
@@ -28,7 +28,7 @@ def clone_keras_layers(model, start_layer, stop_layer):
                 dup_try = 0
             last_len = len(layers_to_process)
             if dup_try > len(layers_to_process):
-                raise Exception("Failed to find a complete graph starting at the given layer!")
+                raise RuntimeError("Failed to find a complete graph starting at the given layer!")
             try:
                 if type(layer.input) is list:
                     layer_inputs = [new_layers[v.name] for v in layer.input]


### PR DESCRIPTION
* Add an `exceptions` module with one custom exception: `UnsupportedModelError`
* Replace each instance of a bare `Exception` with a more explicit exception, either `ValueError`, `RuntimeError`, `TypeError` or `UnsupportedModelError`

Any exceptions raised in a commented out block of code were left alone

closes https://github.com/slundberg/shap/issues/2033