### PR TITLE
fix!: Standardize the shape of `Explanation.base_values` of TreeExplainers

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -237,10 +237,14 @@ class Tree(Explainer):
             assert not self.approximate, "Approximate computation not yet supported for interaction effects!"
             v = self.shap_interaction_values(X)
 
-        # the Explanation object expects an expected value for each row
-        if hasattr(self.expected_value, "__len__"):
+        # the Explanation object expects an `expected_value` for each row
+        if hasattr(self.expected_value, "__len__") and len(self.expected_value) > 1:
+            # `expected_value` is a list / array of numbers, length k, e.g. for multi-output scenarios
+            # we repeat it N times along the first axis, so ev_tiled.shape == (N, k)
             ev_tiled = np.tile(self.expected_value, (v.shape[0], 1))
         else:
+            # `expected_value` is a scalar / array of 1 number, so we simply repeat it for every row in `v`
+            # ev_tiled.shape == (N,)
             ev_tiled = np.tile(self.expected_value, v.shape[0])
 
         # cf. GH issue dsgibbons#66, this conversion to numpy array should be done AFTER

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1033,20 +1033,20 @@ class TestExplainerSklearn:
         model = sklearn.ensemble.HistGradientBoostingClassifier(
             max_iter=10, max_depth=6
         ).fit(X, y)
+        predicted = model.predict_proba(X)
         explainer = shap.TreeExplainer(
             model, shap.sample(X, 10), model_output="predict_proba"
         )
-        shap_values = explainer.shap_values(X)
+
+        explanation = explainer(X)
+        # check the properties of Explanation object
+        num_classes = 2
+        assert explanation.values.shape == (*X.shape, num_classes)
+        assert explanation.base_values.shape == (len(X), num_classes)
 
         # check that SHAP values sum to model output
         assert (
-            np.max(
-                np.abs(
-                    shap_values[0].sum(1)
-                    + explainer.expected_value[0]
-                    - model.predict_proba(X)[:, 0]
-                )
-            )
+            np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
             < 1e-4
         )
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -733,12 +733,18 @@ class TestExplainerSklearn:
         )
         clf.fit(X_train, Y_train)
         predicted = clf.predict_proba(X_test)
-        ex = shap.TreeExplainer(clf)
-        shap_values = ex.shap_values(X_test)
+        explainer = shap.TreeExplainer(clf)
+
+        explanation = explainer(X_test)
+        # check the properties of Explanation object
+        num_classes = 2
+        assert explanation.values.shape == (*X_test.shape, num_classes)
+        assert explanation.base_values.shape == (len(X_test), num_classes)
 
         # check that SHAP values sum to model output
+        class0_exp = explanation[..., 0]
         assert (
-            np.abs(shap_values[0].sum(1) + ex.expected_value[0] - predicted[:, 0]).max()
+            np.abs(class0_exp.values.sum(1) + class0_exp.base_values - predicted[:, 0]).max()
             < 1e-4
         )
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -126,10 +126,17 @@ def _brute_force_tree_shap(tree, x):
 def _validate_shap_values(model, x_test):
     # explain the model's predictions using SHAP values
     tree_explainer = shap.TreeExplainer(model)
-    shap_values = tree_explainer.shap_values(x_test)
-    expected_values = tree_explainer.expected_value
+
+    explanation = tree_explainer(x_test)
+    # check the properties of Explanation object
+    assert explanation.values.shape == (*x_test.shape,)
+    assert explanation.base_values.shape == (x_test.shape[0],)
+
     # validate values sum to the margin prediction of the model plus expected_value
-    assert np.allclose(np.sum(shap_values, axis=1) + expected_values, model.predict(x_test))
+    assert np.allclose(
+        explanation.values.sum(1) + explanation.base_values,
+        model.predict(x_test),
+    )
 
 
 def test_ngboost():

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -849,13 +849,17 @@ class TestExplainerSklearn:
         assert (
             len(expected_values) == est.n_outputs_
         ), "Length of expected_values doesn't match n_outputs_"
