### PR TITLE
CHORE: changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,50 +7,65 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 <!--Changes from new PRs should be put in this section-->
 
+## 0.42.0 - 2023-07-05
+
+This release incorporates many changes that were originally contributed by the SHAP
+community via @dsgibbons's [Community Fork][fork], which has now been merged
+into the main shap repository. PRs from this origin are labelled here as `fork#123`.
+
+[fork]: https://github.com/slundberg/shap/discussions/2942
+
 ### Added
 
 - Added support for python 3.11
-  ([#72](https://github.com/dsgibbons/shap/pull/72) by @connortann)
+  ([fork#72](https://github.com/dsgibbons/shap/pull/72) by @connortann).
 - Added `n_points` parameter to all functions in `shap.datasets`
-  ([#39](https://github.com/dsgibbons/shap/pull/39) by @thatlittleboy).
+  ([fork#39](https://github.com/dsgibbons/shap/pull/39) by @thatlittleboy).
 - Added `__call__` to `KernelExplainer`
   ([#2966](https://github.com/slundberg/shap/pull/2966) by @dwolfeu).
-- Added [contributing guidelines](https://github.com/slundberg/shap/blob/master/CONTRIBUTING.md)
-  ([#2996](https://github.com/slundberg/shap/pull/2996) by @connortann)
+- Added [contributing guidelines][contrib-guide]
+  ([#2996](https://github.com/slundberg/shap/pull/2996) by @connortann).
+
+[contrib-guide]: [https://github.com/slundberg/shap/blob/master/CONTRIBUTING.md]
 
 ### Fixed
 
 - Fixed `plot.waterfall` to support yticklabels with boolean features
-  ([#58](https://github.com/dsgibbons/shap/pull/58) by @dwolfeu).
-- Prevent `TreeExplainer.__call__` from throwing ValueError when passed a pandas DataFrame containing Categorical columns
-  ([#88](https://github.com/dsgibbons/shap/pull/88) by @thatlittleboy).
+  ([fork#58](https://github.com/dsgibbons/shap/pull/58) by @dwolfeu).
+- Prevent `TreeExplainer.__call__` from throwing ValueError when passed a pandas
+  DataFrame containing Categorical columns
+  ([fork#88](https://github.com/dsgibbons/shap/pull/88) by @thatlittleboy).
 - Fixed sampling in `shap.datasets` to sample without replacement
   ([#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
 - Fixed an `UnboundLocalError` problem arising from passing a dictionary input to `shap.plots.bar`
   ([#3001](https://github.com/slundberg/shap/pull/3001) by @thatlittleboy).
+  ([fork#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
+- Fixed an `UnboundLocalError` problem arising from passing a dictionary input
+  to `shap.plots.bar`
+  ([#3001](https://github.com/slundberg/shap/pull/3000) by @thatlittleboy).
 - Fixed tensorflow import issue with Pyspark when using `Gradient`
   ([#2983](https://github.com/slundberg/shap/pull/2983) by @skamdar).
-- Fixed the aspect ratio of the colorbar in `shap.plots.heatmap`, and use the `ax` matplotlib API internally
-  for plotting
+- Fixed the aspect ratio of the colorbar in `shap.plots.heatmap`, and use the
+  `ax` matplotlib API internally for plotting
   ([#3040](https://github.com/slundberg/shap/pull/3040) by @thatlittleboy).
 - Fixed deprecation warnings for `numba>=0.44`
-  ([#9](https://github.com/dsgibbons/shap/pull/9) and
-  [#68](https://github.com/dsgibbons/shap/pull/68) by @connortann)
+  ([fork#9](https://github.com/dsgibbons/shap/pull/9) and
+  [fork#68](https://github.com/dsgibbons/shap/pull/68) by @connortann).
 - Fixed deprecation warnings for `numpy>=1.24` from numpy types
-  ([#7](https://github.com/dsgibbons/shap/pull/7) by @dsgibbons).
+  ([fork#7](https://github.com/dsgibbons/shap/pull/7) by @dsgibbons).
 - Fixed deprecation warnings for `Ipython>=8` from `Ipython.core.display`
-  ([#13](https://github.com/dsgibbons/shap/pull/13) by @thatlittleboy).
+  ([fork#13](https://github.com/dsgibbons/shap/pull/13) by @thatlittleboy).
 - Fixed deprecation warnings for `tensorflow>=2.11` from `tf.optimisers`
-  ([#16](https://github.com/dsgibbons/shap/pull/16) by @simonangerbauer).
+  ([fork#16](https://github.com/dsgibbons/shap/pull/16) by @simonangerbauer).
 - Fixed deprecation warnings for `sklearn>=1.2` from `sklearn.linear_model`
-  ([#22](https://github.com/dsgibbons/shap/pull/22) by @dsgibbons).
+  ([fork#22](https://github.com/dsgibbons/shap/pull/22) by @dsgibbons).
 - Fixed deprecation warnings for `xgboost>=1.4` from `ntree_limit` in tree explainer
   ([#2987](https://github.com/slundberg/shap/pull/2987) by @adnene-guessoum).
 - Fixed build on Windows and MacOS
   ([#3015](https://github.com/slundberg/shap/pull/3015) by @PrimozGodec;
   [#3028](https://github.com/slundberg/shap/pull/3028),
   [#3029](https://github.com/slundberg/shap/pull/3029) and
-  [#3031](https://github.com/slundberg/shap/pull/3031) by @connortann)
+  [#3031](https://github.com/slundberg/shap/pull/3031) by @connortann).
 
 ### Changed
 
@@ -61,38 +76,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 - Deprecated the Boston house price dataset
-  ([#38](https://github.com/dsgibbons/shap/pull/38) by @thatlittleboy).
+  ([fork#38](https://github.com/dsgibbons/shap/pull/38) by @thatlittleboy).
 - Removed the unused `mimic.py` file and `MimicExplainer` code
-  ([#53](https://github.com/dsgibbons/shap/pull/53) by @thatlittleboy).
+  ([fork#53](https://github.com/dsgibbons/shap/pull/53) by @thatlittleboy).
 
 ### Maintenance
 
 - Fixed failing unit tests
-  ([#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
-   [#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
+  ([fork#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
+   [fork#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
    [#3044](https://github.com/slundberg/shap/pull/3044) and
-   [#24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
+   [#dsgibbons24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
 - Include CUDA GPU C extension files in the source distribution
   ([#3009](https://github.com/slundberg/shap/pull/3009) by @jklaise).
 - Fixed installation of package via setuptools
-  ([#51](https://github.com/dsgibbons/shap/pull/51) by @thatlittleboy).
+  ([fork#51](https://github.com/dsgibbons/shap/pull/51) by @thatlittleboy).
 - Introduced a minimal set of `ruff` linting
-  ([#25](https://github.com/dsgibbons/shap/pull/25),
-   [#26](https://github.com/dsgibbons/shap/pull/26),
-   [#27](https://github.com/dsgibbons/shap/pull/27),
+  ([fork#25](https://github.com/dsgibbons/shap/pull/25),
+   [fork#26](https://github.com/dsgibbons/shap/pull/26),
+   [fork#27](https://github.com/dsgibbons/shap/pull/27),
    [#2973](https://github.com/slundberg/shap/pull/2973),
    [#2972](https://github.com/slundberg/shap/pull/2972) and
    [#2976](https://github.com/slundberg/shap/pull/2976) by @connortann;
    [#2968](https://github.com/slundberg/shap/pull/2968),
    [#2986](https://github.com/slundberg/shap/pull/2986) by @thatlittleboy).
 - Updated project metadata to PEP 517
-  ([#3022](https://github.com/slundberg/shap/pull/3022) by @connortann)
+  ([#3022](https://github.com/slundberg/shap/pull/3022) by @connortann).
 - Introduced more thorough testing on CI against newer dependencies
-  ([#61](https://github.com/dsgibbons/shap/pull/61) and
+  ([#dsgibbons61](https://github.com/dsgibbons/shap/pull/61) and
    [#3017](https://github.com/slundberg/shap/pull/3017)
   by @connortann)
 - Reduced unit test time by ~5 mins
-  ([#3046](https://github.com/slundberg/shap/pull/3046) by @connortann)
+  ([#3046](https://github.com/slundberg/shap/pull/3046) by @connortann).
 
 ## [0.41.0] - 2022-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed sampling in `shap.datasets` to sample without replacement
   ([#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
 - Fixed an `UnboundLocalError` problem arising from passing a dictionary input to `shap.plots.bar`
-  ([#3001](https://github.com/slundberg/shap/pull/3000) by @thatlittleboy).
+  ([#3001](https://github.com/slundberg/shap/pull/3001) by @thatlittleboy).
 - Fixed tensorflow import issue with Pyspark when using `Gradient`
   ([#2983](https://github.com/slundberg/shap/pull/2983) by @skamdar).
 - Fixed the aspect ratio of the colorbar in `shap.plots.heatmap`, and use the `ax` matplotlib API internally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support for python 3.11
+  ([#72](https://github.com/dsgibbons/shap/pull/72) by @connortann)
 - Added `n_points` parameter to all functions in `shap.datasets`
-  ([dsgibbons#39](https://github.com/dsgibbons/shap/pull/39) by @thatlittleboy).
+  ([#39](https://github.com/dsgibbons/shap/pull/39) by @thatlittleboy).
 - Added `__call__` to `KernelExplainer`
   ([#2966](https://github.com/slundberg/shap/pull/2966) by @dwolfeu).
 - Added [contributing guidelines](https://github.com/slundberg/shap/blob/master/CONTRIBUTING.md)
@@ -19,11 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `plot.waterfall` to support yticklabels with boolean features
-  ([dsgibbons#58](https://github.com/dsgibbons/shap/pull/58) by @dwolfeu).
+  ([#58](https://github.com/dsgibbons/shap/pull/58) by @dwolfeu).
 - Prevent `TreeExplainer.__call__` from throwing ValueError when passed a pandas DataFrame containing Categorical columns
-  ([dsgibbons#88](https://github.com/dsgibbons/shap/pull/88) by @thatlittleboy).
+  ([#88](https://github.com/dsgibbons/shap/pull/88) by @thatlittleboy).
 - Fixed sampling in `shap.datasets` to sample without replacement
-  ([dsgibbons#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
+  ([#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
 - Fixed an `UnboundLocalError` problem arising from passing a dictionary input to `shap.plots.bar`
   ([#3001](https://github.com/slundberg/shap/pull/3000) by @thatlittleboy).
 - Fixed tensorflow import issue with Pyspark when using `Gradient`
@@ -31,16 +33,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed the aspect ratio of the colorbar in `shap.plots.heatmap`, and use the `ax` matplotlib API internally
   for plotting
   ([#3040](https://github.com/slundberg/shap/pull/3040) by @thatlittleboy).
+- Fixed deprecation warnings for `numba>=0.44`
+  ([#9](https://github.com/dsgibbons/shap/pull/9) and
+  [#68](https://github.com/dsgibbons/shap/pull/68) by @connortann)
 - Fixed deprecation warnings for `numpy>=1.24` from numpy types
-  ([dsgibbons#7](https://github.com/dsgibbons/shap/pull/7) by @dsgibbons).
+  ([#7](https://github.com/dsgibbons/shap/pull/7) by @dsgibbons).
 - Fixed deprecation warnings for `Ipython>=8` from `Ipython.core.display`
-  ([dsgibbons#13](https://github.com/dsgibbons/shap/pull/13) by @thatlittleboy).
+  ([#13](https://github.com/dsgibbons/shap/pull/13) by @thatlittleboy).
 - Fixed deprecation warnings for `tensorflow>=2.11` from `tf.optimisers`
-  ([dsgibbons#16](https://github.com/dsgibbons/shap/pull/16) by @simonangerbauer).
+  ([#16](https://github.com/dsgibbons/shap/pull/16) by @simonangerbauer).
 - Fixed deprecation warnings for `sklearn>=1.2` from `sklearn.linear_model`
-  ([dsgibbons#22](https://github.com/dsgibbons/shap/pull/22) by @dsgibbons).
+  ([#22](https://github.com/dsgibbons/shap/pull/22) by @dsgibbons).
 - Fixed deprecation warnings for `xgboost>=1.4` from `ntree_limit` in tree explainer
   ([#2987](https://github.com/slundberg/shap/pull/2987) by @adnene-guessoum).
+- Fixed build on Windows and MacOS
+  ([#3015](https://github.com/slundberg/shap/pull/3015) by @PrimozGodec;
+  [#3028](https://github.com/slundberg/shap/pull/3028),
+  [#3029](https://github.com/slundberg/shap/pull/3029) and
+  [#3031](https://github.com/slundberg/shap/pull/3031) by @connortann)
 
 ### Changed
 
@@ -51,37 +61,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 - Deprecated the Boston house price dataset
-  ([dsgibbons#38](https://github.com/dsgibbons/shap/pull/38) by @thatlittleboy).
+  ([#38](https://github.com/dsgibbons/shap/pull/38) by @thatlittleboy).
 - Removed the unused `mimic.py` file and `MimicExplainer` code
-  ([dsgibbons#53](https://github.com/dsgibbons/shap/pull/53) by @thatlittleboy).
+  ([#53](https://github.com/dsgibbons/shap/pull/53) by @thatlittleboy).
 
 ### Maintenance
 
 - Fixed failing unit tests
-  ([dsgibbons#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
-   [dsgibbons#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
-   [#3044](https://github.com/slundberg/shap/pull/3044) by @connortann,
-   [dsgibbons#24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
+  ([#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
+   [#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
+   [#3044](https://github.com/slundberg/shap/pull/3044) and
+   [#24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
 - Include CUDA GPU C extension files in the source distribution
   ([#3009](https://github.com/slundberg/shap/pull/3009) by @jklaise).
 - Fixed installation of package via setuptools
-  ([dsgibbons#51](https://github.com/dsgibbons/shap/pull/51) by @thatlittleboy).
+  ([#51](https://github.com/dsgibbons/shap/pull/51) by @thatlittleboy).
 - Introduced a minimal set of `ruff` linting
-  ([dsgibbons#25](https://github.com/dsgibbons/shap/pull/25),
-   [dsgibbons#26](https://github.com/dsgibbons/shap/pull/26),
-   [dsgibbons#27](https://github.com/dsgibbons/shap/pull/27),
+  ([#25](https://github.com/dsgibbons/shap/pull/25),
+   [#26](https://github.com/dsgibbons/shap/pull/26),
+   [#27](https://github.com/dsgibbons/shap/pull/27),
    [#2973](https://github.com/slundberg/shap/pull/2973),
    [#2972](https://github.com/slundberg/shap/pull/2972) and
-   [#2976](https://github.com/slundberg/shap/pull/2976) by @connortann,
+   [#2976](https://github.com/slundberg/shap/pull/2976) by @connortann;
    [#2968](https://github.com/slundberg/shap/pull/2968),
    [#2986](https://github.com/slundberg/shap/pull/2986) by @thatlittleboy).
-- Fixed wheel packaging and updated project metadata to PEP 517
+- Updated project metadata to PEP 517
   ([#3022](https://github.com/slundberg/shap/pull/3022) by @connortann)
 - Introduced more thorough testing on CI against newer dependencies
-  ([dsgibbons#61](https://github.com/dsgibbons/shap/pull/61) and
+  ([#61](https://github.com/dsgibbons/shap/pull/61) and
    [#3017](https://github.com/slundberg/shap/pull/3017)
   by @connortann)
-
+- Reduced unit test time by ~5 mins
+  ([#3046](https://github.com/slundberg/shap/pull/3046) by @connortann)
 
 ## [0.41.0] - 2022-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ into the main shap repository. PRs from this origin are labelled here as `fork#1
   DataFrame containing Categorical columns
   ([fork#88](https://github.com/dsgibbons/shap/pull/88) by @thatlittleboy).
 - Fixed sampling in `shap.datasets` to sample without replacement
-  ([#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
+  ([fork#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
 - Fixed an `UnboundLocalError` problem arising from passing a dictionary input to `shap.plots.bar`
   ([#3001](https://github.com/slundberg/shap/pull/3001) by @thatlittleboy).
   ([fork#36](https://github.com/dsgibbons/shap/pull/36) by @thatlittleboy).
@@ -86,7 +86,7 @@ into the main shap repository. PRs from this origin are labelled here as `fork#1
   ([fork#29](https://github.com/dsgibbons/shap/pull/29) by @dsgibbons,
    [fork#20](https://github.com/dsgibbons/shap/pull/20) by @simonangerbauer,
    [#3044](https://github.com/slundberg/shap/pull/3044) and
-   [#dsgibbons24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
+   [fork#24](https://github.com/dsgibbons/shap/pull/24) by @connortann).
 - Include CUDA GPU C extension files in the source distribution
   ([#3009](https://github.com/slundberg/shap/pull/3009) by @jklaise).
 - Fixed installation of package via setuptools
@@ -103,7 +103,7 @@ into the main shap repository. PRs from this origin are labelled here as `fork#1
 - Updated project metadata to PEP 517
   ([#3022](https://github.com/slundberg/shap/pull/3022) by @connortann).
 - Introduced more thorough testing on CI against newer dependencies
-  ([#dsgibbons61](https://github.com/dsgibbons/shap/pull/61) and
+  ([fork#61](https://github.com/dsgibbons/shap/pull/61) and
    [#3017](https://github.com/slundberg/shap/pull/3017)
   by @connortann)
 - Reduced unit test time by ~5 mins


### PR DESCRIPTION
Updates changelog with recent PRs, in preparation for new release.

Shortens PR URL links to just the number, to keep the changelog as readable as possible.