### PR TITLE
Move tokensizer to shared fixture

### DIFF
--- a/tests/explainers/common.py
+++ b/tests/explainers/common.py
@@ -24,22 +24,6 @@ def basic_xgboost_scenario(max_samples=None, dataset=shap.datasets.adult):
 
     return model, X
 
-def basic_translation_scenario():
-    """ Create a basic transformers translation model and tokenizer.
-    """
-    AutoTokenizer = pytest.importorskip("transformers").AutoTokenizer
-    AutoModelForSeq2SeqLM = pytest.importorskip("transformers").AutoModelForSeq2SeqLM
-
-    tokenizer = AutoTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-es")
-    model = AutoModelForSeq2SeqLM.from_pretrained("Helsinki-NLP/opus-mt-en-es")
-
-    # define the input sentences we want to translate
-    data = [
-        "In this picture, there are four persons: my father, my mother, my brother and my sister.",
-        "Transformers have rapidly become the model of choice for NLP problems, replacing older recurrent neural network models"
-    ]
-
-    return model, tokenizer, data
 
 def test_additivity(explainer_type, model, masker, data, **kwargs):
     """ Test explainer and masker for additivity on a single output prediction problem.

--- a/tests/explainers/conftest.py
+++ b/tests/explainers/conftest.py
@@ -1,0 +1,23 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
+@pytest.fixture(scope="session")
+def basic_translation_scenario():
+    """ Create a basic transformers translation model and tokenizer.
+    """
+    AutoTokenizer = pytest.importorskip("transformers").AutoTokenizer
+    AutoModelForSeq2SeqLM = pytest.importorskip("transformers").AutoModelForSeq2SeqLM
+
+    tokenizer = AutoTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-es")
+    model = AutoModelForSeq2SeqLM.from_pretrained("Helsinki-NLP/opus-mt-en-es")
+
+    # define the input sentences we want to translate
+    data = [
+        "In this picture, there are four persons: my father, my mother, my brother and my sister.",
+        "Transformers have rapidly become the model of choice for NLP problems, replacing older recurrent neural network models"
+    ]
+
+    return model, tokenizer, data

--- a/tests/explainers/test_partition.py
+++ b/tests/explainers/test_partition.py
@@ -3,28 +3,24 @@
 
 # pylint: disable=missing-function-docstring
 import pickle
-import sys
-
-import pytest
 
 import shap
 
 from . import common
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
-def test_translation():
-    model, tokenizer, data = common.basic_translation_scenario()
+def test_translation(basic_translation_scenario):
+    model, tokenizer, data = basic_translation_scenario
     common.test_additivity(shap.explainers.Partition, model, tokenizer, data)
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
-def test_translation_auto():
-    model, tokenizer, data = common.basic_translation_scenario()
+
+def test_translation_auto(basic_translation_scenario):
+    model, tokenizer, data = basic_translation_scenario
     common.test_additivity(shap.Explainer, model, tokenizer, data)
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
-def test_translation_algorithm_arg():
-    model, tokenizer, data = common.basic_translation_scenario()
+
+def test_translation_algorithm_arg(basic_translation_scenario):
+    model, tokenizer, data = basic_translation_scenario
     common.test_additivity(shap.Explainer, model, tokenizer, data, algorithm="partition")
 
 def test_tabular_single_output():
@@ -35,20 +31,20 @@ def test_tabular_multi_output():
     model, data = common.basic_xgboost_scenario(100)
     common.test_additivity(shap.explainers.Partition, model.predict_proba, shap.maskers.Partition(data), data)
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
-def test_serialization():
-    model, tokenizer, data = common.basic_translation_scenario()
+
+def test_serialization(basic_translation_scenario):
+    model, tokenizer, data = basic_translation_scenario
     common.test_serialization(shap.explainers.Partition, model, tokenizer, data)
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
-def test_serialization_no_model_or_masker():
-    model, tokenizer, data = common.basic_translation_scenario()
+
+def test_serialization_no_model_or_masker(basic_translation_scenario):
+    model, tokenizer, data = basic_translation_scenario
     common.test_serialization(
         shap.explainers.Partition, model, tokenizer, data, model_saver=None, masker_saver=None,
         model_loader=lambda _: model, masker_loader=lambda _: tokenizer
     )
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="Integer division bug in HuggingFace on Windows")
-def test_serialization_custom_model_save():
-    model, tokenizer, data = common.basic_translation_scenario()
+
+def test_serialization_custom_model_save(basic_translation_scenario):
+    model, tokenizer, data = basic_translation_scenario
     common.test_serialization(shap.explainers.Partition, model, tokenizer, data, model_saver=pickle.dump, model_loader=pickle.load)


### PR DESCRIPTION
## Overview

- Refactors the test suite to use a fixture for the tokenizer, rather than a regular python function
- Sets the fixure to have `scope="session"`, which should hopefully fix the flaky CI issue with Huggingface

## Checklist

- [X] Closes #3002 
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
- N/A Added entry to `CHANGELOG.md` (if changes will affect users)

It would be helpful to discuss what level of scoping is appropriate for the `Tokenizer` fixture: in particular whether there is a risk of side-effects between tests if the same tokenizer is re-used.