### PR TITLE
MAINT: Fix failing tests, pin XGBoost in test dependencies to 1.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
   "pytest",
   "pytest-mpl",
   "pytest-cov",
-  "xgboost",
+  "xgboost==1.7.6",
   "lightgbm",
   "catboost",
   "gpboost",


### PR DESCRIPTION
## Overview

Closes #3254

Pins XGBoost in test dependencies to `1.7.6`.

## Context

The baseline images we have are signifcantly altered in XGBoost 2.0.0. So, pinning the test dependency to the last working version seems like a pragmatic short-term fix to get the tests working again.

Once the tests are fixed, we should consider:

- Can we get the tests passing without needing this pin? #3256
- How to manage test dependencies. Should they all be pinned?