### PR TITLE
FIX: update code coverage configuration for installed package

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,19 +44,20 @@ jobs:
           - os: windows-latest
             python-version: "3.11"
             extras: "test"
-            name: windows-3.11
+            name: 3.11-windows
           - os: macos-latest
             python-version: "3.11"
             extras: "test"
-            name: macos-3.11
+            name: 3.11-macos
           # Also run tests with only the core dependencies, to ensure we
           # cover the latest version of numpy/pandas. See dsgibbons#46
           - os: ubuntu-latest
             python-version: "3.11"
             extras: "test-core"
-            name: core-3.11
+            name: 3.11-core
       fail-fast: false
-    # Workaround to ensure job name stays the same, so "Required Checks" still present
+    # Workaround to ensure previous job names stay the same
+    # "Required Checks" enfore that a check called "run_tests (3.8)" is present
     name: run_tests (${{ matrix.name && matrix.name || matrix.python-version }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -95,7 +96,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: mpl-results-${{ matrix.python-version }}
+          name: mpl-results-${{ matrix.python-version }}-${{ runner.os }}-${{ matrix.extras }}
           path: mpl-results/
           if-no-files-found: ignore
       - name: Upload coverage to Codecov

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -87,7 +87,7 @@ jobs:
         # - Use "pytest" over "python -m pytest"
         # - Use "append" import mode rather than default "prepend"
         run: >
-          pytest --durations=20
+          pytest --durations=20 -k installed_package
           --cov --cov-report=xml --cov-report=term
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
           --import-mode=append

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -87,8 +87,8 @@ jobs:
         # - Use "pytest" over "python -m pytest"
         # - Use "append" import mode rather than default "prepend"
         run: >
-          pytest --durations=20 -k installed_package
-          --cov --cov-report=xml --cov-report=term
+          pytest --durations=20
+          --cov --cov-report=xml
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
           --import-mode=append
       - name: Upload mpl test report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -88,7 +88,7 @@ jobs:
         # - Use "append" import mode rather than default "prepend"
         run: >
           pytest --durations=20
-          --cov=shap --cov-report=xml --cov-report=term-missing
+          --cov --cov-report=xml --cov-report=term
           --mpl-generate-summary=html --mpl-results-path=./mpl-results
           --import-mode=append
       - name: Upload mpl test report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,11 @@ target-version = "py37"
 "shap/explainers/other/_maple.py" = ["ALL"]
 "shap/plots/colors/_colorconv.py" = ["ALL"]
 
-[tool.coverge.run]
-source_pkgs = "shap"
+[tool.coverage.run]
+source_pkgs = ["shap"]
 
 [tool.coverage.paths]
-combine = ["./", "**/site-packages"]
+combine = ["shap", "*/site-packages/shap"]
 
 [tool.cibuildwheel]
 # Restrict the set of builds to mirror the wheels available in scikit-learn. See #3028

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,12 @@ target-version = "py37"
 "shap/explainers/other/_maple.py" = ["ALL"]
 "shap/plots/colors/_colorconv.py" = ["ALL"]
 
+[tool.coverge.run]
+source_pkgs = "shap"
+
+[tool.coverage.paths]
+combine = ["./", "**/site-packages"]
+
 [tool.cibuildwheel]
 # Restrict the set of builds to mirror the wheels available in scikit-learn. See #3028
 skip = ["cp36-*", "pp*", "*-musllinux_*"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,18 @@
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") != "true", reason="Only enforced when running on CI"
+)
+def test_importing_from_installed_package_not_local_files():
+
+    # If using an editable install (pip install --editable), then shap will
+    # be imported directly from the repo. This is a common setup when developing.
+
+    # However when running tests on CI, we want to test against the *installed* package.
+    # This ensures that the library is packaged correctly.
+
+    import shap
+    assert "site-packages" in shap.__file__


### PR DESCRIPTION
## Changes

- Fixes the code coverage configuration
- Removes the coverage terminal output
- Adds a test to check that pytest has picked up the correct version of SHAP, to be skipped when running locally.

![image](https://github.com/slundberg/shap/assets/71127464/7afa7013-d920-452d-9355-7aed1780f026)


## Context

The code coverage config was inadvertently broken when the tests were configured to run against the installed package rather than the local project. After a lot of trial and error the fix seems to be two parts:
- specifying `coverage.run:source_pckg` to ensure coverage measures the package, not the directory
- specifying `coverage.paths:combine` to relate the package to the local directory.

Without sounding like a broken record, this is another concern which would be much more simple and less error prone with a `src` layout.

TODO:

- [x] Ensure coverage is > 0%
- [x] Get codecov upload working 