### PR TITLE
fix matplotlib.pyplot import name typo

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -40,7 +40,7 @@ def waterfall(shap_values, max_display=10, show=True):
     
     # Turn off interactive plot
     if show is False:
-        plt.ioff()
+        pl.ioff()
     
 
     base_values = shap_values.base_values
@@ -294,7 +294,7 @@ def waterfall(shap_values, max_display=10, show=True):
     if show:
         pl.show()
     else:
-        return plt.gcf()
+        return pl.gcf()
 
 
 
@@ -334,7 +334,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
 
     # Turn off interactive plot
     if show is False:
-        plt.ioff()
+        pl.ioff()
     
     # support passing an explanation object
     upper_bounds = None
@@ -589,4 +589,4 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     if show:
         pl.show()
     else:
-        return plt.gcf()
+        return pl.gcf()


### PR DESCRIPTION
matplotlib.pyplot is imported as pl but accessed in a few places plt (the conventional import name)

this results in NameError when you call shap.plots.waterfall(..., show=False) 

this PR changes all references to that module to pl