### PR TITLE
Build macos arm64 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,4 +137,4 @@ archs = ["x86_64"]
 archs = ["AMD64"]
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64"]
+archs = ["x86_64", "arm64"]


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

SHAP does not provide arm64 wheels for MacOS, which is essential since most of modern Mac computers use this architecture. With this PR, I am enabling the building of amr64 wheels. 

I would also be very happy if arm64 wheels would be added to PyPi as soon as possible.

I ran the building process on the branch, and it successfully build arm64 wheels: https://github.com/PrimozGodec/shap/actions/runs/5504208255

## Checklist

- [ ] Closes #xxxx  <!--Replace xxxx with the GitHub issue number-->
- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
