### PR TITLE
fix: set legend outside plot

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -294,7 +294,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
     pl.xlabel(xlabel, fontsize=13)
 
     if len(values) > 1:
-        pl.legend(fontsize=12)
+        pl.legend(fontsize=12, bbox_to_anchor=(0, 1.02, 1, 0.2))
 
     # color the y tick labels that have the feature values as gray
     # (these fall behind the black ones with just the feature name)


### PR DESCRIPTION
## Overview
Hi,

This is a small fix regarding https://github.com/slundberg/shap/issues/3047 implementing the solution proposed by [damien2012eng](https://github.com/damien2012eng) in the opened issue.

the issue had to do with the overlap of the legend box and the matplotlib plot when specifying cohorts.

It is a very minor fix that i think doesn't warrant a Changelog entry, if i am not mistaken, but it does close the issue if it is accepted.

## Checklist

- [x] Closes #3047 <!--Replace xxxx with the GitHub issue number-->
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
