### PR TITLE
CHORE: Add .git-blame-ignore-revs to remove style changes from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# This file helps clean up the git "blame" view, by ignoring style & refactoring commits.
+# Sorted imports with isort
+6be5b996cc7f048bf04875a8dc7775b2233dbeb4
+# Removed trailing whitespace
+b2a60a31edcc22ed41778cbe3ef93a499d76277f
+# Renormalised file endings
+edb34644a218127437f9e6bb1588bc3246a2c222

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,7 +1,9 @@
-# This file helps clean up the git "blame" view, by ignoring style & refactoring commits.
+# This file helps clean up the git "blame" view, by ignoring repo-wide style & refactoring commits.
 # Sorted imports with isort
 6be5b996cc7f048bf04875a8dc7775b2233dbeb4
 # Removed trailing whitespace
 b2a60a31edcc22ed41778cbe3ef93a499d76277f
+# Fixed end-of-file line endings
+9438e81732d04f9e9c56d98074e6b35615e21a9a
 # Renormalised file endings
 edb34644a218127437f9e6bb1588bc3246a2c222


### PR DESCRIPTION
## Overview

Adds a .git-blame-ignore-revs file with a list of commits to ignore. This will ensure that "git blame" remains a useful tool to see file histories, both locally and in the GitHub UI.

For more info see:

- python black: [Avoiding ruining git blame](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame)
- Github: [ignore commits in blame view](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)
