### PR TITLE
MAINT: address pyspark deprecation warnings in test suite

### DIFF
--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -247,7 +247,7 @@ def test_pyspark_classifier_decision_tree(configure_pyspark_python):
         X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[  # pylint: disable=E1101
             :100]
 
-        shap_values = explainer.shap_values(X)
+        shap_values = explainer.shap_values(X, check_additivity=False)
         expected_values = explainer.expected_value
 
         predictions = model.transform(iris).select("rawPrediction").rdd.map(
@@ -300,7 +300,7 @@ def test_pyspark_regression_decision_tree(configure_pyspark_python):
         explainer = shap.TreeExplainer(model)
         X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop('sepal length (cm)', axis=1)[:100] # pylint: disable=E1101
 
-        shap_values = explainer.shap_values(X)
+        shap_values = explainer.shap_values(X, check_additivity=False)
         expected_values = explainer.expected_value
 
         # validate values sum to the margin prediction of the model plus expected_value


### PR DESCRIPTION
…rk tests, as it is not handled.

## Overview

Closes #3066  <!--Add issue number here, or delete as appropriate-->

## Description of the changes proposed in this pull request:  

Address Pyspark check_additivity
```
tests/explainers/test_tree.py::test_pyspark_classifier_decision_tree
tests/explainers/test_tree.py::test_pyspark_classifier_decision_tree
tests/explainers/test_tree.py::test_pyspark_classifier_decision_tree
tests/explainers/test_tree.py::test_pyspark_regression_decision_tree
tests/explainers/test_tree.py::test_pyspark_regression_decision_tree
tests/explainers/test_tree.py::test_pyspark_regression_decision_tree
  check_additivity requires us to run predictions which is not supported with spark, ignoring. Set check_additivity=False to remove this warning
```
Argument `check_additivity=False` has been added.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
