### PR TITLE
Update wheel building

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,25 +13,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, windows-2019, macOS-11]
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # Used to host cibuildwheel
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.2.2
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: "cp27-* cp35-* pp* *-musllinux_*"
+        uses: pypa/cibuildwheel@v2.13.1
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
           name: bdist_files
@@ -41,17 +38,17 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Build sdist (pep517)
         run: |
-          python -m pip install pep517
-          python -m pep517.build -s .
+          python -m pip install build
+          python -m build --sdist
       - name: Upload sdist
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sdist_files
           path: dist/*.tar.gz
@@ -60,21 +57,22 @@ jobs:
     name: Publish wheels on pypi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'created'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: install requirements
-        run: pip install twine==3.4.2
+        run: pip install twine==4.0.2
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: bdist_files
           path: dist
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: sdist_files
           path: dist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        os: [ubuntu-22.04, windows-2022, macOS-12]
 
     steps:
       - name: Check out the repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ target-version = "py37"
 [tool.cibuildwheel]
 skip = ["cp36-*", "pp*", "*-musllinux_*", "*-manylinux_i686", "*_ppc64le", "*_s390x"]
 build-verbosity = 2
+test-command = "pytest {project}/tests"
+test-extras = ["test", "plots"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,13 @@ target-version = "py37"
 # Don't apply linting/formatting to vendored code
 "shap/explainers/other/_maple.py" = ["ALL"]
 "shap/plots/colors/_colorconv.py" = ["ALL"]
+
+[tool.cibuildwheel]
+skip = ["cp36-*", "pp*", "*-musllinux_*", "*-manylinux_i686", "*_ppc64le", "*_s390x"]
+build-verbosity = 2
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["auto", "aarch64"]


### PR DESCRIPTION
## Overview

While testing wheel building, I realized there were a few script updates need to be made. In this PR, I upgraded the script according to changes last year (after the script was updated last time). I ensured that all `cp` wheels in the Numpy package are built. I skipped some exotic Linux wheels that also don't exist for Numpy since they take a long to build, and if the user needs to build Numpy wheels themselves, he can also build SHAP wheels. 

The updated workflow doesn't run in the PR since it only runs on new releases (when manually triggered). You can see the resulting builds (and wheels) here: https://github.com/PrimozGodec/shap/actions/runs/5287884834.


## Checklist

- [ ] Closes #xxxx  <!--Replace xxxx with the GitHub issue number-->
- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
