### PR TITLE
DOCS: Fix failing ReadTheDocs build, pin Sphinx dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ docs = [
   "ipython",
   "numpydoc",
   "sphinx_rtd_theme",
-  "sphinx",
+  "sphinx<7",
   "nbsphinx",
   "sphinx_github_changelog",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,10 @@ docs = [
   "matplotlib",
   "ipython",
   "numpydoc",
-  "sphinx_rtd_theme",
-  "sphinx<7",
-  "nbsphinx",
-  "sphinx_github_changelog",
+  "sphinx_rtd_theme==0.4.3",
+  "sphinx==6.2.1",
+  "nbsphinx==0.9.2",
+  "sphinx_github_changelog==1.2.1",
   "requests",
 ]
 test-core = ["pytest", "pytest-mpl", "pytest-cov"]


### PR DESCRIPTION
I noticed the docs have started failing unexpectedly. It seems the issue is that the theme we use is not compatible with Sphinx v7.

Related:

- https://github.com/readthedocs/readthedocs.org/issues/10279
- https://github.com/readthedocs/sphinx_rtd_theme/issues/1463

As a fix, this pins the sphinx packages dependencies to a recent working version.

For reference, there are suggestions on reproducible builds in the ReadTheDocs [guide to reproducible builds](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html].

Alternatively, we could consider switching to a Sphinx theme that is apparently better supported, like [furo](https://github.com/pradyunsg/furo)