### PR TITLE
MAINT: only publish to TestPyPI on new releases, fix tag condition

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,6 +60,7 @@ jobs:
     name: Publish wheels on pypi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'created'
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -74,11 +75,10 @@ jobs:
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN  }}  # TODO: confirm this token exists (or use trusted publishing instead)
+          password: ${{ secrets.TEST_PYPI_TOKEN  }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release' && github.event.action == 'created'
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,7 +60,7 @@ jobs:
     name: Publish wheels on pypi
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'created'
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This PR fixes two issues with the `build_wheels` workflow, which I came across in our most recent release.

## Fixing the "if" condition

To determine if wheels should be published to PyPi, we currently have the condition `if: github.event_name == 'release' && github.event.action == 'created'`. However, this did not actually trigger in our most recent Release!

I'm unsure why; perhaps the syntax is outdated. For now, I've triggered an upload to PyPI with a new run of the workflow on a temporary patched branch.

This PR updates the condition to `if: startsWith(github.ref, 'refs/tags')`, as recommended by the [packaging guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/). This should trigger on any tagged commit.

## Only publishing to TestPyPI on tags

This PR also changes the `build_wheels` workflow so that releases to TestPyPI only occur when GitHub releases are made. This is closer to the previous implementation.

With the present setup, we at at risk of inadvertently breaking the release pipeline if we do some steps in the wrong order. This is a possible scenario:
- The version number is incremented to e.g. `1.2.3` , ready for a new release.
- The `build_wheels` workflow is manually triggered, to test cibuildwheel.
  - `shap 1.2.3` is published on TestPyPI
  - It is _not_ published to PyPi
- A GitHub Release `v1.2.3` is created, triggering the workflow again. The TestPyPI step fails, as `1.2.3` already exists. The workflow fails, and the wheels do not arrive at PyPI


Now, the practice of regularly releasing to TestPyPi is recommended in some places and would be a nice goal. However, for it to work we need a dynamic version scheme. For now, I'd advocate for keeping this simple and robust.
 