### PR TITLE
Refactor SingleTree

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1419,8 +1419,8 @@ class SingleTree:
 
         # dictionary output from LightGBM `.dump_model()`
         elif isinstance(tree, dict) and "tree_structure" in tree:
-            start = tree['tree_structure']
-            num_parents = tree['num_leaves'] - 1
+            start = tree["tree_structure"]
+            num_parents = tree["num_leaves"] - 1
             num_nodes = 2 * num_parents + 1
             self.children_left = np.empty(num_nodes, dtype=np.int32)
             self.children_right = np.empty(num_nodes, dtype=np.int32)
@@ -1444,28 +1444,28 @@ class SingleTree:
                     right_child: dict = vertex["right_child"]
                     left_is_branch_node = "split_index" in left_child
                     if left_is_branch_node:
-                        self.children_left[vsplit_idx] = left_child['split_index']
+                        self.children_left[vsplit_idx] = left_child["split_index"]
                     else:
-                        self.children_left[vsplit_idx] = left_child['leaf_index'] + num_parents
+                        self.children_left[vsplit_idx] = left_child["leaf_index"] + num_parents
                     right_is_branch_node = "split_index" in right_child
                     if right_is_branch_node:
-                        self.children_right[vsplit_idx] = right_child['split_index']
+                        self.children_right[vsplit_idx] = right_child["split_index"]
                     else:
-                        self.children_right[vsplit_idx] = right_child['leaf_index'] + num_parents
-                    if vertex['default_left']:
+                        self.children_right[vsplit_idx] = right_child["leaf_index"] + num_parents
+                    if vertex["default_left"]:
                         self.children_default[vsplit_idx] = self.children_left[vsplit_idx]
                     else:
                         self.children_default[vsplit_idx] = self.children_right[vsplit_idx]
 
-                    self.features[vsplit_idx] = vertex['split_feature']
-                    self.thresholds[vsplit_idx] = vertex['threshold']
-                    self.values[vsplit_idx] = [vertex['internal_value']]
-                    self.node_sample_weight[vsplit_idx] = vertex['internal_count']
+                    self.features[vsplit_idx] = vertex["split_feature"]
+                    self.thresholds[vsplit_idx] = vertex["threshold"]
+                    self.values[vsplit_idx] = [vertex["internal_value"]]
+                    self.node_sample_weight[vsplit_idx] = vertex["internal_count"]
                     visited.append(vsplit_idx)
                     queue.append(left_child)
                     queue.append(right_child)
                 else:
-                    vleaf_idx: int = vertex['leaf_index'] + num_parents
+                    vleaf_idx: int = vertex["leaf_index"] + num_parents
                     self.children_left[vleaf_idx] = -1
                     self.children_right[vleaf_idx] = -1
                     self.children_default[vleaf_idx] = -1
@@ -1475,8 +1475,8 @@ class SingleTree:
                     self.children_default[vleaf_idx] = -1
                     self.features[vleaf_idx] = -1
                     self.thresholds[vleaf_idx] = -1
-                    self.values[vleaf_idx] = [vertex['leaf_value']]
-                    self.node_sample_weight[vleaf_idx] = vertex['leaf_count']
+                    self.values[vleaf_idx] = [vertex["leaf_value"]]
+                    self.node_sample_weight[vleaf_idx] = vertex["leaf_count"]
             self.values = np.asarray(self.values)
             self.values = np.multiply(self.values, scaling)
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1392,13 +1392,16 @@ class SingleTree:
             visited, queue = [], [start]
             while queue:
                 vertex = queue.pop(0)
-                if 'split_index' in vertex.keys():
+                is_branch_node = "split_index" in vertex
+                if is_branch_node:
                     if vertex['split_index'] not in visited:
-                        if 'split_index' in vertex['left_child'].keys():
+                        left_is_branch_node = "split_index" in vertex["left_child"]
+                        if left_is_branch_node:
                             self.children_left[vertex['split_index']] = vertex['left_child']['split_index']
                         else:
                             self.children_left[vertex['split_index']] = vertex['left_child']['leaf_index']+num_parents
