### PR TITLE
Replace sample dataset on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ While SHAP can explain the output of any machine learning model, we have develop
 ```python
 import xgboost
 import shap
+from sklearn.datasets import fetch_california_housing
 
 # train an XGBoost model
-X, y = shap.datasets.boston()
+X, y = fetch_california_housing(return_X_y=True, as_frame=True)
 model = xgboost.XGBRegressor().fit(X, y)
 
 # explain the model's predictions using SHAP


### PR DESCRIPTION
`load_boston` has been removed from scikit-learn since version 1.2. Replacing it with California housing sample dataset

Solves #2844 , #2322