### PR TITLE
MAINT: Revert transformer model in tests to previous larger model

### DIFF
--- a/tests/explainers/conftest.py
+++ b/tests/explainers/conftest.py
@@ -13,7 +13,8 @@ def basic_translation_scenario():
 
     # Use a *tiny* tokenizer model, to keep tests running as fast as possible.
     # Nb. At time of writing, this pretrained model requires "protobuf==3.20.3".
-    name = "mesolitica/finetune-translation-t5-super-super-tiny-standard-bahasa-cased"
+    # name = "mesolitica/finetune-translation-t5-super-super-tiny-standard-bahasa-cased"
+    name = "Helsinki-NLP/opus-mt-en-es"
     tokenizer = AutoTokenizer.from_pretrained(name)
     model = AutoModelForSeq2SeqLM.from_pretrained(name)
 


### PR DESCRIPTION
This fixes the test suite, which has started failing recently due to a broken HuggingFace dependency.

#3046 switched the model used in the test suite to a "tiny" model, which reduced CI time by a full 5 minutes. However, it looks like the "tiny" model has been removed from HuggingFace.

This PR restores the previous, larger model. This will increase CI times by ~5mins, but should get the tests passing. So, once tests are fixed, we can find a better smaller model for the tests. Or, we could look for an alternative implementation that is faster and doesn't depend on external resources like HuggingFace.