### PR TITLE
Make sure to include all cuda and C sources in sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ([dsgibbons#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
    [dsgibbons#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
    [dsgibbons#24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
+- Include CUDA GPU C extension files in the source distribution
+  ([#3009](https://github.com/slundberg/shap/pull/3009) by @jklaise).
 - Fixed installation of package via setuptools
   ([dsgibbons#51](https://github.com/dsgibbons/shap/pull/51) by @thatlittleboy).
 - Introduced a minimal set of `ruff` linting

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include shap/cext/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include shap/cext/*
+include shap/plots/resources/*

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,6 @@ def run_setup(
             'shap.plots', 'shap.plots.colors', 'shap.benchmark', 'shap.maskers', 'shap.utils',
             'shap.actions', 'shap.models'
         ],
-        package_data={'shap': ['plots/resources/*', 'cext/tree_shap.h']},
         install_requires=['numpy', 'scipy', 'scikit-learn', 'pandas', 'tqdm>=4.27.0',
                           'packaging>20.9', 'slicer==0.0.7', 'numba', 'cloudpickle'],
         extras_require=extras_require,


### PR DESCRIPTION
## Overview

Currently GPU support is missing for both pre-built wheels (understandable due to needing `nvcc` and a GPU to compile these), but also for the `sdist` uploaded to PyPI (this is an oversight as the sources should be distributed in the `sdist`. This PR fixes that by bringing back the `MANIFEST.in` file specifying to include sources under `shap/cext`.

I have tested that `python -m build` does pick up the files in `MANIFEST.in` and package them into an `sdist`. Furthermore, installing from the `sdist` on a machine with `nvcc` and a GPU compiles the sources and results in a working installation of `shap.explainers.GPUTree`.

For more detailed troubleshooting and info please refer to this comment: https://github.com/slundberg/shap/issues/1834#issuecomment-1597125774

## Checklist

- [x] Closes #1834  <!--Replace xxxx with the GitHub issue number-->
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [x] Added entry to `CHANGELOG.md` (if changes will affect users)
