### PR TITLE
Migrate static packaging metadata from setup.py to pyproject.toml, fix missing metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
 ]
-dynamic = ["version"]
+dynamic = ["version", "optional-dependencies"]
 
 [project.urls]
 Repository = 'http://github.com/slundberg/shap'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,13 @@ Documentation = 'https://shap.readthedocs.io/en/latest/index.html'
 [tool.setuptools]
 packages = [
   'shap',
+  'shap.cext',
   'shap.explainers',
   'shap.explainers.other',
   'shap.explainers._deep',
   'shap.plots',
   'shap.plots.colors',
+  'shap.plots.resources',
   'shap.benchmark',
   'shap.maskers',
   'shap.utils',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,65 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "packaging>20.9"]
+requires = ["setuptools>=61.0", "wheel", "oldest-supported-numpy", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "shap"
+description = "A unified approach to explain the output of any machine learning model."
+readme = "README.md"
+license = {text = "MIT License"}
+authors = [
+    {name = "Scott Lundberg", email = "slund1@cs.washington.edu"},
+]
+requires-python = ">=3.7"
+dependencies = [
+  'numpy',
+  'scipy',
+  'scikit-learn',
+  'pandas',
+  'tqdm>=4.27.0',
+  'packaging>20.9',
+  'slicer==0.0.7',
+  'numba',
+  'cloudpickle'
+]
+classifiers = [
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX",
+  "Operating System :: Unix",
+  "Operating System :: MacOS",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+dynamic = ["version"]
+
+[project.urls]
+Repository = 'http://github.com/slundberg/shap'
+Documentation = 'https://shap.readthedocs.io/en/latest/index.html'
+
+[tool.setuptools]
+packages = [
+  'shap',
+  'shap.explainers',
+  'shap.explainers.other',
+  'shap.explainers._deep',
+  'shap.plots',
+  'shap.plots.colors',
+  'shap.benchmark',
+  'shap.maskers',
+  'shap.utils',
+  'shap.actions',
+  'shap.models'
+]
+zip-safe = false
+
+[tool.setuptools.dynamic]
+version = {attr = "shap.__version__"}
+
+[tool.setuptools.package-data]
+shap = ["plots/resources/*", "cext/*"]
 
 [tool.pytest.ini_options]
 addopts = "--mpl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,29 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
 ]
-dynamic = ["version", "optional-dependencies"]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+plots = ["matplotlib", "ipython"]
+others = ["lime"]
+docs = ["matplotlib", "ipython", "numpydoc", "sphinx_rtd_theme", "sphinx", "nbsphinx"]
+test-core = ["pytest", "pytest-mpl", "pytest-cov"]
+test = [
+  "pytest",
+  "pytest-mpl",
+  "pytest-cov",
+  "xgboost",
+  "lightgbm",
+  "catboost",
+  "pyspark",
+  "pyod",
+  "transformers",
+  "torch",
+  "torchvision",
+  "tensorflow",
+  "sentencepiece",
+  "opencv-python",
+]
 
 [project.urls]
 Repository = 'http://github.com/slundberg/shap'

--- a/setup.py
+++ b/setup.py
@@ -138,48 +138,7 @@ def run_setup(
         except Exception as e:
             raise Exception("Error building cuda module: " + repr(e)) from e
 
-    extras_require = {
-        'plots': [
-            'matplotlib',
-            'ipython'
-        ],
-        'others': [
-            'lime',
-        ],
-        'docs': [
-            'matplotlib',
-            'ipython',
-            'numpydoc',
-            'sphinx_rtd_theme',
-            'sphinx',
-            'nbsphinx',
-        ],
-        'test-core': [
-            "pytest",
-            "pytest-mpl",
-            "pytest-cov",
-        ],
-        'test-extras': [
-            "xgboost",
-            "lightgbm",
-            "catboost",
-            "pyspark",
-            "pyod",
-            "transformers",
-            "torch",
-            "torchvision",
-            "tensorflow",
-            "sentencepiece",
-            "opencv-python",
-        ],
-    }
-    extras_require['test'] = extras_require['test-core'] + extras_require['test-extras']
-    extras_require["all"] = list({i for val in extras_require.values() for i in val})
-
-    setup(
-        extras_require=extras_require,
-        ext_modules=ext_modules,
-    )
+    setup(ext_modules=ext_modules)
 
 
 def try_run_setup(**kwargs):
@@ -207,7 +166,4 @@ def try_run_setup(**kwargs):
 
 # we seem to need this import guard for appveyor
 if __name__ == "__main__":
-    try_run_setup(
-        with_binary=True,
-        with_cuda=True,
-    )
+    try_run_setup(with_binary=True, with_cuda=True)

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,6 @@ import numpy as np
 from packaging.version import Version, parse
 from setuptools import Extension, setup
 
-# to publish use:
-# > python setup.py sdist bdist_wheel upload
-# which depends on ~/.pypirc
-
-
 # This is copied from @robbuckley's fix for Panda's
 # For mac, ensure extensions are built for macos 10.9 when compiling on a
 # 10.9 system or above, overriding distuitls behavior which is to target


### PR DESCRIPTION
## Overview

Moves the majority project metadata from dynamic to static config, in accordance with PEP 621. This supports #2979 by simplifying the build logic and bringing it up to modern standards.

In doing so, I identified and fixed a number of issues with the packaging configuration. The tests suite will now pass against the installed package (rather than just an editable install).

Supports #3012 .

Changes:
- Moves metadata from `setup.py` to `pyproject.toml`
- Replaces the `long_description` keyword with the `readme` file
- Fixes a missing space in the `nvcc` compile command
- Fixes missing `shap.cext` and `shap.plots.resources` in setuptools packages list
- Fixes missing `package-data` metadata
- Removes `shap[all]` dependency group (which is not used, from a search of GitHub)

Relevant docs: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html

Nb. This overlaps a bit with #3021; I've included `package-data` here as static metadata.