### PR TITLE
SHAP on converted models from onnx-tensorflow

### DIFF
--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -23,7 +23,7 @@ def custom_record_gradient(op_name, inputs, attrs, results):
     if op_name == "ResourceGather" and inputs[1].dtype == tf.int32:
         inputs[1].__dict__["_dtype"] = tf.float32
         reset_input = True
-    out = tf_backprop._record_gradient("shap_"+op_name, inputs, attrs, results)
+    out = tf_backprop.record_gradient("shap_"+op_name, inputs, attrs, results)
 
     if reset_input:
         inputs[1].__dict__["_dtype"] = tf.int32

--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -62,6 +62,8 @@ def _get_model_inputs(model):
         str(type(model)).endswith("keras.engine.training.Model'>") or \
         isinstance(model, tf.keras.Model):
         return model.inputs
+    elif str(type(model)).endswith("onnx_tf.backend_rep.TensorflowRep'>"):
+        return model.tensor_dict[model.inputs[0]]
     elif str(type(model)).endswith("tuple'>"):
         return model[0]
     else:
@@ -87,6 +89,8 @@ def _get_model_output(model):
             return model.outputs[0]
         else:
             return model.layers[-1].output
+    elif str(type(model)).endswith("onnx_tf.backend_rep.TensorflowRep'>"):
+        return model.tensor_dict[model.outputs[0]]
     elif str(type(model)).endswith("tuple'>"):
         return model[1]
     else:


### PR DESCRIPTION
We want to run SHAP on models that were converted from onnx using [onnx-tensorflow](https://github.com/onnx/onnx-tensorflow). Using this draft PR, we hope to be able to test against the CI setup from the original slundberg/shap repo.