### PR TITLE
Fix benchmark top-level import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 <!--Changes from new PRs should be put in this section-->
 
+### Fixed
+
+- Fixed circular import issues with `shap.benchmark`
+  ([#3076](https://github.com/slundberg/shap/pull/3076) by @thatlittleboy).
+
 ## 0.42.0 - 2023-07-05
 
 This release incorporates many changes that were originally contributed by the SHAP

--- a/shap/benchmark/_compute.py
+++ b/shap/benchmark/_compute.py
@@ -1,4 +1,4 @@
-from . import BenchmarkResult
+from ._result import BenchmarkResult
 
 
 class ComputeTime():

--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -7,7 +7,7 @@ from shap import Explanation, links
 from shap.maskers import FixedComposite, Image, Text
 from shap.utils import MaskedModel, partition_tree_shuffle, safe_isinstance
 
-from . import BenchmarkResult
+from ._result import BenchmarkResult
 
 
 class ExplanationError():

--- a/shap/benchmark/_sequential.py
+++ b/shap/benchmark/_sequential.py
@@ -10,7 +10,7 @@ from shap import Explanation, links
 from shap.maskers import FixedComposite, Image, Text
 from shap.utils import MaskedModel, safe_isinstance
 
-from . import BenchmarkResult
+from ._result import BenchmarkResult
 
 
 class SequentialMasker():

--- a/tests/benchmark/test_imports.py
+++ b/tests/benchmark/test_imports.py
@@ -1,0 +1,4 @@
+def test_import():
+    # FIXME: Remove this test in the future once the follow-ups from #3076
+    # are handled.
+    import shap.benchmark  # noqa: F401


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

- Changed the import of the files within `shap/benchmark/` to be direct imports instead of importing from the `__init__.py` file.

I've tried `import shap.benchmark` locally and can verify the reported issue in #3075 is fixed.

### Note 

I thought about fixing our tests alongside this PR.  
Right now, the `tests/benchmark/*.py` aren't being collected by pytest because the filenames are not prefixed by `test_`. But the tests themselves are using a somewhat broken API, e.g. `framework` needs to be imported in `benchmark/__init__.py`, and the `SequentialPerturbation()` doesn't have a `model_score` method, etc. 

The fixes there are non-trivial and possibly involve public API changes, so I think we should leave that to a separate PR.

## Checklist

- [X] Closes #3075 <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
- [X] Added entry to `CHANGELOG.md` (if changes will affect users)
