### PR TITLE
remove unused imports

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -2,8 +2,6 @@
 import pandas as pd
 import numpy as np
 import scipy as sp
-import sys
-import warnings
 import copy
 import operator
 import sklearn
@@ -779,7 +777,7 @@ def compute_output_dims(values, base_values, data, output_names):
         output_shape = tuple()
 
     interaction_order = len(values_shape) - len(data_shape) - len(output_shape)
-    values_dims = list(range(len(values_shape)))
+    list(range(len(values_shape)))
     output_dims = range(len(data_shape) + interaction_order, len(values_shape))
     return tuple(output_dims)
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -777,7 +777,6 @@ def compute_output_dims(values, base_values, data, output_names):
         output_shape = tuple()
 
     interaction_order = len(values_shape) - len(data_shape) - len(output_shape)
-    list(range(len(values_shape)))
     output_dims = range(len(data_shape) + interaction_order, len(values_shape))
     return tuple(output_dims)
 

--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -1,5 +1,4 @@
 import queue
-import numpy as np
 import warnings
 import copy
 from ._action import Action

--- a/shap/benchmark/_sequential.py
+++ b/shap/benchmark/_sequential.py
@@ -1,5 +1,5 @@
 from shap.utils import safe_isinstance, MaskedModel
-from shap.maskers import Independent, Partition, Impute, Text, Image, FixedComposite
+from shap.maskers import FixedComposite, Image, Text
 from shap import Explanation, links
 import matplotlib.pyplot as pl
 import sklearn

--- a/shap/benchmark/experiments.py
+++ b/shap/benchmark/experiments.py
@@ -2,10 +2,7 @@ from __future__ import print_function
 from .. import datasets
 from . import metrics
 from . import models
-from . import methods
 from .. import __version__
-import numpy as np
-import sklearn
 import os
 import pickle
 import sys

--- a/shap/benchmark/framework.py
+++ b/shap/benchmark/framework.py
@@ -1,11 +1,7 @@
 import matplotlib.pyplot as plt 
-import pandas as pd 
 import numpy as np 
 import itertools as it 
-import sklearn 
-import shap 
-from sklearn.model_selection import train_test_split
-from shap.utils import safe_isinstance, MaskedModel
+from shap.utils import safe_isinstance
 from . import perturbation
 
 def update(model, attributions, X, y, masker, sort_order, perturbation_method, scores):

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -1,6 +1,5 @@
 import numpy as np
 from tqdm.autonotebook import tqdm
-import gc
 import warnings
 import sklearn.utils
 

--- a/shap/benchmark/metrics.py
+++ b/shap/benchmark/metrics.py
@@ -1,14 +1,8 @@
-from .. import LinearExplainer
-from .. import KernelExplainer
-from .. import SamplingExplainer
-from ..explainers import other
 from .. import __version__
 from . import measures
 from . import methods
 import sklearn
 import numpy as np
-import copy
-import functools
 import time
 import hashlib
 import os

--- a/shap/benchmark/models.py
+++ b/shap/benchmark/models.py
@@ -1,6 +1,5 @@
 import sklearn
 import sklearn.ensemble
-import gc
 from sklearn.preprocessing import StandardScaler
 import numpy as np
 

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -1,9 +1,6 @@
 import numpy as np
-import scipy as sp
-import warnings
 from ._explainer import Explainer
 from ..utils import safe_isinstance, MaskedModel
-from .. import maskers
 
 
 class Additive(Explainer):

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -2,7 +2,6 @@ from ..utils._legacy import convert_to_instance, convert_to_model, match_instanc
 from ..utils._legacy import convert_to_instance_with_index, convert_to_link, IdentityLink, convert_to_data, DenseData, SparseData
 from ..utils import safe_isinstance
 from scipy.special import binom
-from scipy.sparse import issparse
 import numpy as np
 import pandas as pd
 import scipy as sp

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -1,20 +1,12 @@
-import types
-import copy
-import inspect
 from ..utils import MaskedModel
 import numpy as np
-import warnings
 import time
 from tqdm.auto import tqdm
 import queue
-from ..utils import assert_import, record_import_error, safe_isinstance, make_masks, OpChain
+from ..utils import OpChain, make_masks, safe_isinstance
 from .. import Explanation
-from .. import maskers
 from ._explainer import Explainer
 from .. import links
-import cloudpickle
-import pickle
-from ..maskers import Masker
 from ..models import Model
 from numba import jit
 

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -1,17 +1,8 @@
-import functools
-import types
 from ..utils import partition_tree_shuffle, MaskedModel
