### PR TITLE
[BUGFIX] yticklabels in `plots.waterfall()`

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -126,7 +126,7 @@ def waterfall(shap_values, max_display=10, show=True):
             if np.issubdtype(type(features[order[i]]), np.number):
                 yticklabels[rng[i]] = format_value(float(features[order[i]]), "%0.03f") + " = " + feature_names[order[i]]
             else:
-                yticklabels[rng[i]] = features[order[i]] + " = " + feature_names[order[i]]
+                yticklabels[rng[i]] = str(features[order[i]]) + " = " + str(feature_names[order[i]])
 
     # add a last grouped feature to represent the impact of all the features we didn't show
     if num_features < len(values):


### PR DESCRIPTION
This allows for cases where the type of `features[order[i]]` is incompatible with string addition, e.g. boolean type.