### PR TITLE
move shap_values() to __call__ to comply to the usual explainer API

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -105,8 +105,7 @@ class Kernel(Explainer):
         else:
             self.D = self.fnull.shape[0]
 
-
-    def shap_values(self, X, **kwargs):
+    def __call__(self, X, **kwargs):
         """ Estimate the SHAP values for a set of samples.
 
         Parameters
@@ -207,6 +206,11 @@ class Kernel(Explainer):
                     out[i] = explanations[i]
                 return out
 
+
+    def shap_values(self, X, **kwargs):
+        """ Legacy interface for deprecated shap_values call """
+        return self(X, **kwargs)
+        
     def explain(self, incoming_instance, **kwargs):
         # convert incoming input to a standardized iml object
         instance = convert_to_instance(incoming_instance)


### PR DESCRIPTION
This just moves the code from shap_values(self, X, **kwargs) to a new method __call__(self, X, **kwargs) and calls __call__ from shap_values such that the class is usable as the usual Explainers in order to keep the inheritance structure usable (i.e. to treat all explainers the same without ifs for special treatment).