### PR TITLE
Replace warnings.DeprecationWarning with just DeprecationWarning

### DIFF
--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -211,7 +211,7 @@ class Permutation(Explainer):
             attribute of the explainer). For models with vector outputs this returns a list
             of such matrices, one for each output.
         """
-        warnings.warn("shap_values() is deprecated; use __call__().", warnings.DeprecationWarning)
+        warnings.warn("shap_values() is deprecated; use __call__().", DeprecationWarning)
         
         explanation = self(X, max_evals=npermutations * X.shape[1], main_effects=main_effects)
         return explanation.values


### PR DESCRIPTION
As per [this](https://github.com/slundberg/shap/issues/2668) issue, an error is thrown:

`AttributeError: module 'warnings' has no attribute 'DeprecationWarning'`

because `DeprecationWarning` should be referenced as a standalone class rather than as `warnings.DeprecationWarning`.