### PR TITLE
[Bugfix] Fix TypeError at force_plot: can only concatenate str (not float) to str

### DIFF
--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -114,7 +114,7 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
         if feature[1] == "":
             text = feature[2]
         else:
-            text = feature[2] + ' = ' + feature[1]
+            text = feature[2] + ' = ' + str(feature[1])
 
         if text_rotation is not 0:
             va_alignment = 'top'


### PR DESCRIPTION
We got the following TypeError for force_plot at [this line](https://github.com/slundberg/shap/blob/v0.41.0/shap/plots/_force_matplotlib.py#L117) `' = ' + feature[1]`.

feature[1] comes from https://github.com/slundberg/shap/blob/v0.41.0/shap/plots/_force_matplotlib.py#L210
it comes from https://github.com/slundberg/shap/blob/510c4b6a85e4189573ef8290392139586c4292f5/shap/plots/_force.py#L401
and can be non-str object
https://github.com/slundberg/shap/blob/510c4b6a85e4189573ef8290392139586c4292f5/shap/plots/_force.py#L308

This PR converts non-str object at feature[1] to str to fix TypeError at string concatenation.

```
TypeError                                 Traceback (most recent call last)
Input In [85], in <cell line: 4>()
      5 display(pd.DataFrame(X.iloc[rowid]))
      6 try:
----> 7     shap.force_plot(
      8         base_value=expected_value1, 
      9         shap_values=shap_value1[rowid],
     10         features=X.iloc[rowid],
     11         feature_names=X.columns,
     12         # link='logit',
     13         matplotlib=True
     14     )
     15     waterfall(shap_obj[rowid], feature_names=X.columns)
     16 except ValueError as e:
     17     # 1. avoid shap library bug for ValueError: Image size of xxx pixels is too large. It must be less than 2^16 in each direction. 
File /usr/local/lib/python3.8/site-packages/shap/plots/_force.py:164, in force(base_value, shap_values, features, feature_names, out_names, link, plot_cmap, matplotlib, show, figsize, ordering_keys, ordering_keys_time_format, text_rotation, contribution_threshold)
    152     instance = Instance(np.zeros((1, len(feature_names))), features)
    153     e = AdditiveExplanation(
    154         base_value,
    155         np.sum(shap_values[0, :]) + base_value,
   (...)
    161         DenseData(np.zeros((1, len(feature_names))), list(feature_names))
    162     )
--> 164     return visualize(e,
    165                      plot_cmap,
    166                      matplotlib,
    167                      figsize=figsize,
    168                      show=show,
    169                      text_rotation=text_rotation,
    170                      min_perc=contribution_threshold)
    172 else:
    173     if matplotlib:
File /usr/local/lib/python3.8/site-packages/shap/plots/_force.py:334, in visualize(e, plot_cmap, matplotlib, figsize, show, ordering_keys, ordering_keys_time_format, text_rotation, min_perc)
    332 if isinstance(e, AdditiveExplanation):
    333     if matplotlib:
--> 334         return AdditiveForceVisualizer(e, plot_cmap=plot_cmap).matplotlib(figsize=figsize,
    335                                                                 show=show,
    336                                                                 text_rotation=text_rotation,
    337                                                                 min_perc=min_perc)
    338     else:
    339         return AdditiveForceVisualizer(e, plot_cmap=plot_cmap)
File /usr/local/lib/python3.8/site-packages/shap/plots/_force.py:426, in AdditiveForceVisualizer.matplotlib(self, figsize, show, text_rotation, min_perc)
    425 def matplotlib(self, figsize, show, text_rotation, min_perc=0.05):
--> 426     fig = draw_additive_plot(self.data,
    427                              figsize=figsize,
    428                              show=show,
    429                              text_rotation=text_rotation,
    430                              min_perc=min_perc)
    432     return fig
File /usr/local/lib/python3.8/site-packages/shap/plots/_force_matplotlib.py:385, in draw_additive_plot(data, figsize, show, text_rotation, min_perc)
    383 # Add labels
    384 total_effect = np.abs(total_neg) + total_pos
--> 385 fig, ax = draw_labels(fig, ax, out_value, neg_features, 'negative',
    386                       offset_text, total_effect, min_perc=min_perc, text_rotation=text_rotation)
    388 fig, ax = draw_labels(fig, ax, out_value, pos_features, 'positive',
    389                       offset_text, total_effect, min_perc=min_perc, text_rotation=text_rotation)
    391 # higher lower legend
File /usr/local/lib/python3.8/site-packages/shap/plots/_force_matplotlib.py:117, in draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_effect, min_perc, text_rotation)
    115     text = feature[2]
    116 else:
--> 117     text = feature[2] + ' = ' + feature[1]
    119 if text_rotation is not 0:
    120     va_alignment = 'top'
TypeError: can only concatenate str (not "float") to str
```