-        shap_values = np.asarray(explainer.shap_values(X_test)).reshape(
-            est.n_outputs_ * X_test.shape[0], X_test.shape[1]
+
+        explanation = explainer(X_test)
+        # check the properties of Explanation object
+        assert explanation.values.shape == (*X_test.shape, est.n_outputs_)
+        assert explanation.base_values.shape == (len(X_test), est.n_outputs_)
+
+        # check that SHAP values sum to model output for all multioutputs
+        assert (
+            np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
+            < 1e-4
         )
-        phi = np.hstack(
-            (shap_values, np.repeat(expected_values, X_test.shape[0]).reshape(-1, 1))
-        )
-        assert np.allclose(phi.sum(1), predicted.flatten(order="F"), atol=1e-4)
 
     def test_sum_match_extra_trees(self):
         X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1015,11 +1015,18 @@ class TestExplainerSklearn:
         clf.fit(X_train, Y_train)
 
         predicted = clf.predict(X_test)
-        ex = shap.TreeExplainer(clf)
-        shap_values = ex.shap_values(X_test)
+        explainer = shap.TreeExplainer(clf)
+
+        explanation = explainer(X_test)
+        # check the properties of Explanation object
+        assert explanation.values.shape == (*X_test.shape,)
+        assert explanation.base_values.shape == (len(X_test),)
 
         # check that SHAP values sum to model output
-        assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4
+        assert (
+            np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
+            < 1e-4
+        )
 
     def test_HistGradientBoostingClassifier_proba(self):
         X, y = shap.datasets.adult()

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -383,10 +383,14 @@ def test_isolation_forest():
         iso.fit(X)
 
         explainer = shap.TreeExplainer(iso)
-        shap_values = explainer.shap_values(X)
+
+        explanation = explainer(X)
+        # check the properties of Explanation object
+        assert explanation.values.shape == (*X.shape,)
+        assert explanation.base_values.shape == (len(X),)
 
         path_length = _average_path_length(np.array([iso.max_samples_]))[0]
-        score_from_shap = -2 ** (-(np.sum(shap_values, axis=1) + explainer.expected_value) / path_length)
+        score_from_shap = -2 ** (-(explanation.values.sum(1) + explanation.base_values) / path_length)
         assert np.allclose(iso.score_samples(X), score_from_shap, atol=1e-7)
 
 
@@ -400,10 +404,14 @@ def test_pyod_isolation_forest():
         iso.fit(X)
 
         explainer = shap.TreeExplainer(iso)
-        shap_values = explainer.shap_values(X)
+
+        explanation = explainer(X)
+        # check the properties of Explanation object
+        assert explanation.values.shape == (*X.shape,)
+        assert explanation.base_values.shape == (len(X),)
 
         path_length = _average_path_length(np.array([iso.max_samples_]))[0]
-        score_from_shap = -2 ** (-(np.sum(shap_values, axis=1) + explainer.expected_value) / path_length)
+        score_from_shap = -2 ** (-(explanation.values.sum(1) + explanation.base_values) / path_length)
         assert np.allclose(iso.detector_.score_samples(X), score_from_shap, atol=1e-7)
 
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -281,46 +281,68 @@ def test_catboost():
     catboost = pytest.importorskip("catboost")
     # train catboost model
     X, y = shap.datasets.california(n_points=500)
-    X['IsOld'] = (X['HouseAge'] > 30).astype(str)
+    X["IsOld"] = (X["HouseAge"] > 30).astype(str)
     model = catboost.CatBoostRegressor(iterations=30, learning_rate=0.1, random_seed=123)
     p = catboost.Pool(X, y, cat_features=["IsOld"])
     model.fit(p, verbose=False, plot=False)
-
-    # explain the model's predictions using SHAP values
-    ex = shap.TreeExplainer(model)
-    shap_values = ex.shap_values(p)
-
     predicted = model.predict(X)
 
-    assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
-        "SHAP values don't sum to model output!"
+    # explain the model's predictions using SHAP values
+    explainer = shap.TreeExplainer(model)
+
+    explanation = explainer(X)
+    # check the properties of Explanation object
+    assert explanation.values.shape == (*X.shape,)
+    assert explanation.base_values.shape == (len(X),)
+
+    # check that SHAP values sum to model output
+    assert (
+        np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
+        < 1e-4
+    )
 
     X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)
     model = catboost.CatBoostClassifier(iterations=10, learning_rate=0.5, random_seed=12)
     model.fit(X, y, verbose=False, plot=False)
