### PR TITLE
replace numpy aliases with python defaults

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -669,7 +669,7 @@ def _compute_shape(x):
             if first_shape == tuple():
                 return (len(x),)
             else: # we have an array of arrays...
-                matches = np.ones(len(first_shape), dtype=np.bool)
+                matches = np.ones(len(first_shape), dtype=bool)
                 for i in range(1, len(x)):
                     shape = _compute_shape(x[i])
                     assert len(shape) == len(first_shape), "Arrays in Explanation objects must have consistent inner dimensions!"

--- a/shap/benchmark/perturbation.py
+++ b/shap/benchmark/perturbation.py
@@ -88,7 +88,7 @@ class SequentialPerturbation():
             
             masks = []
             for k in range(output_size): 
-                mask = np.ones(mask_shape, dtype=np.bool) * (self.perturbation == "remove")
+                mask = np.ones(mask_shape, dtype=bool) * (self.perturbation == "remove")
                 masks.append(mask.copy().flatten())
 
                 if output_size != 1: 
@@ -213,7 +213,7 @@ class SequentialPerturbation():
                 else: 
                     mask_shape = feature_size 
 
-                mask = np.ones(mask_shape, dtype=np.bool) * (self.perturbation == "remove")
+                mask = np.ones(mask_shape, dtype=bool) * (self.perturbation == "remove")
                 masks = [mask.copy()]
 
                 values = np.zeros(feature_size+1)

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -53,7 +53,7 @@ def imdb(display=False):
 
     with open(cache(github_data_url + "imdb_train.txt")) as f:
         data = f.readlines()
-    y = np.ones(25000, dtype=np.bool)
+    y = np.ones(25000, dtype=bool)
     y[:12500] = 0
     return data, y
 
@@ -71,7 +71,7 @@ def communitiesandcrime(display=False):
 
     # find the indices where the total violent crimes are known
     valid_inds = np.where(np.invert(np.isnan(raw_data.iloc[:,-2])))[0]
-    y = np.array(raw_data.iloc[valid_inds,-2], dtype=np.float)
+    y = np.array(raw_data.iloc[valid_inds,-2], dtype=float)
 
     # extract the predictive features and remove columns with missing values
     X = raw_data.iloc[valid_inds,5:-18]

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -43,7 +43,7 @@ class Additive(Explainer):
                 # num_features = len(model.additive_terms_)
 
                 # fm = MaskedModel(self.model, self.masker, self.link, np.zeros(num_features))
-                # masks = np.ones((1, num_features), dtype=np.bool)
+                # masks = np.ones((1, num_features), dtype=bool)
                 # outputs = fm(masks)
                 # self.model(np.zeros(num_features))
                 # self._zero_offset = self.model(np.zeros(num_features))#model.intercept_#outputs[0]
@@ -56,7 +56,7 @@ class Additive(Explainer):
 
         # pre-compute per-feature offsets
         fm = MaskedModel(self.model, self.masker, self.link, np.zeros(self.masker.shape[1]))
-        masks = np.ones((self.masker.shape[1]+1, self.masker.shape[1]), dtype=np.bool)
+        masks = np.ones((self.masker.shape[1]+1, self.masker.shape[1]), dtype=bool)
         for i in range(1, self.masker.shape[1]+1):
             masks[i,i-1] = False
         outputs = fm(masks)

--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -215,7 +215,7 @@ class TFDeep(Explainer):
         """ Return which inputs of this operation are variable (i.e. depend on the model inputs).
         """
         if op not in self._vinputs:
-            out = np.zeros(len(op.inputs), dtype=np.bool)
+            out = np.zeros(len(op.inputs), dtype=bool)
             for i,t in enumerate(op.inputs):
                 out[i] = t.name in self.between_tensors
             self._vinputs[op] = out

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -111,7 +111,7 @@ class Exact(Explainer):
                 # loop over all the outputs to update the rows
                 coeff = shapley_coefficients(len(inds))
                 row_values = np.zeros((len(fm),) + outputs.shape[1:])
-                mask = np.zeros(len(fm), dtype=np.bool)
+                mask = np.zeros(len(fm), dtype=bool)
                 _compute_grey_code_row_values(row_values, mask, inds, outputs, coeff, extended_delta_indexes, MaskedModel.delta_mask_noop_value)
 
             # Shapley-Taylor interaction values
@@ -120,7 +120,7 @@ class Exact(Explainer):
                 # loop over all the outputs to update the rows
                 coeff = shapley_coefficients(len(inds))
                 row_values = np.zeros((len(fm), len(fm)) + outputs.shape[1:])
