### PR TITLE
FIX: waterfall plot on explanations of sklearn tree models

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -67,7 +67,7 @@ def waterfall(shap_values, max_display=10, show=True):
         )
         raise ValueError(emsg)
 
-    base_values = shap_values.base_values
+    base_values = float(shap_values.base_values)
     features = shap_values.display_data if shap_values.display_data is not None else shap_values.data
     feature_names = shap_values.feature_names
     lower_bounds = getattr(shap_values, "lower_bounds", None)

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -1,6 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import pytest
+from sklearn.tree import DecisionTreeRegressor
 
 import shap
 
@@ -43,3 +45,14 @@ def test_waterfall_legacy(explainer):
     shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0])
     plt.tight_layout()
     return fig
+
+
+def test_waterfall_plot_for_decision_tree_explanation():
+    # Regression tests for GH issue #3129
+    X = pd.DataFrame({"A": [1, 2, 3], "B": [2, 1, 3]})
+    y = pd.Series([1, 2, 3])
+    model = DecisionTreeRegressor()
+    model.fit(X, y)
+    explainer = shap.TreeExplainer(model)
+    explanation = explainer(X)
+    shap.plots.waterfall(explanation[0], show=False)


### PR DESCRIPTION
Fixes waterfall plot when used on explanations made by sklearn trees.

- Closes #3129
- Related #3121