### PR TITLE
chore: add functorch to the cache

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -74,6 +74,7 @@ jobs:
             ${{ env.pythonLocation }}/**/site-packages/pyspark*
             ${{ env.pythonLocation }}/**/site-packages/nvidia*
             ${{ env.pythonLocation }}/**/site-packages/torch*
+            ${{ env.pythonLocation }}/**/site-packages/functorch*
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

Attempt at resolving #3032 once more. Taking a close look at the error message, it says it is looking for `libiomp5.dylib` inside `functorch/.dylibs/` within site packages.

So we should ensure we cache `functorch` alongside `pytorch`.

For reviewers:
> How to check that this PR works?
> => On the MacOS-3.11 action, ensure that the CI/CD is reading from cache, and also the test collection passes.

## Checklist

- [X] Closes #3032 (hopefully!)  <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- Unit tests added (if fixing a bug or adding a new feature)
- Added entry to `CHANGELOG.md` (if changes will affect users)
