### PR TITLE
refactor: remove unnecessary matplotlib try-excepts

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -1,10 +1,4 @@
-import warnings
-
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
+import matplotlib.pyplot as pl
 import numpy as np
 import scipy
 

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -1,20 +1,15 @@
 """ Summary plots of SHAP values across a whole dataset.
 """
 
-
 import warnings
 
+import matplotlib.pyplot as pl
 import numpy as np
 import scipy.cluster
 import scipy.sparse
 import scipy.spatial
 from scipy.stats import gaussian_kde
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from .. import Explanation
 from ..utils import safe_isinstance
 from ..utils._exceptions import DimensionError

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -1,17 +1,10 @@
 """ Visualize cumulative SHAP values."""
 
-
-import warnings
 from typing import Union
 
+import matplotlib.cm as cm
+import matplotlib.pyplot as pl
 import numpy as np
-
-try:
-    import matplotlib.cm as cm
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 
 from ..utils import hclust_ordering
 from ..utils._legacy import LogitLink, convert_to_link

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -1,12 +1,6 @@
-import warnings
-
+import matplotlib.pyplot as pl
 import sklearn
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from ..utils import convert_name
 from . import colors
 from ._labels import labels

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -1,7 +1,6 @@
 """ Visualize the SHAP values with additive force style layouts.
 """
 
-
 import base64
 import json
 import os

--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -1,17 +1,10 @@
-import warnings
-
+import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
-
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
-    from matplotlib import lines
-    from matplotlib.font_manager import FontProperties
-    from matplotlib.patches import PathPatch
-    from matplotlib.path import Path
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
+from matplotlib import lines
+from matplotlib.font_manager import FontProperties
+from matplotlib.patches import PathPatch
+from matplotlib.path import Path
 
 
 def draw_bars(out_value, features, feature_type, width_separators, width_bar):

--- a/shap/plots/_group_difference.py
+++ b/shap/plots/_group_difference.py
@@ -1,12 +1,6 @@
-import warnings
-
+import matplotlib.pyplot as pl
 import numpy as np
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from . import colors
 
 

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -1,9 +1,6 @@
+import matplotlib.pyplot as pl
 import numpy as np
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    pass
 from .. import Explanation
 from ..utils import OpChain
 from . import colors

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -4,6 +4,7 @@ import string
 import warnings
 from typing import Optional
 
+import matplotlib.pyplot as pl
 import numpy as np
 from matplotlib.colors import Colormap
 
@@ -11,10 +12,6 @@ from shap._explanation import Explanation
 
 from ..utils import ordinal_str
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
 try:
     from IPython.display import HTML, display
 except ImportError:

--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -1,13 +1,7 @@
-import warnings
-
+import matplotlib.pyplot as pl
 import numpy as np
 import scipy.stats
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from . import colors
 from ._labels import labels
 

--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -1,16 +1,10 @@
-import warnings
+import matplotlib.pyplot as pl
+import numpy as np
+import pandas as pd
 
 from .. import Explanation
 from ..plots.colors import blue_rgb, light_blue_rgb, red_blue_transparent, red_rgb
 from ..utils import convert_name
-
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
-import numpy as np
-import pandas as pd
 
 
 def compute_bounds(xmin, xmax, xv):

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -1,13 +1,9 @@
 import warnings
 
+import matplotlib
+import matplotlib.pyplot as pl
 import numpy as np
 
-try:
-    import matplotlib
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from .._explanation import Explanation
 from ..utils import approximate_interactions, convert_name
 from ..utils._general import encode_array_if_needed

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -1,17 +1,12 @@
 """ Summary plots of SHAP values (violin plot) across a whole dataset.
 """
 
-
 import warnings
 
+import matplotlib.pyplot as pl
 import numpy as np
 from scipy.stats import gaussian_kde
 
-try:
-    import matplotlib.pyplot as pl
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -1,13 +1,7 @@
-import warnings
-
+import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
-except ImportError:
-    warnings.warn("matplotlib could not be loaded!")
-    pass
 from .. import Explanation
 from ..utils import format_value, safe_isinstance
 from . import colors


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

The `shap/plots/__init__.py` file already does the matplotlib import, like so:

https://github.com/slundberg/shap/blob/ab63310aad99e48958b0b2beb54dcc202797d95e/shap/plots/__init__.py#L1-L4

So there's actually no need for try-except for the matplotlib import in the children modules, because to `import shap.plots._heatmap`, the user will already have imported `shap/plots/__init__.py`.

This PR cleans up the unnecessary try-excepts. There should be no change in the user experience whatsoever.


## Checklist

- Closes #xxxx  <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- Unit tests added (if fixing a bug or adding a new feature)
- Added entry to `CHANGELOG.md` (if changes will affect users)
