### PR TITLE
MAINT: Reduce frequency of pre-commit autoupdates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.286


### PR DESCRIPTION
Reduces frequency of auto-updates, following guidance here:
<https://pre-commit.ci/#configuration>

We get one PR per week, which seems relatively excessive at the moment for minor linter changes.