-                mask = np.zeros(len(fm), dtype=np.bool)
+                mask = np.zeros(len(fm), dtype=bool)
                 _compute_grey_code_row_values_st(row_values, mask, inds, outputs, coeff, extended_delta_indexes, MaskedModel.delta_mask_noop_value)
 
             elif interactions > 2:
@@ -227,7 +227,7 @@ def partition_delta_indexes(partition_tree, all_masks):
     """
 
     # convert the masks to delta index format
-    mask = np.zeros(all_masks.shape[1], dtype=np.bool)
+    mask = np.zeros(all_masks.shape[1], dtype=bool)
     delta_inds = []
     for i in range(len(all_masks)):
         inds = np.where(mask ^ all_masks[i,:])[0]
@@ -249,7 +249,7 @@ def partition_masks(partition_tree):
     M = partition_tree.shape[0] + 1
     mask_matrix = make_masks(partition_tree)
     all_masks = []
-    m00 = np.zeros(M, dtype=np.bool)
+    m00 = np.zeros(M, dtype=bool)
     all_masks.append(m00)
     all_masks.append(~m00)
     #inds_stack = [0,1]
@@ -312,8 +312,8 @@ def gray_code_masks(nbits):
 
     This is based on code from: http://code.activestate.com/recipes/576592-gray-code-generatoriterator/
     """
-    out = np.zeros((2**nbits, nbits), dtype=np.bool)
-    li = np.zeros(nbits, dtype=np.bool)
+    out = np.zeros((2**nbits, nbits), dtype=bool)
+    li = np.zeros(nbits, dtype=bool)
 
     for term in range(2, (1<<nbits)+1):
         if term % 2 == 1: # odd
