### PR TITLE
Update models.py

### DIFF
--- a/shap/benchmark/models.py
+++ b/shap/benchmark/models.py
@@ -3,6 +3,7 @@ import sklearn.ensemble
 import gc
 from sklearn.preprocessing import StandardScaler
 import numpy as np
+from tensorflow import keras
 
 class KerasWrap(object):
     """ A wrapper that allows us to set parameters in the constructor and do a reset before fitting.


### PR DESCRIPTION
keras is no longer supported, please use tf.keras instead. Your TensorFlow version is newer than 2.4.0 and so graph support has been removed in eager mode and some static graphs may not be supported. See PR #1483 for discussion.