### PR TITLE
Update deprecated d3.mouse, and update deprecated webpack content-base

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "jest --verbose ./tests",
-    "dev": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack-dev-server --content-base build/ --open",
+    "dev": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack-dev-server --open",
     "build": "export SET NODE_OPTIONS=--openssl-legacy-provider && webpack --mode production",
     "pub": "export SET NODE_OPTIONS=--openssl-legacy-provider && npm run build && npm publish"
   },

--- a/javascript/visualizers/AdditiveForceArrayVisualizer.jsx
+++ b/javascript/visualizers/AdditiveForceArrayVisualizer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { select, mouse } from "d3-selection";
+import { select, pointer } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { format } from "d3-format";
 import { timeFormat, timeParse } from "d3-time-format";
@@ -148,7 +148,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
     this.xlabel.node().onchange = () => this.internalDraw();
     this.ylabel.node().onchange = () => this.internalDraw();
 
-    this.svg.on("mousemove", x => this.mouseMoved(x));
+    this.svg.on("mousemove", event => this.mouseMoved(event));
     this.svg.on("click", () => alert("This original index of the sample you clicked is " + this.nearestExpIndex));
 
     this.svg.on("mouseout", x => this.mouseOut(x));
@@ -174,7 +174,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
     this.hoverGroup2.attr("display", "none");
   }
 
-  mouseMoved() {
+  mouseMoved(event) {
     let i, nearestExp;
 
     this.hoverLine.attr("display", "");
@@ -186,7 +186,7 @@ class AdditiveForceArrayVisualizer extends React.Component {
     this.hoverGroup1.attr("display", "");
     this.hoverGroup2.attr("display", "");
 
-    let x = mouse(this.svg.node())[0];
+    let x = pointer(event, this.svg.node())[0];
     if (this.props.explanations) {
 
       // Find the nearest explanation to the cursor position

--- a/javascript/webpack.config.js
+++ b/javascript/webpack.config.js
@@ -34,7 +34,10 @@ module.exports = [
       filename: "[name].js"
     },
     module: moduleConfig,
-    resolve: resolveConfig
+    resolve: resolveConfig,
+    devServer: {
+      static: buildDir
+    }
   },
   {
     entry: {


### PR DESCRIPTION
## Overview

Fixes two issues caused by breaking changes in our dependencies:

- Updates a D3 callback in `AdditiveForceArrayVisualizer`
   - Fixes #3132.
   - Switched to `d3.pointer` rather than the deprecated `d3.mouse`.
   - Breaking change was caused by #3114
- Updates the use of `webpack` in dev server 
   - Remove deprecated `--content-base` CLI flag, instead set `static` config value
   - Fixes breaking change caused by #3130

Both issues were not caught by our CI/CD, which is currently very basic. So, I'm interested in any ideas on how we can improve the tests to catch similar issues in future.

Changes were also manually tested, following steps outlined in #3122.