### PR TITLE
Build wheels in parallel, add aarch64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,14 +8,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  generate-wheels-matrix:
+    # Create a matrix of all architectures & versions to build.
+    # This enables the next step to run cibuildwheel in parallel.
+    # From https://iscinumpy.dev/post/cibuildwheel-2-10-0/#only-210
+    name: Generate wheels matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install cibuildwheel
+      # Nb. keep cibuildwheel version pin consistent with job below
+        run: pipx install cibuildwheel==2.14.0
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux \
+              | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos \
+              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows \
+              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.only }}
+    needs: generate-wheels-matrix
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macOS-12]
-
+        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -27,7 +54,9 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.14.0
+        with:
+          only: ${{ matrix.only }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 <!--Changes from new PRs should be put in this section-->
 
+### Added
+
 ### Fixed
 
+### Changed
+
+### Removed
+
+## 0.42.1 - 2023-07-10
+
+Patch release to provide wheels for a broader range of architectures.
+
+- Added wheels for `linux:aarch64` and `macos:arm64`
 - Fixed circular import issues with `shap.benchmark`
   ([#3076](https://github.com/slundberg/shap/pull/3076) by @thatlittleboy).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-## 0.42.1 - 2023-07-10
+## 0.42.1 - 2023-07-11
 
 Patch release to provide wheels for a broader range of architectures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Patch release to provide wheels for a broader range of architectures.
 
 - Added wheels for `linux:aarch64` and `macos:arm64`
+  ([#3078](https://github.com/slundberg/shap/pull/3078) by @PrimozGodec and
+  [#3083](https://github.com/slundberg/shap/pull/3083) by @connortann).
 - Fixed circular import issues with `shap.benchmark`
   ([#3076](https://github.com/slundberg/shap/pull/3076) by @thatlittleboy).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,11 @@ build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
 test-extras = ["test-core", "plots"]
-# skipping cp37 since catboost wheel not available
-# skipping cp38-macosx_x86_64 because of https://github.com/catboost/catboost/issues/2371
-test-skip = "cp37-* cp38-macosx_x86_64"
+# skip tests on cp37 since catboost wheel not available
+# skip tests on cp38-macosx_x86_64 because of https://github.com/catboost/catboost/issues/2371
+# skip tests on emulated architectures, as they are very slow
+# skip tests on *-macosx_arm64 , as cibuildwheel does not support tests on arm64 (yet)
+test-skip = "cp37-* cp38-macosx_x86_64 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ skip = ["cp36-*", "pp*", "*-musllinux_*"]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
-test-extras = ["test", "plots"]
+test-extras = ["test-core", "plots"]
 # skipping cp37 since catboost wheel not available
 # skipping cp38-macosx_x86_64 because of https://github.com/catboost/catboost/issues/2371
 test-skip = "cp37-* cp38-macosx_x86_64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,7 @@ source_pkgs = ["shap"]
 combine = ["shap", "*/site-packages/shap"]
 
 [tool.cibuildwheel]
-# Restrict the set of builds to mirror the wheels available in scikit-learn. See #3028
-skip = ["cp36-*", "pp*", "*-musllinux_*"]
+skip = ["pp*", "*-musllinux_*"]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
@@ -131,7 +130,7 @@ test-extras = ["test-core", "plots"]
 test-skip = "cp37-* cp38-macosx_x86_64"
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64"]
+archs = ["x86_64", "aarch64"]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.42.0"
+__version__ = "0.42.1"
 
 from ._explanation import Explanation, Cohorts
 


### PR DESCRIPTION
This PR should prepare us for a patch release `0.42.1`. I've bumped the version number and changelog accordingly.

Changes:

- Modifies our wheel job to run in parallel, which is must faster and makes the jobs more understandable.
- Changes the cibuildwheel dependencies from `test` to `test-core`, to only run the limited test set on the built wheels.
- Adds `aarch64` on linux, closes #3061
- Skips tests on emulated architectures (which are very slow)

Example [wheel build workflow run](https://github.com/slundberg/shap/actions/runs/5540996538) (passes).

Example job matrix:

![image](https://github.com/slundberg/shap/assets/71127464/a0852ec8-36aa-49c3-9208-018f458a281e)