### PR TITLE
CI: Fix specification of python version in build_wheels.yml

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
 
       - name: Build sdist (pep517)
         run: |
@@ -61,8 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
 
       - name: install requirements
         run: pip install twine==4.0.2


### PR DESCRIPTION
## Overview

Fixes a mis-specification of `python-version` in `build_wheels.yml`.

The a step in the action refers to `matrix.python-version`, which does not exist. Consequently, the step throws a warning and then picks up a random python version depending on the runner. This change pins it to 3.11.

## Checklist

- [X] Related: #3012
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- N/A Unit tests added (if fixing a bug or adding a new feature)
- N/A Added entry to `CHANGELOG.md` (if changes will affect users)
