### PR TITLE
CI: cancel only concurrent builds on PRs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel only PR intermediate builds
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   run_tests:


### PR DESCRIPTION
## Overview

Modifies our CI job so that tests on the master branch are not cancelled by concurrency.

## Context

The run status of the tests job is used as an indicator of the health of the CI pipeline, displayed in the "tests: passing" badge on the README.

If a run is cancelled for concurrency reasons, this will lead to a false positive status of "Tests: Failing". It also leads to notifications to maintainers. This PR ensures that only intermediate builds on PRs are cancelled, and all runs on the master branch are left to complete.

Implementation inspired by (ie copied directly from) tensorflow's approach:
https://github.com/styfle/cancel-workflow-action/issues/133#issuecomment-1040039549
