### PR TITLE
Fix/ngboost col sample lt 1

### DIFF
--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -139,11 +139,31 @@ def _validate_shap_values(model, x_test):
     )
 
 
-def test_ngboost():
+@pytest.mark.parametrize("col_sample", [1.0, 0.9])
+def test_ngboost_models_prediction_equal(col_sample):
+    from shap.explainers._tree import TreeEnsemble
+
+    ngboost = pytest.importorskip("ngboost")
+    X, y = shap.datasets.california(n_points=500)
+
+    model = ngboost.NGBRegressor(n_estimators=2, col_sample=col_sample).fit(X, y)
+
+    tree_ensemble = TreeEnsemble(model=model,
+                                data=X,
+                                data_missing=None,
+                                model_output=0,
+                                )
+    y_pred = model.predict(X)
+    y_pred_tree_ensemble = tree_ensemble.predict(X)
+    assert (y_pred == y_pred_tree_ensemble).all()
+
+
+@pytest.mark.parametrize("col_sample", [1.0, 0.9])
+def test_ngboost_sum_of_shap_values(col_sample):
     ngboost = pytest.importorskip("ngboost")
 
     X, y = shap.datasets.california(n_points=500)
-    model = ngboost.NGBRegressor(n_estimators=20).fit(X, y)
+    model = ngboost.NGBRegressor(n_estimators=20, col_sample=col_sample).fit(X, y)
     predicted = model.predict(X)
 
     # explain the model's predictions using SHAP values


### PR DESCRIPTION
## Overview

Closes #3261  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
This PR only solves the problem if we have just 1 estimator. So for this script:
```python
import shap 
import ngboost as ngb
import numpy as np

X, y = shap.datasets.california(n_points=500)
model = ngb.NGBRegressor(n_estimators=1, col_sample = 0.9).fit(X, y)

predicted = model.predict(X)

# explain the model's predictions using SHAP values
explainer = shap.TreeExplainer(model, model_output=0)

explanation = explainer(X_predict_explain)

# check that SHAP values sum to model output
assert (
    np.abs(explanation.values.sum(1) + explanation.base_values - predicted).max()
    < 1e-5
)
```


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)

Here is a breakdown of the issue: If we use ngboost with `col_sample < 1` some columns of X get dropped, the rest is reordered, see [here](https://github.com/stanfordmlgroup/ngboost/blob/master/ngboost/ngboost.py#L147-L151). Unfortunately, this might be different for each estimator. Which means, we would need to rewrite the `shap_values` function or `predict` function, not quite sure though.

