### PR TITLE
sklearn column-vector fix

### DIFF
--- a/tests/explainers/test_linear.py
+++ b/tests/explainers/test_linear.py
@@ -183,7 +183,7 @@ def test_sparse():
 
     # train linear model
     model = LogisticRegression()
-    model.fit(X, y)
+    model.fit(X, y.squeeze())
 
     # explain the model's predictions using SHAP values
     explainer = shap.LinearExplainer(model, X)


### PR DESCRIPTION
## Overview

Closes corresponding task in #3066  

Description of the changes proposed in this pull request:
The warning `  A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().` come from the line with `model.fit`.
The target vector is now squeezed to make sure there is no extra dimension.


## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
