### PR TITLE
waterfall: more generic check for numeric feats

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -124,8 +124,8 @@ def waterfall(shap_values, max_display=10, show=True):
         if features is None:
             yticklabels[rng[i]] = feature_names[order[i]]
         else:
-            if isinstance(features[order[i]], int) or isinstance(features[order[i]], float):
-                yticklabels[rng[i]] = format_value(features[order[i]], "%0.03f") + " = " + feature_names[order[i]]
+            if np.issubdtype(type(features[order[i]]), np.number):
+                yticklabels[rng[i]] = format_value(float(features[order[i]]), "%0.03f") + " = " + feature_names[order[i]]
             else:
                 yticklabels[rng[i]] = features[order[i]] + " = " + feature_names[order[i]]
 


### PR DESCRIPTION
Without that I get this error when passing my shap values (which are stored as an array of numpy.float64):
```python
File ~/.pyenv/versions/3.9.13/lib/python3.9/site-packages/shap/plots/_waterfall.py:130, in waterfall(shap_values, max_display, show)
    128             yticklabels[rng[i]] = format_value(float(features[order[i]]), "%0.03f") + " = " + feature_names[order[i]]
    129         else:
--> 130             yticklabels[rng[i]] = features[order[i]] + " = " + feature_names[order[i]]
    132 # add a last grouped feature to represent the impact of all the features we didn't show
    133 if num_features < len(values):

UFuncTypeError: ufunc 'add' did not contain a loop with signature matching types (dtype('bool'), dtype('<U3')) -> None
```

It still works with native python type, ie.
```python
a=5.0
np.issubdtype(type(a), np.number)
True
```

An alternative solution would the to switch the if/else and test for string first.