### PR TITLE
refactor: general cleaning up of the tree module

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -76,31 +76,37 @@ class Tree(Explainer):
 
         data : numpy.array or pandas.DataFrame
             The background dataset to use for integrating out features. This argument is optional when
-            feature_perturbation="tree_path_dependent", since in that case we can use the number of training
-            samples that went down each tree path as our background dataset (this is recorded in the model object).
+            ``feature_perturbation="tree_path_dependent"``, since in that case we can use the number of training
+            samples that went down each tree path as our background dataset (this is recorded in the ``model``
+            object).
 
         feature_perturbation : "interventional" (default) or "tree_path_dependent" (default when data=None)
-            Since SHAP values rely on conditional expectations we need to decide how to handle correlated
-            (or otherwise dependent) input features. The "interventional" approach breaks the dependencies between
-            features according to the rules dictated by causal inference (Janzing et al. 2019). Note that the
-            "interventional" option requires a background dataset and its runtime scales linearly with the size
-            of the background dataset you use. Anywhere from 100 to 1000 random background samples are good
-            sizes to use. The "tree_path_dependent" approach is to just follow the trees and use the number
-            of training examples that went down each leaf to represent the background distribution. This approach
-            does not require a background dataset and so is used by default when no background dataset is provided.
+            Since SHAP values rely on conditional expectations, we need to decide how to handle correlated
+            (or otherwise dependent) input features.
+            The "interventional" approach breaks the dependencies between features according to the rules
+            dictated by causal inference (Janzing et al. 2019). Note that the "interventional" option
+            requires a background dataset ``data``, and its runtime scales linearly with the size of the
+            background dataset you use. Anywhere from 100 to 1000 random background samples are good
+            sizes to use.
+            The "tree_path_dependent" approach is to just follow the trees and use the number of training
+            examples that went down each leaf to represent the background distribution. This approach
+            does not require a background dataset, and so is used by default when no background dataset
+            is provided.
 
         model_output : "raw", "probability", "log_loss", or model method name
-            What output of the model should be explained. If "raw", then we explain the raw output of the
-            trees, which varies by model. For regression models, "raw" is the standard output. For binary
-            classification in XGBoost, this is the log odds ratio. If model_output is the name of a supported
-            prediction method on the model object, then we explain the output of that model method name.
-            For example, model_output="predict_proba" explains the result of calling `model.predict_proba`.
+            What output of the model should be explained.
+            If "raw", then we explain the raw output of the trees, which varies by model. For regression models,
+            "raw" is the standard output. For binary classification in XGBoost, this is the log odds ratio.
+            If ``model_output`` is the name of a supported prediction method on the ``model`` object, then we
+            explain the output of that model method name. For example, ``model_output="predict_proba"``
+            explains the result of calling ``model.predict_proba``.
             If "probability", then we explain the output of the model transformed into probability space
-            (note that this means the SHAP values now sum to the probability output of the model). If "log_loss",
-            then we explain the log base e of the model loss function, so that the SHAP values sum up to the
-            log loss of the model for each sample. This is helpful for breaking down model performance by feature.
+            (note that this means the SHAP values now sum to the probability output of the model).
+            If "log_loss", then we explain the log base e of the model loss function, so that the SHAP values
+            sum up to the log loss of the model for each sample. This is helpful for breaking down model
+            performance by feature.
             Currently the "probability" and "log_loss" options are only supported when
-            feature_dependence="independent".
+            ``feature_dependence="interventional"``.
 
         Examples
         --------

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -319,8 +319,8 @@ class Tree(Explainer):
             An array of label values for each sample. Used when explaining loss functions.
 
         tree_limit : None (default) or int
-            Limit the number of trees used by the model. By default None means no use the limit of the
-            original model, and -1 means no limit.
+            Limit the number of trees used by the model. By default, the limit of the original model
+            is used (``None``). ``-1`` means no limit.
 
         approximate : bool
             Run fast, but only roughly approximate the Tree SHAP values. This runs a method
