### PR TITLE
DOCS: Fixup sidebar, add captions and restore logo

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,6 +47,7 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf generated/*
 
 .PHONY: html
 html:

--- a/docs/api_examples.rst
+++ b/docs/api_examples.rst
@@ -44,11 +44,12 @@ models
 
 Work in progress.
 
-.. toctree::
-    :glob:
-    :maxdepth: 1
+.. TODO: Uncomment this toctree once we have at least one example to share
+    .. toctree::
+        :glob:
+        :maxdepth: 1
 
-    example_notebooks/api_examples/models/*
+        example_notebooks/api_examples/models/*
 
 
 .. _plots_examples:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,18 +26,31 @@ SHAP can be installed from either `PyPI <https://pypi.org/project/shap>`_ or
    conda install -c conda-forge shap
 
 
-Contents
-========
+.. toctree::
+   :maxdepth: 2
+   :caption: Introduction
+
+   Topical overviews <overviews>
 
 .. toctree::
    :maxdepth: 2
+   :caption: Examples
 
-   Topical overviews <overviews>
    Tabular examples <tabular_examples>
    Text examples <text_examples>
    Image examples <image_examples>
    Genomic examples <genomic_examples>
-   Benchmarks <benchmarks>
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
    API reference <api>
    API examples <api_examples>
+   Benchmarks <benchmarks>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Releases
+
    Release notes <release_notes>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,5 @@ SHAP can be installed from either `PyPI <https://pypi.org/project/shap>`_ or
 
 .. toctree::
    :maxdepth: 1
-   :caption: Releases
 
    Release notes <release_notes>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ docs = [
   "matplotlib",
   "ipython",
   "numpydoc",
-  "sphinx_rtd_theme==0.4.3",
+  "sphinx_rtd_theme==1.2.2",
   "sphinx==6.2.1",
   "nbsphinx==0.9.2",
   "sphinx_github_changelog==1.2.1",


### PR DESCRIPTION
## Overview

A few improvements and fixes to the navigation sidebar in the docs:

- Gets the logo working again, by updating the pinned version of sphinx_rtd_theme.
- Splits the top-level toctree into a few subsections, to help make the documentation a bit more navigable.
- Reduces the `maxdepth` parameter of the Release Notes, to avoid cluttering the top level Index page

Plus two minor fixes whilst we're at it:

- Updates `make clean` to ensure it cleans up the `generated` directory
- Comments out an empty `toctree` directive, to fix a warning in the Sphinx build

## Motivation

I'm inspired by the <https://documentation.divio.com> system for clearly separating different types of documentation:

- "Explanation", in our case the Topical Overviews
- "How-to guides", in our case the Examples
- "Reference", the API references and API examples (and I think the Benchmarks?)
- "Tutorials", which we don't really have

## Screenshots

Before:

![image](https://github.com/shap/shap/assets/71127464/ebad25f6-01fc-4908-a10a-7790f148cf9a)

After:

![image](https://github.com/shap/shap/assets/71127464/2fa0ad83-2710-4083-b98b-f06932652ca0)