@@ -334,7 +334,7 @@ def gray_code_indexes(nbits):
     This is a more efficient represenation of the gray_code_masks version.
     """
     out = np.ones(2**nbits, dtype=np.int) * MaskedModel.delta_mask_noop_value
-    li = np.zeros(nbits, dtype=np.bool)
+    li = np.zeros(nbits, dtype=bool)
     for term in range((1<<nbits)-1):
         if term % 2 == 1: # odd
             for i in range(-1,-nbits,-1):

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -123,7 +123,7 @@ class Partition(Explainer):
 
         # make sure we have the base value and current value outputs
         M = len(fm)
-        m00 = np.zeros(M, dtype=np.bool)
+        m00 = np.zeros(M, dtype=bool)
         # if not fixed background or no base value assigned then compute base value for a row
         if self._curr_base_value is None or not getattr(self.masker, "fixed_background", False):
             self._curr_base_value = fm(m00.reshape(1, -1))[0]
@@ -194,7 +194,7 @@ class Partition(Explainer):
         #r = self.masker
         #masks = np.zeros(2*len(inds)+1, dtype=np.int)
         M = len(fm)
-        m00 = np.zeros(M, dtype=np.bool)
+        m00 = np.zeros(M, dtype=bool)
         #f00 = fm(m00.reshape(1,-1))[0]
         base_value = f00
         #f11 = fm(~m00.reshape(1,-1))[0]

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -68,7 +68,7 @@ class Permutation(Explainer):
 
         # loop over many permutations
         inds = fm.varying_inputs()
-        inds_mask = np.zeros(len(fm), dtype=np.bool)
+        inds_mask = np.zeros(len(fm), dtype=bool)
         inds_mask[inds] = True
         masks = np.zeros(2*len(inds)+1, dtype=np.int)
         masks[0] = MaskedModel.delta_mask_noop_value

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -243,8 +243,9 @@ class Tree(Explainer):
             flat_output = True
             X = X.reshape(1, X.shape[0])
         if X.dtype != self.model.input_dtype:
-            X = X.astype(self.model.input_dtype)
-        X_missing = np.isnan(X, dtype=np.bool)
+            self.astype = X.astype(self.model.input_dtype)
+            X = self.astype
+        X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 
@@ -1083,7 +1084,7 @@ class TreeEnsemble:
             X = X.reshape(1, X.shape[0])
         if X.dtype.type != self.input_dtype:
             X = X.astype(self.input_dtype)
-        X_missing = np.isnan(X, dtype=np.bool)
+        X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -243,8 +243,7 @@ class Tree(Explainer):
             flat_output = True
             X = X.reshape(1, X.shape[0])
         if X.dtype != self.model.input_dtype:
-            self.astype = X.astype(self.model.input_dtype)
-            X = self.astype
+            X = X.astype(self.model.input_dtype)
         X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"

--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -52,7 +52,7 @@ from .explainer import Explainer
 #         if len(X.shape) == 1:
 
 #             phi = np.zeros((X.shape[0] + 1, n_outputs))
-#             x_missing = np.zeros(X.shape[0], dtype=np.bool)
+#             x_missing = np.zeros(X.shape[0], dtype=bool)
 #             for t in self.trees:
 #                 self.tree_shap(t, X, x_missing, phi)
 #             phi /= len(self.trees)
@@ -64,7 +64,7 @@ from .explainer import Explainer
 
 #         elif len(X.shape) == 2:
 #             phi = np.zeros((X.shape[0], X.shape[1] + 1, n_outputs))
-#             x_missing = np.zeros(X.shape[1], dtype=np.bool)
+#             x_missing = np.zeros(X.shape[1], dtype=bool)
 #             for i in range(X.shape[0]):
 #                 for t in self.trees:
 #                     self.tree_shap(t, X[i,:], x_missing, phi[i,:,:])
@@ -193,7 +193,7 @@ class TreeExplainer:
         if len(X.shape) == 1:
 
             phi = np.zeros(X.shape[0] + 1, n_outputs)
-            x_missing = np.zeros(X.shape[0], dtype=np.bool)
+            x_missing = np.zeros(X.shape[0], dtype=bool)
             for t in self.trees:
                 self.tree_shap(t, X, x_missing, phi)
             phi /= len(self.trees)
@@ -205,7 +205,7 @@ class TreeExplainer:
 
         elif len(X.shape) == 2:
             phi = np.zeros((X.shape[0], X.shape[1] + 1, n_outputs))
-            x_missing = np.zeros(X.shape[1], dtype=np.bool)
+            x_missing = np.zeros(X.shape[1], dtype=bool)
             for i in range(X.shape[0]):
                 for t in self.trees:
                     self.tree_shap(t, X[i,:], x_missing, phi[i,:,:])

--- a/shap/maskers/_composite.py
+++ b/shap/maskers/_composite.py
@@ -56,7 +56,7 @@ class Composite(Masker):
 
     #     # if mask is not given then we mask all features
     #     if mask is None:
-    #         mask = np.zeros(np.prod(x.shape), dtype=np.bool)
+    #         mask = np.zeros(np.prod(x.shape), dtype=bool)
 
     #     out = x * mask + self.background_data * np.invert(mask)
 

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -54,7 +54,7 @@ class Image(Masker):
         # note if this masker can use different background for different samples
         self.fixed_background = not isinstance(self.mask_value, str)
 
-        #self.scratch_mask = np.zeros(self.input_shape[:-1], dtype=np.bool)
+        #self.scratch_mask = np.zeros(self.input_shape[:-1], dtype=bool)
         self.last_xid = None
 
     def __call__(self, mask, x):
@@ -74,7 +74,7 @@ class Image(Masker):
 
         # if mask is not given then we mask the whole image
         if mask is None:
-            mask = np.zeros(np.prod(x.shape), dtype=np.bool)
+            mask = np.zeros(np.prod(x.shape), dtype=bool)
 
         if isinstance(self.mask_value, str):
             if self.blur_kernel is not None:

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -76,16 +76,16 @@ class Tabular(Masker):
         else:
             self.clustering = None
 
-        # self._last_mask = np.zeros(self.data.shape[1], dtype=np.bool)
+        # self._last_mask = np.zeros(self.data.shape[1], dtype=bool)
         self._masked_data = data.copy()
-        self._last_mask = np.zeros(data.shape[1], dtype=np.bool)
+        self._last_mask = np.zeros(data.shape[1], dtype=bool)
         self.shape = self.data.shape
         self.supports_delta_masking = True
         # self._last_x = None
-        # self._data_variance = np.ones(self.data.shape, dtype=np.bool)
+        # self._data_variance = np.ones(self.data.shape, dtype=bool)
 
         # this is property that allows callers to check what rows actually changed since last time.
-        # self.changed_rows = np.ones(self.data.shape[0], dtype=np.bool)
+        # self.changed_rows = np.ones(self.data.shape[0], dtype=bool)
 
     def __call__(self, mask, x):
 
@@ -99,7 +99,7 @@ class Tabular(Masker):
             variants = ~self.invariants(x)
             curr_delta_inds = np.zeros(len(mask), dtype=np.int)
             num_masks = (mask >= 0).sum()
-            varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=np.bool)
+            varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=bool)
             masked_inputs_out = np.zeros((num_masks * self.shape[0], self.shape[1]))
             self._last_mask[:] = False
             self._masked_data[:] = self.data

--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -259,7 +259,7 @@ class Text(Masker):
         """
         self._update_s_cache(s)
 