@@ -338,8 +338,8 @@ class Tree(Explainer):
         array or list
             For models with a single output this returns a matrix of SHAP values
             (# samples x # features). Each row sums to the difference between the model output for that
-            sample and the expected value of the model output (which is stored in the expected_value
-            attribute of the explainer when it is constant). For models with vector outputs this returns
+            sample and the expected value of the model output (which is stored in the ``expected_value``
+            attribute of the explainer when it is constant). For models with vector outputs, this returns
             a list of such matrices, one for each output.
         """
         # see if we have a default tree_limit in place.
@@ -415,9 +415,9 @@ class Tree(Explainer):
 
                 return out
 
-        X, y, X_missing, flat_output, tree_limit, check_additivity = self._validate_inputs(X, y,
-                                                                                           tree_limit,
-                                                                                           check_additivity)
+        X, y, X_missing, flat_output, tree_limit, check_additivity = self._validate_inputs(
+            X, y, tree_limit, check_additivity
+        )
         transform = self.model.get_transform()
 
         # run the core algorithm using the C extension
@@ -479,20 +479,20 @@ class Tree(Explainer):
             An array of label values for each sample. Used when explaining loss functions (not yet supported).
 
         tree_limit : None (default) or int
-            Limit the number of trees used by the model. By default None means no use the limit of the
-            original model, and -1 means no limit.
+            Limit the number of trees used by the model. By default, the limit of the original model
+            is used (``None``). ``-1`` means no limit.
 
         Returns
         -------
         array or list
-            For models with a single output this returns a tensor of SHAP values
+            For models with a single output, this returns a tensor of SHAP values
             (# samples x # features x # features). The matrix (# features x # features) for each sample sums
             to the difference between the model output for that sample and the expected value of the model output
-            (which is stored in the expected_value attribute of the explainer). Each row of this matrix sums to the
+            (which is stored in the ``expected_value`` attribute of the explainer). Each row of this matrix sums to the
             SHAP value for that feature for that sample. The diagonal entries of the matrix represent the
-            "main effect" of that feature on the prediction and the symmetric off-diagonal entries represent the
-            interaction effects between all pairs of features for that sample. For models with vector outputs
-            this returns a list of tensors, one for each output.
+            "main effect" of that feature on the prediction. The symmetric off-diagonal entries represent the
+            interaction effects between all pairs of features for that sample.
+            For models with vector outputs, this returns a list of tensors, one for each output.
         """
 
         assert self.model.model_output == "raw", "Only model_output = \"raw\" is supported for SHAP interaction values right now!"

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1110,23 +1110,35 @@ class TreeEnsemble:
         """
         if self.model_output == "raw":
             transform = "identity"
-        elif self.model_output == "probability" or self.model_output == "probability_doubled":
+        elif self.model_output in ("probability", "probability_doubled"):
             if self.tree_output == "log_odds":
                 transform = "logistic"
             elif self.tree_output == "probability":
                 transform = "identity"
             else:
-                raise NotImplementedError("model_output = \"probability\" is not yet supported when model.tree_output = \"" + self.tree_output + "\"!")
+                emsg = (
+                    "model_output = \"probability\" is not yet supported when model.tree_output = "
+                    f"\"{self.tree_output}\"!"
+                )
+                raise NotImplementedError(emsg)
         elif self.model_output == "log_loss":
-
             if self.objective == "squared_error":
                 transform = "squared_loss"
             elif self.objective == "binary_crossentropy":
                 transform = "logistic_nlogloss"
             else:
-                raise NotImplementedError("model_output = \"log_loss\" is not yet supported when model.objective = \"" + self.objective + "\"!")
+                emsg = (
+                    "model_output = \"log_loss\" is not yet supported when model.objective = "
+                    f"\"{self.objective}\"!"
+                )
+                raise NotImplementedError(emsg)
         else:
-            raise ValueError(f"Unrecognized model_output parameter value: {str(self.model_output)}! If model.{str(self.model_output)} is a valid function open a github issue to ask that this method be supported. If you want 'predict_proba' just use 'probability' for now.")
+            emsg = (
+                f"Unrecognized model_output parameter value: {str(self.model_output)}! "
+                f"If `model.{str(self.model_output)}` is a valid function, open a github issue to ask "
+                "that this method be supported. If you want 'predict_proba' just use 'probability' for now."
+            )
+            raise ValueError(emsg)
 
         return transform
 
@@ -1441,6 +1453,7 @@ class SingleTree:
             self.values
         )
 
+
 class IsoTree(SingleTree):
     """
     In sklearn the tree of the Isolation Forest does not calculated in a good way.
@@ -1613,7 +1626,6 @@ class XGBTreeModelLoader:
                 "node_sample_weight": self.sum_hess[i]
             }, data=data, data_missing=data_missing))
         return trees
