### PR TITLE
CHORE: remove redundant MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include shap/cext/*
-include shap/plots/resources/*


### PR DESCRIPTION
## Overview

Removes the redundant manifest file. Other changes originally in this PR were superceeded by #3022, as packaging is now handled by `[tool.setuptools.package-data]` in `pyproject.toml`.

Previous description:

<details>

Supports #3012 and #2979.

- Reinstates the `package_data` argument in setup.py, partially reverting #3009
- Removes MANIFEST.in
- Broadens the package data to `cext/*` rather than just `cext/tree_shap.h`

From the [packaging docs](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#manifest-in):

> Note MANIFEST.in does not affect binary distributions such as wheels.

Once this is merged, #3017 will prevent similar issues from occuring on CI in future.

</details>