### PR TITLE
Numpy version in conflict with bool

### DIFF
--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -79,7 +79,10 @@ class Tabular(Masker):
 
         # self._last_mask = np.zeros(self.data.shape[1], dtype=bool)
         self._masked_data = data.copy()
-        self._last_mask = np.zeros(data.shape[1], dtype=bool)
+        if int(np.__version__.split('.')[0]) <= 1 and int(np.__version__.split('.')[1]) <= 17:
+            self._last_mask = np.zeros(data.shape[1], dtype=bool)
+        else:
+            self._last_mask = np.zeros(data.shape[1], dtype=bool_)
         self.shape = self.data.shape
         self.supports_delta_masking = True
         # self._last_x = None
@@ -101,7 +104,10 @@ class Tabular(Masker):
             variants = ~self.invariants(x)
             curr_delta_inds = np.zeros(len(mask), dtype=int)
             num_masks = (mask >= 0).sum()
-            varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=bool)
+            if int(np.__version__.split('.')[0]) <= 1 and int(np.__version__.split('.')[1]) <= 17:
+                varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=bool)
+            else:
+                varying_rows_out = np.zeros((num_masks, self.shape[0]), dtype=bool_)
             masked_inputs_out = np.zeros((num_masks * self.shape[0], self.shape[1]))
             self._last_mask[:] = False
             self._masked_data[:] = self.data


### PR DESCRIPTION
AttributeError: module 'numpy' has no attribute 'bool'. `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations