### PR TITLE
fix: slice `feature_names` properly in Explanation objects with square `.values`

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -118,13 +118,13 @@ class Explanation(metaclass=MetaExplanation):
         if output_names is None and len(self.output_dims) == 1:
             output_names = [f"Output {i}" for i in range(values_shape[self.output_dims[0]])]
 
-        if len(_compute_shape(feature_names)) == 1: # TODOsomeday: should always be an alias once slicer supports per-row aliases
-            if len(values_shape) >= 1 and len(feature_names) == values_shape[0]:
-                feature_names = Alias(list(feature_names), 0)
-            elif len(values_shape) >= 2 and len(feature_names) == values_shape[1]:
+        if len(_compute_shape(feature_names)) == 1:  # TODO: should always be an alias once slicer supports per-row aliases
+            if len(values_shape) >= 2 and len(feature_names) == values_shape[1]:
                 feature_names = Alias(list(feature_names), 1)
+            elif len(values_shape) >= 1 and len(feature_names) == values_shape[0]:
+                feature_names = Alias(list(feature_names), 0)
 
-        if len(_compute_shape(output_names)) == 1: # TODOsomeday: should always be an alias once slicer supports per-row aliases
+        if len(_compute_shape(output_names)) == 1:  # TODO: should always be an alias once slicer supports per-row aliases
             output_names = Alias(list(output_names), self.output_dims[0])
             # if len(values_shape) >= 1 and len(output_names) == values_shape[0]:
             #     output_names = Alias(list(output_names), 0)

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -79,7 +79,7 @@ def test_feature_names_slicing_for_square_arrays(random_seed):
     featnames = list("abcde")
 
     exp = shap.Explanation(
-        # usually this arises as the shap values of N=6 samples, k=5 features
+        # an array of this shape typically arises as the shap values of N=6 samples, k=5 features
         values=rs.rand(6, 5),
         feature_names=featnames,
         output_names=featnames,
@@ -90,7 +90,7 @@ def test_feature_names_slicing_for_square_arrays(random_seed):
     assert column_e.feature_names == "e"
 
     exp = shap.Explanation(
-        # usually this arises as the shap values of N=5 samples, k=5 features
+        # an array of this shape typically arises as the shap values of N=5 samples, k=5 features
         values=rs.rand(5, 5),
         feature_names=featnames,
         output_names=featnames,

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -58,3 +58,40 @@ def test_explanation_hstack_errors(random_seed):
             base_values=np.ones(20) * 0.987,
         )
         _ = base_exp.hstack(exp2)
+
+
+def test_issue_2722(random_seed):
+    """Checks that feature names and output names in Explanations are properly sliced with
+    "square" arrays (N==k).
+
+    For 2D arrays, there is an ambiguity in how to assign the feature names to the slicer index.
+    E.g. if feature_names is a list of 5 elements, and the shap_values is a (5,5) array, it's ambiguous
+    whether the axis=0 or axis=1 refers to the "feature columns".
+
+    This test ensures that we give higher priority to axis=1 for the feature_names (and output_names)
+    for square arrays. Since most of the time, the 2D shap values arrays are assembled as
+    (# samples, # features).
+
+    cf. GH Issue #2722.
+    """
+    rs = np.random.RandomState(random_seed)
+    featnames = list("abcde")
+
+    exp = shap.Explanation(
+        # usually this arises as the shap values of N=5 samples, k=5 features
+        values=rs.rand(5, 5),
+        feature_names=featnames,
+        output_names=featnames,
+    )
+    first_sample = exp[0]
+    # this used to return "a" incorrectly, instead of ["a","b","c","d","e"]
+    assert first_sample.feature_names == first_sample.output_names == featnames
+
+    exp = shap.Explanation(
+        # usually this arises as the shap values of N=6 samples, k=5 features
+        values=rs.rand(6, 5),
+        feature_names=featnames,
+        output_names=featnames,
+    )
+    first_sample = exp[0]
+    assert first_sample.feature_names == first_sample.output_names == featnames

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -60,16 +60,17 @@ def test_explanation_hstack_errors(random_seed):
         _ = base_exp.hstack(exp2)
 
 
-def test_issue_2722(random_seed):
-    """Checks that feature names and output names in Explanations are properly sliced with
-    "square" arrays (N==k).
+def test_square_explanation_feature_names_slicing_issue_2699(random_seed):
+    """Checks that feature names in Explanations are properly sliced with "square"
+    arrays (N==k).
 
-    For 2D arrays, there is an ambiguity in how to assign the feature names to the slicer index.
-    E.g. if feature_names is a list of 5 elements, and the shap_values is a (5,5) array, it's ambiguous
-    whether the axis=0 or axis=1 refers to the "feature columns".
+    For 2D arrays, there is an ambiguity in how to assign the feature names to the
+    slicer index. E.g. if feature_names is a list of 5 elements, and the shap_values is
+    a (5,5) array, it's ambiguous whether the axis=0 or axis=1 refers to the "feature
+    columns".
 
-    This test ensures that we give higher priority to axis=1 for the feature_names (and output_names)
-    for square arrays. Since most of the time, the 2D shap values arrays are assembled as
+    This test ensures that we give higher priority to axis=1 for the feature_names for
+    square arrays. Since most of the time, the 2D shap values arrays are assembled as
     (# samples, # features).
 
     cf. GH Issue #2722, #2699.

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -72,10 +72,21 @@ def test_issue_2722(random_seed):
     for square arrays. Since most of the time, the 2D shap values arrays are assembled as
     (# samples, # features).
 
-    cf. GH Issue #2722.
+    cf. GH Issue #2722, #2699.
     """
     rs = np.random.RandomState(random_seed)
     featnames = list("abcde")
+
+    exp = shap.Explanation(
+        # usually this arises as the shap values of N=6 samples, k=5 features
+        values=rs.rand(6, 5),
+        feature_names=featnames,
+        output_names=featnames,
+    )
+    first_sample = exp[0]
+    assert first_sample.feature_names == first_sample.output_names == featnames
+    column_e = exp[..., "e"]
+    assert column_e.feature_names == "e"
 
     exp = shap.Explanation(
         # usually this arises as the shap values of N=5 samples, k=5 features
@@ -86,12 +97,5 @@ def test_issue_2722(random_seed):
     first_sample = exp[0]
     # this used to return "a" incorrectly, instead of ["a","b","c","d","e"]
     assert first_sample.feature_names == first_sample.output_names == featnames
-
-    exp = shap.Explanation(
-        # usually this arises as the shap values of N=6 samples, k=5 features
-        values=rs.rand(6, 5),
-        feature_names=featnames,
-        output_names=featnames,
-    )
-    first_sample = exp[0]
-    assert first_sample.feature_names == first_sample.output_names == featnames
+    column_e = exp[..., "e"]
+    assert column_e.feature_names == "e"

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -60,7 +60,8 @@ def test_explanation_hstack_errors(random_seed):
         _ = base_exp.hstack(exp2)
 
 
-def test_feature_names_slicing_for_square_arrays(random_seed):
+@pytest.mark.parametrize("N", [4, 5, 6])
+def test_feature_names_slicing_for_square_arrays(random_seed, N):
     """Checks that feature names in Explanations are properly sliced with "square"
     arrays (N==k).
 
@@ -79,24 +80,13 @@ def test_feature_names_slicing_for_square_arrays(random_seed):
     featnames = list("abcde")
 
     exp = shap.Explanation(
-        # an array of this shape typically arises as the shap values of N=6 samples, k=5 features
-        values=rs.rand(6, 5),
+        # an array of this shape typically arises as the shap values of N samples, k=5 features
+        values=rs.rand(N, 5),
         feature_names=featnames,
         output_names=featnames,
     )
     first_sample = exp[0]
-    assert first_sample.feature_names == first_sample.output_names == featnames
-    column_e = exp[..., "e"]
-    assert column_e.feature_names == "e"
-
-    exp = shap.Explanation(
-        # an array of this shape typically arises as the shap values of N=5 samples, k=5 features
-        values=rs.rand(5, 5),
-        feature_names=featnames,
-        output_names=featnames,
-    )
-    first_sample = exp[0]
-    # this used to return "a" incorrectly, instead of ["a","b","c","d","e"]
+    # exp[0] used to return "a" incorrectly when N=5 here, instead of ["a","b","c","d","e"]
     assert first_sample.feature_names == first_sample.output_names == featnames
     column_e = exp[..., "e"]
     assert column_e.feature_names == "e"

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -60,7 +60,7 @@ def test_explanation_hstack_errors(random_seed):
         _ = base_exp.hstack(exp2)
 
 
-def test_square_explanation_feature_names_slicing_issue_2699(random_seed):
+def test_feature_names_slicing_for_square_arrays(random_seed):
     """Checks that feature names in Explanations are properly sliced with "square"
     arrays (N==k).
 


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

* Ensures that we slice `feature_names` **correctly** in Explanation objects with "square" `.values` ("square" := the shap values array has the same number of feature columns as number of samples).
* Add a test to ensure we don't have regressions in the future.

### Explanation

First, some background. For 2D arrays, there is an ambiguity in how to assign the feature names to the slicer index.
E.g. if `feature_names` is a list of 5 elements, say `[a,b,c,d,e]`, and the `shap_values` is a (5,5) array, it's ambiguous
whether the axis=0 or axis=1 in `shap_values` refers to the "feature columns".

Previously, the code assigned `axis=0` with higher priority. This causes problems like #2722 because when users index into the explanation object like `explanation[0]` expecting to get the first sample's shap values / data (e.g. for inputting into waterfall plot),  
`Slicer` would slice this `[0]` into axis=0, which it incorrectly assumes to be the `.feature_names`.
This means that the resulting Explanation object's `.feature_names` would be (`a` == `feature_names[0]`) instead of the full `feature_names[:]` array.

See the test code for an explicit example.

This PR changes such that at least for 2+ dimensional square arrays, we always assume the feature column is on axis=1 instead of axis=0. I believe this to be a more reasonable assumption.
Since most of the time, the 2D shap values arrays are assembled as (# samples, # features).

For non-square arrays, there's no change, since there is no ambiguity which axis the `feature_names` array should refer to (obviously, it would be the axis with the same length as `feature_names`).

## Checklist

- [X] Closes #2699, closes #2722, closes #2394 <!--Replace xxxx with the GitHub issue number-->
- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
- [ ] Added entry to `CHANGELOG.md` (if changes will affect users)
