### PR TITLE
FIX: Add fixture to set pyspark python driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed failing unit tests
   ([dsgibbons#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
    [dsgibbons#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
+   [#3044](https://github.com/slundberg/shap/pull/3044) by @connortann,
    [dsgibbons#24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
 - Include CUDA GPU C extension files in the source distribution
   ([#3009](https://github.com/slundberg/shap/pull/3009) by @jklaise).

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2,6 +2,7 @@
 import itertools
 import math
 import pickle
+import sys
 
 import numpy as np
 import pandas as pd
@@ -203,7 +204,13 @@ def test_ngboost():
         explainer.shap_values(X).sum(1) + explainer.expected_value - model.predict(X))) < 1e-5
 
 
-def test_pyspark_classifier_decision_tree():
+@pytest.fixture
+def configure_pyspark_python(monkeypath):
+    monkeypath.setenv("PYSPARK_PYTHON", sys.executable)
+    monkeypath.setenv("PYSPARK_DRIVER_PYTHON", sys.executable)
+
+
+def test_pyspark_classifier_decision_tree(configure_pyspark_python):
     # pylint: disable=bare-except
     pyspark = pytest.importorskip("pyspark")
     pytest.importorskip("pyspark.ml")
@@ -258,7 +265,7 @@ def test_pyspark_classifier_decision_tree():
     spark.stop()
 
 
-def test_pyspark_regression_decision_tree():
+def test_pyspark_regression_decision_tree(configure_pyspark_python):
     # pylint: disable=bare-except
     pyspark = pytest.importorskip("pyspark")
     pytest.importorskip("pyspark.ml")

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -205,9 +205,9 @@ def test_ngboost():
 
 
 @pytest.fixture
-def configure_pyspark_python(monkeypath):
-    monkeypath.setenv("PYSPARK_PYTHON", sys.executable)
-    monkeypath.setenv("PYSPARK_DRIVER_PYTHON", sys.executable)
+def configure_pyspark_python(monkeypatch):
+    monkeypatch.setenv("PYSPARK_PYTHON", sys.executable)
+    monkeypatch.setenv("PYSPARK_DRIVER_PYTHON", sys.executable)
 
 
 def test_pyspark_classifier_decision_tree(configure_pyspark_python):


### PR DESCRIPTION
Closes #3012

The cibuildwheel on Windows is currently failing due to a pyspark error, as the works have a different python version than the driver. This PR adds a fixture to fix this via environment variables.

Example runs:
https://github.com/slundberg/shap/actions/workflows/build_wheels.yml

Previous failing test:

<details>

```
================================== FAILURES ===================================
  ____________________ test_pyspark_classifier_decision_tree ____________________
  
      def test_pyspark_classifier_decision_tree():
          # pylint: disable=bare-except
          pyspark = pytest.importorskip("pyspark")
          pytest.importorskip("pyspark.ml")
          try:
              spark = pyspark.sql.SparkSession.builder.config(
                  conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
          except:
              pytest.skip("Could not create pyspark context")
      
          iris_sk = sklearn.datasets.load_iris()
          iris = pd.DataFrame(data=np.c_[iris_sk['data'], iris_sk['target']],
                              columns=iris_sk['feature_names'] + ['target'])[:100]
          col = ["sepal_length", "sepal_width", "petal_length", "petal_width", "type"]
          iris = spark.createDataFrame(iris, col)
          iris = pyspark.ml.feature.VectorAssembler(inputCols=col[:-1], outputCol="features").transform(
              iris)
  >       iris = pyspark.ml.feature.StringIndexer(inputCol="type", outputCol="label").fit(iris).transform(
              iris)
  
  D:\a\shap\shap\tests\explainers\test_tree.py:223: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  ..\venv-test\lib\site-packages\pyspark\ml\base.py:205: in fit
      return self._fit(dataset)
  ..\venv-test\lib\site-packages\pyspark\ml\wrapper.py:381: in _fit
      java_model = self._fit_java(dataset)
  ..\venv-test\lib\site-packages\pyspark\ml\wrapper.py:378: in _fit_java
      return self._java_obj.fit(dataset._jdf)
  ..\venv-test\lib\site-packages\py4j\java_gateway.py:1322: in __call__
      return_value = get_return_value(
  ..\venv-test\lib\site-packages\pyspark\errors\exceptions\captured.py:169: in deco
      return f(*a, **kw)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  
  answer = 'xro79'
  gateway_client = <py4j.clientserver.JavaClient object at 0x000001D8A0997130>
  target_id = 'o63', name = 'fit'
  
      def get_return_value(answer, gateway_client, target_id=None, name=None):
          """Converts an answer received from the Java gateway into a Python object.
      
          For example, string representation of integers are converted to Python
          integer, string representation of objects are converted to JavaObject
          instances, etc.
      
          :param answer: the string returned by the Java gateway
          :param gateway_client: the gateway client used to communicate with the Java
              Gateway. Only necessary if the answer is a reference (e.g., object,
              list, map)
          :param target_id: the name of the object from which the answer comes from
              (e.g., *object1* in `object1.hello()`). Optional.
          :param name: the name of the member from which the answer comes from
              (e.g., *hello* in `object1.hello()`). Optional.
          """
          if is_error(answer)[0]:
              if len(answer) > 1:
                  type = answer[1]
                  value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
                  if answer[1] == REFERENCE_TYPE:
  >                   raise Py4JJavaError(
                          "An error occurred while calling {0}{1}{2}.\n".
                          format(target_id, ".", name), value)
  E                   py4j.protocol.Py4JJavaError: An error occurred while calling o63.fit.
  E                   : org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (fv-az411-556.4oxf4n2mvjkerjqzlchgjvcyfa.gx.internal.cloudapp.net executor driver): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  E                     File "C:\Users\runneradmin\AppData\Local\Temp\cibw-run-6cnzsr1v\cp38-win_amd64\venv-test\Lib\site-packages\pyspark\python\lib\pyspark.zip\pyspark\worker.py", line 683, in main
  E                   RuntimeError: Python in worker has different version 3.9 than that in driver 3.8, PySpark cannot run with different minor versions. Please check environment variables PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON are correctly set.
```

</details>