### PR TITLE
docs: Missing datasets documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,8 +130,10 @@ datasets
 .. autosummary::
     :toctree: generated/
 
+    shap.datasets.a1a
     shap.datasets.adult
     shap.datasets.boston
+    shap.datasets.california
     shap.datasets.communitiesandcrime
     shap.datasets.corrgroups60
     shap.datasets.diabetes
@@ -139,4 +141,6 @@ datasets
     shap.datasets.imdb
     shap.datasets.independentlinear60
     shap.datasets.iris
+    shap.datasets.linnerud
     shap.datasets.nhanesi
+    shap.datasets.rank

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -34,8 +34,11 @@ def imagenet50(display=False, resolution=224, n_points=None): # pylint: disable=
     return X, y
 
 @deprecated()
-def boston(display=False, n_points=None): # pylint: disable=unused-argument
-    """ Return the boston housing data in a nice package. """
+def boston(display=False, n_points=None):
+    """Return the boston housing data in a nice package (DEPRECATED).
+
+    This dataset is deprecated, please use :func:`shap.datasets.california` instead.
+    """
     d = sklearn.datasets.load_boston()
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
     target = d.target # pylint: disable=E1101

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -37,7 +37,8 @@ def imagenet50(display=False, resolution=224, n_points=None): # pylint: disable=
 def boston(display=False, n_points=None):
     """Return the boston housing data in a nice package (DEPRECATED).
 
-    This dataset is deprecated, please use :func:`shap.datasets.california` instead.
+    This dataset is deprecated and will be removed in the next version (0.43.0).
+    Please use :func:`shap.datasets.california` instead.
     """
     d = sklearn.datasets.load_boston()
     df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Add in the rest of the datasets that are missing to the API reference page.
* Make it clearer that Boston dataset is deprecated in the API reference page.

![image](https://github.com/slundberg/shap/assets/30731072/d7d85890-f3f4-43b5-8491-2d0d0b899584)


## Checklist

- Closes #xxxx  <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- Unit tests added (if fixing a bug or adding a new feature)
- Added entry to `CHANGELOG.md` (if changes will affect users)
