### PR TITLE
[BUGFIX] Fixed TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -126,7 +126,7 @@ def waterfall(shap_values, max_display=10, show=True):
             if np.issubdtype(type(features[order[i]]), np.number):
                 yticklabels[rng[i]] = format_value(float(features[order[i]]), "%0.03f") + " = " + feature_names[order[i]]
             else:
-                yticklabels[rng[i]] = features[order[i]] + " = " + feature_names[order[i]]
+                yticklabels[rng[i]] = str(features[order[i]]) + " = " + feature_names[order[i]]
 
     # add a last grouped feature to represent the impact of all the features we didn't show
     if num_features < len(values):


### PR DESCRIPTION
This PR fixes the following TypeError.

```
TypeError                                 Traceback (most recent call last)
Input In [84], in <cell line: 4>()
      6 try:
      7     shap.force_plot(expected_value1, shap_value1[rowid], X.iloc[rowid], matplotlib=True)
----> 8     shap.plots.waterfall(shap_obj[rowid])
      9 except ValueError as e:        
     10     # avoid shap library bug for now: Image size of xxx pixels is too large. It must be less than 2^16 in each direction.       
     11     errmsg = ''.join(traceback.format_exception_only(type(e), e)).strip()
File /usr/local/lib/python3.8/site-packages/shap/plots/_waterfall.py:129, in waterfall(shap_values, max_display, show)
    127             yticklabels[rng[i]] = format_value(float(features[order[i]]), "%0.03f") + " = " + feature_names[order[i]]
    128         else:
--> 129             yticklabels[rng[i]] = features[order[i]] + " = " + feature_names[order[i]]
    131 # add a last grouped feature to represent the impact of all the features we didn't show
    132 if num_features < len(values):
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

No drawback expected.

```
>>> str(None)+"="
'None='
>>> str("aaa")+"="
'aaa='
>>> str(1)+"="
'1='
```