### PR TITLE
chore: start testing ngboost and gpboost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ test = [
   "xgboost",
   "lightgbm",
   "catboost",
+  "gpboost",
+  "ngboost",
   "pyspark",
   "pyod",
   "transformers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
   "lightgbm",
   "catboost",
   "gpboost",
-  "ngboost",
+  "ngboost;python_version<'3.11'",  # FIXME: pending py3.11 support
   "pyspark",
   "pyod",
   "transformers",

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -324,7 +324,7 @@ def test_gpboost():
     gpboost = pytest.importorskip("gpboost")
     # train gpboost model
     X, y = shap.datasets.california(n_points=500)
-    data_train = gpboost.Dataset(X, y, categorical_feature=[8])
+    data_train = gpboost.Dataset(X, y)
     model = gpboost.train(params={'objective': 'regression_l2', 'learning_rate': 0.1, 'verbose': 0},
                           train_set=data_train, num_boost_round=10)
 
@@ -332,7 +332,7 @@ def test_gpboost():
     ex = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
     shap_values = ex.shap_values(X)
 
-    predicted = model.predict(X, raw_score=True)
+    predicted = model.predict(X, pred_latent=True)
 
     assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
         "SHAP values don't sum to model output!"


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Added `ngboost` and `gpboost` into our test dependencies so their tests won't be skipped anymore.
* Changed the deprecated parameter `raw_score` to `pred_latent` to make tests pass.


## Checklist

- Closes #xxxx  <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- Unit tests added (if fixing a bug or adding a new feature)
- Added entry to `CHANGELOG.md` (if changes will affect users)
