### PR TITLE
Fixed IPython deprecation warning

### DIFF
--- a/shap/benchmark/plots.py
+++ b/shap/benchmark/plots.py
@@ -436,7 +436,7 @@ red_blue_solid = LinearSegmentedColormap('red_blue_solid', {
     'alpha': ((0.0, 1, 1),
               (1.0, 1, 1))
 })
-from IPython.core.display import HTML
+from IPython.display import HTML
 def plot_grids(dataset, model_names, out_dir=None):
 
     if out_dir is not None:

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -8,7 +8,7 @@ import string
 import json
 import random
 try:
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
     from IPython import get_ipython
     have_ipython = True
 except ImportError:

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     warnings.warn("matplotlib could not be loaded!")
 try:
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
 except ImportError:
     warnings.warn("IPython could not be loaded!")
 from . import colors

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -6,7 +6,7 @@ import random
 import string
 import json
 try:
-    from IPython.core.display import display as ipython_display, HTML
+    from IPython.display import display as ipython_display, HTML
     have_ipython = True
 except ImportError:
     have_ipython = False
@@ -821,12 +821,12 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
              + "</div>" \
              + "</div>"
 
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
     return display(HTML(out))
 
 def text_to_text(shap_values):        
 
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
     # unique ID added to HTML elements and function to avoid collision of differnent instances
     uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
 


### PR DESCRIPTION
When using IPython versions greater than 7.14, there is a deprecation warning thrown indicating that all imports from `IPython.core.display` should be switched to `IPython.display`. This PR makes that fix.