### PR TITLE
fixed Tree.__call__  to support lightgmb: plain DataFrame needs to be passed to predict()

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -208,12 +208,15 @@ class Tree(Explainer):
 
         if safe_isinstance(X, "pandas.core.frame.DataFrame"):
             feature_names = list(X.columns)
+            if self.model.model_type == "lightgbm":
+                X_original = X
             X = X.values
         else:
             feature_names = getattr(self, "data_feature_names", None)
 
         if not interactions:
-            v = self.shap_values(X, y=y, from_call=True, check_additivity=check_additivity, approximate=self.approximate)
+            v = self.shap_values(X_original if self.model.model_type == "lightgbm" else X,
+                                 y=y, from_call=True, check_additivity=check_additivity, approximate=self.approximate)
             if type(v) is list:
                 v = np.stack(v, axis=-1) # put outputs at the end
         else:


### PR DESCRIPTION
This problem  https://github.com/slundberg/shap/issues/2144
is fixed by my pull request. 
