### PR TITLE
ENH: Explicitly define public API in modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,6 @@ ignore = [
 ]
 
 [tool.ruff.per-file-ignores]
-# Unused imports often intentional in top-level __init__.py
-"__init__.py" = ["F401"]
 # Don't apply linting/formatting to vendored code
 "shap/explainers/other/_maple.py" = ["ALL"]
 "shap/plots/colors/_colorconv.py" = ["ALL"]

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,22 +1,21 @@
-# flake8: noqa
 
 __version__ = "0.42.1"
 
-from ._explanation import Explanation, Cohorts
-
 # explainers
-from .explainers._explainer import Explainer
-from .explainers._kernel import Kernel as KernelExplainer
-from .explainers._sampling import Sampling as SamplingExplainer
-from .explainers._tree import Tree as TreeExplainer
-from .explainers._gpu_tree import GPUTree as GPUTreeExplainer
+
+from ._explanation import Cohorts, Explanation
+from .explainers import other
+from .explainers._additive import Additive as AdditiveExplainer
 from .explainers._deep import Deep as DeepExplainer
+from .explainers._explainer import Explainer
+from .explainers._gpu_tree import GPUTree as GPUTreeExplainer
 from .explainers._gradient import Gradient as GradientExplainer
+from .explainers._kernel import Kernel as KernelExplainer
 from .explainers._linear import Linear as LinearExplainer
 from .explainers._partition import Partition as PartitionExplainer
 from .explainers._permutation import Permutation as PermutationExplainer
-from .explainers._additive import Additive as AdditiveExplainer
-from .explainers import other
+from .explainers._sampling import Sampling as SamplingExplainer
+from .explainers._tree import Tree as TreeExplainer
 
 _no_matplotlib_warning = "matplotlib is not installed so plotting is not available! Run `pip install matplotlib` " \
                          "to fix this."
@@ -33,24 +32,26 @@ class UnsupportedModule:
 
 
 try:
-    import matplotlib
+    import matplotlib  # noqa: F401
     have_matplotlib = True
 except ImportError:
     have_matplotlib = False
 if have_matplotlib:
     from . import plots
+    from .plots._bar import bar_legacy as bar_plot
     from .plots._beeswarm import summary_legacy as summary_plot
-    from .plots._decision import decision as decision_plot, multioutput_decision as multioutput_decision_plot
-    from .plots._scatter import dependence_legacy as dependence_plot
-    from .plots._force import force as force_plot, initjs, save_html, getjs
+    from .plots._decision import decision as decision_plot
+    from .plots._decision import multioutput_decision as multioutput_decision_plot
+    from .plots._embedding import embedding as embedding_plot
+    from .plots._force import force as force_plot
+    from .plots._force import getjs, initjs, save_html
+    from .plots._group_difference import group_difference as group_difference_plot
     from .plots._image import image as image_plot
     from .plots._monitoring import monitoring as monitoring_plot
-    from .plots._embedding import embedding as embedding_plot
     from .plots._partial_dependence import partial_dependence as partial_dependence_plot
-    from .plots._bar import bar_legacy as bar_plot
-    from .plots._waterfall import waterfall as waterfall_plot
-    from .plots._group_difference import group_difference as group_difference_plot
+    from .plots._scatter import dependence_legacy as dependence_plot
     from .plots._text import text as text_plot
+    from .plots._waterfall import waterfall as waterfall_plot
 else:
     summary_plot = unsupported
     decision_plot = unsupported
@@ -73,13 +74,56 @@ else:
 
 
 # other stuff :)
-from . import datasets
-from . import utils
-from . import links
-
+from . import datasets, links, utils
 from .actions._optimizer import ActionOptimizer
+from .utils import approximate_interactions, sample
 
 #from . import benchmark
-
 from .utils._legacy import kmeans
-from .utils import sample, approximate_interactions
+
+# Use __all__ to let type checkers know what is part of the public API.
+__all__ = [
+    # Explanations
+    "Cohorts",
+    "Explanation",
+    "AdditiveExplainer",
+    "DeepExplainer",
+    "Explainer",
+    "GPUTreeExplainer",
+    "GradientExplainer",
+    "KernelExplainer",
+    "LinearExplainer",
+    "PartitionExplainer",
+    "PermutationExplainer",
+    "SamplingExplainer",
+    "TreeExplainer",
+    "other",
+
+    # Plots
+    "plots",
+    "initjs",
+    "getjs",
+    "save_html",
+    "bar_plot",
+    "decision_plot",
+    "dependence_plot",
+    "embedding_plot",
+    "force_plot",
+    "group_difference_plot",
+    "image_plot",
+    "monitoring_plot",
+    "multioutput_decision_plot",
+    "partial_dependence_plot",
+    "summary_plot",
+    "text_plot",
+    "waterfall_plot",
+
+    # Other stuff
+    "datasets",
+    "utils",
+    "links",
+    "ActionOptimizer",
+    "kmeans",
+    "sample",
+    "approximate_interactions",
+]

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,9 +1,9 @@
 
 __version__ = "0.42.1"
 
