### PR TITLE
Fix waterfall plotting

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -40,7 +40,7 @@ def waterfall(shap_values, max_display=10, show=True):
     
     # Turn off interactive plot
     if show is False:
-        plt.ioff()
+        pl.ioff()
     
 
     base_values = shap_values.base_values
@@ -294,7 +294,7 @@ def waterfall(shap_values, max_display=10, show=True):
     if show:
         pl.show()
     else:
-        return plt.gcf()
+        return pl.gcf()
 
 
 
@@ -334,7 +334,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
     # Turn off interactive plot
     if show is False:
-        plt.ioff()
+        pl.ioff()
     
     # support passing an explanation object
     upper_bounds = None
@@ -589,4 +589,4 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     if show:
         pl.show()
     else:
-        return plt.gcf()
+        return pl.gcf()


### PR DESCRIPTION
The waterfall plot imports and uses `matplotlib` as `pl`, but 4 lines use it as `plt`, causing errors.
This commit fixes the issue.