### PR TITLE
corrected register_backward_hook warning

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -76,7 +76,7 @@ class PyTorchDeep(Explainer):
                 handles_list.extend(self.add_handles(child, forward_handle, backward_handle))
         else:  # leaves
             handles_list.append(model.register_forward_hook(forward_handle))
-            handles_list.append(model.register_backward_hook(backward_handle))
+            handles_list.append(model.register_full_backward_hook(backward_handle))
         return handles_list
 
     def remove_attributes(self, model):


### PR DESCRIPTION
pytorch depreciated register_backward_hook in latest version

warning I got:
"Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior."