### PR TITLE
docs: add cross referencing to several plots functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Updates to docstrings of several `shap.plots` functions
-  ([#3003](https://github.com/slundberg/shap/pull/3003) by @thatlittleboy).
+  ([#3003](https://github.com/slundberg/shap/pull/3003),
+   [#3005](https://github.com/slundberg/shap/pull/3005) by @thatlittleboy).
 
 ### Removed
 

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -20,25 +20,31 @@ from ._utils import (
 # TODO: Have the Explanation object track enough data so that we can tell (and so show) how many instances are in each cohort
 def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clustering_cutoff=0.5,
         merge_cohorts=False, show_data="auto", show=True):
-    """ Create a bar plot of a set of SHAP values.
+    """Create a bar plot of a set of SHAP values.
 
-    If a single sample is passed then we plot the SHAP values as a bar chart. If an
-    Explanation with many samples is passed then we plot the mean absolute value for
-    each feature column as a bar chart.
+    If a single sample is passed, then we plot the SHAP values as a bar chart. If an
+    :class:`.Explanation` with many samples is passed, then we plot the mean absolute
+    value for each feature column as a bar chart.
 
 
     Parameters
     ----------
     shap_values : shap.Explanation or shap.Cohorts or dictionary of shap.Explanation objects
-        A single row of a SHAP Explanation object (i.e. shap_values[0]) or a multi-row Explanation
-        object that we want to summarize.
+        A single row of a SHAP :class:`.Explanation` object (i.e. ``shap_values[0]``) or
+        a multi-row Explanation object that we want to summarize.
 
     max_display : int
-        The maximum number of bars to display.
+        How many top features to include in the bar plot (default is 10).
 
     show : bool
-        If show is set to False then we don't call the matplotlib.pyplot.show() function. This allows
-        further customization of the plot by the caller after the bar() function is finished.
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
+
+    Examples
+    --------
+
+    See `bar plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/bar.html>`_.
 
     """
 

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -34,17 +34,33 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
     Parameters
     ----------
     shap_values : Explanation
-        This is an Explanation object containing a matrix of SHAP values (# samples x # features).
+        This is an :class:`.Explanation` object containing a matrix of SHAP values
+        (# samples x # features).
 
     max_display : int
-        How many top features to include in the plot (default is 20, or 7 for interaction plots)
+        How many top features to include in the plot (default is 10, or 7 for
+        interaction plots).
+
+    show : bool
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
+
+    color_bar : bool
+        Whether to draw the color bar (legend).
 
     plot_size : "auto" (default), float, (float, float), or None
-        What size to make the plot. By default the size is auto-scaled based on the number of
-        features that are being displayed. Passing a single float will cause each row to be that
-        many inches high. Passing a pair of floats will scale the plot by that
-        number of inches. If None is passed then the size of the current figure will be left
-        unchanged.
+        What size to make the plot. By default, the size is auto-scaled based on the
+        number of features that are being displayed. Passing a single float will cause
+        each row to be that many inches high. Passing a pair of floats will scale the
+        plot by that number of inches. If ``None`` is passed, then the size of the
+        current figure will be left unchanged.
+
+    Examples
+    --------
+
+    See `beeswarm plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/beeswarm.html>`_.
+
     """
 
     if not isinstance(shap_values, Explanation):

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -244,29 +244,32 @@ def decision(
     ----------
     base_value : float or numpy.ndarray
         This is the reference value that the feature contributions start from. Usually, this is
-        explainer.expected_value.
+        ``explainer.expected_value``.
 
     shap_values : numpy.ndarray
-        Matrix of SHAP values (# features) or (# samples x # features) from explainer.shap_values(). Or cube of SHAP
-        interaction values (# samples x # features x # features) from explainer.shap_interaction_values().
+        Matrix of SHAP values (# features) or (# samples x # features) from
+        ``explainer.shap_values()``. Or cube of SHAP interaction values (# samples x
+        # features x # features) from ``explainer.shap_interaction_values()``.
 
     features : numpy.array or pandas.Series or pandas.DataFrame or numpy.ndarray or list
         Matrix of feature values (# features) or (# samples x # features). This provides the values of all the
         features and, optionally, the feature names.
 
     feature_names : list or numpy.ndarray
-        List of feature names (# features). If None, names may be derived from the features argument if a Pandas
-        object is provided. Otherwise, numeric feature names will be generated.
+        List of feature names (# features). If ``None``, names may be derived from the
+        ``features`` argument if a Pandas object is provided. Otherwise, numeric feature
+        names will be generated.
 
     feature_order : str or None or list or numpy.ndarray
-        Any of "importance" (the default), "hclust" (hierarchical clustering), "none", or a list/array of indices.
+        Any of "importance" (the default), "hclust" (hierarchical clustering), ``None``,
+        or a list/array of indices.
 
     feature_display_range: slice or range
-        The slice or range of features to plot after ordering features by feature_order. A step of 1 or None
+        The slice or range of features to plot after ordering features by ``feature_order``. A step of 1 or ``None``
         will display the features in ascending order. A step of -1 will display the features in descending order. If
-        feature_display_range=None, slice(-1, -21, -1) is used (i.e. show the last 20 features in descending order).
-        If shap_values contains interaction values, the number of features is automatically expanded to include all
-        possible interactions: N(N + 1)/2 where N = shap_values.shape[1].
+        ``feature_display_range=None``, ``slice(-1, -21, -1)`` is used (i.e. show the last 20 features in descending order).
+        If ``shap_values`` contains interaction values, the number of features is automatically expanded to include all
+        possible interactions: N(N + 1)/2 where N = ``shap_values.shape[1]``.
 
     highlight : Any
         Specify which observations to draw in a different line style. All numpy indexing methods are supported. For
@@ -277,7 +280,7 @@ def decision(
         log-odds into probabilities.
 
     plot_color : str or matplotlib.colors.ColorMap
-        Color spectrum used to draw the plot lines. If str, a registered matplotlib color name is assumed.
+        Color spectrum used to draw the plot lines. If ``str``, a registered matplotlib color name is assumed.
 
     axis_color : str or int
         Color used to draw plot axes.
@@ -289,39 +292,46 @@ def decision(
         Alpha blending value in [0, 1] used to draw plot lines.
 
     color_bar : bool
-        Whether to draw the color bar.
+        Whether to draw the color bar (legend).
 
     auto_size_plot : bool
-        Whether to automatically size the matplotlib plot to fit the number of features displayed. If `False`,
-        specify the plot size using matplotlib before calling this function.
+        Whether to automatically size the matplotlib plot to fit the number of features
+        displayed. If ``False``, specify the plot size using matplotlib before calling
+        this function.
 
     title : str
         Title of the plot.
 
     xlim: tuple[float, float]
-        The extents of the x-axis (e.g. (-1.0, 1.0)). If not specified, the limits are determined by the
-        maximum/minimum predictions centered around base_value when link='identity'. When link='logit', the
-        x-axis extents are (0, 1) centered at 0.5. x_lim values are not transformed by the link function. This
-        argument is provided to simplify producing multiple plots on the same scale for comparison.
+        The extents of the x-axis (e.g. ``(-1.0, 1.0)``). If not specified, the limits
+        are determined by the maximum/minimum predictions centered around base_value
+        when ``link="identity"``. When ``link="logit"``, the x-axis extents are ``(0,
+        1)`` centered at 0.5. ``xlim`` values are not transformed by the ``link``
+        function. This argument is provided to simplify producing multiple plots on the
+        same scale for comparison.
 
     show : bool
-        Whether to automatically display the plot.
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
 
     return_objects : bool
-        Whether to return a DecisionPlotResult object containing various plotting features. This can be used to
-        generate multiple decision plots using the same feature ordering and scale.
+        Whether to return a :obj:`DecisionPlotResult` object containing various plotting
+        features. This can be used to generate multiple decision plots using the same
+        feature ordering and scale.
 
     ignore_warnings : bool
         Plotting many data points or too many features at a time may be slow, or may create very large plots. Set
-        this argument to `True` to override hard-coded limits that prevent plotting large amounts of data.
+        this argument to ``True`` to override hard-coded limits that prevent plotting large amounts of data.
 
     new_base_value : float
-        SHAP values are relative to a base value; by default, the expected value of the model's raw predictions. Use
-        `new_base_value` to shift the base value to an arbitrary value (e.g. the cutoff point for a binary
+        SHAP values are relative to a base value. By default, this base value is the
+        expected value of the model's raw predictions. Use ``new_base_value`` to shift
+        the base value to an arbitrary value (e.g. the cutoff point for a binary
         classification task).
 
     legend_labels : list of str
-        List of legend labels. If `None`, legend will not be shown.
+        List of legend labels. If ``None``, legend will not be shown.
 
     legend_location : str
         Legend location. Any of "best", "upper right", "upper left", "lower left", "lower right", "right",
@@ -330,14 +340,18 @@ def decision(
     Returns
     -------
     DecisionPlotResult or None
-        Returns a DecisionPlotResult object if `return_objects=True`. Returns `None` otherwise (the default).
+        Returns a :obj:`DecisionPlotResult` object if ``return_objects=True``. Returns ``None`` otherwise (the default).
 
-    Example
-    -------
+    Examples
+    --------
+
     Plot two decision plots using the same feature order and x-axis.
+
         >>> range1, range2 = range(20), range(20, 40)
         >>> r = decision_plot(base, shap_values[range1], features[range1], return_objects=True)
         >>> decision_plot(base, shap_values[range2], features[range2], feature_order=r.feature_idx, xlim=r.xlim)
+
+    See more `decision plot examples here <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/decision_plot.html>`_.
 
     """
 

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -28,21 +28,22 @@ from ._labels import labels
 def force(base_value, shap_values=None, features=None, feature_names=None, out_names=None, link="identity",
           plot_cmap="RdBu", matplotlib=False, show=True, figsize=(20,3), ordering_keys=None, ordering_keys_time_format=None,
           text_rotation=0, contribution_threshold=0.05):
-    """ Visualize the given SHAP values with an additive force layout.
+    """Visualize the given SHAP values with an additive force layout.
 
     Parameters
     ----------
     base_value : float
-        This is the reference value that the feature contributions start from. For SHAP values it should
-        be the value of explainer.expected_value.
+        This is the reference value that the feature contributions start from.
+        For SHAP values, it should be the value of ``explainer.expected_value``.
 
     shap_values : numpy.array
-        Matrix of SHAP values (# features) or (# samples x # features). If this is a 1D array then a single
-        force plot will be drawn, if it is a 2D array then a stacked force plot will be drawn.
+        Matrix of SHAP values (# features) or (# samples x # features). If this is a
+        1D array, then a single force plot will be drawn. If it is a 2D array, then a
+        stacked force plot will be drawn.
 
     features : numpy.array
         Matrix of feature values (# features) or (# samples x # features). This provides the values of all the
-        features, and should be the same shape as the shap_values argument.
+        features, and should be the same shape as the ``shap_values`` argument.
 
     feature_names : list
         List of feature names (# features).
@@ -51,12 +52,13 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
         The name of the output of the model (plural to support multi-output plotting in the future).
 
     link : "identity" or "logit"
-        The transformation used when drawing the tick mark labels. Using logit will change log-odds numbers
+        The transformation used when drawing the tick mark labels. Using "logit" will change log-odds numbers
         into probabilities.
 
     matplotlib : bool
-        Whether to use the default Javascript output, or the (less developed) matplotlib output. Using matplotlib
-        can be helpful in scenarios where rendering Javascript/HTML is inconvenient.
+        Whether to use the default Javascript output, or the (less developed) matplotlib output.
+        Using matplotlib can be helpful in scenarios where rendering Javascript/HTML
+        is inconvenient.
 
     contribution_threshold : float
         Controls the feature names/values that are displayed on force plot.
@@ -257,16 +259,18 @@ def save_html(out_file, plot, full_html=True):
     Parameters
     ----------
     out_file : str or file
-        Location or file to be written to
+        Location or file to be written to.
+
     plot : BaseVisualizer
-        Visualizer returned by shap.force_plot()
+        Visualizer returned by :func:`shap.plots.force()`.
+
     full_html : boolean (default: True)
-        If True, writes a complete HTML document starting
-        with an <html> tag. If False, only script and div
+        If ``True``, writes a complete HTML document starting
+        with an ``<html>`` tag. If ``False``, only script and div
         tags are included.
     """
 
-    assert isinstance(plot, BaseVisualizer), "save_html requires a Visualizer returned by shap.force_plot()."
+    assert isinstance(plot, BaseVisualizer), "`save_html` requires a Visualizer returned by `shap.plots.force()`."
     internal_open = False
     if type(out_file) == str:
         out_file = open(out_file, "w", encoding="utf-8")

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -14,36 +14,45 @@ def heatmap(shap_values, instance_order=Explanation.hclust(), feature_values=Exp
     """Create a heatmap plot of a set of SHAP values.
 
     This plot is designed to show the population substructure of a dataset using supervised
-    clustering and a heatmap. Supervised clustering involves clustering data points not by their original
-    feature values but by their explanations. By default we cluster using shap.utils.hclust_ordering
+    clustering and a heatmap.
+    Supervised clustering involves clustering data points not by their original
+    feature values but by their explanations.
+    By default, we cluster using :func:`shap.utils.hclust_ordering`,
     but any clustering can be used to order the samples.
 
     Parameters
     ----------
     shap_values : shap.Explanation
-        A multi-row Explanation object that we want to visualize in a cluster ordering.
+        A multi-row :class:`.Explanation` object that we want to visualize in a
+        cluster ordering.
 
     instance_order : OpChain or numpy.ndarray
         A function that returns a sort ordering given a matrix of SHAP values and an axis, or
-        a direct sample ordering given as an numpy.ndarray.
+        a direct sample ordering given as an ``numpy.ndarray``.
 
     feature_values : OpChain or numpy.ndarray
         A function that returns a global summary value for each input feature, or an array of such values.
 
     feature_order : None, OpChain, or numpy.ndarray
         A function that returns a sort ordering given a matrix of SHAP values and an axis, or
-        a direct input feature ordering given as an numpy.ndarray. If None then we use
-        feature_values.argsort
+        a direct input feature ordering given as an ``numpy.ndarray``.
+        If ``None``, then we use ``feature_values.argsort``.
 
     max_display : int
-        The maximum number of features to display.
+        The maximum number of features to display (default is 10).
 
     show : bool
-        If show is set to False then we don't call the matplotlib.pyplot.show() function. This allows
-        further customization of the plot by the caller after the bar() function is finished.
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
 
     plot_width: int, default 8
         The width of the heatmap plot.
+
+    Examples
+    --------
+
+    See `heatmap plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/heatmap.html>`_.
 
     """
 

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -8,8 +8,7 @@ import matplotlib.pyplot as pl
 import numpy as np
 from matplotlib.colors import Colormap
 
-from shap._explanation import Explanation
-
+from .._explanation import Explanation
 from ..utils import ordinal_str
 
 try:
@@ -33,23 +32,27 @@ def image(shap_values: Explanation or np.ndarray,
           labelpad: Optional[float] = None,
           cmap: Optional[str or Colormap] = colors.red_transparent_blue,
           show: Optional[bool] = True):
-    """ Plots SHAP values for image inputs.
+    """Plots SHAP values for image inputs.
 
     Parameters
     ----------
     shap_values : [numpy.array]
-        List of arrays of SHAP values. Each array has the shap (# samples x width x height x channels), and the
-        length of the list is equal to the number of model outputs that are being explained.
+        List of arrays of SHAP values. Each array has the shape
+        (# samples x width x height x channels), and the
+        length of the list is equal to the number of model outputs that are being
+        explained.
 
     pixel_values : numpy.array
-        Matrix of pixel values (# samples x width x height x channels) for each image. It should be the same
-        shape as each array in the shap_values list of arrays.
+        Matrix of pixel values (# samples x width x height x channels) for each image.
+        It should be the same
+        shape as each array in the ``shap_values`` list of arrays.
 
     labels : list or np.ndarray
-        List or np.ndarray (# samples x top_k classes) of names for each of the model outputs that are being explained.
+        List or ``np.ndarray`` (# samples x top_k classes) of names for each of the
+        model outputs that are being explained.
 
     true_labels: list
-        List of a true image labels to plot
+        List of a true image labels to plot.
 
     width : float
         The width of the produced matplotlib plot.
@@ -58,8 +61,15 @@ def image(shap_values: Explanation or np.ndarray,
         How much padding to use around the model output labels.
 
     show : bool
-        Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
         to be customized further after it has been created.
+
+    Examples
+    --------
+
+    See `image plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/image.html>`_.
+
     """
 
     # support passing an explanation object

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -15,44 +15,47 @@ from ._labels import labels
 def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=colors.red_blue,
             dot_size=16, x_jitter="auto", alpha=1, title=None, xmin=None, xmax=None, ymin=None, ymax=None,
             overlay=None, ax=None, ylabel="SHAP value", show=True):
-    """ Create a SHAP dependence scatter plot, colored by an interaction feature.
+    """Create a SHAP dependence scatter plot, colored by an interaction feature.
 
     Plots the value of the feature on the x-axis and the SHAP value of the same feature
     on the y-axis. This shows how the model depends on the given feature, and is like a
-    richer extenstion of classical parital dependence plots. Vertical dispersion of the
+    richer extension of classical parital dependence plots. Vertical dispersion of the
     data points represents interaction effects. Grey ticks along the y-axis are data
     points where the feature's value was NaN.
 
-    Note that if you want to change the data being displayed you can update the
-    shap_values.display_features attribute and it will then be used for plotting instead of
-    shap_values.data.
-
+    Note that if you want to change the data being displayed, you can update the
+    ``shap_values.display_features`` attribute and it will then be used for plotting instead of
+    ``shap_values.data``.
 
     Parameters
     ----------
     shap_values : shap.Explanation
-        A single column of a SHAP Explanation object (i.e. shap_values[:,"Feature A"]).
+        A single column of an :class:`.Explanation` object (i.e.
+        ``shap_values[:,"Feature A"]``).
 
     color : string or shap.Explanation
-        How to color the scatter plot points. This can be a fixed color string, or a Explanation object.
-        If it is an explanation object then the scatter plot points are colored by the feature that
-        seems to have the strongest interaction effect with the feature given by the shap_values argument.
-        This is calculated using shap.utils.approximate_interactions.
-        If only a single column of an Explanation object is passed then that feature column will be used
-        to color the data points.
+        How to color the scatter plot points. This can be a fixed color string, or an
+        :class:`.Explanation` object. If it is an :class:`.Explanation` object, then the
+        scatter plot points are colored by the feature that seems to have the strongest
+        interaction effect with the feature given by the ``shap_values`` argument. This
+        is calculated using :func:`shap.utils.approximate_interactions`. If only a
+        single column of an :class:`.Explanation` object is passed, then that
+        feature column will be used to color the data points.
 
     hist : bool
-        Whether to show a light histogram along the x-axis to show the density of the data. Note that the
-        histogram is normalized that that if all the point were in a single bin then that bin would span
-        the full height of the plot.
+        Whether to show a light histogram along the x-axis to show the density of the
+        data. Note that the histogram is normalized such that if all the points were in
+        a single bin, then that bin would span the full height of the plot. Defaults to
+        ``True``.
 
-    x_jitter : 'auto' or float (0 - 1)
-        Adds random jitter to feature values. May increase plot readability when a feature
-        is discrete. By default x_jitter is chosen base on auto-detection of categorical features
+    x_jitter : 'auto' or float
+        Adds random jitter to feature values by specifying a float between 0 to 1. May
+        increase plot readability when a feature is discrete. By default, ``x_jitter``
+        is chosen based on auto-detection of categorical features.
 
     alpha : float
-        The transparency of the data points (between 0 and 1). This can be useful to the
-        show density of the data points when using a large dataset.
+        The transparency of the data points (between 0 and 1). This can be useful to
+        show the density of the data points when using a large dataset.
 
     xmin : float or string
         Represents the lower bound of the plot's x-axis. It can be a string of the format
@@ -63,11 +66,20 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         "percentile(float)" to denote that percentile of the feature's value used on the x-axis.
 
     ax : matplotlib Axes object
-         Optionally specify an existing matplotlib Axes object, into which the plot will be placed.
-         In this case we do not create a Figure, otherwise we do.
+        Optionally specify an existing matplotlib ``Axes`` object, into which the plot will be placed.
+        In this case, we do not create a ``Figure``, otherwise we do.
+
+    show : bool
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
+
+    Examples
+    --------
+
+    See `scatter plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/scatter.html>`_.
 
     """
-
 
     assert str(type(shap_values)).endswith("Explanation'>"), "The shap_values parameter must be a shap.Explanation object!"
 
@@ -154,7 +166,6 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
                 display_features = np.hstack([display_features, shap_values2.display_data[:,mask]])
         color = None
         interaction_index = "auto"
-
 
     if type(shap_values_arr) is list:
         raise TypeError("The passed shap_values_arr are a list not an array! If you have a list of explanations try " \
@@ -457,8 +468,6 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
         with warnings.catch_warnings(): # ignore expected matplotlib warnings
             warnings.simplefilter("ignore", RuntimeWarning)
             pl.show()
-
-
 
 
 def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, display_features=None,

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -17,7 +17,7 @@ except ImportError:
 # TODO: we should support text output explanations (from models that output text not numbers), this would require the force
 # the force plot and the coloring to update based on mouseovers (or clicks to make it fixed) of the output text
 def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator='', xmin=None, xmax=None, cmax=None, display=True):
-    """ Plots an explanation of a string of text using coloring and interactive labels.
+    """Plots an explanation of a string of text using coloring and interactive labels.
 
     The output is interactive HTML and you can click on any token to toggle the display of the
     SHAP value assigned to that token.
@@ -25,19 +25,24 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
     Parameters
     ----------
     shap_values : [numpy.array]
-        List of arrays of SHAP values. Each array has the shap values for a string(# input_tokens x output_tokens).
+        List of arrays of SHAP values. Each array has the shap values for a string (#input_tokens x output_tokens).
 
     num_starting_labels : int
-        Number of tokens (sorted in decending order by corresponding SHAP values) that are uncovered in the initial view. When set to 0 all tokens
-        covered.
+        Number of tokens (sorted in descending order by corresponding SHAP values)
+        that are uncovered in the initial view.
+        When set to 0, all tokens are covered.
 
     grouping_threshold : float
-        If the component substring effects are less than a grouping_threshold fraction of an unlowered interaction effect then we
-        visualize the entire group as a single chunk. This is primarily used for explanations that were computed with fixed_context set to 1 or 0
-        when using the Partition explainer, since this causes interaction effects to be left on internal nodes rather than lowered.
+        If the component substring effects are less than a ``grouping_threshold``
+        fraction of an unlowered interaction effect, then we visualize the entire group
+        as a single chunk. This is primarily used for explanations that were computed
+        with fixed_context set to 1 or 0 when using the :class:`.explainers.Partition`
+        explainer, since this causes interaction effects to be left on internal nodes
+        rather than lowered.
 
     separator : string
-        The string seperator that joins tokens grouped by interation effects and unbroken string spans.
+        The string separator that joins tokens grouped by interaction effects and
+        unbroken string spans. Defaults to the empty string ``""``.
 
     xmin : float
         Minimum shap value bound.
@@ -49,7 +54,12 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
         Maximum absolute shap value for sample. Used for scaling colors for input tokens.
 
     display: bool
-        Whether to display or return html to further manipulate or embed. default: True
+        Whether to display or return html to further manipulate or embed. Default: ``True``
+
+    Examples
+    --------
+
+    See `text plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/text.html>`_.
 
     """
 

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -28,29 +28,44 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
 
     Parameters
     ----------
-    shap_values : numpy.array
-        For single output explanations this is a matrix of SHAP values (# samples x # features).
+    shap_values : Explanation, or numpy.array
+        For single output explanations, this is a matrix of SHAP values (# samples x # features).
 
     features : numpy.array or pandas.DataFrame or list
-        Matrix of feature values (# samples x # features) or a feature_names list as shorthand
+        Matrix of feature values (# samples x # features) or a ``feature_names`` list as
+        shorthand.
 
     feature_names : list
-        Names of the features (length # features)
+        Names of the features (length: # features).
 
     max_display : int
-        How many top features to include in the plot (default is 20)
+        How many top features to include in the plot (default is 20).
 
     plot_type : "violin", or "layered_violin".
-        What type of summary plot to produce. A "layered_violin" plot shows the distribution
-        of the SHAP values of each variable. A "violin" plot is the same, except with outliers
-        drawn as scatter points.
+        What type of summary plot to produce. A "layered_violin" plot shows the
+        distribution of the SHAP values of each variable. A "violin" plot is the same,
+        except with outliers drawn as scatter points.
+
+    color_bar : bool
+        Whether to draw the color bar (legend).
+
+    show : bool
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
 
     plot_size : "auto" (default), float, (float, float), or None
-        What size to make the plot. By default the size is auto-scaled based on the number of
+        What size to make the plot. By default, the size is auto-scaled based on the number of
         features that are being displayed. Passing a single float will cause each row to be that
         many inches high. Passing a pair of floats will scale the plot by that
-        number of inches. If None is passed then the size of the current figure will be left
+        number of inches. If ``None`` is passed, then the size of the current figure will be left
         unchanged.
+
+    Examples
+    --------
+
+    See `violin plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/violin.html>`_.
+
     """
 
     # support passing an explanation object

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -18,22 +18,30 @@ def waterfall(shap_values, max_display=10, show=True):
     The SHAP value of a feature represents the impact of the evidence provided by that feature on the model's
     output. The waterfall plot is designed to visually display how the SHAP values (evidence) of each feature
     move the model output from our prior expectation under the background data distribution, to the final model
-    prediction given the evidence of all the features. Features are sorted by the magnitude of their SHAP values
-    with the smallest magnitude features grouped together at the bottom of the plot when the number of features
-    in the models exceeds the ``max_display`` parameter.
+    prediction given the evidence of all the features.
+
+    Features are sorted by the magnitude of their SHAP values with the smallest
+    magnitude features grouped together at the bottom of the plot when the number of
+    features in the models exceeds the ``max_display`` parameter.
 
     Parameters
     ----------
     shap_values : Explanation
-        A one-dimensional :class:`shap.Explanation` object that contains the feature values and SHAP values to plot.
+        A one-dimensional :class:`.Explanation` object that contains the feature values and SHAP values to plot.
 
     max_display : str
-        The maximum number of features to plot.
+        The maximum number of features to plot (default is 10).
 
     show : bool
         Whether ``matplotlib.pyplot.show()`` is called before returning.
         Setting this to ``False`` allows the plot to be customized further after it
         has been created.
+
+    Examples
+    --------
+
+    See `waterfall plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/waterfall.html>`_.
+
     """
 
     # Turn off interactive plot


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Documentation improvements to `shap.plots` functions, mostly to add in cross-references, fix typos, add links to API example notebooks etc.

Waiting on #3003 to be merged first, since this PR logically builds upon the changes from that PR. (DONE)

## Checklist

- Closes #xxxx  <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [x] Added entry to `CHANGELOG.md` (if changes will affect users)
