### PR TITLE
MAINT: address Matplotlib deprecation warnings in test suite

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -91,7 +91,7 @@ class Kernel(Explainer):
         self.link = convert_to_link(link)
         self.keep_index = kwargs.get("keep_index", False)
         self.keep_index_ordered = kwargs.get("keep_index_ordered", False)
-        self.model = convert_to_model(model, self.keep_index)
+        self.model = convert_to_model(model, keep_index=self.keep_index)
         self.data = convert_to_data(data, keep_index=self.keep_index)
         model_null = match_model_to_data(self.model, self.data)
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -89,9 +89,9 @@ class Kernel(Explainer):
 
         # convert incoming inputs to standardized iml objects
         self.link = convert_to_link(link)
-        self.model = convert_to_model(model)
         self.keep_index = kwargs.get("keep_index", False)
         self.keep_index_ordered = kwargs.get("keep_index_ordered", False)
+        self.model = convert_to_model(model, self.keep_index)
         self.data = convert_to_data(data, keep_index=self.keep_index)
         model_null = match_model_to_data(self.model, self.data)
 

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -97,7 +97,7 @@ class Model:
         self.out_names = out_names
 
 
-def convert_to_model(val):
+def convert_to_model(val, keep_index=False):
     if isinstance(val, Model):
         out = val
     else:
@@ -105,11 +105,12 @@ def convert_to_model(val):
 
     # Fix for the sklearn warning
     # 'X does not have valid feature names, but <model> was fitted with feature names'
-    f_self = getattr(out.f, "__self__", None)
-    if f_self and hasattr(f_self, "feature_names_in_"):
-        # Make a copy so that the feature names are not removed from the original model
-        out = copy.deepcopy(out)
-        out.f.__self__.feature_names_in_ = None
+    if not keep_index: # when using keep index, a dataframe with expected features names is expected to be passed
+        f_self = getattr(out.f, "__self__", None)
+        if f_self and hasattr(f_self, "feature_names_in_"):
+            # Make a copy so that the feature names are not removed from the original model
+            out = copy.deepcopy(out)
+            out.f.__self__.feature_names_in_ = None
 
     return out
 

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -98,6 +98,17 @@ class Model:
 
 
 def convert_to_model(val, keep_index=False):
+    """ Convert a model to a Model object.
+
+    Parameters
+    ----------
+    val : function or Model object
+        The model function or a Model object.
+
+    keep_index : bool
+        If True then the index values will be passed to the model function as the first argument.
+        When this is False the feature names will be removed from the model object to avoid unnecessary warnings.
+    """
     if isinstance(val, Model):
         out = val
     else:


### PR DESCRIPTION
## Overview

Closes corresponding task in #3066  

Description of the changes proposed in this pull request:
Address the warning:  
`tests/explainers/test_kernel.py: 21 warnings
  X has feature names, but LinearRegression was fitted without feature names`  
When using `keep_index` argument, features names was deleted by the function `convert_to_model`.
This argument is passed to the function to avoid this behavior.

## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)