### PR TITLE
FIX: Test against a full install, not an editable install

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Use "eager" update strategy in case cached dependencies are outdated
-          pip install --upgrade --upgrade-strategy eager -e '.[test,plots]'
+          pip install --upgrade --upgrade-strategy eager '.[test,plots]'
       - name: Test with pytest
         run: |
           python -m pytest --durations=20 \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -61,10 +61,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Use "eager" update strategy in case cached dependencies are outdated
+          # Using regular install NOT editable install: see GH #3020
           pip install --upgrade --upgrade-strategy eager '.[test,plots]'
       - name: Test with pytest
         run: |
-          python -m pytest --durations=20 \
+          # Using "pytest" over "python -m pytest" to avoid adding working directory to sys.path
+          pytest --durations=20 \
           --cov=shap --cov-report=xml --cov-report=term-missing \
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
       - name: Upload mpl test report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,10 +65,13 @@ jobs:
           pip install --upgrade --upgrade-strategy eager '.[test,plots]'
       - name: Test with pytest
         run: |
-          # Using "pytest" over "python -m pytest" to avoid adding working directory to sys.path
+          # Ensure we avoid adding current working directory to sys.path:
+          # - Use "pytest" over "python -m pytest"
+          # - Use "append" import mode rather than default "prepend"
           pytest --durations=20 \
           --cov=shap --cov-report=xml --cov-report=term-missing \
-          --mpl-generate-summary=html --mpl-results-path=./mpl-results
+          --mpl-generate-summary=html --mpl-results-path=./mpl-results \
+          --import-mode=append
       - name: Upload mpl test report
         if: failure()
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ([dsgibbons#39](https://github.com/dsgibbons/shap/pull/39) by @thatlittleboy).
 - Added `__call__` to `KernelExplainer`
   ([#2966](https://github.com/slundberg/shap/pull/2966) by @dwolfeu).
+- Added [contributing guidelines](https://github.com/slundberg/shap/blob/master/CONTRIBUTING.md)
+  ([#2996](https://github.com/slundberg/shap/pull/2996) by @connortann)
 
 ### Fixed
 
@@ -64,10 +66,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    [dsgibbons#26](https://github.com/dsgibbons/shap/pull/26),
    [dsgibbons#27](https://github.com/dsgibbons/shap/pull/27),
    [#2973](https://github.com/slundberg/shap/pull/2973),
-   [#2972](https://github.com/slundberg/shap/pull/2972),
+   [#2972](https://github.com/slundberg/shap/pull/2972) and
    [#2976](https://github.com/slundberg/shap/pull/2976) by @connortann,
    [#2968](https://github.com/slundberg/shap/pull/2968),
    [#2986](https://github.com/slundberg/shap/pull/2986) by @thatlittleboy).
+- Fixed wheel packaging and updated project metadata to PEP 517
+  ([#3022](https://github.com/slundberg/shap/pull/3022) by @connortann)
+- Introduced more thorough testing on CI against newer dependencies
+  ([dsgibbons#61](https://github.com/dsgibbons/shap/pull/61) and
+   [#3017](https://github.com/slundberg/shap/pull/3017)
+  by @connortann)
 
 
 ## [0.41.0] - 2022-06-16


### PR DESCRIPTION
## Overview

Fixes #3020.

- Removes the `--editable / -e` flag from the `pip install` command during CI, to trigger a full wheel build & install.
- Changes the pytest invocation from to avoid adding the current working directory to sys.path
- Changes the pytest import mode from `prepend` to `append`

This is a rather temporary fix to an important problem, so I would advocate for switching to a `src` layout as strongly recommended by pytest.

Supports #2979.