### PR TITLE
Fix: Waterfall plot .base_values error #2140

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -42,7 +42,7 @@ def waterfall(shap_values, max_display=10, show=True):
     if show is False:
         plt.ioff()
 
-    base_values = shap_values.base_values
+    base_values = shap_values.base_values[0]
     features = shap_values.display_data if shap_values.display_data is not None else shap_values.data
     feature_names = shap_values.feature_names
     lower_bounds = getattr(shap_values, "lower_bounds", None)


### PR DESCRIPTION
I have had the same issue as [this issue here](https://github.com/slundberg/shap/issues/2140). The fix is to ensure that `base_values` is forced to be scalar.

This may break under the circumstance that the `base_values` attribute of `shap_values` is already scalar.