### PR TITLE
fix ntree_limit deprecation warning in _tree.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed deprecation warnings for ntree_limit in `xgboost>=1.4` in tree explainer
+  ([#2987](https://github.com/slundberg/shap/pull/2987))
 - Fixed failing unit tests
   ([#29](https://github.com/dsgibbons/shap/pull/29),
   [#20](https://github.com/dsgibbons/shap/pull/20),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed deprecation warnings for ntree_limit in `xgboost>=1.4` in tree explainer
-  ([#2987](https://github.com/slundberg/shap/pull/2987))
 - Fixed failing unit tests
   ([#29](https://github.com/dsgibbons/shap/pull/29),
   [#20](https://github.com/dsgibbons/shap/pull/20),
@@ -38,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ([#16](https://github.com/dsgibbons/shap/pull/16)).
 - Fixed deprecation warnings for `sklearn>=1.2` from `sklearn.linear_model`
   ([#22](https://github.com/dsgibbons/shap/pull/22)).
+- Fixed deprecation warnings for `xgboost>=1.4` from `ntree_limit` in tree explainer
+  ([#2987](https://github.com/slundberg/shap/pull/2987)).
 - Fixed installation of package via setuptools
   ([#51](https://github.com/dsgibbons/shap/pull/51)).
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -344,7 +344,7 @@ class Tree(Explainer):
                     tree_limit = 0
                 try:
                     phi = self.model.original_model.predict(
-                        X, ntree_limit=tree_limit, pred_contribs=True,
+                        X, iteration_range=(0, tree_limit), pred_contribs=True,
                         approx_contribs=approximate, validate_features=False
                     )
                 except ValueError as e:
@@ -354,7 +354,7 @@ class Tree(Explainer):
                 if check_additivity and self.model.model_output == "raw":
                     xgb_tree_limit = tree_limit // self.model.num_stacked_models
                     model_output_vals = self.model.original_model.predict(
-                        X, ntree_limit=xgb_tree_limit, output_margin=True,
+                        X, iteration_range=(0, xgb_tree_limit), output_margin=True,
                         validate_features=False
                     )
 
@@ -493,7 +493,7 @@ class Tree(Explainer):
             if tree_limit == -1:
                 tree_limit = 0
             xgb_tree_limit = tree_limit // self.model.num_stacked_models
-            phi = self.model.original_model.predict(X, ntree_limit=xgb_tree_limit, pred_interactions=True, validate_features=False)
+            phi = self.model.original_model.predict(X, iteration_range=(0, xgb_tree_limit), pred_interactions=True, validate_features=False)
 
             # note we pull off the last column and keep it as our expected_value
             if len(phi.shape) == 4:


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

Related to issue https://github.com/slundberg/shap/issues/2984#issuecomment-1589509879 . 

fixes the deprecation warning mentionned in the issue by using iteration_range instead of ntree_limit as advised by xgboost documentation since version 1.4 ( https://github.com/dmlc/xgboost/releases/tag/v1.4.0 ).

## Checklist

- [x] Closes #2984 
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [x] Added entry to `CHANGELOG.md` (if changes will affect users)
