### PR TITLE
Add __call__ method to KernelExplainer

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -150,7 +150,13 @@ class Kernel(Explainer):
         else:
             ev_tiled = np.tile(self.expected_value, v.shape[0])
 
-        return Explanation(v, base_values=ev_tiled, data=X, feature_names=feature_names, compute_time=time.time() - start_time)
+        return Explanation(
+            v,
+            base_values=ev_tiled,
+            data=X,
+            feature_names=feature_names,
+            compute_time=time.time() - start_time,
+        )
 
     def shap_values(self, X, **kwargs):
         """ Estimate the SHAP values for a set of samples.

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -32,10 +32,6 @@ from ._explainer import Explainer
 from .._explanation import Explanation
 import time
 
-# Suppress the sklearn warning
-# 'UserWarning: X does not have valid feature names, but <model> was fitted with feature names'
-warnings.filterwarnings('ignore', module='sklearn')
-
 log = logging.getLogger('shap')
 
 
@@ -136,7 +132,6 @@ class Kernel(Explainer):
 
         if safe_isinstance(X, "pandas.core.frame.DataFrame"):
             feature_names = list(X.columns)
-            X = X.values
         else:
             feature_names = getattr(self, "data_feature_names", None)
        

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -18,11 +18,18 @@ from tqdm.auto import tqdm
 
 from .._explanation import Explanation
 from ..utils import safe_isinstance
-from ..utils._legacy import (DenseData, IdentityLink, SparseData,
-                             convert_to_data, convert_to_instance,
-                             convert_to_instance_with_index, convert_to_link,
-                             convert_to_model, match_instance_to_data,
-                             match_model_to_data)
+from ..utils._legacy import (
+    DenseData,
+    IdentityLink,
+    SparseData,
+    convert_to_data,
+    convert_to_instance,
+    convert_to_instance_with_index,
+    convert_to_link,
+    convert_to_model,
+    match_instance_to_data,
+    match_model_to_data,
+)
 from ._explainer import Explainer
 
 log = logging.getLogger('shap')
@@ -132,11 +139,11 @@ class Kernel(Explainer):
             feature_names = list(X.columns)
         else:
             feature_names = getattr(self, "data_feature_names", None)
-       
+
         v = self.shap_values(X)
         if type(v) is list:
             v = np.stack(v, axis=-1) # put outputs at the end
-        
+
         # the explanation object expects an expected value for each row
         if hasattr(self.expected_value, "__len__"):
             ev_tiled = np.tile(self.expected_value, (v.shape[0],1))

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -2,6 +2,7 @@ import copy
 import gc
 import itertools
 import logging
+import time
 import warnings
 
 import numpy as np
@@ -15,22 +16,14 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
 
-from ..utils import safe_isinstance
-from ..utils._legacy import (
-    DenseData,
-    IdentityLink,
-    SparseData,
-    convert_to_data,
-    convert_to_instance,
-    convert_to_instance_with_index,
-    convert_to_link,
-    convert_to_model,
-    match_instance_to_data,
-    match_model_to_data,
-)
-from ._explainer import Explainer
 from .._explanation import Explanation
-import time
+from ..utils import safe_isinstance
+from ..utils._legacy import (DenseData, IdentityLink, SparseData,
+                             convert_to_data, convert_to_instance,
+                             convert_to_instance_with_index, convert_to_link,
+                             convert_to_model, match_instance_to_data,
+                             match_model_to_data)
+from ._explainer import Explainer
 
 log = logging.getLogger('shap')
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -56,6 +56,11 @@ class Kernel(Explainer):
         Note: for sparse case we accept any sparse matrix but convert to lil format for
         performance.
 
+    feature_names : list
+        The names of the features in the background dataset. If the background dataset is
+        supplied as a pandas.DataFrame, then feature_names can be set to None (the default value)
+        and the feature names will be taken as the column names of the dataframe.
+
     link : "identity" or "logit"
         A generalized linear model link to connect the feature importance values to the model
         output. Since the feature importance values, phi, sum up to the model output, it often makes

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -96,9 +96,18 @@ class Model:
 
 def convert_to_model(val):
     if isinstance(val, Model):
-        return val
+        out = val
     else:
-        return Model(val, None)
+        out = Model(val, None)
+
+    # Fix for the sklearn warning
+    # 'X does not have valid feature names, but <model> was fitted with feature names'
+    out = copy.deepcopy(out)
+    f_self = getattr(out.f,'__self__',None)
+    if f_self and hasattr(f_self,'feature_names_in_'):
+        f_self.feature_names_in_ = None
+
+    return out
 
 
 def match_model_to_data(model, data):

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -3,6 +3,7 @@ import pandas as pd
 import scipy.sparse
 from sklearn.cluster import KMeans
 from sklearn.impute import SimpleImputer
+import copy
 
 
 def kmeans(X, k, round_values=True):

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -104,10 +104,11 @@ def convert_to_model(val):
 
     # Fix for the sklearn warning
     # 'X does not have valid feature names, but <model> was fitted with feature names'
-    out = copy.deepcopy(out)
     f_self = getattr(out.f,'__self__',None)
     if f_self and hasattr(f_self,'feature_names_in_'):
-        f_self.feature_names_in_ = None
+        # Make a copy so that the feature names are not removed from the original model
+        out = copy.deepcopy(out)
+        out.f.__self__.feature_names_in_ = None
 
     return out
 

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -1,9 +1,10 @@
+import copy
+
 import numpy as np
 import pandas as pd
 import scipy.sparse
 from sklearn.cluster import KMeans
 from sklearn.impute import SimpleImputer
-import copy
 
 
 def kmeans(X, k, round_values=True):

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -104,8 +104,8 @@ def convert_to_model(val):
 
     # Fix for the sklearn warning
     # 'X does not have valid feature names, but <model> was fitted with feature names'
-    f_self = getattr(out.f,'__self__',None)
-    if f_self and hasattr(f_self,'feature_names_in_'):
+    f_self = getattr(out.f, "__self__", None)
+    if f_self and hasattr(f_self, "feature_names_in_"):
         # Make a copy so that the feature names are not removed from the original model
         out = copy.deepcopy(out)
         out.f.__self__.feature_names_in_ = None

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -74,8 +74,8 @@ def test_kernel_shap_with_call_method():
     explainer = shap.KernelExplainer(svm.predict_proba, X_train, nsamples=100, link="logit")
     shap_values = explainer(X_test)
 
-    # plot the SHAP values for the Setosa output of the first instance
-    shap.force_plot(shap_values[0])
+    # plot the SHAP values for the Versicolour output of the first instance
+    shap.force_plot(shap_values[0][:,1])
 
 def test_kernel_shap_with_dataframe():
     """ Test with a Pandas DataFrame.

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -58,6 +58,25 @@ def test_front_page_model_agnostic_rank():
     # plot the SHAP values for the Setosa output of the first instance
     shap.force_plot(explainer.expected_value[0], shap_values[0][0, :], X_test.iloc[0, :], link="logit")
 
