### PR TITLE
MAINT: fixup overly permissive regex pattern

### DIFF
--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -221,7 +221,7 @@ class Text(Masker):
         # convert the text segments to tokens that the partition tree function expects
         tokens = []
         space_end = re.compile(r"^.*\W$")
-        letter_start = re.compile(r"^[A-z]")
+        letter_start = re.compile(r"^[A-Za-z]")
         for i, v in enumerate(self._segments_s):
             if i > 0 and space_end.match(self._segments_s[i-1]) is None and letter_start.match(v) is not None and tokens[i-1] != "":
                 tokens.append("##" + v.strip())


### PR DESCRIPTION
## Overview

Fixes a Code Scanning alert (38). A very small change. I don't see any security risk in this instance, so fixing this alert is just housekeeping.

From the code scanning alert:

> It's easy to write a regular expression range that matches a wider range of characters than you intended.
> For example, `[a-zA-z]` matches all lowercase and all uppercase letters, as you would expect, but it also matches the characters: `[ \ ] ^ _ `.`

> See https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html

