### PR TITLE
FIX: replace print statements with warning in DeepExplainer

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -228,7 +228,7 @@ def deeplift_grad(module, grad_input, grad_output):
         if op_handler[module_type].__name__ not in ['passthrough', 'linear_1d']:
             return op_handler[module_type](module, grad_input, grad_output)
     else:
-        print(f'Warning: unrecognized nn.Module: {module_type}')
+        warnings.warn(f'unrecognized nn.Module: {module_type}')
         return grad_input
 
 


### PR DESCRIPTION
## Overview

Closes #3252 

Description of the changes proposed in this pull request:
Replace a warning that is written as a `print` to a `warning.warn`  


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
