### PR TITLE
[TREE EXPLAINER] LightGBM Booster 'objective' Parameter Membership

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -347,7 +347,7 @@ class Tree(Explainer):
                 assert not approximate, "approximate=True is not supported for LightGBM models!"
                 phi = self.model.original_model.predict(X, num_iteration=tree_limit, pred_contrib=True)
                 # Note: the data must be joined on the last axis
-                if self.model.original_model.params['objective'] == 'binary':
+                if 'objective' in self.model.original_model.params and self.model.original_model.params['objective'] == 'binary':
                     if not from_call:
                         warnings.warn('LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray')
                     phi = np.concatenate((0-phi, phi), axis=-1)


### PR DESCRIPTION
LightGBM boosters do not necessarily have `'objective'` in their param dictionary.

The documented default behavior in LightGBM is to assume regression without auto-setting the `'objective'` key in the `Booster.params` dictionary if `'objective'` is missing from `param` (a dictionary passed into the Training API function `train`). [1]

The following is a link to a notebook containing details for error reproduction and viewing the stack trace:
[Notebook for Reproduction](https://nbviewer.org/github/ngupta20/XAI/blob/572066ef3d57085cbd69f6cf912ff5b5d9cf35fc/notebooks/lgbm_objective.ipynb)

Thanks in advance @slundberg and all active contributors for your responsiveness!
