### PR TITLE
refactor: Improve waterfall plot docs and checks using Explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Updates to docstrings of several `shap.plots` functions
+  ([#3003](https://github.com/slundberg/shap/pull/3003) by @thatlittleboy).
 
 ### Removed
 

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -59,16 +59,20 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
         )
         raise TypeError(emsg)
 
-    if len(shap_values.shape) == 1:
-        raise ValueError(
+    sv_shape = shap_values.shape
+    if len(sv_shape) == 1:
+        emsg = (
             "The beeswarm plot does not support plotting a single instance, please pass "
             "an explanation matrix with many instances!"
         )
-    elif len(shap_values.shape) > 2:
-        raise ValueError(
+        raise ValueError(emsg)
+    elif len(sv_shape) > 2:
+        emsg = (
             "The beeswarm plot does not support plotting explanations with instances that have more "
             "than one dimension!"
         )
+        raise ValueError(emsg)
+
     shap_exp = shap_values
     # we make a copy here, because later there are places that might modify this array
     values = np.copy(shap_exp.values)

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -98,7 +98,7 @@ def waterfall(shap_values, max_display=10, show=True):
     neg_low = []
     neg_high = []
     loc = base_values + values.sum()
-    yticklabels = ["" for i in range(num_features + 1)]
+    yticklabels = ["" for _ in range(num_features + 1)]
 
     # size the plot based on how many features we are plotting
     plt.gcf().set_size_inches(8, num_features * row_height + 1.5)
@@ -182,20 +182,20 @@ def waterfall(shap_values, max_display=10, show=True):
             pos_lefts[i], pos_inds[i], max(dist-hl_scaled, 0.000001), 0,
             head_length=min(dist, hl_scaled),
             color=colors.red_rgb, width=bar_width,
-            head_width=bar_width
+            head_width=bar_width,
         )
 
         if pos_low is not None and i < len(pos_low):
             plt.errorbar(
                 pos_lefts[i] + pos_widths[i], pos_inds[i],
                 xerr=np.array([[pos_widths[i] - pos_low[i]], [pos_high[i] - pos_widths[i]]]),
-                ecolor=colors.light_red_rgb
+                ecolor=colors.light_red_rgb,
             )
 
         txt_obj = plt.text(
             pos_lefts[i] + 0.5*dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
             horizontalalignment='center', verticalalignment='center', color="white",
-            fontsize=12
+            fontsize=12,
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
@@ -207,7 +207,7 @@ def waterfall(shap_values, max_display=10, show=True):
             txt_obj = plt.text(
                 pos_lefts[i] + (5/72)*bbox_to_xscale + dist, pos_inds[i], format_value(pos_widths[i], '%+0.02f'),
                 horizontalalignment='left', verticalalignment='center', color=colors.red_rgb,
-                fontsize=12
+                fontsize=12,
             )
 
     # draw the negative arrows
@@ -218,20 +218,20 @@ def waterfall(shap_values, max_display=10, show=True):
             neg_lefts[i], neg_inds[i], -max(-dist-hl_scaled, 0.000001), 0,
             head_length=min(-dist, hl_scaled),
             color=colors.blue_rgb, width=bar_width,
-            head_width=bar_width
+            head_width=bar_width,
         )
 
         if neg_low is not None and i < len(neg_low):
             plt.errorbar(
                 neg_lefts[i] + neg_widths[i], neg_inds[i],
                 xerr=np.array([[neg_widths[i] - neg_low[i]], [neg_high[i] - neg_widths[i]]]),
-                ecolor=colors.light_blue_rgb
+                ecolor=colors.light_blue_rgb,
             )
 
         txt_obj = plt.text(
             neg_lefts[i] + 0.5*dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
             horizontalalignment='center', verticalalignment='center', color="white",
-            fontsize=12
+            fontsize=12,
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
@@ -243,7 +243,7 @@ def waterfall(shap_values, max_display=10, show=True):
             txt_obj = plt.text(
                 neg_lefts[i] - (5/72)*bbox_to_xscale + dist, neg_inds[i], format_value(neg_widths[i], '%+0.02f'),
                 horizontalalignment='right', verticalalignment='center', color=colors.blue_rgb,
-                fontsize=12
+                fontsize=12,
             )
 
     # draw the y-ticks twice, once in gray and then again with just the feature names in black

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -18,26 +18,27 @@ from ._labels import labels
 # why a feature is pushing down or up. Perhaps the best way to do this would be with an ICE plot hanging off
 # of the bar...
 def waterfall(shap_values, max_display=10, show=True):
-    """ Plots an explantion of a single prediction as a waterfall plot.
+    """Plots an explanation of a single prediction as a waterfall plot.
 
     The SHAP value of a feature represents the impact of the evidence provided by that feature on the model's
     output. The waterfall plot is designed to visually display how the SHAP values (evidence) of each feature
     move the model output from our prior expectation under the background data distribution, to the final model
     prediction given the evidence of all the features. Features are sorted by the magnitude of their SHAP values
     with the smallest magnitude features grouped together at the bottom of the plot when the number of features
-    in the models exceeds the max_display parameter.
+    in the models exceeds the ``max_display`` parameter.
 
     Parameters
     ----------
     shap_values : Explanation
-        A one-dimensional Explanation object that contains the feature values and SHAP values to plot.
+        A one-dimensional :class:`shap.Explanation` object that contains the feature values and SHAP values to plot.
 
     max_display : str
         The maximum number of features to plot.
 
     show : bool
-        Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
-        to be customized further after it has been created.
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot to be customized further after it
+        has been created.
     """
 
     # Turn off interactive plot

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -1,11 +1,30 @@
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
 import shap
 
 
+def test_waterfall_input_is_explanation():
+    """Checks an error is raised if a non-Explanation object is passed as input.
+    """
+    with pytest.raises(
+        TypeError,
+        match="waterfall plot requires an `Explanation` object",
+    ):
+        _ = shap.plots.waterfall(np.random.randn(20, 5), show=False)
+
+
+def test_waterfall_wrong_explanation_shape(explainer):
+    explanation = explainer(explainer.data)
+
+    emsg = "waterfall plot can currently only plot a single explanation"
+    with pytest.raises(ValueError, match=emsg):
+        shap.plots.waterfall(explanation, show=False)
+
+
 @pytest.mark.mpl_image_compare(tolerance=3)
-def test_waterfall(explainer): # pylint: disable=redefined-outer-name
+def test_waterfall(explainer):
     """ Test the new waterfall plot.
     """
     fig = plt.figure()
@@ -16,11 +35,11 @@ def test_waterfall(explainer): # pylint: disable=redefined-outer-name
 
 
 @pytest.mark.mpl_image_compare(tolerance=3)
-def test_waterfall_legacy(explainer): # pylint: disable=redefined-outer-name
+def test_waterfall_legacy(explainer):
     """ Test the old waterfall plot.
     """
     shap_values = explainer.shap_values(explainer.data)
     fig = plt.figure()
-    shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0]) # pylint: disable=protected-access
+    shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0])
     plt.tight_layout()
     return fig


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Introduce some code formatting to the docs and cross-reference to internal api docs, e.g. <img src="https://github.com/slundberg/shap/assets/30731072/e5d5e462-20a9-45bb-af3d-122f4f397610" width=400>
* A simple refactor, to do the input validity checks for `shap.plots.waterfall` via the `Explanation` object rather than checking the arrays. -> Consequently, we raise an error message referencing the Explanation object rather than the slicer arrays.
* Add tests to ensure the above changes works as expected. (Copied from `_beeswarm.py`)



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
- [x] Added entry to `CHANGELOG.md` (if changes will affect users)