-
 
     def read(self, dtype):
         size = struct.calcsize(dtype)

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -22,8 +22,6 @@ from ._explainer import Explainer
 
 warnings.formatwarning = lambda msg, *args, **kwargs: str(msg) + '\n' # ignore everything except the message
 
-# pylint: disable=unsubscriptable-object
-
 try:
     from .. import _cext
 except ImportError as e:
@@ -658,7 +656,14 @@ class TreeEnsemble:
             self.trees = [SingleTree(t, data=data, data_missing=data_missing) for t in model["trees"]]
         elif type(model) is list and type(model[0]) == SingleTree: # old-style direct-load format
             self.trees = model
-        elif safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor", "econml.grf._base_grf.BaseGRF"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.RandomForestRegressor",
+                "sklearn.ensemble.forest.RandomForestRegressor",
+                "econml.grf._base_grf.BaseGRF",
+            ],
+        ):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -666,7 +671,13 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "raw_value"
-        elif safe_isinstance(model, ["sklearn.ensemble.IsolationForest", "sklearn.ensemble._iforest.IsolationForest"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.IsolationForest",
+                "sklearn.ensemble._iforest.IsolationForest",
+            ],
+        ):
             self.dtype = np.float32
             scaling = 1.0 / len(model.estimators_) # output is average of trees
             self.trees = [IsoTree(e.tree_, f, scaling=scaling, data=data, data_missing=data_missing) for e, f in zip(model.estimators_, model.estimators_features_)]
@@ -684,7 +695,13 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "raw_value"
-        elif safe_isinstance(model, ["sklearn.ensemble.ExtraTreesRegressor", "sklearn.ensemble.forest.ExtraTreesRegressor"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.ExtraTreesRegressor",
+                "sklearn.ensemble.forest.ExtraTreesRegressor",
+            ]
+        ):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -700,19 +717,38 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "raw_value"
-        elif safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor", "econml.grf._base_grftree.GRFTree"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.tree.DecisionTreeRegressor",
+                "sklearn.tree.tree.DecisionTreeRegressor",
+                "econml.grf._base_grftree.GRFTree",
+            ],
+        ):
             self.internal_dtype = model.tree_.value.dtype.type
             self.input_dtype = np.float32
             self.trees = [SingleTree(model.tree_, data=data, data_missing=data_missing)]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "raw_value"
-        elif safe_isinstance(model, ["sklearn.tree.DecisionTreeClassifier", "sklearn.tree.tree.DecisionTreeClassifier"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.tree.DecisionTreeClassifier",
+                "sklearn.tree.tree.DecisionTreeClassifier",
+            ],
+        ):
             self.internal_dtype = model.tree_.value.dtype.type
             self.input_dtype = np.float32
             self.trees = [SingleTree(model.tree_, normalize=True, data=data, data_missing=data_missing)]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "probability"
-        elif safe_isinstance(model, ["sklearn.ensemble.RandomForestClassifier", "sklearn.ensemble.forest.RandomForestClassifier"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.RandomForestClassifier",
+                "sklearn.ensemble.forest.RandomForestClassifier",
+            ],
+        ):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -720,7 +756,13 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, normalize=True, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "probability"
-        elif safe_isinstance(model, ["sklearn.ensemble.ExtraTreesClassifier", "sklearn.ensemble.forest.ExtraTreesClassifier"]): # TODO: add unit test for this case
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.ExtraTreesClassifier",
+                "sklearn.ensemble.forest.ExtraTreesClassifier",
+            ],
+        ): # TODO: add unit test for this case
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -728,13 +770,31 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, normalize=True, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "probability"
-        elif safe_isinstance(model, ["sklearn.ensemble.GradientBoostingRegressor", "sklearn.ensemble.gradient_boosting.GradientBoostingRegressor"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.GradientBoostingRegressor",
+                "sklearn.ensemble.gradient_boosting.GradientBoostingRegressor",
+            ],
+        ):
             self.input_dtype = np.float32
 
             # currently we only support the mean and quantile estimators
-            if safe_isinstance(model.init_, ["sklearn.ensemble.MeanEstimator", "sklearn.ensemble.gradient_boosting.MeanEstimator"]):
+            if safe_isinstance(
+                model.init_,
+                [
+                    "sklearn.ensemble.MeanEstimator",
+                    "sklearn.ensemble.gradient_boosting.MeanEstimator",
+                ],
+            ):
                 self.base_offset = model.init_.mean
-            elif safe_isinstance(model.init_, ["sklearn.ensemble.QuantileEstimator", "sklearn.ensemble.gradient_boosting.QuantileEstimator"]):
+            elif safe_isinstance(
+                model.init_,
+                [
+                    "sklearn.ensemble.QuantileEstimator",
+                    "sklearn.ensemble.gradient_boosting.QuantileEstimator",
+                ],
+            ):
                 self.base_offset = model.init_.quantile
             elif safe_isinstance(model.init_, "sklearn.dummy.DummyRegressor"):
                 self.base_offset = model.init_.constant_[0]
@@ -807,7 +867,14 @@ class TreeEnsemble:
                     self.trees.append(SingleTree(tree, data=data, data_missing=data_missing))
             self.objective = objective_name_map.get(model.loss, None)
             self.tree_output = "log_odds"
-        elif safe_isinstance(model, ["sklearn.ensemble.GradientBoostingClassifier","sklearn.ensemble._gb.GradientBoostingClassifier", "sklearn.ensemble.gradient_boosting.GradientBoostingClassifier"]):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.GradientBoostingClassifier",
+                "sklearn.ensemble._gb.GradientBoostingClassifier",
+                "sklearn.ensemble.gradient_boosting.GradientBoostingClassifier",
+            ],
+        ):
             self.input_dtype = np.float32
 
             # TODO: deal with estimators for each class
@@ -816,7 +883,13 @@ class TreeEnsemble:
                 raise InvalidModelError(emsg)
 
             # currently we only support the logs odds estimator
-            if safe_isinstance(model.init_, ["sklearn.ensemble.LogOddsEstimator", "sklearn.ensemble.gradient_boosting.LogOddsEstimator"]):
+            if safe_isinstance(
+                model.init_,
+                [
+                    "sklearn.ensemble.LogOddsEstimator",
+                    "sklearn.ensemble.gradient_boosting.LogOddsEstimator",
+                ],
+            ):
                 self.base_offset = model.init_.prior
                 self.tree_output = "log_odds"
             elif safe_isinstance(model.init_, "sklearn.dummy.DummyClassifier"):
@@ -872,7 +945,7 @@ class TreeEnsemble:
                 [
                     "pyspark.ml.classification.DecisionTreeClassificationModel",
                     "pyspark.ml.regression.DecisionTreeRegressionModel",
-                ]
+                ],
             ):
                 self.trees = [SingleTree(model, normalize=normalize, scaling=1)]
             else:
@@ -1035,7 +1108,7 @@ class TreeEnsemble:
                 "ngboost.ngboost.NGBoost",
                 "ngboost.api.NGBRegressor",
                 "ngboost.api.NGBClassifier",
-            ]
+            ],
         ):
             assert model.base_models, "The NGBoost model has empty `base_models`! Have you called `model.fit`?"
             if self.model_output == "raw":
@@ -1389,7 +1462,8 @@ class SingleTree:
 
             nodes = [t.lstrip() for t in tree[:-1].split("\n")]
             nodes_dict = {}
-            for n in nodes: nodes_dict[int(n.split(":")[0])] = n.split(":")[1]
+            for n in nodes:
+                nodes_dict[int(n.split(":")[0])] = n.split(":")[1]
             m = max(nodes_dict.keys())+1
             children_left = -1*np.ones(m,dtype="int32")
             children_right = -1*np.ones(m,dtype="int32")
@@ -1403,7 +1477,7 @@ class SingleTree:
             for i in range(0,len(keys_lst)):
                 value = values_lst[i]
                 key = keys_lst[i]
-                if ("leaf" in value):
+                if "leaf" in value:
                     # Extract values
                     val = float(value.split("leaf=")[1].split(",")[0])
                     node_sample_weight_val = float(value.split("cover=")[1])

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -840,19 +840,40 @@ class TreeEnsemble:
                 normalize = False
                 self.tree_output = "raw_value"
             # Spark Random forest, create 1 weighted (avg) tree per sub-model
-            if safe_isinstance(model, "pyspark.ml.classification.RandomForestClassificationModel") \
-                    or safe_isinstance(model, "pyspark.ml.regression.RandomForestRegressionModel"):
+            if safe_isinstance(
+                model,
+                [
+                    "pyspark.ml.classification.RandomForestClassificationModel",
+                    "pyspark.ml.regression.RandomForestRegressionModel",
+                ],
+            ):
                 sum_weight = sum(model.treeWeights)  # output is average of trees
-                self.trees = [SingleTree(tree, normalize=normalize, scaling=model.treeWeights[i]/sum_weight) for i, tree in enumerate(model.trees)]
+                self.trees = [
+                    SingleTree(tree, normalize=normalize, scaling=model.treeWeights[i] / sum_weight)
+                    for i, tree in enumerate(model.trees)
+                ]
             # Spark GBT, create 1 weighted (learning rate) tree per sub-model
-            elif safe_isinstance(model, "pyspark.ml.classification.GBTClassificationModel") \
-                    or safe_isinstance(model, "pyspark.ml.regression.GBTRegressionModel"):
-                self.objective = "squared_error" # GBT subtree use the variance
+            elif safe_isinstance(
+                model,
+                [
+                    "pyspark.ml.classification.GBTClassificationModel",
+                    "pyspark.ml.regression.GBTRegressionModel",
+                ],
+            ):
+                self.objective = "squared_error"  # GBT subtree use the variance
                 self.tree_output = "raw_value"
-                self.trees = [SingleTree(tree, normalize=False, scaling=model.treeWeights[i]) for i, tree in enumerate(model.trees)]
+                self.trees = [
+                    SingleTree(tree, normalize=False, scaling=model.treeWeights[i])
+                    for i, tree in enumerate(model.trees)
+                ]
             # Spark Basic model (single tree)
-            elif safe_isinstance(model, "pyspark.ml.classification.DecisionTreeClassificationModel") \
-                    or safe_isinstance(model, "pyspark.ml.regression.DecisionTreeRegressionModel"):
+            elif safe_isinstance(
+                model,
+                [
+                    "pyspark.ml.classification.DecisionTreeClassificationModel",
+                    "pyspark.ml.regression.DecisionTreeRegressionModel",
+                ]
+            ):
                 self.trees = [SingleTree(model, normalize=normalize, scaling=1)]
             else:
                 emsg = f"Unsupported Spark model type: {type(model)}"
@@ -1008,7 +1029,14 @@ class TreeEnsemble:
             self.trees = [SingleTree(e.tree_, normalize=True, scaling=scaling, data=data, data_missing=data_missing) for e in model.estimators_]
             self.objective = objective_name_map.get(model.criterion, None)
             self.tree_output = "probability"
-        elif safe_isinstance(model, "ngboost.ngboost.NGBoost") or safe_isinstance(model, "ngboost.api.NGBRegressor") or safe_isinstance(model, "ngboost.api.NGBClassifier"):
+        elif safe_isinstance(
+            model,
+            [
+                "ngboost.ngboost.NGBoost",
+                "ngboost.api.NGBRegressor",
+                "ngboost.api.NGBClassifier",
+            ]
+        ):
             assert model.base_models, "The NGBoost model has empty `base_models`! Have you called `model.fit`?"
             if self.model_output == "raw":
                 param_idx = 0 # default to the first parameter of the output distribution

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -336,7 +336,7 @@ class Tree(Explainer):
         Returns
         -------
         array or list
