### PR TITLE
Fix shrinking to -inf and blowing up to inf of mask_aug and eyAdj_aug of KernelExplainer

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -550,6 +550,10 @@ class Kernel(Explainer):
             eyAdj_aug = np.hstack((eyAdj, eyAdj - (self.link.f(self.fx[dim]) - self.link.f(self.fnull[dim]))))
             eyAdj_aug *= w_sqrt_aug
             mask_aug = np.transpose(w_sqrt_aug * np.transpose(np.vstack((self.maskMatrix, self.maskMatrix - 1))))
+            mask_aug[np.isinf(mask_aug)] = 0
+            mask_aug[np.isneginf(mask_aug)] = 0
+            eyAdj_aug[np.isinf(eyAdj_aug)] = 0
+            eyAdj_aug[np.isneginf(eyAdj_aug)] = 0
             #var_norms = np.array([np.linalg.norm(mask_aug[:, i]) for i in range(mask_aug.shape[1])])
 
             # select a fixed number of top features

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -887,5 +887,6 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
         pl.xlabel(labels['GLOBAL_VALUE'], fontsize=13)
     else:
         pl.xlabel(labels['VALUE'], fontsize=13)
+    pl.tight_layout()
     if show:
         pl.show()

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -887,6 +887,5 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
         pl.xlabel(labels['GLOBAL_VALUE'], fontsize=13)
     else:
         pl.xlabel(labels['VALUE'], fontsize=13)
-    pl.tight_layout()
     if show:
         pl.show()


### PR DESCRIPTION
This behavior occurs when the dimensionality of the feature vectors being fed into the KernelExplainer is very large. L1 regularization consequently runs into issues when trying to convert the -inf values to floats. This fixes the issue I ran into myself as well as the following issues most probably: #577 and #1268 . 