### PR TITLE
chore: bump minimum version of tqdm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ def run_setup(
             'shap.actions', 'shap.models'
         ],
         package_data={'shap': ['plots/resources/*', 'cext/tree_shap.h']},
-        install_requires=['numpy', 'scipy', 'scikit-learn', 'pandas', 'tqdm>4.25.0',
+        install_requires=['numpy', 'scipy', 'scikit-learn', 'pandas', 'tqdm>=4.27.0',
                           'packaging>20.9', 'slicer==0.0.7', 'numba', 'cloudpickle'],
         extras_require=extras_require,
         ext_modules=ext_modules,


### PR DESCRIPTION
Just a minor change. We have a few files in `shap` that rely on `import tqdm.auto`, which only came into `tqdm` after version `4.26.0`. See the repo: https://github.com/tqdm/tqdm/blob/v4.27.0/auto/__init__.py. (v.s. tag==v4.26.0)

Shouldn't be a major issue for most folks regardless, since it's such an old version.

Closes #714 