### PR TITLE
ENH: Rename explainers to usual long-form names for consistency with docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,14 +25,16 @@ explainers
     :toctree: generated/
 
     shap.Explainer
-    shap.explainers.Tree
-    shap.explainers.GPUTree
-    shap.explainers.Linear
-    shap.explainers.Permutation
-    shap.explainers.Partition
-    shap.explainers.Sampling
-    shap.explainers.Additive
-    shap.explainers.Deep
+    shap.TreeExplainer
+    shap.GPUTreeExplainer
+    shap.LinearExplainer
+    shap.PermutationExplainer
+    shap.PartitionExplainer
+    shap.SamplingExplainer
+    shap.AdditiveExplainer
+    shap.DeepExplainer
+    shap.KernelExplainer
+    shap.GradientExplainer
     shap.explainers.Exact
     shap.explainers.other.Coefficient
     shap.explainers.other.Random

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,7 +35,7 @@ explainers
     shap.DeepExplainer
     shap.KernelExplainer
     shap.GradientExplainer
-    shap.explainers.Exact
+    shap.ExactExplainer
     shap.explainers.other.Coefficient
     shap.explainers.other.Random
     shap.explainers.other.LimeTabular

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -409,30 +409,27 @@ def setup(app):
 
     # need to assign the names here, otherwise autodoc won't document these classes,
     # and will instead just say 'alias of ...'
-    shap.explainers.Tree.__name__ = "Tree"
-    shap.explainers.Tree.__module__ = "shap.explainers"
-    shap.explainers.GPUTree.__name__ = "GPUTree"
-    shap.explainers.GPUTree.__module__ = "shap.explainers"
-    shap.explainers.Linear.__name__ = "Linear"
-    shap.explainers.Linear.__module__ = "shap.explainers"
-    shap.explainers.Permutation.__name__ = "Permutation"
-    shap.explainers.Permutation.__module__ = "shap.explainers"
-    shap.explainers.Partition.__name__ = "Partition"
-    shap.explainers.Partition.__module__ = "shap.explainers"
-    shap.explainers.Sampling.__name__ = "Sampling"
-    shap.explainers.Sampling.__module__ = "shap.explainers"
-    shap.explainers.Additive.__name__ = "Additive"
-    shap.explainers.Additive.__module__ = "shap.explainers"
-    # shap.TreeExplainer.__name__ = 'TreeExplainer'
-    # shap.GPUTreeExplainer.__name__ = 'GPUTreeExplainer'
-    # shap.LinearExplainer.__name__ = 'LinearExplainer'
-    # shap.KernelExplainer.__name__ = 'KernelExplainer'
-    # shap.SamplingExplainer.__name__ = 'SamplingExplainer'
-    # shap.DeepExplainer.__name__ = 'DeepExplainer'
-    # shap.GradientExplainer.__name__ = 'GradientExplainer'
-    # shap.PartitionExplainer.__name__ = 'PartitionExplainer'
-    # shap.PermutationExplainer.__name__ = 'PermutationExplainer'
-    # shap.AdditiveExplainer.__name__ = 'AdditiveExplainer'
+    shap.AdditiveExplainer.__name__ = "AdditiveExplainer"
+    shap.AdditiveExplainer.__module__ = "shap"
+    shap.DeepExplainer.__name__ = "DeepExplainer"
+    shap.DeepExplainer.__module__ = "shap"
+    shap.GPUTreeExplainer.__name__ = "GPUTreeExplainer"
+    shap.GPUTreeExplainer.__module__ = "shap"
+    shap.GradientExplainer.__name__ = "GradientExplainer"
+    shap.GradientExplainer.__module__ = "shap"
+    shap.KernelExplainer.__name__ = "KernelExplainer"
+    shap.KernelExplainer.__module__ = "shap"
+    shap.LinearExplainer.__name__ = "LinearExplainer"
+    shap.LinearExplainer.__module__ = "shap"
+    shap.PartitionExplainer.__name__ = "PartitionExplainer"
+    shap.PartitionExplainer.__module__ = "shap"
+    shap.PermutationExplainer.__name__ = "PermutationExplainer"
+    shap.PermutationExplainer.__module__ = "shap"
+    shap.SamplingExplainer.__name__ = "SamplingExplainer"
+    shap.SamplingExplainer.__module__ = "shap"
+    shap.TreeExplainer.__name__ = "TreeExplainer"
+    shap.TreeExplainer.__module__ = "shap"
+
     app.connect("build-finished", build_finished)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -405,31 +405,7 @@ texinfo_documents = [
 
 
 def setup(app):
-    import shap
-
-    # need to assign the names here, otherwise autodoc won't document these classes,
-    # and will instead just say 'alias of ...'
-    shap.AdditiveExplainer.__name__ = "AdditiveExplainer"
-    shap.AdditiveExplainer.__module__ = "shap"
-    shap.DeepExplainer.__name__ = "DeepExplainer"
-    shap.DeepExplainer.__module__ = "shap"
-    shap.GPUTreeExplainer.__name__ = "GPUTreeExplainer"
-    shap.GPUTreeExplainer.__module__ = "shap"
-    shap.GradientExplainer.__name__ = "GradientExplainer"
-    shap.GradientExplainer.__module__ = "shap"
-    shap.KernelExplainer.__name__ = "KernelExplainer"
-    shap.KernelExplainer.__module__ = "shap"
-    shap.LinearExplainer.__name__ = "LinearExplainer"
-    shap.LinearExplainer.__module__ = "shap"
-    shap.PartitionExplainer.__name__ = "PartitionExplainer"
-    shap.PartitionExplainer.__module__ = "shap"
-    shap.PermutationExplainer.__name__ = "PermutationExplainer"
-    shap.PermutationExplainer.__module__ = "shap"
-    shap.SamplingExplainer.__name__ = "SamplingExplainer"
-    shap.SamplingExplainer.__module__ = "shap"
-    shap.TreeExplainer.__name__ = "TreeExplainer"
-    shap.TreeExplainer.__module__ = "shap"
-
+    import shap  # noqa: F401
     app.connect("build-finished", build_finished)
 
 

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -5,17 +5,18 @@ from ._explanation import Cohorts, Explanation
 
 # explainers
 from .explainers import other
-from .explainers._additive import Additive as AdditiveExplainer
-from .explainers._deep import Deep as DeepExplainer
+from .explainers._additive import AdditiveExplainer
+from .explainers._deep import DeepExplainer
+from .explainers._exact import ExactExplainer
 from .explainers._explainer import Explainer
-from .explainers._gpu_tree import GPUTree as GPUTreeExplainer
-from .explainers._gradient import Gradient as GradientExplainer
-from .explainers._kernel import Kernel as KernelExplainer
-from .explainers._linear import Linear as LinearExplainer
-from .explainers._partition import Partition as PartitionExplainer
-from .explainers._permutation import Permutation as PermutationExplainer
-from .explainers._sampling import Sampling as SamplingExplainer
-from .explainers._tree import Tree as TreeExplainer
+from .explainers._gpu_tree import GPUTreeExplainer
+from .explainers._gradient import GradientExplainer
+from .explainers._kernel import KernelExplainer
+from .explainers._linear import LinearExplainer
+from .explainers._partition import PartitionExplainer
+from .explainers._permutation import PermutationExplainer
+from .explainers._sampling import SamplingExplainer
+from .explainers._tree import TreeExplainer
 
 _no_matplotlib_warning = "matplotlib is not installed so plotting is not available! Run `pip install matplotlib` " \
                          "to fix this."
@@ -96,6 +97,7 @@ __all__ = [
     "other",
     "AdditiveExplainer",
     "DeepExplainer",
+    "ExactExplainer",
     "Explainer",
     "GPUTreeExplainer",
     "GradientExplainer",

--- a/shap/explainers/__init__.py
+++ b/shap/explainers/__init__.py
@@ -1,24 +1,38 @@
-from ._additive import Additive
-from ._deep import Deep
-from ._exact import Exact
-from ._gpu_tree import GPUTree
-from ._linear import Linear
-from ._partition import Partition
-from ._permutation import Permutation
-from ._sampling import Sampling
-from ._tree import Tree
+from ._additive import AdditiveExplainer
+from ._deep import DeepExplainer
+from ._exact import ExactExplainer
+from ._gpu_tree import GPUTreeExplainer
+from ._gradient import GradientExplainer
+from ._kernel import KernelExplainer
+from ._linear import LinearExplainer
+from ._partition import PartitionExplainer
+from ._permutation import PermutationExplainer
+from ._sampling import SamplingExplainer
+from ._tree import TreeExplainer
 
-# from ._gradient import Gradient
-# from ._kernel import Kernel
+# Alternative legacy "short-form" aliases, which are kept here for backwards-compatibility
+Additive = AdditiveExplainer
+Deep = DeepExplainer
+Exact = ExactExplainer
+GPUTree = GPUTreeExplainer
+Gradient = GradientExplainer
+Kernel = KernelExplainer
+Linear = LinearExplainer
+Partition = PartitionExplainer
+Permutation = PermutationExplainer
+Sampling = SamplingExplainer
+Tree = TreeExplainer
 
 __all__ = [
-    "Additive",
-    "Deep",
-    "Exact",
-    "GPUTree",
-    "Linear",
-    "Partition",
-    "Permutation",
-    "Sampling",
-    "Tree",
+    "AdditiveExplainer",
+    "DeepExplainer",
+    "ExactExplainer",
+    "GPUTreeExplainer",
+    "GradientExplainer",
+    "KernelExplainer",
+    "LinearExplainer",
+    "PartitionExplainer",
+    "PermutationExplainer",
+    "SamplingExplainer",
+    "TreeExplainer",
 ]

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -4,7 +4,7 @@ from ..utils import MaskedModel, safe_isinstance
 from ._explainer import Explainer
 
 
-class Additive(Explainer):
+class AdditiveExplainer(Explainer):
     """ Computes SHAP values for generalized additive models.
 
     This assumes that the model only has first-order effects. Extending this to

--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -3,7 +3,7 @@ from .deep_pytorch import PyTorchDeep
 from .deep_tf import TFDeep
 
 
-class Deep(Explainer):
+class DeepExplainer(Explainer):
     """ Meant to approximate SHAP values for deep learning models.
 
     This is an enhanced version of the DeepLIFT algorithm (Deep SHAP) where, similar to Kernel SHAP, we

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -16,7 +16,7 @@ from ._explainer import Explainer
 log = logging.getLogger('shap')
 
 
-class Exact(Explainer):
+class ExactExplainer(Explainer):
     """ Computes SHAP values via an optimized exact enumeration.
 
     This works well for standard Shapley value maskers for models with less than ~15 features that vary

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -142,11 +142,11 @@ class Explainer(Serializable):
             if algorithm == "auto":
 
                 # use implementation-aware methods if possible
-                if explainers.Linear.supports_model_with_masker(model, self.masker):
+                if explainers.LinearExplainer.supports_model_with_masker(model, self.masker):
                     algorithm = "linear"
-                elif explainers.Tree.supports_model_with_masker(model, self.masker): # TODO: check for Partition?
+                elif explainers.TreeExplainer.supports_model_with_masker(model, self.masker): # TODO: check for Partition?
                     algorithm = "tree"
-                elif explainers.Additive.supports_model_with_masker(model, self.masker):
+                elif explainers.AdditiveExplainer.supports_model_with_masker(model, self.masker):
                     algorithm = "additive"
 
                 # otherwise use a model agnostic method
@@ -172,26 +172,26 @@ class Explainer(Serializable):
 
             # build the right subclass
             if algorithm == "exact":
-                self.__class__ = explainers.Exact
-                explainers.Exact.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
+                self.__class__ = explainers.ExactExplainer
+                explainers.ExactExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
             elif algorithm == "permutation":
-                self.__class__ = explainers.Permutation
-                explainers.Permutation.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, seed=seed, **kwargs)
+                self.__class__ = explainers.PermutationExplainer
+                explainers.PermutationExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, seed=seed, **kwargs)
             elif algorithm == "partition":
-                self.__class__ = explainers.Partition
-                explainers.Partition.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, output_names=self.output_names, **kwargs)
+                self.__class__ = explainers.PartitionExplainer
+                explainers.PartitionExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, output_names=self.output_names, **kwargs)
             elif algorithm == "tree":
-                self.__class__ = explainers.Tree
-                explainers.Tree.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
+                self.__class__ = explainers.TreeExplainer
+                explainers.TreeExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
             elif algorithm == "additive":
-                self.__class__ = explainers.Additive
-                explainers.Additive.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
+                self.__class__ = explainers.AdditiveExplainer
+                explainers.AdditiveExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
             elif algorithm == "linear":
-                self.__class__ = explainers.Linear
-                explainers.Linear.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
+                self.__class__ = explainers.LinearExplainer
+                explainers.LinearExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
             elif algorithm == "deep":
-                self.__class__ = explainers.Deep
-                explainers.Deep.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
+                self.__class__ = explainers.DeepExplainer
+                explainers.DeepExplainer.__init__(self, self.model, self.masker, link=self.link, feature_names=self.feature_names, linearize_link=linearize_link, **kwargs)
             else:
                 raise InvalidAlgorithmError("Unknown algorithm type passed: %s!" % algorithm)
 

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from ..utils import assert_import, record_import_error
-from ._tree import Tree, feature_perturbation_codes, output_transform_codes
+from ._tree import TreeExplainer, feature_perturbation_codes, output_transform_codes
 
 try:
     from .. import _cext_gpu
@@ -11,7 +11,7 @@ except ImportError as e:
 # pylint: disable=W0223
 
 
-class GPUTree(Tree):
+class GPUTreeExplainer(TreeExplainer):
     """
     Experimental GPU accelerated version of TreeExplainer. Currently requires source build with
     cuda available and 'CUDA_PATH' environment variable defined.
@@ -55,7 +55,7 @@ class GPUTree(Tree):
 
     Examples
     --------
-    See `GPUTree explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/GPUTree.html>`_
+    See `GPUTree explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/GPUTreeExplainer.html>`_
     """
 
     def shap_values(self, X, y=None, tree_limit=None, approximate=False, check_additivity=True,

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -18,7 +18,7 @@ tf = None
 torch = None
 
 
-class Gradient(Explainer):
+class GradientExplainer(Explainer):
     """ Explains a model using expected gradients (an extension of integrated gradients).
 
     Expected gradients an extension of the integrated gradients method (Sundararajan et al. 2017), a

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -35,7 +35,7 @@ from ._explainer import Explainer
 log = logging.getLogger('shap')
 
 
-class Kernel(Explainer):
+class KernelExplainer(Explainer):
     """Uses the Kernel SHAP method to explain the output of any function.
 
     Kernel SHAP is a method that uses a special weighted linear regression

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -14,7 +14,7 @@ from ..utils._exceptions import (
 from ._explainer import Explainer
 
 
-class Linear(Explainer):
+class LinearExplainer(Explainer):
     """ Computes SHAP values for a linear model, optionally accounting for inter-feature correlations.
 
     This computes the SHAP values for a linear model and can account for the correlations among
@@ -51,7 +51,7 @@ class Linear(Explainer):
 
     Examples
     --------
-    See `Linear explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/Linear.html>`_
+    See `Linear explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/LinearExplainer.html>`_
     """
 
     def __init__(self, model, masker, link=links.identity, nsamples=1000, feature_perturbation=None, **kwargs):
@@ -90,7 +90,7 @@ class Linear(Explainer):
 
 
         # extract what we need from the given model object
-        self.coef, self.intercept = Linear._parse_model(model)
+        self.coef, self.intercept = LinearExplainer._parse_model(model)
 
         # extract the data
         if issubclass(type(self.masker), (maskers.Independent, maskers.Partition)):
@@ -280,7 +280,7 @@ class Linear(Explainer):
             return False
 
         try:
-            Linear._parse_model(model)
+            LinearExplainer._parse_model(model)
         except Exception:
             return False
         return True

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -14,7 +14,7 @@ from ._explainer import Explainer
 # pylint: disable=unsubscriptable-object
 
 
-class Partition(Explainer):
+class PartitionExplainer(Explainer):
 
     def __init__(self, model, masker, *, output_names=None, link=links.identity, linearize_link=True,
                  feature_names=None, **call_args):
@@ -60,7 +60,7 @@ class Partition(Explainer):
 
         Examples
         --------
-        See `Partition explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/Partition.html>`_
+        See `Partition explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/PartitionExplainer.html>`_
         """
 
         super().__init__(model, masker, link=link, linearize_link=linearize_link, algorithm="partition", \
@@ -107,7 +107,7 @@ class Partition(Explainer):
         # if we have gotten default arguments for the call function we need to wrap ourselves in a new class that
         # has a call function with those new default arguments
         if len(call_args) > 0:
-            class Partition(self.__class__):
+            class PartitionExplainer(self.__class__):
                 # this signature should match the __call__ signature of the class defined below
                 def __call__(self, *args, max_evals=500, fixed_context=None, main_effects=False, error_bounds=False, batch_size="auto",
                              outputs=None, silent=False):
@@ -115,8 +115,8 @@ class Partition(Explainer):
                         *args, max_evals=max_evals, fixed_context=fixed_context, main_effects=main_effects, error_bounds=error_bounds,
                         batch_size=batch_size, outputs=outputs, silent=silent
                     )
-            Partition.__call__.__doc__ = self.__class__.__call__.__doc__
-            self.__class__ = Partition
+            PartitionExplainer.__call__.__doc__ = self.__class__.__call__.__doc__
+            self.__class__ = PartitionExplainer
             for k, v in call_args.items():
                 self.__call__.__kwdefaults__[k] = v
 
@@ -198,7 +198,7 @@ class Partition(Explainer):
         }
 
     def __str__(self):
-        return "shap.explainers.Partition()"
+        return "shap.explainers.PartitionExplainer()"
 
     def owen(self, fm, f00, f11, max_evals, output_indexes, fixed_context, batch_size, silent):
         """ Compute a nested set of recursive Owen values based on an ordering recursion.

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -8,7 +8,7 @@ from ..utils import MaskedModel, partition_tree_shuffle
 from ._explainer import Explainer
 
 
-class Permutation(Explainer):
+class PermutationExplainer(Explainer):
     """ This method approximates the Shapley values by iterating through permutations of the inputs.
 
     This is a model agnostic explainer that guarantees local accuracy (additivity) by iterating completely
@@ -56,15 +56,15 @@ class Permutation(Explainer):
         # has a call function with those new default arguments
         if len(call_args) > 0:
             # this signature should match the __call__ signature of the class defined below
-            class Permutation(self.__class__):
+            class PermutationExplainer(self.__class__):
                 def __call__(self, *args, max_evals=500, main_effects=False, error_bounds=False, batch_size="auto",
                              outputs=None, silent=False):
                     return super().__call__(
                         *args, max_evals=max_evals, main_effects=main_effects, error_bounds=error_bounds,
                         batch_size=batch_size, outputs=outputs, silent=silent
                     )
-            Permutation.__call__.__doc__ = self.__class__.__call__.__doc__
-            self.__class__ = Permutation
+            PermutationExplainer.__call__.__doc__ = self.__class__.__call__.__doc__
+            self.__class__ = PermutationExplainer
             for k, v in call_args.items():
                 self.__call__.__kwdefaults__[k] = v
 
@@ -211,4 +211,4 @@ class Permutation(Explainer):
         return explanation.values
 
     def __str__(self):
-        return "shap.explainers.Permutation()"
+        return "shap.explainers.PermutationExplainer()"

--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -6,12 +6,12 @@ import pandas as pd
 from .._explanation import Explanation
 from ..utils import safe_isinstance
 from ..utils._legacy import convert_to_instance, match_instance_to_data
-from ._kernel import Kernel
+from ._kernel import KernelExplainer
 
 log = logging.getLogger('shap')
 
 
-class Sampling(Kernel):
+class SamplingExplainer(KernelExplainer):
     """Computes SHAP values using an extension of the Shapley sampling values explanation method
     (also known as IME).
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -46,7 +46,7 @@ feature_perturbation_codes = {
 }
 
 
-class Tree(Explainer):
+class TreeExplainer(Explainer):
     """ Uses Tree SHAP algorithms to explain the output of ensemble tree models.
 
     Tree SHAP is a fast and exact method to estimate SHAP values for tree models and ensembles of trees,

--- a/tests/explainers/test_exact.py
+++ b/tests/explainers/test_exact.py
@@ -11,40 +11,40 @@ from . import common
 
 def test_interactions():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_interactions_additivity(shap.explainers.Exact, model.predict, data, data)
+    common.test_interactions_additivity(shap.explainers.ExactExplainer, model.predict, data, data)
 
 def test_tabular_single_output_auto_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Exact, model.predict, data, data)
