### PR TITLE
MAINT: Add release note template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,7 @@ changelog:
       - ci
     authors:
       - dependabot
+      - pre-commit-ci
   categories:
     - title: Added
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,21 +2,25 @@ changelog:
   exclude:
     labels:
       - skip-changelog
-      - documentation
-      - ci
     authors:
       - dependabot
       - pre-commit-ci
   categories:
+    - title: Breaking changes
+      labels:
+        - BREAKING
     - title: Added
       labels:
         - enhancement
-    - title: Changed
-      labels:
-        - BREAKING
     - title: Fixed
       labels:
         - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - ci
     - title: Other Changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+      - documentation
+      - ci
+    authors:
+      - dependabot
+  categories:
+    - title: Added
+      labels:
+        - enhancement
+    - title: Changed
+      labels:
+        - BREAKING
+    - title: Fixed
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adds a template file for easier auto-generation of release notes according to category.

Docs for reference: <https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes>

Nb. The automatically generated release notes do not have to be perfect, as we can edit them after the first-pass has been generated. So, I think it is better to err on the side of producing too much information, as we can then easily strip out anything superfluous manually and remove any unused sections.

Example screenshot (Prior to manual edit):

![image](https://github.com/shap/shap/assets/71127464/4443a468-d619-4398-a46f-e0dfff012067)