-            For models with a single output this returns a matrix of SHAP values
+            For models with a single output, this returns a matrix of SHAP values
             (# samples x # features). Each row sums to the difference between the model output for that
             sample and the expected value of the model output (which is stored in the ``expected_value``
             attribute of the explainer when it is constant). For models with vector outputs, this returns

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -104,7 +104,7 @@ class Tree(Explainer):
             sum up to the log loss of the model for each sample. This is helpful for breaking down model
             performance by feature.
             Currently the "probability" and "log_loss" options are only supported when
-            ``feature_dependence="interventional"``.
+            ``feature_perturbation="interventional"``.
 
         Examples
         --------

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -502,7 +502,10 @@ class Tree(Explainer):
             tree_limit = -1 if self.model.tree_limit is None else self.model.tree_limit
 
         # shortcut using the C++ version of Tree SHAP in XGBoost
-        if self.model.model_type == "xgboost" and self.feature_perturbation == "tree_path_dependent":
+        if (
+            self.model.model_type == "xgboost"
+            and self.feature_perturbation == "tree_path_dependent"
+        ):
             import xgboost
             if not isinstance(X, xgboost.core.DMatrix):
                 X = xgboost.DMatrix(X)
@@ -700,7 +703,7 @@ class TreeEnsemble:
             [
                 "sklearn.ensemble.ExtraTreesRegressor",
                 "sklearn.ensemble.forest.ExtraTreesRegressor",
-            ]
+            ],
         ):
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
@@ -1208,7 +1211,7 @@ class TreeEnsemble:
         else:
             emsg = (
                 f"Unrecognized model_output parameter value: {str(self.model_output)}! "
-                f"If `model.{str(self.model_output)}` is a valid function, open a github issue to ask "
+                f"If `model.{str(self.model_output)}` is a valid function, open a Github issue to ask "
                 "that this method be supported. If you want 'predict_proba' just use 'probability' for now."
             )
             raise ValueError(emsg)
@@ -1301,7 +1304,7 @@ class SingleTree:
             self.values = self.values * scaling
             self.node_sample_weight = tree.weighted_n_node_samples.astype(np.float64)
 
-        elif type(tree) is dict and 'features' in tree:
+        elif type(tree) is dict and "features" in tree:
             self.children_left = tree["children_left"].astype(np.int32)
             self.children_right = tree["children_right"].astype(np.int32)
             self.children_default = tree["children_default"].astype(np.int32)
@@ -1311,7 +1314,7 @@ class SingleTree:
             self.node_sample_weight = tree["node_sample_weight"]
 
         # deprecated dictionary support (with sklearn singular style "feature" and "value" names)
-        elif type(tree) is dict and 'children_left' in tree:
+        elif type(tree) is dict and "children_left" in tree:
             self.children_left = tree["children_left"].astype(np.int32)
             self.children_right = tree["children_right"].astype(np.int32)
             self.children_default = tree["children_default"].astype(np.int32)
@@ -1320,8 +1323,13 @@ class SingleTree:
             self.values = tree["value"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
-        elif safe_isinstance(tree, "pyspark.ml.classification.DecisionTreeClassificationModel") \
-                or safe_isinstance(tree, "pyspark.ml.regression.DecisionTreeRegressionModel"):
+        elif safe_isinstance(
+            tree,
+            [
+                "pyspark.ml.classification.DecisionTreeClassificationModel",
+                "pyspark.ml.regression.DecisionTreeRegressionModel",
+            ],
+        ):
             #model._java_obj.numNodes() doesn't give leaves, need to recompute the size
             def getNumNodes(node, size):
                 size = size + 1

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -867,7 +867,7 @@ class TestExplainerSklearn:
         note: this test used to fail in native TreeExplainer code due to memory corruption
         """
         newsgroups_train, newsgroups_test, _ = create_binary_newsgroups_data()
-        pipeline = self._create_random_forest_vectorizer()
+        pipeline = self._create_vectorizer_for_randomforestclassifier()
         pipeline.fit(newsgroups_train.data, newsgroups_train.target)
         rf = pipeline.named_steps['rf']
         vectorizer = pipeline.named_steps["vectorizer"]


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

There shouldn't be any functional changes in this PR, just cleaning up of the code and documentation in 2 files

* `shap/explainers/_tree.py`
* `tests/explainers/test_tree.py` : refactor sklearn into its own class, similar to what was done for LGBM in an earlier PR. EDIT: the purpose of this refactor is purely organizational, please read the discussion [here](https://github.com/dsgibbons/shap/pull/88#discussion_r1210869174)

Mini port of the (now stale) PR: #1306 

## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
