### PR TITLE
Fix #2087

### DIFF
--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -102,10 +102,15 @@ class Permutation(Explainer):
                     row_values = np.zeros((len(fm),) + outputs.shape[1:])
 
                 # update our SHAP value estimates
-                for i,ind in enumerate(inds):
+                i = 0
+                # forward
+                for ind in inds:
                     row_values[ind] += outputs[i+1] - outputs[i]
-                for i,ind in enumerate(inds):
-                    row_values[ind] += outputs[i+1] - outputs[i]
+                    i += 1
+                # backward
+                for ind in inds:
+                    row_values[ind] += outputs[i] - outputs[i+1]
+                    i += 1
 
             if npermutations == 0:
                 raise Exception("max_evals is too low for the Permutation explainer, it must be at least 2 * num_features + 1!")


### PR DESCRIPTION
Hi, 
I am proposing a very simple fix for the issue #2087. Now, all model evaluations stored in `outputs` are used to compute 
the Permutation Shapley values, and not just the first half.