### PR TITLE
MAINT: Add wheels for musllinux arch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,11 @@ source_pkgs = ["shap"]
 combine = ["shap", "*/site-packages/shap"]
 
 [tool.cibuildwheel]
-skip = ["pp*", "*-musllinux_*"]
+# Restrict the set of builds to mirror the wheels available in scipy. See #3028
+# skip *-musllinux_aarch64 since numpy doesn't provid those wheels
+# skip cp38-musllinux_x86_64 since numpy never provided cp38 musllinux wheels
+#  they introduced musllinux in 1.25 when they already dropped cp38
+skip = ["pp*", "*-musllinux_aarch64", "cp38-musllinux_x86_64"]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
@@ -147,7 +151,8 @@ test-extras = ["test-core", "plots"]
 # skip tests on cp38-macosx_x86_64 because of https://github.com/catboost/catboost/issues/2371
 # skip tests on emulated architectures, as they are very slow
 # skip tests on *-macosx_arm64 , as cibuildwheel does not support tests on arm64 (yet)
-test-skip = "cp38-macosx_x86_64 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64"
+# skip tests on *-musllinux*" since llvmlite and numba do not provide musllinux wheels
+test-skip = "cp38-macosx_x86_64 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
## Overview

Compared with Scipy, SHAP will offer all wheels except musllinux in the next releases. With this PR, I am also trying to add musllinux wheels that are also available for numpy/scipy. Musllinux wheels are mostly used for containers.

Currently, I am testing wheels building here https://github.com/PrimozGodec/shap/actions/runs/5533568616, but having musllinux wheels is not as necessary as other wheels, so it is not necessary to have them in next patch release.


## Checklist

- [x] Closes #3089
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
