### PR TITLE
WIP: Fix ngboost shapley value estimation for col_sample < 1

### DIFF
--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -139,11 +139,12 @@ def _validate_shap_values(model, x_test):
     )
 
 
-def test_ngboost():
+@pytest.mark.parametrize("col_sample", [1.0, 0.9])
+def test_ngboost(col_sample: float):
     ngboost = pytest.importorskip("ngboost")
 
     X, y = shap.datasets.california(n_points=500)
-    model = ngboost.NGBRegressor(n_estimators=20).fit(X, y)
+    model = ngboost.NGBRegressor(n_estimators=20, col_sample=col_sample).fit(X, y)
     predicted = model.predict(X)
 
     # explain the model's predictions using SHAP values


### PR DESCRIPTION
This adds a test to reproduce the issue in #3261.

As of yet this is just a test, I have not found a fix..
