### PR TITLE
FIX: remove ipython import warning from top-level shap import

### DIFF
--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -25,7 +25,7 @@ _no_matplotlib_warning = "matplotlib is not installed so plotting is not availab
 
 # plotting (only loaded if matplotlib is present)
 def unsupported(*args, **kwargs):
-    warnings.warn(_no_matplotlib_warning)
+    raise ImportError(_no_matplotlib_warning)
 
 
 class UnsupportedModule:
@@ -39,6 +39,7 @@ try:
 except ImportError:
     have_matplotlib = False
 if have_matplotlib:
+    from . import plots
     from .plots._beeswarm import summary_legacy as summary_plot
     from .plots._decision import decision as decision_plot, multioutput_decision as multioutput_decision_plot
     from .plots._scatter import dependence_legacy as dependence_plot

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -30,7 +30,7 @@ def unsupported(*args, **kwargs):
 
 class UnsupportedModule:
     def __getattribute__(self, item):
-        raise ValueError(_no_matplotlib_warning)
+        raise ImportError(_no_matplotlib_warning)
 
 
 try:

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,5 +1,4 @@
 # flake8: noqa
-import warnings
 
 __version__ = "0.42.0"
 

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -1,20 +1,20 @@
 import json
 import random
 import string
-import warnings
 from typing import Optional
 
 import matplotlib.pyplot as pl
 import numpy as np
 from matplotlib.colors import Colormap
 
-from .._explanation import Explanation
-from ..utils import ordinal_str
-
 try:
     from IPython.display import HTML, display
+    have_ipython = True
 except ImportError:
-    warnings.warn("IPython could not be loaded!")
+    have_ipython = False
+
+from .._explanation import Explanation
+from ..utils import ordinal_str
 from ..utils._legacy import kmeans
 from . import colors
 
@@ -190,6 +190,8 @@ def image_to_text(shap_values):
         for each sample
 
     """
+    if not have_ipython:
+        raise ImportError("IPython is required for this function but could not be imported")
 
     if len(shap_values.values.shape) == 5:
         for i in range(shap_values.values.shape[0]):

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -191,7 +191,11 @@ def image_to_text(shap_values):
 
     """
     if not have_ipython:
-        raise ImportError("IPython is required for this function but could not be imported")
+        msg = (
+            "IPython is required for this function but is not installed."
+            " Fix this with `pip install ipython`."
+        )
+        raise ImportError(msg)
 
     if len(shap_values.values.shape) == 5:
         for i in range(shap_values.values.shape[0]):

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -112,7 +112,7 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
                 separator=separator, xmin=xmin, xmax=xmax, cmax=cmax, display=False
             )
         if display:
-            ipython_display(HTML(out))
+            _ipython_display_html(out)
             return
         else:
             return out
@@ -211,7 +211,7 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
             out += "</div>"
         out += "</div>"
         if display:
-            ipython_display(HTML(out))
+            _ipython_display_html(out)
             return
         else:
             return out
@@ -256,7 +256,7 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
                 separator=separator, xmin=xmin, xmax=xmax, cmax=cmax, display=False
             )
         if display:
-            ipython_display(HTML(out))
+            _ipython_display_html(out)
             return
         else:
             return out
@@ -325,7 +325,7 @@ def text(shap_values, num_starting_labels=0, grouping_threshold=0.01, separator=
     out += "</div>"
 
     if display:
-        ipython_display(HTML(out))
+        _ipython_display_html(out)
         return
     else:
         return out
@@ -831,7 +831,7 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
              + "</div>" \
              + "</div>"
 
-    return ipython_display(HTML(out))
+    return _ipython_display_html(out)
 
 def text_to_text(shap_values):
 
@@ -887,7 +887,7 @@ def text_to_text(shap_values):
     </script>
     """
 
-    ipython_display(HTML(javascript + html))
+    _ipython_display_html(javascript + html)
 
 def saliency_plot(shap_values):
 
@@ -1339,3 +1339,14 @@ def unpack_shap_explanation_contents(shap_values):
     clustering = getattr(shap_values, "clustering", None)
 
     return np.array(values), clustering
+
+
+def _ipython_display_html(data):
+    """Check IPython is installed, then display HTML"""
+    if not have_ipython:
+        msg = (
+            "IPython is required for this function but is not installed."
+            " Fix this with `pip install ipython`."
+        )
+        raise ImportError(msg)
+    return ipython_display(HTML(data))


### PR DESCRIPTION
Fixes #3086

Removes the warning raised in `_image.py` if Ipython is not installed, and instead lazily raises an `ImportError` if the relevant function is called.

Also raises a more informative error in `_text.py`, where IPython's `HTML` and `display` functions may not be defined if not imported.