### PR TITLE
Fix GradientExplainer when tabular data is passed, instead of image

### DIFF
--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -69,7 +69,10 @@ class Gradient(Explainer):
         if isinstance(data, pd.DataFrame):
             self.features = data.columns.values
         else:
-            self.features = list(range(data[0].shape[1]))
+            if len(data[0].shape) == 1:
+                self.features = list(range(data[0].shape[0]))
+            else:
+                self.features = list(range(data[0].shape[1]))
         
         if framework == 'tensorflow':
             self.explainer = _TFGradient(model, data, session, batch_size, local_smoothing)


### PR DESCRIPTION
When tabular data is used, instead of images, the attribute `self.features` raise an exception because the shape of the first element (`data[0]`) is not a tuple, but a single element, with the number of feature in it.

An additional check is introduced to allow for tabular data, with 2D tensors.