### PR TITLE
refactor: remove assertions in `force` plot, test verify_valid_cmap

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -314,14 +314,20 @@ def ensure_not_numpy(x):
     else:
         return x
 
+
 def verify_valid_cmap(cmap):
-    assert (isinstance(cmap, str) or isinstance(cmap, list) or str(type(cmap)).endswith("unicode'>")
-        ),"Plot color map must be string or list! not: " + str(type(cmap))
+    """Checks that cmap is either a str or list of hex colors"""
+    if not (isinstance(cmap, (str, list)) or str(type(cmap)).endswith("unicode'>")):
+        emsg = f"Plot color map must be string or list! Not {type(cmap)}"
+        raise ValueError(emsg)
+
     if isinstance(cmap, list):
-        assert (len(cmap) > 1), "Color map must be at least two colors."
+        if len(cmap) < 2:
+            raise ValueError("Color map must be at least two colors.")
         _rgbstring = re.compile(r'#[a-fA-F0-9]{6}$')
         for color in cmap:
-             assert(bool(_rgbstring.match(color))),"Invalid color found in CMAP."
+            if not _rgbstring.match(color):
+                raise ValueError(f"Invalid color {color} found in cmap")
 
     return cmap
 

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -32,9 +32,11 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
 
     Parameters
     ----------
-    base_value : float
-        This is the reference value that the feature contributions start from.
+    base_value : float or shap.Explanation
+        If a float is passed in, this is the reference value that the feature contributions start from.
         For SHAP values, it should be the value of ``explainer.expected_value``.
