### PR TITLE
FIX: 1-d-numpy and pd input for gradient explainer

### DIFF
--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -77,7 +77,7 @@ class Gradient(Explainer):
         if isinstance(data, pd.DataFrame):
             self.features = data.columns.values
         else:
-            self.features = list(range(data[0].shape[1]))
+            self.features = None
 
         if framework == 'tensorflow':
             self.explainer = _TFGradient(model, data, session, batch_size, local_smoothing)
@@ -177,6 +177,8 @@ class _TFGradient(Explainer):
         if type(self.model_inputs) != list:
             self.model_inputs = [self.model_inputs]
         self.multi_input = len(self.model_inputs) > 1
+        if isinstance(data, pd.DataFrame):
+            data = [data.values]
         if type(data) != list:
             data = [data]
 

--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -1,6 +1,7 @@
 from urllib.error import HTTPError
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import shap
@@ -272,13 +273,10 @@ def test_pytorch_multiple_inputs(random_seed):
     d = np.abs(sums - diff).sum()
     assert d / (np.abs(diff).sum()+0.01) < 0.1, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())
 
-def test_tf_pd_input(random_seed):
-    """ Test tabular (batch_size, features) pd.DataFrame input. """
-    pd = pytest.importorskip('pandas')
+@pytest.mark.parametrize("input_type", ["numpy", "dataframe"])
+def test_tf_input(random_seed, input_type):
+    """ Test tabular (batch_size, features) pd.DataFrame and numpy input. """
     tf = pytest.importorskip('tensorflow')
-    import pandas as pd
-    import tensorflow as tf
-
     tf.random.set_seed(random_seed)
 
     batch_size = 10
@@ -286,7 +284,8 @@ def test_tf_pd_input(random_seed):
     feature_names = [f"TF_pd_test_feature_{i}" for i in range(num_features)]
 
     background = np.zeros((batch_size, num_features))
-    background = pd.DataFrame(background, columns=feature_names)
+    if input_type == "dataframe":
+        background = pd.DataFrame(background, columns=feature_names)
     x1 = np.ones((batch_size, num_features))
 
     model = tf.keras.Sequential([
@@ -295,38 +294,16 @@ def test_tf_pd_input(random_seed):
     ])
     model.compile(optimizer='adam', loss='mse')
 
-    # testing pd input
     e = shap.GradientExplainer(model, background)
     shap_values = e.shap_values(x1[:1])
 
-    diff = (model.predict(x1[:1]) - model.predict(background.values)).mean(0)
-    sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
-    d = np.abs(sums - diff).sum()
-    assert d / (np.abs(diff).sum() + 0.01) < 0.1, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())
+    if input_type == "dataframe":
+        diff = (model.predict(x1[:1]) - model.predict(background.values)).mean(0)
+    elif input_type == "numpy":
+        diff = (model.predict(x1[:1]) - model.predict(background)).mean(0)
+    else:
+        raise NotImplementedError("Input type %s not implemented" % input_type)
 
-def test_tf_np_input(random_seed):
-    """ Test tabular (batch_size, features) np.array input. """
-    tf = pytest.importorskip('tensorflow')
-    import tensorflow as tf
-    tf.random.set_seed(random_seed)
-
-    batch_size = 10
-    num_features = 5
-
-    background = np.zeros((batch_size, num_features))
-    x1 = np.ones((batch_size, num_features))
-
-    model = tf.keras.Sequential([
-        tf.keras.layers.Dense(10, input_shape=(num_features,), activation='relu'),
-        tf.keras.layers.Dense(1, activation='linear')
-    ])
-    model.compile(optimizer='adam', loss='mse')
-
-    # testing pd input
-    e = shap.GradientExplainer(model, background)
-    shap_values = e.shap_values(x1[:1])
-
-    diff = (model.predict(x1[:1]) - model.predict(background)).mean(0)
     sums = np.array([shap_values[i].sum() for i in range(len(shap_values))])
     d = np.abs(sums - diff).sum()
     assert d / (np.abs(diff).sum() + 0.01) < 0.1, "Sum of SHAP values does not match difference! %f" % (d / np.abs(diff).sum())


### PR DESCRIPTION
## Overview

Closes #3152, #2607 (#3025)

Description of the changes proposed in this pull request:

#3152 is fixed by simply converting a pd.Dataframe to its underlying np.array in `_TFGradient` (after setting the feature names in `Gradient`).

#2607 (#3025) seemed stale, so I figured I'd close that by simply setting the feature_names to None if there is no pd.Dataframe provided. It seems like the labels are set by the plots if the feature names are None, so there is no need to set them to a list of numbers here. 
Additionaly, an extra parameter can be added here for the feature names (like some explainers already do). But I am unsure whether, going forward, you would want to keep that logic in the plots themselves only.

Added two unit tests for simple pd and np 1-d inputs.

Let me know if anything needs changing.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