-    ex = shap.TreeExplainer(model)
-    shap_values = ex.shap_values(X)
-
     predicted = model.predict(X, prediction_type="RawFormulaVal")
-    assert np.abs(shap_values.sum(1) + ex.expected_value - predicted).max() < 1e-4, \
-        "SHAP values don't sum to model output!"
+
+    # explain the model's predictions using SHAP values
+    explainer = shap.TreeExplainer(model)
+
+    explanation = explainer(X)
+    # check the properties of Explanation object
+    assert explanation.values.shape == (*X.shape,)
+    assert explanation.base_values.shape == (len(X),)
+
+    # check that SHAP values sum to model output
+    assert (
+        np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
+        < 1e-4
+    )
 
 
 def test_catboost_categorical():
     catboost = pytest.importorskip("catboost")
     X, y = shap.datasets.california(n_points=500)
-    X['IsOld'] = (X['HouseAge'] > 30).astype(str)
+    X["IsOld"] = (X["HouseAge"] > 30).astype(str)
 
     model = catboost.CatBoostRegressor(100, cat_features=['IsOld'], verbose=False)
     model.fit(X, y)
-
-    explainer = shap.TreeExplainer(model)
-    shap_values = explainer.shap_values(X)
-
     predicted = model.predict(X)
 
-    assert np.abs(shap_values.sum(1) + explainer.expected_value - predicted).max() < 1e-4, \
-        "SHAP values don't sum to model output!"
+    # explain the model's predictions using SHAP values
+    explainer = shap.TreeExplainer(model)
+
+    explanation = explainer(X)
+    # check the properties of Explanation object
+    assert explanation.values.shape == (*X.shape,)
+    assert explanation.base_values.shape == (len(X),)
+
+    # check that SHAP values sum to model output
+    assert (
+        np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
+        < 1e-4
+    )
 
 
 # TODO: Test tree_limit argument

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1075,16 +1075,19 @@ class TestExplainerSklearn:
     def test_HistGradientBoostingRegressor(self):
         X, y = shap.datasets.diabetes()
         model = sklearn.ensemble.HistGradientBoostingRegressor(
-            max_iter=1000, max_depth=6
+            max_iter=500, max_depth=6
         ).fit(X, y)
+        predicted = model.predict(X)
         explainer = shap.TreeExplainer(model)
-        shap_values = explainer.shap_values(X)
+
+        explanation = explainer(X)
+        # check the properties of Explanation object
+        assert explanation.values.shape == (*X.shape,)
+        assert explanation.base_values.shape == (len(X),)
 
         # check that SHAP values sum to model output
         assert (
-            np.max(
-                np.abs(shap_values.sum(1) + explainer.expected_value - model.predict(X))
-            )
+            np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
             < 1e-4
         )
 


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* (!) Standardize the shape of `Explanation.base_values` of `TreeExplainers`, to make it more predictable. In short:
    * We will now no longer get `base_values` arrays of shape `(N,1)`, it will be of shape `(N,)` instead. Otherwise `(N,2)` etc. for multioutput models.
    * Read the background for this change below.
    * An **API-breaking** change.
