### PR TITLE
chore: re-enable ruff F811 and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ ignore = [
 [tool.ruff.per-file-ignores]
 # Unused imports often intentional in top-level __init__.py 
 "__init__.py" = ["F401"]
+# Don't apply linting/formatting to vendored code
+"shap/explainers/other/_maple.py" = ["ALL"]
+"shap/plots/colors/_colorconv.py" = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ addopts = "--mpl"
 testpaths = ["tests"]
 
 [tool.ruff]
-select = ["F"]
-ignore = [
+select = [
+    "F", # Pyflakes
 ]
+ignore = []
 
 [tool.ruff.per-file-ignores]
 # Unused imports often intentional in top-level __init__.py 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,8 @@ addopts = "--mpl"
 testpaths = ["tests"]
 
 [tool.ruff]
-# Aim to get all pyflakes logical errors ("F") passing
 select = ["F"]
-# For now, deselect rules that do not pass
 ignore = [
-  "F811", # Redefinition of unused variable
 ]
 
 [tool.ruff.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ testpaths = ["tests"]
 select = [
     "F", # Pyflakes
 ]
-ignore = []
 
 [tool.ruff.per-file-ignores]
 # Unused imports often intentional in top-level __init__.py 

--- a/shap/benchmark/experiments.py
+++ b/shap/benchmark/experiments.py
@@ -12,7 +12,6 @@ from multiprocessing import Pool
 import itertools
 import copy
 import random
-import time
 try:
     from queue import Queue
 except ImportError:

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -6,7 +6,7 @@ import warnings
 import sklearn
 import copy
 from contextlib import contextmanager
-import sys, os
+import os
 
 
 if (sys.version_info < (3, 0)):


### PR DESCRIPTION
F811 ruff rule is "Redefinition of unused variable".

One thing to note is that `_maple.py` is a piece of vendored code, so I've opted to exclude ruff linting for it (to avoid making changes to it).