### PR TITLE
IMDB: fix UnicodeDecodeError

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -64,7 +64,7 @@ def imdb(display=False): # pylint: disable=unused-argument
     Paper to cite when using the data is: http://www.aclweb.org/anthology/P11-1015
     """
 
-    with open(cache(github_data_url + "imdb_train.txt")) as f:
+    with open(cache(github_data_url + "imdb_train.txt"), encoding="utf8") as f:
         data = f.readlines()
     y = np.ones(25000, dtype=np.bool)
     y[:12500] = 0


### PR DESCRIPTION
Fix i,ssue
when calling `shap.datasets.imdb()`
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 3913: character maps to <undefined>`