### PR TITLE
Update numba version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy<1.22'], # <1.22 is because of numba
         install_requires=['numpy<1.22', 'scipy', 'scikit-learn', 'pandas', 'tqdm>4.25.0', # numpy versions are for numba
-                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.45.0', 'cloudpickle'],
+                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.46.0', 'cloudpickle'],
         extras_require=extras_require,
         ext_modules=ext_modules,
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy<1.22'], # <1.22 is because of numba
         install_requires=['numpy<1.22', 'scipy', 'scikit-learn', 'pandas', 'tqdm>4.25.0', # numpy versions are for numba
-                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.48.0', 'cloudpickle'],
+                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.49.0', 'cloudpickle'],
         extras_require=extras_require,
         ext_modules=ext_modules,
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy<1.22'], # <1.22 is because of numba
         install_requires=['numpy<1.22', 'scipy', 'scikit-learn', 'pandas', 'tqdm>4.25.0', # numpy versions are for numba
-                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.46.0', 'cloudpickle'],
+                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.48.0', 'cloudpickle'],
         extras_require=extras_require,
         ext_modules=ext_modules,
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ def run_setup(with_binary, test_xgboost, test_lightgbm, test_catboost, test_spar
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy<1.22'], # <1.22 is because of numba
         install_requires=['numpy<1.22', 'scipy', 'scikit-learn', 'pandas', 'tqdm>4.25.0', # numpy versions are for numba
-                          'packaging>20.9', 'slicer==0.0.7', 'numba', 'cloudpickle'],
+                          'packaging>20.9', 'slicer==0.0.7', 'numba>=0.45.0', 'cloudpickle'],
         extras_require=extras_require,
         ext_modules=ext_modules,
         classifiers=[


### PR DESCRIPTION
With `shap==0.40.0`, various versions of `numba` installations give errors during or after installation:

`numba==0.1` gives this when trying to import:
<img width="1025" alt="Pasted Graphic 12" src="https://user-images.githubusercontent.com/22552445/171477784-03db19a5-0645-4584-9ac0-5c655e59ad2b.png">

`numba<0.45.0` gives this when trying to install:
<img width="1715" alt="Pasted Graphic 13" src="https://user-images.githubusercontent.com/22552445/171477842-9cbda59f-d394-410c-a7b3-ae1dca7e80f3.png">

`numba<=0.48.0` has a successful installation and but failed import:
<img width="1379" alt="Pasted Graphic 14" src="https://user-images.githubusercontent.com/22552445/171477939-8e23f9d0-de8c-4c2c-9d0f-32b539cccf8f.png">
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/22552445/171478037-692f0e85-476b-48b7-8137-b24f954d1488.png">

`numba>=0.49.0` works successfully!
<img width="1534" alt="image" src="https://user-images.githubusercontent.com/22552445/171495810-efe5c2e0-7eed-45c0-be21-662c740b2cea.png">

Updating the `numba` allowed versions to avoid these failures
These were all run with py3.8 in a fresh environment with `shap==0.40.0`