### PR TITLE
fix: lightgbm segfaults due to multiprocessing

### DIFF
--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -120,7 +120,7 @@ def lightgbm_base():
         return pytest.param("lightgbm.LGBMRegressor", marks=pytest.mark.skip)
     X, y = datasets['regression']
 
-    model = lightgbm.LGBMRegressor()
+    model = lightgbm.LGBMRegressor(n_jobs=1)
     model.fit(X, y)
     return model.booster_, X, model.predict(X)
 
@@ -133,7 +133,7 @@ def lightgbm_regression():
         return pytest.param("lightgbm.LGBMRegressor", marks=pytest.mark.skip)
     X, y = datasets['regression']
 
-    model = lightgbm.LGBMRegressor()
+    model = lightgbm.LGBMRegressor(n_jobs=1)
     model.fit(X, y)
     return model, X, model.predict(X)
 
@@ -146,7 +146,7 @@ def lightgbm_binary_classifier():
         return pytest.param("lightgbm.LGBMClassifier", marks=pytest.mark.skip)
     X, y = datasets['binary']
 
-    model = lightgbm.LGBMClassifier()
+    model = lightgbm.LGBMClassifier(n_jobs=1)
     model.fit(X, y)
     return model, X, model.predict(X, raw_score=True)
 
@@ -159,7 +159,7 @@ def lightgbm_multiclass_classifier():
         return pytest.param("lightgbm.LGBMClassifier", marks=pytest.mark.skip)
     X, y = datasets['multiclass']
 
-    model = lightgbm.LGBMClassifier()
+    model = lightgbm.LGBMClassifier(n_jobs=1)
     model.fit(X, y)
     return model, X, model.predict(X, raw_score=True)
 


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Set `n_jobs` to 1 on lightgbm models. Leaving them to default/auto would result in segmentation faults on MacOS.

Before the change, 

![image](https://github.com/slundberg/shap/assets/30731072/0eec12f4-2003-4ae6-8a88-f7256e277911)

Verified locally that after the changes, pytest test collection occurs normally without segfaults.  

## Checklist

- [X] Closes #3032  <!--Replace xxxx with the GitHub issue number-->
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- Added entry to `CHANGELOG.md` (if changes will affect users)