+def test_kernel_shap_with_call_method():
+    """ Test the __call__ method of the Kernel class
+    """
+
+    # print the JS visualization code to the notebook
+    shap.initjs()
+
+    # train a SVM classifier
+    X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.iris(), test_size=0.1, random_state=0)
+    svm = sklearn.svm.SVC(kernel='rbf', probability=True)
+    svm.fit(X_train, Y_train)
+
+    # use Kernel SHAP to explain test set predictions
+    explainer = shap.KernelExplainer(svm.predict_proba, X_train, nsamples=100, link="logit")
+    shap_values = explainer(X_test)
+
+    # plot the SHAP values for the Setosa output of the first instance
+    shap.force_plot(shap_values[0])
+
 def test_kernel_shap_with_dataframe():
     """ Test with a Pandas DataFrame.
     """


### PR DESCRIPTION
Currently the `KernelExplainer` class inherits its `__call__` method from the superclass `Explainer`. This is a problem for `KernelExplainer` because it does not have a `masker` attribute, e.g. [this SO question](https://stackoverflow.com/questions/75137492/attributeerror-kernel-object-has-no-attribute-masker-during-training-of-svc). I based the new `__call__` method on that of the `TreeExplainer`.

This is a port of https://github.com/dsgibbons/shap/pull/107.