### PR TITLE
MAINT: Remove deprecated system_packages from RtD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,4 +13,3 @@ python:
       path: .
       extra_requirements:
         - docs
-  system_packages: true


### PR DESCRIPTION
## Overview

Removes the deprecated key `system_packages` from `.readthedocs.yml`

## Context

From a ReadTheDocs email:

> Read the Docs used to pre-install common scientific Python packages like scipy, numpy, pandas, matplotlib and others at system level to speed up the build process. However, with all the work done in the Python ecosystem and the introduction of "wheels", these packages are a lot easier to install via pip install and these pre-installed packages are not required anymore. If you have Apt package dependencies, they can be installed with build.apt_packages.
>
> With the introduction of our new "Ubuntu 20.04" and "Ubuntu 22.04" Docker images, we stopped pre-installing these extra Python packages and we encouraged users to install and pin all their dependencies using a requirements.txt file. We have already stopped supporting "use system packages" on these newer images.
>
> We are removing the "use system packages" feature on August 29th. Make sure you are installing all the required dependecies to build your project's documentation using a requirements.txt file and specifying it in your .readthedocs.yaml.
