### PR TITLE
fix(deep_pytorch): replace deprecated register_backward_hook() by reg…

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -311,7 +311,7 @@ def maxpool(module, grad_input, grad_output):
         xmax_pos, rmax_pos = torch.chunk(pool_to_unpool[module.__class__.__name__](
             grad_output[0] * diffs, indices, module.kernel_size, module.stride,
             module.padding, list(module.x.shape)), 2)
-        
+
     grad_input = [None for _ in grad_input]
     grad_input[0] = torch.where(torch.abs(delta_in) < 1e-7, torch.zeros_like(delta_in),
                            (xmax_pos + rmax_pos) / delta_in).repeat(dup0)


### PR DESCRIPTION
…ister_full_backward_hook() and remove special handling for MaxPool1d (was a workaround prior register_full_backward_hook() existed) #2124

## Overview

Closes #2124 

Description of the changes proposed in this pull request:
- Uses `register_full_backward_hook` instead of deprecated `register_backward_hook` in torch deep explainer.
- Removes workaround code for maxpool1d which is no longer needed since `register_full_backward_hook` returns the expected results.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
