### PR TITLE
[BUGFIX] ignore_inds should not be tuple

### DIFF
--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -63,7 +63,7 @@ def potential_interactions(shap_values_column, shap_values_matrix):
     """
 
     # ignore inds that are identical to the column 
-    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)
+    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)[0]
     
     values = shap_values_matrix.values
     X = shap_values_matrix.data


### PR DESCRIPTION
ignore_inds doesn't work unless there is only one index to ignore

np.where returns a tuple the same length as the number of dimensions of the array.
since the array has 1 dimension, we need to take the first index

## Example Error
```
ipdb> i in ignore_inds
*** ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
ipdb> ignore_inds
(array([ 1,  5,  7, 12, 20, 27, 30, 33, 34, 36, 40, 41, 42, 43, 44, 45, 47,
       48, 49], dtype=int64),)
```