### PR TITLE
Return matplotlib plot when show False

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -315,6 +315,8 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     
     if show:
         pl.show()
+    else:
+        return pl
 
 
 


### PR DESCRIPTION
The idea of this PR is to return the matplotib plot when show False so the user
can furher modify or save it. This could extend to all plots that have a `show`
param

To be honest this is what show=False advertises it does so I might as well be 
missing something
