### PR TITLE
docs: fix the heading levels in some notebooks

### DIFF
--- a/notebooks/tabular_examples/model_agnostic/Multioutput Regression SHAP.ipynb
+++ b/notebooks/tabular_examples/model_agnostic/Multioutput Regression SHAP.ipynb
@@ -619,7 +619,7 @@
         "id": "dsqdv2hjDxcQ"
       },
       "source": [
-        "# Create Multi-Output Regression Model"
+        "## Create Multi-Output Regression Model"
       ]
     },
     {
@@ -628,7 +628,7 @@
         "id": "-V1-MOrsEuVV"
       },
       "source": [
-        "## Create Data"
+        "### Create Data"
       ]
     },
     {
@@ -698,7 +698,7 @@
         "id": "Yh04cjdtKVA6"
       },
       "source": [
-        "## Create Model"
+        "### Create Model"
       ]
     },
     {
@@ -732,7 +732,7 @@
         "id": "75BCkGTOL2UI"
       },
       "source": [
-        "## Train Model"
+        "### Train Model"
       ]
     },
     {
@@ -866,7 +866,7 @@
         "id": "N4_3msWUNvN7"
       },
       "source": [
-        "## Model Prediction"
+        "### Model Prediction"
       ]
     },
     {
@@ -913,7 +913,7 @@
         "id": "G1vnASuZPuDF"
       },
       "source": [
-        "# Get SHAP Values and Plots"
+        "## Get SHAP Values and Plots"
       ]
     },
     {
@@ -1672,7 +1672,7 @@
         "id": "TkkKvl0KOC_K"
       },
       "source": [
-        "# Reference"
+        "## Reference"
       ]
     },
     {

--- a/notebooks/tabular_examples/tree_based_models/Perfomance Comparison.ipynb
+++ b/notebooks/tabular_examples/tree_based_models/Perfomance Comparison.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Speed comparison of gradient boosting libraries for shap values calculations"
+    "# Speed comparison of gradient boosting libraries for shap values calculations"
    ]
   },
   {
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### parameters"
+    "## Parameters"
    ]
   },
   {


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Fix heading levels used in some Jupyter notebooks, to prevent them from appearing in the sidebar

Before:

<img src="https://github.com/shap/shap/assets/30731072/9a16086c-2e91-4944-abc9-fc4b62fb9cc4" width=400>

These 3 are actually subheadings in the "SHAP Values for Multi-Output Regression Models" notebook, but because they were of the same heading level as the title of the notebook, it was showing up in the sidebar.

After:

<img src="https://github.com/shap/shap/assets/30731072/5f88a9fc-69da-4f10-b23c-d9cf1e35fe62" width=400>