+        However, it is recommended to pass in a SHAP :class:`.Explanation` object instead (``shap_values``
+        is not necessary in this case).
 
     shap_values : numpy.array
         Matrix of SHAP values (# features) or (# samples x # features). If this is a

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -244,11 +244,16 @@ def getjs():
 
 
 def initjs():
+    """Initialize the necessary javascript libraries for interactive force plots.
+
+    Run this only in a notebook environment with IPython installed.
+    """
     assert have_ipython, "IPython must be installed to use initjs()! Run `pip install ipython` and then restart shap."
+
     logo_path = os.path.join(os.path.split(__file__)[0], "resources", "logoSmallGray.png")
     with open(logo_path, "rb") as f:
         logo_data = f.read()
-    logo_data = base64.b64encode(logo_data).decode('utf-8')
+    logo_data = base64.b64encode(logo_data).decode("utf-8")
     display(HTML(
         f"<div align='center'><img src='data:image/png;base64,{logo_data}' /></div>" +
         getjs()
@@ -465,7 +470,7 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
             raise TypeError(emsg)
 
         # order the samples by their position in a hierarchical clustering
-        if all([e.model.f == arr[1].model.f for e in arr]):
+        if all(e.model.f == arr[1].model.f for e in arr):
             clustOrder = hclust_ordering(np.vstack([e.effects for e in arr]))
         else:
             emsg = "Tried to visualize an array of explanations from different models!"
@@ -487,7 +492,7 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
             "ordering_keys": list(ordering_keys) if hasattr(ordering_keys, '__iter__') else None,
             "ordering_keys_time_format": ordering_keys_time_format,
         }
-        for (ind,e) in enumerate(arr):
+        for ind, e in enumerate(arr):
             self.data["explanations"].append({
                 "outValue": ensure_not_numpy(e.out_value),
                 "simIndex": ensure_not_numpy(clustOrder[ind])+1,

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -325,9 +325,11 @@ def verify_valid_cmap(cmap):
 
     return cmap
 
+
 def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True,
               ordering_keys=None, ordering_keys_time_format=None, text_rotation=0, min_perc=0.05):
     plot_cmap = verify_valid_cmap(plot_cmap)
+
     if isinstance(e, AdditiveExplanation):
         if matplotlib:
             return AdditiveForceVisualizer(e, plot_cmap=plot_cmap).matplotlib(figsize=figsize,
@@ -338,16 +340,20 @@ def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True,
             return AdditiveForceVisualizer(e, plot_cmap=plot_cmap)
     elif isinstance(e, Explanation):
         if matplotlib:
-            assert False, "Matplotlib plot is only supported for additive explanations"
-        else:
-            return SimpleListVisualizer(e)
+            raise ValueError("Matplotlib plot is only supported for additive explanations")
+        return SimpleListVisualizer(e)
     elif isinstance(e, Sequence) and len(e) > 0 and isinstance(e[0], AdditiveExplanation):
         if matplotlib:
-            assert False, "Matplotlib plot is only supported for additive explanations"
-        else:
-            return AdditiveForceArrayVisualizer(e, plot_cmap=plot_cmap, ordering_keys=ordering_keys, ordering_keys_time_format=ordering_keys_time_format)
+            raise ValueError("Matplotlib plot is only supported for additive explanations")
+        return AdditiveForceArrayVisualizer(
+            e,
+            plot_cmap=plot_cmap,
+            ordering_keys=ordering_keys,
+            ordering_keys_time_format=ordering_keys_time_format,
+        )
     else:
-        assert False, "visualize() can only display Explanation objects (or arrays of them)!"
+        raise ValueError("visualize() can only display Explanation objects (or arrays of them)!")
+
 
 class BaseVisualizer:
     pass

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -98,7 +98,9 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
                             "shap.force_plot(explainer.expected_value[0], shap_values[0]).")
 
 
-    assert not isinstance(shap_values, list), "The shap_values arg looks multi output, try shap_values[i]."
+    if isinstance(shap_values, list):
+        emsg = "The shap_values arg looks multi output, try `shap_values[i]` instead."
+        raise TypeError(emsg)
 
     link = convert_to_link(link)
 
@@ -270,7 +272,9 @@ def save_html(out_file, plot, full_html=True):
         tags are included.
     """
 
-    assert isinstance(plot, BaseVisualizer), "`save_html` requires a Visualizer returned by `shap.plots.force()`."
+    if not isinstance(plot, BaseVisualizer):
+        raise TypeError("`save_html` requires a Visualizer returned by `shap.plots.force()`.")
+
     internal_open = False
     if isinstance(out_file, str):
         out_file = open(out_file, "w", encoding="utf-8")
@@ -368,7 +372,9 @@ class BaseVisualizer:
 
 class SimpleListVisualizer(BaseVisualizer):
     def __init__(self, e):
-        assert isinstance(e, Explanation), "SimpleListVisualizer can only visualize Explanation objects!"
+        if not isinstance(e, Explanation):
+            emsg = "SimpleListVisualizer can only visualize Explanation objects!"
+            raise TypeError(emsg)
 
         # build the json data
         features = {}
@@ -403,8 +409,9 @@ class SimpleListVisualizer(BaseVisualizer):
 
 class AdditiveForceVisualizer(BaseVisualizer):
     def __init__(self, e, plot_cmap="RdBu"):
-        assert isinstance(e, AdditiveExplanation), \
-            "AdditiveForceVisualizer can only visualize AdditiveExplanation objects!"
+        if not isinstance(e, AdditiveExplanation):
+            emsg = "AdditiveForceVisualizer can only visualize AdditiveExplanation objects!"
+            raise TypeError(emsg)
 
         # build the json data
         features = {}
@@ -450,14 +457,19 @@ class AdditiveForceVisualizer(BaseVisualizer):
 
 class AdditiveForceArrayVisualizer(BaseVisualizer):
     def __init__(self, arr, plot_cmap="RdBu", ordering_keys=None, ordering_keys_time_format=None):
-        assert isinstance(arr[0], AdditiveExplanation), \
-            "AdditiveForceArrayVisualizer can only visualize arrays of AdditiveExplanation objects!"
+        if not isinstance(arr[0], AdditiveExplanation):
+            emsg = (
+                "AdditiveForceArrayVisualizer can only visualize arrays of "
+                "AdditiveExplanation objects!"
+            )
+            raise TypeError(emsg)
 
         # order the samples by their position in a hierarchical clustering
         if all([e.model.f == arr[1].model.f for e in arr]):
             clustOrder = hclust_ordering(np.vstack([e.effects for e in arr]))
         else:
-            assert False, "Tried to visualize an array of explanations from different models!"
+            emsg = "Tried to visualize an array of explanations from different models!"
+            raise ValueError(emsg)
 
         # make sure that we put the higher predictions first...just for consistency
         if sum(arr[clustOrder[0]].effects) < sum(arr[clustOrder[-1]].effects):

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -90,13 +90,15 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
         elif len(base_value) > 1 and np.all(base_value == base_value[0]):
             base_value = base_value[0]
 
-    if isinstance(base_value, np.ndarray) or isinstance(base_value, list):
+    if isinstance(base_value, (np.ndarray, list)):
         if not isinstance(shap_values, list) or len(shap_values) != len(base_value):
-            raise Exception("In v0.20 force_plot now requires the base value as the first parameter! " \
-                            "Try shap.force_plot(explainer.expected_value, shap_values) or " \
-                            "for multi-output models try " \
-                            "shap.force_plot(explainer.expected_value[0], shap_values[0]).")
-
+            emsg = (
+                "In v0.20, force plot now requires the base value as the first parameter! "
+                "Try shap.plots.force(explainer.expected_value, shap_values) or "
+                "for multi-output models try "
+                "shap.plots.force(explainer.expected_value[0], shap_values[0])."
+            )
+            raise Exception(emsg)
 
     if isinstance(shap_values, list):
         emsg = "The shap_values arg looks multi output, try `shap_values[i]` instead."

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -288,14 +288,8 @@ def save_html(out_file, plot, full_html=True):
     if full_html:
         out_file.write("<html><head><meta http-equiv='content-type' content='text/html'; charset='utf-8'>")
 
-    out_file.write("<script>\n")
-
     # dump the js code
-    bundle_path = os.path.join(os.path.split(__file__)[0], "resources", "bundle.js")
-    with open(bundle_path, encoding="utf-8") as f:
-        bundle_data = f.read()
-    out_file.write(bundle_data)
-    out_file.write("</script>")
+    out_file.write(getjs())
 
     if full_html:
         out_file.write("</head><body>\n")

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -338,10 +338,12 @@ def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True,
 
     if isinstance(e, AdditiveExplanation):
         if matplotlib:
-            return AdditiveForceVisualizer(e, plot_cmap=plot_cmap).matplotlib(figsize=figsize,
-                                                                    show=show,
-                                                                    text_rotation=text_rotation,
-                                                                    min_perc=min_perc)
+            return AdditiveForceVisualizer(e, plot_cmap=plot_cmap).matplotlib(
+                figsize=figsize,
+                show=show,
+                text_rotation=text_rotation,
+                min_perc=min_perc,
+            )
         else:
             return AdditiveForceVisualizer(e, plot_cmap=plot_cmap)
     elif isinstance(e, Explanation):

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -25,9 +25,22 @@ from ..utils._legacy import Data, DenseData, Instance, Link, Model, convert_to_l
 from ._labels import labels
 
 
-def force(base_value, shap_values=None, features=None, feature_names=None, out_names=None, link="identity",
-          plot_cmap="RdBu", matplotlib=False, show=True, figsize=(20,3), ordering_keys=None, ordering_keys_time_format=None,
-          text_rotation=0, contribution_threshold=0.05):
+def force(
+    base_value,
+    shap_values=None,
+    features=None,
+    feature_names=None,
+    out_names=None,
+    link="identity",
+    plot_cmap="RdBu",
+    matplotlib=False,
+    show=True,
+    figsize=(20, 3),
+    ordering_keys=None,
+    ordering_keys_time_format=None,
+    text_rotation=0,
+    contribution_threshold=0.05,
+):
     """Visualize the given SHAP values with an additive force layout.
 
     Parameters
@@ -57,10 +70,22 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
         The transformation used when drawing the tick mark labels. Using "logit" will change log-odds numbers
         into probabilities.
 
+    plot_cmap : str or list[str]
+        Color map to use. It can be a string (defaults to ``RdBu``) or a list of hex color strings.
+
     matplotlib : bool
         Whether to use the default Javascript output, or the (less developed) matplotlib output.
         Using matplotlib can be helpful in scenarios where rendering Javascript/HTML
-        is inconvenient.
+        is inconvenient. Defaults to False.
+
+    show : bool
+        Whether ``matplotlib.pyplot.show()`` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
+        Only applicable when ``matplotlib`` is set to True.
+
+    figsize :
+        Figure size of the matplotlib output.
 
     contribution_threshold : float
         Controls the feature names/values that are displayed on force plot.
@@ -218,7 +243,21 @@ class Explanation:
 
 
 class AdditiveExplanation(Explanation):
+    """Data structure for AdditiveForceVisualizer / AdditiveForceArrayVisualizer."""
+
     def __init__(self, base_value, out_value, effects, effects_var, instance, link, model, data):
+        """
+
+        Parameters
+        ----------
+        base_value : float
+            This is the reference value that the feature contributions start from.
+            For SHAP values, it should be the value of ``explainer.expected_value``.
+
+        out_value : float
+            The model prediction value, taken as the sum of the SHAP values across all
+            features and the ``base_value``.
+        """
         self.base_value = base_value
         self.out_value = out_value
         self.effects = effects
@@ -341,8 +380,24 @@ def verify_valid_cmap(cmap):
     return cmap
 
 
-def visualize(e, plot_cmap="RdBu", matplotlib=False, figsize=(20,3), show=True,
-              ordering_keys=None, ordering_keys_time_format=None, text_rotation=0, min_perc=0.05):
+def visualize(
+    e,
+    plot_cmap="RdBu",
+    matplotlib=False,
+    figsize=(20, 3),
+    show=True,
+    ordering_keys=None,
+    ordering_keys_time_format=None,
+    text_rotation=0,
+    min_perc=0.05,
+):
+    """Main interface for switching between matplotlib / javascript force plots.
+
+    Parameters
+    ----------
+    e : AdditiveExplanation
+        Contains the data necessary for additive force plots.
+    """
     plot_cmap = verify_valid_cmap(plot_cmap)
 
     if isinstance(e, AdditiveExplanation):
@@ -413,7 +468,19 @@ class SimpleListVisualizer(BaseVisualizer):
 
 
 class AdditiveForceVisualizer(BaseVisualizer):
+    """Visualizer for a single Additive Force plot."""
+
     def __init__(self, e, plot_cmap="RdBu"):
+        """
+
+        Parameters
+        ----------
+        e : AdditiveExplanation
+            Contains the data necessary for additive force plots.
+
+        plot_cmap : str or list[str]
+            Color map to use. It can be a string (defaults to ``RdBu``) or a list of hex color strings.
+        """
         if not isinstance(e, AdditiveExplanation):
             emsg = "AdditiveForceVisualizer can only visualize AdditiveExplanation objects!"
             raise TypeError(emsg)
@@ -432,7 +499,7 @@ class AdditiveForceVisualizer(BaseVisualizer):
             "link": str(e.link),
             "featureNames": e.data.group_names,
             "features": features,
-            "plot_cmap": plot_cmap
+            "plot_cmap": plot_cmap,
         }
 
     def html(self, label_margin=20):
@@ -461,6 +528,8 @@ class AdditiveForceVisualizer(BaseVisualizer):
 
 
 class AdditiveForceArrayVisualizer(BaseVisualizer):
+    """Visualizer for a sequence of AdditiveExplanation, as a stacked force plot."""
+
     def __init__(self, arr, plot_cmap="RdBu", ordering_keys=None, ordering_keys_time_format=None):
         if not isinstance(arr[0], AdditiveExplanation):
             emsg = (

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -144,11 +144,13 @@ def force(base_value, shap_values=None, features=None, feature_names=None, out_n
 
         # check that the shape of the shap_values and features match
         if len(features) != shap_values.shape[1]:
-            msg = "Length of features is not equal to the length of shap_values!"
+            emsg = "Length of features is not equal to the length of shap_values!"
             if len(features) == shap_values.shape[1] - 1:
-                msg += " You might be using an old format shap_values array with the base value " \
-                       "as the last column. In this case just pass the array without the last column."
-            raise Exception(msg)
+                emsg += (
+                    " You might be using an old format shap_values array with the base value "
+                    "as the last column. In this case, just pass the array without the last column."
+                )
+            raise Exception(emsg)
 
         instance = Instance(np.zeros((1, len(feature_names))), features)
         e = AdditiveExplanation(

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from ..plots._force_matplotlib import draw_additive_plot
 from ..utils import hclust_ordering
+from ..utils._exceptions import DimensionError
 from ..utils._legacy import Data, DenseData, Instance, Link, Model, convert_to_link
 from ._labels import labels
 
@@ -125,7 +126,7 @@ def force(
                 "for multi-output models try "
                 "shap.plots.force(explainer.expected_value[0], shap_values[0])."
             )
-            raise Exception(emsg)
+            raise TypeError(emsg)
 
     if isinstance(shap_values, list):
         emsg = "The shap_values arg looks multi output, try `shap_values[i]` instead."
@@ -177,7 +178,7 @@ def force(
                     " You might be using an old format shap_values array with the base value "
                     "as the last column. In this case, just pass the array without the last column."
                 )
-            raise Exception(emsg)
+            raise DimensionError(emsg)
 
         instance = Instance(np.zeros((1, len(feature_names))), features)
         e = AdditiveExplanation(

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -367,8 +367,8 @@ def ensure_not_numpy(x):
 def verify_valid_cmap(cmap):
     """Checks that cmap is either a str or list of hex colors"""
     if not (isinstance(cmap, (str, list)) or str(type(cmap)).endswith("unicode'>")):
-        emsg = f"Plot color map must be string or list! Not {type(cmap)}"
-        raise ValueError(emsg)
+        emsg = f"Plot color map must be string or list! Not {type(cmap)}."
+        raise TypeError(emsg)
 
     if isinstance(cmap, list):
         if len(cmap) < 2:
@@ -376,7 +376,7 @@ def verify_valid_cmap(cmap):
         _rgbstring = re.compile(r'#[a-fA-F0-9]{6}$')
         for color in cmap:
             if not _rgbstring.match(color):
-                raise ValueError(f"Invalid color {color} found in cmap")
+                raise ValueError(f"Invalid color {color} found in cmap.")
 
     return cmap
 

--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -223,7 +223,8 @@ def format_data(data):
         def convert_func(x):
             return 1 / (1 + np.exp(-x))
     else:
-        assert False, "ERROR: Unrecognized link function: " + str(data['link'])
+        emsg = f"ERROR: Unrecognized link function: {data['link']}"
+        raise ValueError(emsg)
 
     # Convert negative feature values to plot values
     neg_val = data['outValue']

--- a/tests/plots/test_force.py
+++ b/tests/plots/test_force.py
@@ -4,8 +4,40 @@ import numpy as np
 import pytest
 
 matplotlib.use('Agg')
-import shap  # pylint: disable=wrong-import-position
+import shap  # noqa: E402
 
+
+@pytest.mark.parametrize(
+    "cmap, emsg",
+    [
+        ("coolwarm", None),
+        (["#000000", "#ffffff"], None),
+        (777, "Plot color map must be string or list!"),
+        ([], "Color map must be at least two colors"),
+        (["#8834BB"], "Color map must be at least two colors"),
+        (["#883488", "#Gg8888"], r"Invalid color .+ found in cmap"),
+        (["#883488", "#1111119"], r"Invalid color .+ found in cmap"),
+    ],
+    ids=[
+        "valid-str",
+        "valid-list[str]",
+        "invalid-dtype1",
+        "invalid-insufficient-colors1",
+        "invalid-insufficient-colors2",
+        "invalid-hexcolor-in-list1",
+        "invalid-hexcolor-in-list2",
+    ],
+)
+def test_verify_valid_cmap(cmap, emsg):
+    from shap.plots._force import verify_valid_cmap
+
+    if emsg is None:
+        # Valid cmaps
+        _ = verify_valid_cmap(cmap)
+    else:
+        # Invalid cmaps
+        with pytest.raises(ValueError, match=emsg):
+            verify_valid_cmap(cmap)
 
 def test_random_force_plot_mpl_with_data():
     """ Test if force plot with matplotlib works.

--- a/tests/plots/test_force.py
+++ b/tests/plots/test_force.py
@@ -2,6 +2,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from pytest import param
 
 matplotlib.use('Agg')
 import shap  # noqa: E402
@@ -10,22 +11,13 @@ import shap  # noqa: E402
 @pytest.mark.parametrize(
     "cmap, emsg",
     [
-        ("coolwarm", None),
-        (["#000000", "#ffffff"], None),
-        (777, "Plot color map must be string or list!"),
-        ([], "Color map must be at least two colors"),
-        (["#8834BB"], "Color map must be at least two colors"),
-        (["#883488", "#Gg8888"], r"Invalid color .+ found in cmap"),
-        (["#883488", "#1111119"], r"Invalid color .+ found in cmap"),
-    ],
-    ids=[
-        "valid-str",
-        "valid-list[str]",
-        "invalid-dtype1",
-        "invalid-insufficient-colors1",
-        "invalid-insufficient-colors2",
-        "invalid-hexcolor-in-list1",
-        "invalid-hexcolor-in-list2",
+        param("coolwarm", None, id="valid-str"),
+        param(["#000000", "#ffffff"], None, id="valid-list[str]"),
+        param(777, "Plot color map must be string or list!", id="invalid-dtype1"),
+        param([], "Color map must be at least two colors", id="invalid-insufficient-colors1"),
+        param(["#8834BB"], "Color map must be at least two colors", id="invalid-insufficient-colors2"),
+        param(["#883488", "#Gg8888"], r"Invalid color .+ found in cmap", id="invalid-hexcolor-in-list1"),
+        param(["#883488", "#1111119"], r"Invalid color .+ found in cmap", id="invalid-hexcolor-in-list2"),
     ],
 )
 def test_verify_valid_cmap(cmap, emsg):
@@ -38,6 +30,7 @@ def test_verify_valid_cmap(cmap, emsg):
         # Invalid cmaps
         with pytest.raises(ValueError, match=emsg):
             verify_valid_cmap(cmap)
+
 
 def test_random_force_plot_mpl_with_data():
     """ Test if force plot with matplotlib works.


### PR DESCRIPTION
## Overview

This PR is part of a larger effort of refactoring `_force.py` and `_force_matplotlib.py`. This PR covers some of the smaller / non-functional changes, so we can focus on the core functionalities in the following PR.

Description of the changes proposed in this pull request:

* Removed most `assert` statements for enforcing logic, as it is not good practice. The only exception is the use of assert to test for `IPython` to be installed. (No strong reason for this, if there is a more suitable Exception type suggested, I can change it).
* Added a set of tests for `verify_valid_cmap()` function (defined inside `_force.py`). To ensure no errors are introduced in the refactoring.
* Add docstrings for some functions in `_force.py`.
* Re-use an existing `getjs()` function to read the js bundle (DRY principle).
* Added docstring for `initjs()`, just a quality-of-life improvement.

## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