+    common.test_additivity(shap.explainers.ExactExplainer, model.predict, data, data)
 
 def test_tabular_multi_output_auto_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Exact, model.predict_proba, data, data)
+    common.test_additivity(shap.explainers.ExactExplainer, model.predict_proba, data, data)
 
 def test_tabular_single_output_partition_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Exact, model.predict, shap.maskers.Partition(data), data)
+    common.test_additivity(shap.explainers.ExactExplainer, model.predict, shap.maskers.Partition(data), data)
 
 def test_tabular_multi_output_partition_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Exact, model.predict_proba, shap.maskers.Partition(data), data)
+    common.test_additivity(shap.explainers.ExactExplainer, model.predict_proba, shap.maskers.Partition(data), data)
 
 def test_tabular_single_output_independent_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Exact, model.predict, shap.maskers.Independent(data), data)
+    common.test_additivity(shap.explainers.ExactExplainer, model.predict, shap.maskers.Independent(data), data)
 
 def test_tabular_multi_output_independent_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Exact, model.predict_proba, shap.maskers.Independent(data), data)
+    common.test_additivity(shap.explainers.ExactExplainer, model.predict_proba, shap.maskers.Independent(data), data)
 
 def test_serialization():
     model, data = common.basic_xgboost_scenario()
-    common.test_serialization(shap.explainers.Exact, model.predict, data, data)
+    common.test_serialization(shap.explainers.ExactExplainer, model.predict, data, data)
 
 def test_serialization_no_model_or_masker():
     model, data = common.basic_xgboost_scenario()
     common.test_serialization(
-        shap.explainers.Exact, model.predict, data, data,
+        shap.explainers.ExactExplainer, model.predict, data, data,
         model_saver=False, masker_saver=False,
         model_loader=lambda _: model.predict, masker_loader=lambda _: data
     )
@@ -52,6 +52,6 @@ def test_serialization_no_model_or_masker():
 def test_serialization_custom_model_save():
     model, data = common.basic_xgboost_scenario()
     common.test_serialization(
-        shap.explainers.Exact, model.predict, data, data,
+        shap.explainers.ExactExplainer, model.predict, data, data,
         model_saver=pickle.dump, model_loader=pickle.load
     )

--- a/tests/explainers/test_linear.py
+++ b/tests/explainers/test_linear.py
@@ -36,12 +36,12 @@ def test_tied_pair_new():
     mu = np.zeros(3)
     Sigma = np.array([[1, 0.999999, 0], [0.999999, 1, 0], [0, 0, 1]])
     X = np.ones((1, 3))
-    explainer = shap.explainers.Linear((beta, 0), shap.maskers.Impute({"mean": mu, "cov": Sigma}))
+    explainer = shap.explainers.LinearExplainer((beta, 0), shap.maskers.Impute({"mean": mu, "cov": Sigma}))
     assert np.abs(explainer.shap_values(X) - np.array([0.5, 0.5, 0])).max() < 0.05
 
 def test_wrong_masker():
     with pytest.raises(NotImplementedError):
-        shap.explainers.Linear((0, 0), shap.maskers.Fixed())
+        shap.explainers.LinearExplainer((0, 0), shap.maskers.Fixed())
 
 def test_tied_triple():
     beta = np.array([0, 1, 0, 0])
@@ -87,7 +87,7 @@ def test_sklearn_linear_new():
     model.fit(X, y)
 
     # explain the model's predictions using SHAP values
-    explainer = shap.explainers.Linear(model, X)
+    explainer = shap.explainers.LinearExplainer(model, X)
     shap_values = explainer(X)
     assert np.abs(shap_values.values.sum(1) + shap_values.base_values - model.predict(X)).max() < 1e-6
     assert np.abs(shap_values.base_values[0] - model.predict(X).mean()) < 1e-6
@@ -206,5 +206,5 @@ def test_feature_perturbation_sets_correct_masker(feature_pertubation, masker):
     model = Ridge(0.1)
     model.fit(X, y)
 
-    explainer = shap.explainers.Linear(model, X, feature_perturbation=feature_pertubation)
+    explainer = shap.explainers.LinearExplainer(model, X, feature_perturbation=feature_pertubation)
     assert isinstance(explainer.masker, masker)

--- a/tests/explainers/test_partition.py
+++ b/tests/explainers/test_partition.py
@@ -11,7 +11,7 @@ from . import common
 
 def test_translation(basic_translation_scenario):
     model, tokenizer, data = basic_translation_scenario
-    common.test_additivity(shap.explainers.Partition, model, tokenizer, data)
+    common.test_additivity(shap.explainers.PartitionExplainer, model, tokenizer, data)
 
 
 def test_translation_auto(basic_translation_scenario):
@@ -25,16 +25,16 @@ def test_translation_algorithm_arg(basic_translation_scenario):
 
 def test_tabular_single_output():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Partition, model.predict, shap.maskers.Partition(data), data)
+    common.test_additivity(shap.explainers.PartitionExplainer, model.predict, shap.maskers.Partition(data), data)
 
 def test_tabular_multi_output():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Partition, model.predict_proba, shap.maskers.Partition(data), data)
+    common.test_additivity(shap.explainers.PartitionExplainer, model.predict_proba, shap.maskers.Partition(data), data)
 
 
 def test_serialization(basic_translation_scenario):
     model, tokenizer, data = basic_translation_scenario
-    common.test_serialization(shap.explainers.Partition, model, tokenizer, data)
+    common.test_serialization(shap.explainers.PartitionExplainer, model, tokenizer, data)
 
 
 def test_serialization_no_model_or_masker(basic_translation_scenario):
@@ -47,4 +47,4 @@ def test_serialization_no_model_or_masker(basic_translation_scenario):
 
 def test_serialization_custom_model_save(basic_translation_scenario):
     model, tokenizer, data = basic_translation_scenario
-    common.test_serialization(shap.explainers.Partition, model, tokenizer, data, model_saver=pickle.dump, model_loader=pickle.load)
+    common.test_serialization(shap.explainers.PartitionExplainer, model, tokenizer, data, model_saver=pickle.dump, model_loader=pickle.load)

--- a/tests/explainers/test_permutation.py
+++ b/tests/explainers/test_permutation.py
@@ -26,45 +26,45 @@ def test_exact_second_order(random_seed):
     right_answer[:, 2] += data[:, 2]
     right_answer[:, 2] += (data[:, 2] * data[:, 3]) / 2
     right_answer[:, 3] += (data[:, 2] * data[:, 3]) / 2
-    shap_values = shap.explainers.Permutation(model, np.zeros((1,5)))(data)
+    shap_values = shap.explainers.PermutationExplainer(model, np.zeros((1,5)))(data)
 
     assert np.allclose(right_answer, shap_values.values)
 
 def test_tabular_single_output_auto_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Permutation, model.predict, data, data)
+    common.test_additivity(shap.explainers.PermutationExplainer, model.predict, data, data)
 
 def test_tabular_multi_output_auto_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Permutation, model.predict_proba, data, data)
+    common.test_additivity(shap.explainers.PermutationExplainer, model.predict_proba, data, data)
 
 def test_tabular_single_output_partition_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Permutation, model.predict, shap.maskers.Partition(data), data)
+    common.test_additivity(shap.explainers.PermutationExplainer, model.predict, shap.maskers.Partition(data), data)
 
 def test_tabular_multi_output_partition_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Permutation, model.predict_proba, shap.maskers.Partition(data), data)
+    common.test_additivity(shap.explainers.PermutationExplainer, model.predict_proba, shap.maskers.Partition(data), data)
 
 def test_tabular_single_output_independent_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Permutation, model.predict, shap.maskers.Independent(data), data)
+    common.test_additivity(shap.explainers.PermutationExplainer, model.predict, shap.maskers.Independent(data), data)
 
 def test_tabular_multi_output_independent_masker():
     model, data = common.basic_xgboost_scenario(100)
-    common.test_additivity(shap.explainers.Permutation, model.predict_proba, shap.maskers.Independent(data), data)
+    common.test_additivity(shap.explainers.PermutationExplainer, model.predict_proba, shap.maskers.Independent(data), data)
 
 def test_serialization():
     model, data = common.basic_xgboost_scenario()
     common.test_serialization(
-        shap.explainers.Permutation, model.predict, data, data,
+        shap.explainers.PermutationExplainer, model.predict, data, data,
         rtol=0.1, atol=0.05, max_evals=100000
     )
 
 def test_serialization_no_model_or_masker():
     model, data = common.basic_xgboost_scenario()
     common.test_serialization(
-        shap.explainers.Permutation, model.predict, data, data,
+        shap.explainers.PermutationExplainer, model.predict, data, data,
         model_saver=False, masker_saver=False,
         model_loader=lambda _: model.predict, masker_loader=lambda _: data,
         rtol=0.1, atol=0.05, max_evals=100000
@@ -73,6 +73,6 @@ def test_serialization_no_model_or_masker():
 def test_serialization_custom_model_save():
     model, data = common.basic_xgboost_scenario()
     common.test_serialization(
-        shap.explainers.Permutation, model.predict, data, data,
+        shap.explainers.PermutationExplainer, model.predict, data, data,
         model_saver=pickle.dump, model_loader=pickle.load, rtol=0.1, atol=0.05, max_evals=100000
     )

--- a/tests/explainers/test_sampling.py
+++ b/tests/explainers/test_sampling.py
@@ -17,7 +17,7 @@ def test_null_model_small():
 
 def test_null_model_small_new():
 
-    explainer = shap.explainers.Sampling(lambda x: np.zeros(x.shape[0]), np.ones((2, 4)), nsamples=100)
+    explainer = shap.explainers.SamplingExplainer(lambda x: np.zeros(x.shape[0]), np.ones((2, 4)), nsamples=100)
     shap_values = explainer(np.ones((1, 4)))
     assert np.sum(np.abs(shap_values.values)) < 1e-8
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1353,7 +1353,7 @@ class TestExplainerXGBoost:
 
         # after this fix, this line should not error
         explainer = shap.TreeExplainer(model)
-        assert isinstance(explainer, shap.explainers.Tree)
+        assert isinstance(explainer, shap.explainers.TreeExplainer)
 
 
 class TestExplainerLightGBM:


### PR DESCRIPTION
## Overview

Closes #3244 

User-facing changes:
- Updates the docs to use the usual long names such as `TreeExplainer`, rather than the short form `Tree`.
- Adds missing explainers  `Kernel` and `Gradient`.

Implementation changes:
- Update the source code to use the long-form names, rather than the short-form names which are later aliased.

## TODO

- [x] Decide how to handle explainers in `shap.explainers.other` that are not present in the top-level namespace and do not have a "long-form" alias
- [x] Decide our long-term objective for handling these aliases (deprecate the short form? Or just prefer the long form?)