### PR TITLE
Add explicit dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/javascript/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Creates an explict dependabot configuration, as recommended in the GitHub docs.

For now, this just looks as javascript packages. In future, it could be useful if we pin dev dependencies. If we end up with too many PRs, we could configure the `groups` parameter to make dependabot do updates in bulk.

Should help get dependabot working again: since the migration to the SHAP org, the bot cannot rebase old PRs e.g. #2826