-                        if 'split_index' in vertex['right_child'].keys():
+                        right_is_branch_node = "split_index" in vertex["right_child"]
+                        if right_is_branch_node:
                             self.children_right[vertex['split_index']] = vertex['right_child']['split_index']
                         else:
                             self.children_right[vertex['split_index']] = vertex['right_child']['leaf_index']+num_parents

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1391,7 +1391,7 @@ class SingleTree:
             self.node_sample_weight = np.empty((2*num_parents+1), dtype=np.float64)
             visited, queue = [], [start]
             while queue:
-                vertex = queue.pop(0)
+                vertex = queue.pop(0)  # TODO(perf): benchmark this against deque.popleft()
                 is_branch_node = "split_index" in vertex
                 if is_branch_node:
                     if vertex['split_index'] not in visited:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1400,8 +1400,9 @@ class SingleTree:
                     vsplit_idx: int = vertex["split_index"]
                     if vsplit_idx in visited:
                         continue
-                    left_child = vertex["left_child"]
-                    right_child = vertex["right_child"]
+
+                    left_child: dict = vertex["left_child"]
+                    right_child: dict = vertex["right_child"]
                     left_is_branch_node = "split_index" in left_child
                     if left_is_branch_node:
                         self.children_left[vsplit_idx] = left_child['split_index']
@@ -1416,6 +1417,7 @@ class SingleTree:
                         self.children_default[vsplit_idx] = self.children_left[vsplit_idx]
                     else:
                         self.children_default[vsplit_idx] = self.children_right[vsplit_idx]
+
                     self.features[vsplit_idx] = vertex['split_feature']
                     self.thresholds[vsplit_idx] = vertex['threshold']
                     self.values[vsplit_idx] = [vertex['internal_value']]
@@ -1424,7 +1426,7 @@ class SingleTree:
                     queue.append(left_child)
                     queue.append(right_child)
                 else:
-                    vleaf_idx = vertex['leaf_index'] + num_parents
+                    vleaf_idx: int = vertex['leaf_index'] + num_parents
                     self.children_left[vleaf_idx] = -1
                     self.children_right[vleaf_idx] = -1
                     self.children_default[vleaf_idx] = -1

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1395,30 +1395,31 @@ class SingleTree:
                 is_branch_node = "split_index" in vertex
                 if is_branch_node:
                     vsplit_idx: int = vertex["split_index"]
-                    if vsplit_idx not in visited:
-                        left_child = vertex["left_child"]
-                        right_child = vertex["right_child"]
-                        left_is_branch_node = "split_index" in left_child
-                        if left_is_branch_node:
-                            self.children_left[vsplit_idx] = left_child['split_index']
-                        else:
-                            self.children_left[vsplit_idx] = left_child['leaf_index'] + num_parents
-                        right_is_branch_node = "split_index" in right_child
-                        if right_is_branch_node:
-                            self.children_right[vsplit_idx] = right_child['split_index']
-                        else:
-                            self.children_right[vsplit_idx] = right_child['leaf_index'] + num_parents
-                        if vertex['default_left']:
-                            self.children_default[vsplit_idx] = self.children_left[vsplit_idx]
-                        else:
-                            self.children_default[vsplit_idx] = self.children_right[vsplit_idx]
-                        self.features[vsplit_idx] = vertex['split_feature']
-                        self.thresholds[vsplit_idx] = vertex['threshold']
-                        self.values[vsplit_idx] = [vertex['internal_value']]
-                        self.node_sample_weight[vsplit_idx] = vertex['internal_count']
-                        visited.append(vsplit_idx)
-                        queue.append(left_child)
-                        queue.append(right_child)
+                    if vsplit_idx in visited:
+                        continue
+                    left_child = vertex["left_child"]
+                    right_child = vertex["right_child"]
+                    left_is_branch_node = "split_index" in left_child
+                    if left_is_branch_node:
+                        self.children_left[vsplit_idx] = left_child['split_index']
+                    else:
+                        self.children_left[vsplit_idx] = left_child['leaf_index'] + num_parents
+                    right_is_branch_node = "split_index" in right_child
+                    if right_is_branch_node:
+                        self.children_right[vsplit_idx] = right_child['split_index']
+                    else:
+                        self.children_right[vsplit_idx] = right_child['leaf_index'] + num_parents
+                    if vertex['default_left']:
+                        self.children_default[vsplit_idx] = self.children_left[vsplit_idx]
+                    else:
+                        self.children_default[vsplit_idx] = self.children_right[vsplit_idx]
+                    self.features[vsplit_idx] = vertex['split_feature']
+                    self.thresholds[vsplit_idx] = vertex['threshold']
+                    self.values[vsplit_idx] = [vertex['internal_value']]
+                    self.node_sample_weight[vsplit_idx] = vertex['internal_count']
+                    visited.append(vsplit_idx)
+                    queue.append(left_child)
+                    queue.append(right_child)
                 else:
                     self.children_left[vertex['leaf_index']+num_parents] = -1
                     self.children_right[vertex['leaf_index']+num_parents] = -1

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1285,9 +1285,48 @@ class TreeEnsemble:
 
 
 class SingleTree:
