### PR TITLE
MAINT: Fix path filter issue, move linter to seperate workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: lint
+
+on:
+    push:
+      branches:
+        - master
+    pull_request:
+      branches:
+        - master
+
+jobs:
+    precommit-check:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,16 +20,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  linting:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - uses: pre-commit/action@v3.0.0
-
   run_tests:
     strategy:
       matrix:


### PR DESCRIPTION
## Overview

An unintended side-effect of implementing workflow-level path filters for the unit tests on #3107 is that the precommit linter no longer runs on all PRs.

This PR address that my moving the linter to a seperate workflow, that runs regardless of the path filter.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
