### PR TITLE
Add GH Action for precommit hooks

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,6 +20,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - uses: pre-commit/action@v3.0.0
+
   run_tests:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Interim measure to ensure precommit hooks are run on CI.

In future, we should plan to remove this action when the GH Check is implemented via pre-commit.ci rather than GH Actions. In the meantime, the priority is to ensure the Check is enabled one way or another.