### PR TITLE
Fix Issue #2528

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -12,6 +12,8 @@ import itertools
 import warnings
 import gc
 from sklearn.linear_model import LassoLarsIC, Lasso, lars_path
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
 from ._explainer import Explainer
 
@@ -562,7 +564,9 @@ class Kernel(Explainer):
             # use an adaptive regularization method
             elif self.l1_reg == "auto" or self.l1_reg == "bic" or self.l1_reg == "aic":
                 c = "aic" if self.l1_reg == "auto" else self.l1_reg
-                nonzero_inds = np.nonzero(LassoLarsIC(criterion=c).fit(mask_aug, eyAdj_aug).coef_)[0]
+                model = make_pipeline(StandardScaler(with_mean=False), LassoLarsIC(criterion=c, normalize=False))
+                nonzero_inds = np.nonzero(model.fit(mask_aug, eyAdj_aug)[1].coef_)[0]
+
 
             # use a fixed regularization coeffcient
             else:


### PR DESCRIPTION
Fix a deprecation warning in `sklearn.linear_model.LassoLarsIC`.

The deprecation concerns the `normalize` keyword, which is currently equal to `True` by default. In order to replicate the current behaviour _after_ deprecation, we follow sklearn's [documentation on LassoLarsIC](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LassoLarsIC.html) and do the following:

1. Take care of normalization with a `sklearn.preprocessing.StandardScaler`
2. Explicitly pass `normalize=False` to the `LassoLarsIC`

From the resulting pipeline, the Lasso object can be recovered with `model[1]`.