-# explainers
-
 from ._explanation import Cohorts, Explanation
+
+# explainers
 from .explainers import other
 from .explainers._additive import Additive as AdditiveExplainer
 from .explainers._deep import Deep as DeepExplainer
@@ -53,20 +53,22 @@ if have_matplotlib:
     from .plots._text import text as text_plot
     from .plots._waterfall import waterfall as waterfall_plot
 else:
+    bar_plot = unsupported
     summary_plot = unsupported
     decision_plot = unsupported
     multioutput_decision_plot = unsupported
-    dependence_plot = unsupported
+    embedding_plot = unsupported
     force_plot = unsupported
+    getjs = unsupported
     initjs = unsupported
     save_html = unsupported
+    group_difference_plot = unsupported
     image_plot = unsupported
     monitoring_plot = unsupported
-    embedding_plot = unsupported
     partial_dependence_plot = unsupported
-    bar_plot = unsupported
-    waterfall_plot = unsupported
+    dependence_plot = unsupported
     text_plot = unsupported
+    waterfall_plot = unsupported
     # If matplotlib is available, then the plots submodule will be directly available.
     # If not, we need to define something that will issue a meaningful warning message
     # (rather than ModuleNotFound).

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -85,9 +85,11 @@ from .utils._legacy import kmeans
 
 # Use __all__ to let type checkers know what is part of the public API.
 __all__ = [
-    # Explanations
     "Cohorts",
     "Explanation",
+
+    # Explainers
+    "other",
     "AdditiveExplainer",
     "DeepExplainer",
     "Explainer",
@@ -99,33 +101,32 @@ __all__ = [
     "PermutationExplainer",
     "SamplingExplainer",
     "TreeExplainer",
-    "other",
 
     # Plots
     "plots",
-    "initjs",
-    "getjs",
-    "save_html",
     "bar_plot",
+    "summary_plot",
     "decision_plot",
-    "dependence_plot",
+    "multioutput_decision_plot",
     "embedding_plot",
     "force_plot",
+    "getjs",
+    "initjs",
+    "save_html",
     "group_difference_plot",
     "image_plot",
     "monitoring_plot",
-    "multioutput_decision_plot",
     "partial_dependence_plot",
-    "summary_plot",
+    "dependence_plot",
     "text_plot",
     "waterfall_plot",
 
     # Other stuff
     "datasets",
-    "utils",
     "links",
+    "utils",
     "ActionOptimizer",
-    "kmeans",
-    "sample",
     "approximate_interactions",
+    "sample",
+    "kmeans",
 ]

--- a/shap/actions/__init__.py
+++ b/shap/actions/__init__.py
@@ -1,1 +1,3 @@
 from ._action import Action
+
+__all__ = ["Action"]

--- a/shap/benchmark/__init__.py
+++ b/shap/benchmark/__init__.py
@@ -2,5 +2,8 @@ from ._compute import ComputeTime
 from ._explanation_error import ExplanationError
 from ._result import BenchmarkResult
 from ._sequential import SequentialMasker
+
 # from . import framework
 # from .. import datasets
+
+__all__ = ["ComputeTime", "ExplanationError", "BenchmarkResult", "SequentialMasker"]

--- a/shap/explainers/__init__.py
+++ b/shap/explainers/__init__.py
@@ -7,5 +7,18 @@ from ._partition import Partition
 from ._permutation import Permutation
 from ._sampling import Sampling
 from ._tree import Tree
+
 # from ._gradient import Gradient
 # from ._kernel import Kernel
+
+__all__ = [
+    "Additive",
+    "Deep",
+    "Exact",
+    "GPUTree",
+    "Linear",
+    "Partition",
+    "Permutation",
+    "Sampling",
+    "Tree",
+]

--- a/shap/explainers/other/__init__.py
+++ b/shap/explainers/other/__init__.py
@@ -6,7 +6,6 @@ from ._maple import Maple, TreeMaple
 from ._random import Random
 from ._treegain import TreeGain
 
-
 __all__ = [
     "Coefficient",
     "LimeTabular",

--- a/shap/explainers/other/__init__.py
+++ b/shap/explainers/other/__init__.py
@@ -3,3 +3,12 @@ from ._lime import LimeTabular
 from ._maple import Maple, TreeMaple
 from ._random import Random
 from ._treegain import TreeGain
+
+__all__ = [
+    "Coefficent",
+    "LimeTabular",
+    "Maple",
+    "TreeMaple",
+    "Random",
+    "TreeGain",
+]

--- a/shap/maskers/__init__.py
+++ b/shap/maskers/__init__.py
@@ -6,3 +6,16 @@ from ._masker import Masker
 from ._output_composite import OutputComposite
 from ._tabular import Impute, Independent, Partition
 from ._text import Text
+
+__all__ = [
+    "Composite",
+    "Fixed",
+    "FixedComposite",
+    "Image",
+    "Masker",
+    "OutputComposite",
+    "Impute",
+    "Independent",
+    "Partition",
+    "Text",
+]

--- a/shap/models/__init__.py
+++ b/shap/models/__init__.py
@@ -3,3 +3,11 @@ from ._teacher_forcing import TeacherForcing
 from ._text_generation import TextGeneration
 from ._topk_lm import TopKLM
 from ._transformers_pipeline import TransformersPipeline
+
+__all__ = [
+    "Model",
+    "TeacherForcing",
+    "TextGeneration",
+    "TopKLM",
+    "TransformersPipeline",
+]

--- a/shap/plots/__init__.py
+++ b/shap/plots/__init__.py
@@ -1,5 +1,5 @@
 try:
-    import matplotlib
+    import matplotlib  # noqa: F401
 except ImportError:
     raise ImportError("matplotlib is not installed so plotting is not available! Run `pip install matplotlib` to fix this.")
 
@@ -18,3 +18,23 @@ from ._scatter import scatter
 from ._text import text
 from ._violin import violin
 from ._waterfall import waterfall
+
+__all__ = [
+    "bar",
+    "beeswarm",
+    "benchmark",
+    "decision",
+    "embedding",
+    "force",
+    "initjs",
+    "group_difference",
+    "heatmap",
+    "image",
+    "image_to_text",
+    "monitoring",
+    "partial_dependence",
+    "scatter",
+    "text",
+    "violin",
+    "waterfall",
+]

--- a/shap/plots/colors/__init__.py
+++ b/shap/plots/colors/__init__.py
@@ -13,3 +13,19 @@ from ._colors import (
     transparent_blue,
     transparent_red,
 )
+
+__all__ = [
+    "blue_rgb",
+    "gray_rgb",
+    "light_blue_rgb",
+    "light_red_rgb",
+    "red_blue",
+    "red_blue_circle",
+    "red_blue_no_bounds",
+    "red_blue_transparent",
+    "red_rgb",
+    "red_transparent_blue",
+    "red_white_blue",
+    "transparent_blue",
+    "transparent_red",
+]

--- a/shap/utils/__init__.py
+++ b/shap/utils/__init__.py
@@ -21,3 +21,26 @@ from ._general import (
 )
 from ._masked_model import MaskedModel, make_masks
 from ._show_progress import show_progress
+
+__all__ = [
+    "delta_minimization_order",
+    "hclust",
+    "hclust_ordering",
+    "partition_tree",
+    "partition_tree_shuffle",
+    "OpChain",
+    "approximate_interactions",
+    "assert_import",
+    "convert_name",
+    "format_value",
+    "ordinal_str",
+    "potential_interactions",
+    "record_import_error",
+    "safe_isinstance",
+    "sample",
+    "shapley_coefficients",
+    "suppress_stderr",
+    "MaskedModel",
+    "make_masks",
+    "show_progress",
+]


### PR DESCRIPTION
## Overview

Changes:

- Adds `__all__` to the various submodule `__init__.py`s, to define the public API
- Sort imports
- Enables ruff linter
  - Removes `noqa` from top level init.py
  - Removes "unused import" exception

## Motivation

According to PEP 8, we should define the public API:

> To better support introspection, modules should explicitly declare the names in their public API using the __all__ attribute.

The `__all__` variable lets type checkers know what is part of the public API, and prevents false positive ruff `unused-import` errors.