-        invariants = np.zeros(len(self._tokenized_s), dtype=np.bool)
+        invariants = np.zeros(len(self._tokenized_s), dtype=bool)
         if self.keep_prefix > 0:
             invariants[:self.keep_prefix] = True
         if self.keep_suffix > 0:

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -274,11 +274,11 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         interaction_feature_values = encode_array_if_needed(features[:, interaction_index])
         cv = interaction_feature_values
         cd = display_features[:, interaction_index]
-        clow = np.nanpercentile(cv.astype(np.float), 5)
-        chigh = np.nanpercentile(cv.astype(np.float), 95)
+        clow = np.nanpercentile(cv.astype(float), 5)
+        chigh = np.nanpercentile(cv.astype(float), 95)
         if clow == chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
         if type(cd[0]) == str:
             cname_map = {}
             for i in range(len(cv)):
@@ -290,8 +290,8 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
 
         # discritize colors for categorical features
         if categorical_interaction and clow != chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
             bounds = np.linspace(clow, chigh, min(int(chigh - clow + 2), cmap.N-1))
             color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
 
@@ -301,7 +301,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         if x_jitter > 1: x_jitter = 1
         xvals = xv.copy()
         if isinstance(xvals[0], float):
-            xvals = xvals.astype(np.float)
+            xvals = xvals.astype(float)
             xvals = xvals[~np.isnan(xvals)]
         xvals = np.unique(xvals) # returns a sorted array
         if len(xvals) >= 2:
@@ -628,11 +628,11 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         interaction_feature_values = encode_array_if_needed(features[:, interaction_index])
         cv = interaction_feature_values
         cd = display_features[:, interaction_index]
-        clow = np.nanpercentile(cv.astype(np.float), 5)
-        chigh = np.nanpercentile(cv.astype(np.float), 95)
+        clow = np.nanpercentile(cv.astype(float), 5)
+        chigh = np.nanpercentile(cv.astype(float), 95)
         if clow == chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
         if type(cd[0]) == str:
             cname_map = {}
             for i in range(len(cv)):
@@ -644,8 +644,8 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
 
         # discritize colors for categorical features
         if categorical_interaction and clow != chigh:
-            clow = np.nanmin(cv.astype(np.float))
-            chigh = np.nanmax(cv.astype(np.float))
+            clow = np.nanmin(cv.astype(float))
+            chigh = np.nanmax(cv.astype(float))
             bounds = np.linspace(clow, chigh, min(int(chigh - clow + 2), cmap.N-1))
             color_norm = matplotlib.colors.BoundaryNorm(bounds, cmap.N-1)
 
@@ -654,7 +654,7 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
         if x_jitter > 1: x_jitter = 1
         xvals = xv.copy()
         if isinstance(xvals[0], float):
-            xvals = xvals.astype(np.float)
+            xvals = xvals.astype(float)
             xvals = xvals[~np.isnan(xvals)]
         xvals = np.unique(xvals) # returns a sorted array
         if len(xvals) >= 2:

--- a/shap/plots/colors/_colorconv.py
+++ b/shap/plots/colors/_colorconv.py
@@ -613,8 +613,8 @@ _integer_types = (np.byte, np.ubyte,          # 8 bits
                   np.longlong, np.ulonglong)  # 64 bits
 _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
                    for t in _integer_types}
-dtype_range = {np.bool_: (False, True),
-               np.bool8: (False, True),
+dtype_range = {bool_: (False, True),
+               bool8: (False, True),
                np.float16: (-1, 1),
                np.float32: (-1, 1),
                np.float64: (-1, 1)}

--- a/shap/plots/colors/_colorconv.py
+++ b/shap/plots/colors/_colorconv.py
@@ -613,8 +613,8 @@ _integer_types = (np.byte, np.ubyte,          # 8 bits
                   np.longlong, np.ulonglong)  # 64 bits
 _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
                    for t in _integer_types}
