### PR TITLE
Enh/3263: PyTorchDeep now also allows to check for additivity (activated by default)

### DIFF
--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -86,6 +86,7 @@ class Deep(Explainer):
             self.explainer = PyTorchDeep(model, data)
 
         self.expected_value = self.explainer.expected_value
+        self.explainer.framework = framework
 
     def shap_values(self, X, ranked_outputs=None, output_rank_order='max', check_additivity=True):
         """ Return approximate SHAP values for the model applied to the data given by X.

--- a/shap/explainers/_deep/deep_utils.py
+++ b/shap/explainers/_deep/deep_utils.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+
+def _check_additivity(explainer, model_output_values, output_phis):
+    TOLERANCE = 1e-2
+
+    assert len(explainer.expected_value) == model_output_values.shape[1], "Length of expected values and model outputs does not match."
+
+    for l in range(len(explainer.expected_value)):
+        if not explainer.multi_input:
+            diffs = model_output_values[:, l] - explainer.expected_value[l] - output_phis[l].sum(axis=tuple(range(1, output_phis[l].ndim)))
+        else:
+            diffs = model_output_values[:, l] - explainer.expected_value[l]
+
+            for i in range(len(output_phis[l])):
+                diffs -= output_phis[l][i].sum(axis=tuple(range(1, output_phis[l][i].ndim)))
+
+        maxdiff = np.abs(diffs).max()
+
+        assert maxdiff < TOLERANCE, "The SHAP explanations do not sum up to the model's output! This is either because of a " \
+                                    "rounding error or because an operator in your computation graph was not fully supported. If " \
+                                    "the sum difference of %f is significant compared to the scale of your model outputs, please post " \
+                                    f"as a github issue, with a reproducible example so we can debug it. Used framework: {explainer.framework} - Max. diff: {maxdiff} - Tolerance: {TOLERANCE}"


### PR DESCRIPTION
## Overview

Closes #3263 

Description of the changes proposed in this pull request:
- PyTorchDeep now also allows to check for additivity (sum of shapley values should equal model output)
- Activate this check by default


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