* Add tests for all the major TreeExplainer types (lightgbm, xgboost, sklearn, catboost, ...) and also tried to cover regression / binary classification / multiclass classification as far as possible.
    * Tests are now **explicitly** testing for the shapes on the `.base_values` and `.values` arrays. 
    * <s>`XGBRegressor` is notably missing from the coverage here, I will add a test for this eventually when I do a overhaul of the xgboost tests. (created an issue #3123 to track this)</s>

The code change is fairly simple, but the implications are potentially big.  
To reviewers: For API breaking changes like this, I would advocate for having at least 2 members approving the PR before the merge, if possible.

---

## Background

We have received a slew of bug reports arising from the inconsistencies of the shapes of `Explanation.base_values`, which causes `IndexError` problems when users input these `Explanation` objects into our plotting functions.

See issues #2255, #2855 , #2140, #1801 for more background and in-depth diagnosis. In short, we have some tree explainers that give a `Explanation.base_values.shape` of `(N,1)` while others give `(N,)`. Which results in users having to write hacks like [this](https://github.com/shap/shap/issues/1801#issuecomment-811091856) or [this](https://github.com/shap/shap/issues/2255#issuecomment-962260490) to get around the inconsistency.

### What is the inconsistency, *exactly*?

Consider the following:

```python
import xgboost
import sklearn
import shap

X, y = shap.datasets.adult(n_points=500)

# === xgboost ===
clf = xgboost.XGBRegressor().fit(X, y)
explainer = shap.Explainer(clf)
explanation = explainer(X)
print(f"XGboost {explanation.base_values.shape=}")  # (500,)
shap.plots.waterfall(explanation[0], show=False)  # no Error!


# === sklearn ===
clf = sklearn.ensemble.RandomForestRegressor().fit(X, y)
explainer = shap.Explainer(clf)
explanation = explainer(X)
print(f"Sklearn {explanation.base_values.shape=}")  # (500,1)
shap.plots.waterfall(explanation[0], show=False)  # throws Error!
```

The code is exactly the same, only a different regressor was used. Yet one throws an error, and the other doesn't.  
See below for the list of affected models (those that used to return a basevalues shape `(N,1)` before this PR).

### What are the alternatives instead of the decisions made in this PR?

1. We can make all of our plotting functions (e.g. `shap.plots.bar`, `shap.plots.waterfall`, ...) all handle this shape inconsistency internally. But that's just a workaround which is prone to failing in the future. See an example PR here: PR #2667.
2. **Note** that only the output of `Tree.__call__()` is standardized here, not `Tree.expected_value`. Which would itself also be a breaking change itself.
    * We can definitely consider standardizing `Tree.expected_value` in the future, but this decision shouldn't make-or-break this PR.
    * The reason I didn't standardize `expected_value` of the TreeExplainer's yet is just that the changes there is potentially more complicated. We have to look into every Tree implementation and ensure the output shapes are consistent. This PR alone is sufficient to close off most of the problems that people are facing with `base_values` shape, and we can take this opportunity to educate users to use `Explanation` objects as *the standard* API instead of using the raw expected value on the Explainer.
    * There is a *related* problem where the various Tree's give inconsistent shapes of the SHAP values array. The biggest offender is the binary classification case with `XGBClassifier` and `LGBMClassifier`. The former returns a `(N,k)` array, while the latter returns a list of `(N,k)` arrays. For other examples, scan through the tests in `test_tree.py` and compare the `explanation.values.shape` across the various scenarios. I think if we ever standardize `Tree.expected_value`, it should be executed/standardized together with the `Tree.shap_values()` output.

### Which models are *actually* affected?

First of all, it's important to note that none of the other Explainers are affected, only `TreeExplainer`.  

These are the models & tests that changed from failing -> passing when we made this breaking change:

- Model: `sklearn.ensemble.GradientBoostingClassifier`
    - `tests/explainers/test_tree.py::TestExplainerSklearn::test_sum_match_gradient_boosting_classifier`
- Model: `sklearn.ensemble.GradientBoostingRegressor`
    - `tests/explainers/test_tree.py::TestExplainerSklearn::test_sum_match_gradient_boosting_regressor`
- Model: `sklearn.ensemble.HistGradientBoostingRegressor`
    - `tests/explainers/test_tree.py::TestExplainerSklearn::test_HistGradientBoostingRegressor`
-  Model: `sklearn.ensemble.IsolationForest`
    - `tests/explainers/test_tree.py::test_isolation_forest`
- Model: `pyod.models.iforest`
    - `tests/explainers/test_tree.py::test_pyod_isolation_forest`
- Model: `ngboost.NGBRegressor`
    - `tests/explainers/test_tree.py::test_ngboost`
- Model: `gpboost.GPModel`
    - `tests/explainers/test_tree.py::test_gpboost`

All of the above models & associated TreeExplainers had their `Explanation.base_values.shape` change from `(N,1)` to `(N,)`.  
As far as I could tell, the other supported Tree models are not affected.

### What is the final benefit / result?

All TreeExplainer's models should be able to run the example at the beginning of the post now, without having to fumble around with the array shapes. 🎉

## Checklist

- [X] Closes #2255, closes #2855 , closes #2140. Related to #1420, #1801. Also, we can close #2667 after this PR is merged.
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