-dtype_range = {bool_: (False, True),
-               bool8: (False, True),
+dtype_range = {np.bool_: (False, True),
+               np.bool8: (False, True),
                np.float16: (-1, 1),
                np.float32: (-1, 1),
                np.float64: (-1, 1)}

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -80,7 +80,7 @@ def potential_interactions(shap_values_column, shap_values_matrix):
     inc = max(min(int(len(x) / 10.0), 50), 1)
     interactions = []
     for i in range(X.shape[1]):
-        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=np.float)
+        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=float)
 
         val_other = encoded_val_other
         v = 0.0
@@ -132,7 +132,7 @@ def approximate_interactions(index, shap_values, X, feature_names=None):
     inc = max(min(int(len(x) / 10.0), 50), 1)
     interactions = []
     for i in range(X.shape[1]):
-        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=np.float)
+        encoded_val_other = encode_array_if_needed(X[inds, i][srt], dtype=float)
 
         val_other = encoded_val_other
         v = 0.0

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -53,7 +53,7 @@ class MaskedModel():
             # we need to convert from delta masking to a full masking call because we were given a delta masking
             # input but the masker does not support delta masking
             else: 
-                full_masks = np.zeros((int(np.sum(masks >= 0)), self._masker_cols), dtype=np.bool)
+                full_masks = np.zeros((int(np.sum(masks >= 0)), self._masker_cols), dtype=bool)
                 _convert_delta_mask_to_full(masks, full_masks)
                 return self._full_masking_call(full_masks, batch_size=batch_size)
 
@@ -66,7 +66,7 @@ class MaskedModel():
         # else:
         #out = []
         do_delta_masking = getattr(self.masker, "reset_delta_masking", None) is not None
-        last_mask = np.zeros(masks.shape[1], dtype=np.bool)
+        last_mask = np.zeros(masks.shape[1], dtype=bool)
         batch_positions = np.zeros(len(masks)+1, dtype=np.int)
         #masked_inputs = np.zeros((len(masks) * self.masker.max_output_samples, masks.shape[1]))
         all_masked_inputs = []
@@ -95,7 +95,7 @@ class MaskedModel():
 
             # see which rows have been updated, so we can only evaluate the model on the rows we need to
             if i == 0 or self._variants is None:
-                varying_rows.append(np.ones(num_mask_samples[i], dtype=np.bool))
+                varying_rows.append(np.ones(num_mask_samples[i], dtype=bool))
                 num_varying_rows[i] = num_mask_samples[i]
             else:
                 # a = np.any(self._variants & delta_mask, axis=1)
@@ -402,7 +402,7 @@ def make_masks(cluster_matrix):
         pos += len(inds)
         indptr[i+1] = pos
     mask_matrix = scipy.sparse.csr_matrix(
-        (np.ones(len(indices), dtype=np.bool), indices, indptr),
+        (np.ones(len(indices), dtype=bool), indices, indptr),
         shape=(len(mask_matrix_inds), M)
     )
 

--- a/tests/explainers/common.py
+++ b/tests/explainers/common.py
@@ -52,9 +52,9 @@ def test_additivity(explainer_type, model, masker, data, **kwargs):
         for i in range(shap_values.shape[0]):
             row = shap_values[i]
             if callable(explainer.masker.shape):
-                all_on_masked = explainer.masker(np.ones(explainer.masker.shape(data[i])[1], dtype=np.bool), data[i])
+                all_on_masked = explainer.masker(np.ones(explainer.masker.shape(data[i])[1], dtype=bool), data[i])
             else:
-                all_on_masked = explainer.masker(np.ones(explainer.masker.shape[1], dtype=np.bool), data[i])
+                all_on_masked = explainer.masker(np.ones(explainer.masker.shape[1], dtype=bool), data[i])
             if not isinstance(all_on_masked, tuple):
                 all_on_masked = (all_on_masked,)
             out = explainer.model(*all_on_masked)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -167,7 +167,7 @@ def test_xgboost_mixed_types():
 
     X, y = shap.datasets.boston()
     X["LSTAT"] = X["LSTAT"].astype(np.int64)
-    X["B"] = X["B"].astype(np.bool)
+    X["B"] = X["B"].astype(bool)
     bst = xgboost.train({"learning_rate": 0.01, "silent": 1}, xgboost.DMatrix(X, label=y), 1000)
     shap_values = shap.TreeExplainer(bst).shap_values(X)
     shap.dependence_plot(0, shap_values, X, show=False)


### PR DESCRIPTION
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

using the aliases of builtin types e.g. np.float is deprecated. using shap in other projects that require numpy 1.20.0 therefore raises warnings. this PR replaces (hopefully all of) the numpy aliases with the python defaults.