-    """ A single decision tree.
+    """A single decision tree.
 
     The primary point of this object is to parse many different tree types into a common format.
+
+    Attributes
+    ----------
+    children_left : numpy.array
+        A 1d array of length #nodes. The index ``i`` of this array contains the index of
+        the left-child of the ``i-th`` node in the tree. An index of -1 is used to
+        represent that the ``i-th`` node is a leaf/terminal node.
+
+    children_right : numpy.array
+        Same as ``children_left``, except it contains the index of the right child of
+        each ``i-th`` node in the tree.
+
+    children_default : numpy.array
+        A 1d numpy array of length #nodes. The index ``i`` of this array contains either
+        the index of the left-child / right-child of the ``i-th`` node in the tree,
+        depending on whether the default split (for handling missing values) is left /
+        right. An index of -1 is used to represent that the ``i-th`` node is a leaf
+        node.
+
+    features : numpy.array
+        A 1d numpy array of length #nodes. The value at the ``i-th`` position is the
+        index of the feature chosen for the split at node ``i``. Leaf nodes have no
+        splits, so is -1.
+
+    thresholds : numpy.array
+        A 1d numpy array of length #nodes. The value at the ``i-th`` position is the
+        threshold used for the split at node ``i``. Leaf nodes have no thresholds, so is
+        -1.
+
+    values : numpy.array
+        A 1d numpy array of length #nodes. The index ``i`` of this array contains the
+        raw predicted value that would be produced by node ``i`` if it were a leaf node.
+
+    node_sample_weight : numpy.array
+        A 1d numpy array of length #nodes. The index ``i`` contains the number of
+        records (usually from the training data) that falls into node ``i``.
+
+    max_depth : int
+        The max depth of the tree.
     """
     def __init__(self, tree, normalize=False, scaling=1.0, data=None, data_missing=None):
         assert_import("cext")

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1421,17 +1421,18 @@ class SingleTree:
                     queue.append(left_child)
                     queue.append(right_child)
                 else:
-                    self.children_left[vertex['leaf_index']+num_parents] = -1
-                    self.children_right[vertex['leaf_index']+num_parents] = -1
-                    self.children_default[vertex['leaf_index']+num_parents] = -1
-                    self.features[vertex['leaf_index']+num_parents] = -1
-                    self.children_left[vertex['leaf_index']+num_parents] = -1
-                    self.children_right[vertex['leaf_index']+num_parents] = -1
-                    self.children_default[vertex['leaf_index']+num_parents] = -1
-                    self.features[vertex['leaf_index']+num_parents] = -1
-                    self.thresholds[vertex['leaf_index']+num_parents] = -1
-                    self.values[vertex['leaf_index']+num_parents] = [vertex['leaf_value']]
-                    self.node_sample_weight[vertex['leaf_index']+num_parents] = vertex['leaf_count']
+                    vleaf_idx = vertex['leaf_index'] + num_parents
+                    self.children_left[vleaf_idx] = -1
+                    self.children_right[vleaf_idx] = -1
+                    self.children_default[vleaf_idx] = -1
+                    self.features[vleaf_idx] = -1
+                    self.children_left[vleaf_idx] = -1
+                    self.children_right[vleaf_idx] = -1
+                    self.children_default[vleaf_idx] = -1
+                    self.features[vleaf_idx] = -1
+                    self.thresholds[vleaf_idx] = -1
+                    self.values[vleaf_idx] = [vertex['leaf_value']]
+                    self.node_sample_weight[vleaf_idx] = vertex['leaf_count']
             self.values = np.asarray(self.values)
             self.values = np.multiply(self.values, scaling)
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1394,28 +1394,31 @@ class SingleTree:
                 vertex = queue.pop(0)  # TODO(perf): benchmark this against deque.popleft()
                 is_branch_node = "split_index" in vertex
                 if is_branch_node:
-                    if vertex['split_index'] not in visited:
-                        left_is_branch_node = "split_index" in vertex["left_child"]
+                    vsplit_idx: int = vertex["split_index"]
+                    if vsplit_idx not in visited:
+                        left_child = vertex["left_child"]
+                        right_child = vertex["right_child"]
+                        left_is_branch_node = "split_index" in left_child
                         if left_is_branch_node:
-                            self.children_left[vertex['split_index']] = vertex['left_child']['split_index']
+                            self.children_left[vsplit_idx] = left_child['split_index']
                         else:
-                            self.children_left[vertex['split_index']] = vertex['left_child']['leaf_index']+num_parents
-                        right_is_branch_node = "split_index" in vertex["right_child"]
+                            self.children_left[vsplit_idx] = left_child['leaf_index'] + num_parents
+                        right_is_branch_node = "split_index" in right_child
                         if right_is_branch_node:
-                            self.children_right[vertex['split_index']] = vertex['right_child']['split_index']
+                            self.children_right[vsplit_idx] = right_child['split_index']
                         else:
-                            self.children_right[vertex['split_index']] = vertex['right_child']['leaf_index']+num_parents
+                            self.children_right[vsplit_idx] = right_child['leaf_index'] + num_parents
                         if vertex['default_left']:
-                            self.children_default[vertex['split_index']] = self.children_left[vertex['split_index']]
+                            self.children_default[vsplit_idx] = self.children_left[vsplit_idx]
                         else:
-                            self.children_default[vertex['split_index']] = self.children_right[vertex['split_index']]
-                        self.features[vertex['split_index']] = vertex['split_feature']
-                        self.thresholds[vertex['split_index']] = vertex['threshold']
-                        self.values[vertex['split_index']] = [vertex['internal_value']]
-                        self.node_sample_weight[vertex['split_index']] = vertex['internal_count']
-                        visited.append(vertex['split_index'])
-                        queue.append(vertex['left_child'])
-                        queue.append(vertex['right_child'])
+                            self.children_default[vsplit_idx] = self.children_right[vsplit_idx]
+                        self.features[vsplit_idx] = vertex['split_feature']
+                        self.thresholds[vsplit_idx] = vertex['threshold']
+                        self.values[vsplit_idx] = [vertex['internal_value']]
+                        self.node_sample_weight[vsplit_idx] = vertex['internal_count']
+                        visited.append(vsplit_idx)
+                        queue.append(left_child)
+                        queue.append(right_child)
                 else:
                     self.children_left[vertex['leaf_index']+num_parents] = -1
                     self.children_right[vertex['leaf_index']+num_parents] = -1

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1381,14 +1381,17 @@ class SingleTree:
         # dictionary output from LightGBM `.dump_model()`
         elif isinstance(tree, dict) and "tree_structure" in tree:
             start = tree['tree_structure']
-            num_parents = tree['num_leaves']-1
-            self.children_left = np.empty((2*num_parents+1), dtype=np.int32)
-            self.children_right = np.empty((2*num_parents+1), dtype=np.int32)
-            self.children_default = np.empty((2*num_parents+1), dtype=np.int32)
-            self.features = np.empty((2*num_parents+1), dtype=np.int32)
-            self.thresholds = np.empty((2*num_parents+1), dtype=np.float64)
-            self.values = [-2]*(2*num_parents+1)
-            self.node_sample_weight = np.empty((2*num_parents+1), dtype=np.float64)
+            num_parents = tree['num_leaves'] - 1
+            num_nodes = 2 * num_parents + 1
+            self.children_left = np.empty(num_nodes, dtype=np.int32)
+            self.children_right = np.empty(num_nodes, dtype=np.int32)
+            self.children_default = np.empty(num_nodes, dtype=np.int32)
+            self.features = np.empty(num_nodes, dtype=np.int32)
+            self.thresholds = np.empty(num_nodes, dtype=np.float64)
+            self.values = [-2 for _ in range(num_nodes)]
+            self.node_sample_weight = np.empty(num_nodes, dtype=np.float64)
+
+            # BFS traversal through the tree structure
             visited, queue = [], [start]
             while queue:
                 vertex = queue.pop(0)  # TODO(perf): benchmark this against deque.popleft()

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1378,7 +1378,8 @@ class SingleTree:
                 self.values = (self.values.T / self.values.sum(1)).T
             self.values = self.values * scaling
 
-        elif type(tree) == dict and 'tree_structure' in tree: # LightGBM model dump
+        # dictionary output from LightGBM `.dump_model()`
+        elif isinstance(tree, dict) and "tree_structure" in tree:
             start = tree['tree_structure']
             num_parents = tree['num_leaves']-1
             self.children_left = np.empty((2*num_parents+1), dtype=np.int32)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -11,6 +11,7 @@ import sklearn
 import sklearn.pipeline
 
 import shap
+from shap.explainers._tree import SingleTree
 from shap.utils._exceptions import InvalidModelError
 
 
@@ -769,6 +770,57 @@ def test_xgboost_buffer_strip():
     # after this fix, this line should not error
     explainer = shap.TreeExplainer(model)
     assert isinstance(explainer, shap.explainers.Tree)
+
+
+class TestSingleTree:
+    """Tests for the SingleTree class."""
+
+    def test_singletree_lightgbm_basic(self):
+        """A basic test for checking that a LightGBM dump_model() dictionary
+        is parsed properly into a SingleTree object.
+        """
+
+        # Stump (only root node) tree
+        # FIXME: this test should NOT throw a KeyError, see #2044
+        with pytest.raises(KeyError, match="leaf_index"):
+            sample_tree = {
+                "tree_index": 256,
+                "num_leaves": 1,
+                "num_cat": 0,
+                "shrinkage": 1,
+                "tree_structure": {
+                    "leaf_value": 0,
+                },
+            }
+            stree = SingleTree(sample_tree)
+            # just ensure that this does not error out
+            assert stree.children_left[0] == -1
+
+        # Depth=1 tree
+        sample_tree = {
+            "tree_index": 0,
+            "num_leaves": 2,
+            "num_cat": 0,
+            "shrinkage": 0.1,
+            "tree_structure": {
+                "split_index": 0,
+                "split_feature": 1,
+                "split_gain": 0.001471,
+                "threshold": 0,
+                "decision_type": "<=",
+                "default_left": True,
+                "missing_type": "None",
+                "internal_value": 0,
+                "internal_weight": 0,
+                "internal_count": 100,
+                "left_child": {"leaf_index": 0, "leaf_value": 0.0667, "leaf_weight": 0.00157, "leaf_count": 33},
+                "right_child": {"leaf_index": 1, "leaf_value": -0.0667, "leaf_weight": 0.00175, "leaf_count": 67},
+            },
+        }
+
+        stree = SingleTree(sample_tree)
+        # just ensure that the tree is parsed correctly
+        assert stree.node_sample_weight[0] == 100
 
 
 class TestExplainerSklearn:


### PR DESCRIPTION
## Overview

I've recently been looking into fixing the bug reported in #2044. And in doing so, I just did some refactoring to make the code (hopefully) a little cleaner and easier to understand.  
And then it should be easier to review the PR that contains the actual bug fix (coming soon).

The commits are intentionally atomic so they can be reviewed one at a time. 

Description of the changes proposed in this pull request:
- Added docstrings for `SingleTree` class, to list down the available attributes on that class + what they individually mean. Just for our collective understanding only. It's not rendered into the public API documentation.
- Added an *intentionally failing* test that demonstrates the problem in #2044. The fix will come in the next PR.
    - The other reason why I added a test is to hopefully convince that there wasn't any bugs introduced as a result of this refactor.
- There were a lot of repetitive dictionary lookups in the original implementation. I saved the lookup value into a local variable and reused it, so the code is more concise and should technically run just a tad faster (I didn't bother benchmarking).
- Refactored the if-else logic for `if vertex['split_index'] not in visited:` to use the [guard clause pattern](https://sourcery.ai/blog/explaining-refactorings-3/) (saves us 1 level of indentation).


## Checklist

- [X] Related to #2044  <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
- Added entry to `CHANGELOG.md` (if changes will affect users)
