### PR TITLE
Explainer algorithm argument should not mention 'kernel' in docstring

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -53,7 +53,7 @@ class Explainer(Serializable):
             units. For more details on how link functions work see any overview of link functions for generalized
             linear models.
 
-        algorithm : "auto", "permutation", "partition", "tree", "kernel", "sampling", "linear", "deep", or "gradient"
+        algorithm : "auto", "permutation", "partition", "tree", "sampling", "linear", "deep", or "gradient"
             The algorithm used to estimate the Shapley values. There are many different algorithms that
             can be used to estimate the Shapley values (and the related value for constrained games), each
             of these algorithms have various tradeoffs and are preferrable in different situations. By

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -53,7 +53,7 @@ class Explainer(Serializable):
             units. For more details on how link functions work see any overview of link functions for generalized
             linear models.
 
-        algorithm : "auto", "permutation", "partition", "tree", "sampling", "linear", "deep", or "gradient"
+        algorithm : "auto", "permutation", "partition", "tree", or "linear"
             The algorithm used to estimate the Shapley values. There are many different algorithms that
             can be used to estimate the Shapley values (and the related value for constrained games), each
             of these algorithms have various tradeoffs and are preferrable in different situations. By


### PR DESCRIPTION
* In `shap` version `0.40.0`, I get the following error when I pass in `kernel`, `sampling`, `deep`, or `gradient` as the algorithm to use in the Shapley calculation:

```
>               raise Exception("Unknown algorithm type passed: %s!" % algorithm)
E               Exception: Unknown algorithm type passed: {insert above mentioned algorithms}
```

* I checked the docs and noticed there was a mismatch between the implementation and documentation