### PR TITLE
Enh: deprecate legacy plots and code

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -373,7 +373,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 
 #     return max(left_val, right_val) + 1, max(left_sum, right_sum)
 
-@deprecated("bar_legacy is being deprecated in Version 0.43.0")
+@deprecated("bar_legacy is being deprecated in Version 0.43.0. This will be removed in Version 0.44")
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):
 
     # unwrap pandas series

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as pl
 import numpy as np
 import scipy
+from sklearn.utils import deprecated
 
 from .. import Cohorts, Explanation
 from ..utils import format_value, ordinal_str
@@ -372,6 +373,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 
 #     return max(left_val, right_val) + 1, max(left_sum, right_sum)
 
+@deprecated("bar_legacy is being deprecated in Version 0.43.0")
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):
 
     # unwrap pandas series

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -436,7 +436,7 @@ def is_color_map(color):
 
 # TODO: remove unused title argument / use title argument
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
-@deprecated("summary_legacy is being deprecated in Version 0.43.0")
+@deprecated("summary_legacy is being deprecated in Version 0.43.0. This will be removed in Version 0.44")
 def summary_legacy(shap_values, features=None, feature_names=None, max_display=None, plot_type=None,
                  color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
                  color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -9,6 +9,7 @@ import scipy.cluster
 import scipy.sparse
 import scipy.spatial
 from scipy.stats import gaussian_kde
+from sklearn.utils import deprecated
 
 from .. import Explanation
 from ..utils import safe_isinstance
@@ -435,6 +436,7 @@ def is_color_map(color):
 
 # TODO: remove unused title argument / use title argument
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
+@deprecated("summary_legacy is being deprecated in Version 0.43.0")
 def summary_legacy(shap_values, features=None, feature_names=None, max_display=None, plot_type=None,
                  color=None, axis_color="#333333", title=None, alpha=1, show=True, sort=True,
                  color_bar=True, plot_size="auto", layered_violin_max_num_bins=20, class_names=None,

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -471,7 +471,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
             warnings.simplefilter("ignore", RuntimeWarning)
             pl.show()
 
-@deprecated("dependence_legacy is being deprecated in Version 0.43.0")
+@deprecated("dependence_legacy is being deprecated in Version 0.43.0. This will be removed in Version 0.44")
 def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, display_features=None,
                       interaction_index="auto",
                       color="#1E88E5", axis_color="#333333", cmap=None,

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -3,6 +3,7 @@ import warnings
 import matplotlib
 import matplotlib.pyplot as pl
 import numpy as np
+from sklearn.utils import deprecated
 
 from .._explanation import Explanation
 from ..utils import approximate_interactions, convert_name
@@ -470,7 +471,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
             warnings.simplefilter("ignore", RuntimeWarning)
             pl.show()
 
-
+@deprecated("dependence_legacy is being deprecated in Version 0.43.0")
 def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, display_features=None,
                       interaction_index="auto",
                       color="#1E88E5", axis_color="#333333", cmap=None,

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -1,6 +1,7 @@
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from sklearn.utils import deprecated
 
 from .. import Explanation
 from ..utils import format_value, safe_isinstance
@@ -317,7 +318,7 @@ def waterfall(shap_values, max_display=10, show=True):
     else:
         return plt.gcf()
 
-
+@deprecated("waterfall_legacy is being deprecated in Version 0.43.0")
 def waterfall_legacy(expected_value, shap_values=None, features=None, feature_names=None, max_display=10, show=True):
     """ Plots an explanation of a single prediction as a waterfall plot.
 

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -318,7 +318,7 @@ def waterfall(shap_values, max_display=10, show=True):
     else:
         return plt.gcf()
 
-@deprecated("waterfall_legacy is being deprecated in Version 0.43.0")
+@deprecated("waterfall_legacy is being deprecated in Version 0.43.0. This will be removed in Version 0.44")
 def waterfall_legacy(expected_value, shap_values=None, features=None, feature_names=None, max_display=10, show=True):
     """ Plots an explanation of a single prediction as a waterfall plot.
 

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -5,8 +5,10 @@ import pandas as pd
 import scipy.sparse
 from sklearn.cluster import KMeans
 from sklearn.impute import SimpleImputer
+from sklearn.utils import deprecated
 
 
+@deprecated("kmeans is being deprecated in Version 0.43.0. This will be removed in Version 0.44")
 def kmeans(X, k, round_values=True):
     """ Summarize a dataset with k mean samples weighted by the number of data points they
     each represent.

--- a/tests/plots/test_bar.py
+++ b/tests/plots/test_bar.py
@@ -80,19 +80,3 @@ def test_simple_bar_with_cohorts_dict():
     )
     plt.tight_layout()
     return fig
-
-def test_bar_legacy_deprecation_warning(explainer):
-    rs = np.random.RandomState(42)
-    plt.figure()
-    with pytest.warns(FutureWarning, match="bar_legacy is being deprecated in Version 0.43.0"):
-        shap.plots._bar.bar_legacy({
-            "t1": shap.Explanation(
-                values=rs.randn(40, 5),
-                base_values=np.ones(40) * 0.5,
-            ),
-            "t2": shap.Explanation(
-                values=rs.randn(20, 5),
-                base_values=np.ones(20) * 0.5,
-            ),
-        },
-        show=False)

--- a/tests/plots/test_bar.py
+++ b/tests/plots/test_bar.py
@@ -80,3 +80,19 @@ def test_simple_bar_with_cohorts_dict():
     )
     plt.tight_layout()
     return fig
+
+def test_bar_legacy_deprecation_warning(explainer):
+    rs = np.random.RandomState(42)
+    fig = plt.figure()
+    with pytest.warns(FutureWarning, match="bar_legacy is being deprecated in Version 0.43.0"):
+        shap.plots._bar.bar_legacy({
+            "t1": shap.Explanation(
+                values=rs.randn(40, 5),
+                base_values=np.ones(40) * 0.5,
+            ),
+            "t2": shap.Explanation(
+                values=rs.randn(20, 5),
+                base_values=np.ones(20) * 0.5,
+            ),
+        },
+        show=False)

--- a/tests/plots/test_bar.py
+++ b/tests/plots/test_bar.py
@@ -83,7 +83,7 @@ def test_simple_bar_with_cohorts_dict():
 
 def test_bar_legacy_deprecation_warning(explainer):
     rs = np.random.RandomState(42)
-    fig = plt.figure()
+    plt.figure()
     with pytest.warns(FutureWarning, match="bar_legacy is being deprecated in Version 0.43.0"):
         shap.plots._bar.bar_legacy({
             "t1": shap.Explanation(

--- a/tests/plots/test_beeswarm.py
+++ b/tests/plots/test_beeswarm.py
@@ -55,3 +55,9 @@ def test_simple_beeswarm(explainer):
     shap.plots.beeswarm(shap_values)
     plt.tight_layout()
     return fig
+
+def test_summary_legacy_deprecation_warning(explainer):
+    shap_values = explainer(explainer.data)
+    fig = plt.figure()
+    with pytest.warns(FutureWarning, match="summary_legacy is being deprecated in Version 0.43.0"):
+        shap.plots._beeswarm.summary_legacy(shap_values)

--- a/tests/plots/test_beeswarm.py
+++ b/tests/plots/test_beeswarm.py
@@ -58,6 +58,6 @@ def test_simple_beeswarm(explainer):
 
 def test_summary_legacy_deprecation_warning(explainer):
     shap_values = explainer(explainer.data)
-    fig = plt.figure()
+    plt.figure()
     with pytest.warns(FutureWarning, match="summary_legacy is being deprecated in Version 0.43.0"):
         shap.plots._beeswarm.summary_legacy(shap_values)

--- a/tests/plots/test_dependence.py
+++ b/tests/plots/test_dependence.py
@@ -1,5 +1,6 @@
 import matplotlib
 import numpy as np
+import pytest
 
 matplotlib.use('Agg')
 import shap  # pylint: disable=wrong-import-position
@@ -14,3 +15,7 @@ def test_random_dependence_no_interaction():
     """ Make sure a dependence plot does not crash when we are not showing interactions.
     """
     shap.dependence_plot(0, np.random.randn(20, 5), np.random.randn(20, 5), show=False, interaction_index=None)
+
+def test_dependence_legacy_deprecation_warning(explainer):
+    with pytest.warns(FutureWarning, match="dependence_legacy is being deprecated in Version 0.43.0. This will be removed in Version 0.44"):
+        shap.plots._scatter.dependence_legacy(0, np.random.randn(20, 5), np.random.randn(20, 5), show=False, interaction_index=None)

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -59,6 +59,6 @@ def test_waterfall_plot_for_decision_tree_explanation():
 
 def test_waterfall_legacy_deprecation_warning(explainer):
     shap_values = explainer.shap_values(explainer.data)
-    fig = plt.figure()
+    plt.figure()
     with pytest.warns(FutureWarning, match="waterfall_legacy is being deprecated in Version 0.43.0"):
         shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0])

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -59,6 +59,5 @@ def test_waterfall_plot_for_decision_tree_explanation():
 
 def test_waterfall_legacy_deprecation_warning(explainer):
     shap_values = explainer.shap_values(explainer.data)
-    plt.figure()
-    with pytest.warns(FutureWarning, match="waterfall_legacy is being deprecated in Version 0.43.0"):
+    with pytest.warns(FutureWarning, match="waterfall_legacy is being deprecated in Version 0.43.0. This will be removed in Version 0.44"):
         shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0])

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -56,3 +56,9 @@ def test_waterfall_plot_for_decision_tree_explanation():
     explainer = shap.TreeExplainer(model)
     explanation = explainer(X)
     shap.plots.waterfall(explanation[0], show=False)
+
+def test_waterfall_legacy_deprecation_warning(explainer):
+    shap_values = explainer.shap_values(explainer.data)
+    fig = plt.figure()
+    with pytest.warns(FutureWarning, match="waterfall_legacy is being deprecated in Version 0.43.0"):
+        shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0])


### PR DESCRIPTION
## Overview

Part of #3156  

Description of the changes proposed in this pull request:
* Added deprecation decorators using sklearn deprecated since its an existing dependency. 
* Decorators added to: bar_legacy, summary_legacy, dependence_legacy, waterfall_legacy
* Added unit tests for dependence_legacy, summary_legacy, and waterfall_legacy. 
* Added decorator for kmeans in utils/._legacy.py

Potentially could create own decorator using the python warnings module. 
Did not include unit tests for bar_legacy as function is breaking outside of decorator. 

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