-from .._explanation import Explanation
 from ._explainer import Explainer
 import numpy as np
-import pandas as pd
-import scipy as sp
-import pickle
-import cloudpickle
 import warnings
 from .. import links
-from .. import maskers
-from ..maskers import Masker
 from ..models import Model
 
 class Permutation(Explainer):

--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -54,9 +54,7 @@ class Sampling(Kernel):
             feature_names = None # we can make self.feature_names from background data eventually if we have it
 
         v = self.shap_values(X, nsamples=nsamples)
-        tuple()
         if type(v) is list:
-            (len(v),)
             v = np.stack(v, axis=-1) # put outputs at the end
         e = Explanation(v, self.expected_value, X, feature_names=feature_names)#, output_shape=output_shape)
         return e

--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -1,5 +1,4 @@
-from ..utils._legacy import convert_to_instance, convert_to_model, match_instance_to_data, match_model_to_data
-from ..utils._legacy import convert_to_instance_with_index, convert_to_link, IdentityLink, convert_to_data, DenseData
+from ..utils._legacy import convert_to_instance, match_instance_to_data
 from ..utils import safe_isinstance
 from .._explanation import Explanation
 from ._kernel import Kernel
@@ -55,9 +54,9 @@ class Sampling(Kernel):
             feature_names = None # we can make self.feature_names from background data eventually if we have it
 
         v = self.shap_values(X, nsamples=nsamples)
-        output_shape = tuple()
+        tuple()
         if type(v) is list:
-            output_shape = (len(v),)
+            (len(v),)
             v = np.stack(v, axis=-1) # put outputs at the end
         e = Explanation(v, self.expected_value, X, feature_names=feature_names)#, output_shape=output_shape)
         return e

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1,12 +1,8 @@
 import time
 import numpy as np
 import scipy.special
-import multiprocessing
-import sys
 import json
-import os
 import struct
-import itertools
 from packaging import version
 from ._explainer import Explainer
 from ..utils import assert_import, record_import_error, safe_isinstance

--- a/shap/explainers/mimic.py
+++ b/shap/explainers/mimic.py
@@ -1,6 +1,4 @@
-import numpy as np
-import multiprocessing
-import sys
+
 from .explainer import Explainer
 
 try:

--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -5,7 +5,6 @@ module which uses a compiled C++ implmentation.
 """
 import numpy as np
 #import numba
-from .explainer import Explainer
 from ..utils._exceptions import ExplainerError
 
 # class TreeExplainer(Explainer):

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -6,11 +6,10 @@ except ImportError:
     pass
 from ._labels import labels
 from ..utils import format_value, ordinal_str
-from ._utils import convert_ordering, convert_color, merge_nodes, get_sort_order, sort_inds, dendrogram_coords
+from ._utils import convert_ordering, merge_nodes, get_sort_order, sort_inds, dendrogram_coords
 from . import colors
 import numpy as np
 import scipy
-import copy
 from .. import Explanation, Cohorts
 
 

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -11,10 +11,9 @@ try:
     import matplotlib.pyplot as pl
 except ImportError:
     warnings.warn("matplotlib could not be loaded!")
-    pass
 from ._labels import labels
 from . import colors
-from ..utils import safe_isinstance, OpChain, format_value
+from ..utils import safe_isinstance
 from ._utils import convert_ordering, convert_color, merge_nodes, get_sort_order, sort_inds
 from .. import Explanation
 
@@ -254,7 +253,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
 
     # here we build our feature names, accounting for the fact that some features might be merged together
     feature_inds = feature_order[:max_display]
-    y_pos = np.arange(len(feature_inds), 0, -1)
+    np.arange(len(feature_inds), 0, -1)
     feature_names_new = []
     for pos,inds in enumerate(orig_inds):
         if len(inds) == 1:
@@ -442,7 +441,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
     # support passing an explanation object
     if str(type(shap_values)).endswith("Explanation'>"):
         shap_exp = shap_values
-        base_value = shap_exp.base_values
+        shap_exp.base_values
         shap_values = shap_exp.values
         if features is None:
             features = shap_exp.data
@@ -699,7 +698,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
                 ds /= np.max(ds) * 3
 
                 values = features[:, i]
-                window_size = max(10, len(values) // 20)
+                max(10, len(values) // 20)
                 smooth_values = np.zeros(len(xs) - 1)
                 sort_inds = np.argsort(shaps)
                 trailing_pos = 0
@@ -788,7 +787,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
             # order the feature data so we can apply percentiling
             order = np.argsort(feature)
             # x axis is located at y0 = pos, with pos being there for offset
-            y0 = np.ones(num_x_points) * pos
+            np.ones(num_x_points) * pos
             # calculate kdes:
             ys = np.zeros((nbins, num_x_points))
             for i in range(nbins):

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -253,7 +253,6 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
 
     # here we build our feature names, accounting for the fact that some features might be merged together
     feature_inds = feature_order[:max_display]
-    np.arange(len(feature_inds), 0, -1)
     feature_names_new = []
     for pos,inds in enumerate(orig_inds):
         if len(inds) == 1:
@@ -441,7 +440,6 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
     # support passing an explanation object
     if str(type(shap_values)).endswith("Explanation'>"):
         shap_exp = shap_values
-        shap_exp.base_values
         shap_values = shap_exp.values
         if features is None:
             features = shap_exp.data
@@ -698,7 +696,6 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
                 ds /= np.max(ds) * 3
 
                 values = features[:, i]
-                max(10, len(values) // 20)
                 smooth_values = np.zeros(len(xs) - 1)
                 sort_inds = np.argsort(shaps)
                 trailing_pos = 0
@@ -786,8 +783,6 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
             nbins = thesebins.shape[0] - 1
             # order the feature data so we can apply percentiling
             order = np.argsort(feature)
-            # x axis is located at y0 = pos, with pos being there for offset
-            np.ones(num_x_points) * pos
             # calculate kdes:
             ys = np.zeros((nbins, num_x_points))
             for i in range(nbins):

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -1,4 +1,3 @@
-import numpy as np
 import sklearn
 import warnings
 try:

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -1,7 +1,5 @@
 import numpy as np
-import warnings
 from . import colors
-from ..utils import ordinal_str
 import random
 import string
 import json
@@ -265,8 +263,8 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
 
     # build out HTML output one word one at a time
     top_inds = np.argsort(-np.abs(values))[:num_starting_labels]
-    maxv = values.max()
-    minv = values.min()
+    values.max()
+    values.min()
     out = ""
     # ev_str = str(shap_values.base_values)
     # vsum_str = str(values.sum())

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -263,8 +263,6 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
 
     # build out HTML output one word one at a time
     top_inds = np.argsort(-np.abs(values))[:num_starting_labels]
-    values.max()
-    values.min()
     out = ""
     # ev_str = str(shap_values.base_values)
     # vsum_str = str(values.sum())

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy as sp
-from scipy.spatial.distance import pdist
 from numba import jit
 import sklearn
 import warnings

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -1,12 +1,9 @@
 import re
-import pandas as pd
 import numpy as np
 import scipy as sp
-from scipy.spatial.distance import pdist
 import sys
 import warnings
 import sklearn
-import importlib
 import copy
 from contextlib import contextmanager
 import sys, os
@@ -65,7 +62,7 @@ def potential_interactions(shap_values_column, shap_values_matrix):
     # ignore inds that are identical to the column 
     ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)
     
-    values = shap_values_matrix.values
+    shap_values_matrix.values
     X = shap_values_matrix.data
 
     if X.shape[0] > 10000:

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -61,8 +61,6 @@ def potential_interactions(shap_values_column, shap_values_matrix):
 
     # ignore inds that are identical to the column 
     ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)
-    
-    shap_values_matrix.values
     X = shap_values_matrix.data
 
     if X.shape[0] > 10000:

--- a/shap/utils/image.py
+++ b/shap/utils/image.py
@@ -1,9 +1,7 @@
 import cv2
-import json
 import matplotlib.pyplot as plt 
 import numpy as np
 import os
-import requests
 import shap
 from textwrap import wrap
 

--- a/tests/benchmark/perturbation.py
+++ b/tests/benchmark/perturbation.py
@@ -1,5 +1,4 @@
 import numpy as np
-import shap 
 import shap.benchmark as benchmark 
 from transformers import AutoTokenizer
 from shap.maskers import Independent, Partition, Impute, Text, Image, FixedComposite


### PR DESCRIPTION
There are a few unused imports (though it is complicated as some seem unused but are used):
I ran the following to find them:
```
flake8 --select F401
```

Note to try to save time I ran [autoflake](https://github.com/PyCQA/autoflake) which also removes some unused variables. I'm not sure how dangerous this is!