### PR TITLE
use display_data in plots.force if available

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -75,7 +75,10 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
         base_value = shap_exp.base_values
         shap_values = shap_exp.values
         if features is None:
-            features = shap_exp.data
+            if shap_exp.display_data is None:
+                features = shap_exp.data
+            else:
+                features = shap_exp.display_data
         if sp.sparse.issparse(features):
             features = features.toarray().flatten()
         if feature_names is None:


### PR DESCRIPTION
Fix #2096 

Changed `plots.force` to use `display_data` in preference to `data` if it exists.