### PR TITLE
use small bart model

### DIFF
--- a/tests/explainers/conftest.py
+++ b/tests/explainers/conftest.py
@@ -14,7 +14,8 @@ def basic_translation_scenario():
     # Use a *tiny* tokenizer model, to keep tests running as fast as possible.
     # Nb. At time of writing, this pretrained model requires "protobuf==3.20.3".
     # name = "mesolitica/finetune-translation-t5-super-super-tiny-standard-bahasa-cased"
-    name = "Helsinki-NLP/opus-mt-en-es"
+    # name = "Helsinki-NLP/opus-mt-en-es"
+    name = "hf-internal-testing/tiny-random-BartModel"
     tokenizer = AutoTokenizer.from_pretrained(name)
     model = AutoModelForSeq2SeqLM.from_pretrained(name)
 


### PR DESCRIPTION
## Overview

Works towards #3045 <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
- use internal huggingface testing model which is [really small (~140kB)](https://huggingface.co/hf-internal-testing/tiny-random-BartModel/tree/main)

One of the transformers maintainers mentions the (internal-hf-testing) models [here](https://github.com/huggingface/transformers/issues/15308#issuecomment-1022641924) so they should be stable. We could also just republish the model in one of our repositories, if one expresses the wish.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
