### PR TITLE
Replaced all tqdm imports with tqdm.auto

### DIFF
--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -1,7 +1,7 @@
 import time
 
 import numpy as np
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from shap import Explanation, links
 from shap.maskers import FixedComposite, Image, Text

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 import sklearn.utils
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 _remove_cache = {}
 def remove_retrain(nmask, X_train, y_train, X_test, y_test, attr_test, model_generator, metric, trained_model, random_state):

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 from scipy.sparse import issparse
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 from .. import links, maskers
 from ..utils import safe_isinstance


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

I replaced all tqdm imports in modules with [tqdm.auto](https://tqdm.github.io/docs/shortcuts/#tqdmauto) so they wouldn't raise warnings when importing shap in a notebook environment. This was the old warning I was trying to resolve:

![image](https://github.com/shap/shap/assets/12672027/312abe13-f8e8-4327-a98c-14c9cd9aeabb)

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
