### PR TITLE
FIX: Remove breaking instance of ragged array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ into the main shap repository. PRs from this origin are labelled here as `fork#1
   [#3028](https://github.com/slundberg/shap/pull/3028),
   [#3029](https://github.com/slundberg/shap/pull/3029) and
   [#3031](https://github.com/slundberg/shap/pull/3031) by @connortann).
+- Fixed creation of ragged arrays in `shap.explainers.Exact`
+  ([#3064](https://github.com/slundberg/shap/pull/3064) by @connortann).
 
 ### Changed
 

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -286,7 +286,10 @@ def partition_masks(partition_tree):
             inds_list0[i] = inverse_order[inds_list0[i]]
             inds_list1[i] = inverse_order[inds_list1[i]]
 
-    return all_masks[order], np.array([[np.array(on), np.array(off)] for on,off in inds_lists])
+    # Care: inds_lists have different lengths, so partition_masks_inds is a "ragged" array. See GH #3063
+    partition_masks = all_masks[order]
+    partition_masks_inds = [[np.array(on), np.array(off)] for on, off in inds_lists]
+    return partition_masks, partition_masks_inds
 
 # TODO: this should be a jit function... which would require preallocating the inds_lists (sizes are 2**depth of that ind)
 # TODO: we could also probable avoid making the masks at all and just record the deltas if we want...


### PR DESCRIPTION
## Overview

Closes #3063

- Updates the representation of `Exact._partition_masks_inds` to be a list, rather than a numpy array. This object contains arrays with varying lengths; aka a "ragged" array. These are deprecated in numpy, and in numpy 1.24+ they throw a ValueError.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
- [x] Added entry to `CHANGELOG.md` (if changes will affect users)
