### PR TITLE
FIX: Xgboost sklearn model parameters that should be passed to xgboost.DMatrix

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1666,9 +1666,8 @@ def get_xgboost_dmatrix_properties(model):
     properties_to_pass = ["missing", "n_jobs", "enable_categorical", "feature_types"]
     dmatrix_attributes = {}
     for attribute in properties_to_pass:
-        value = getattr(model, attribute)
-        if value is not None:
-            dmatrix_attributes[attribute] = value
+        if hasattr(model, attribute):
+            dmatrix_attributes[attribute] = getattr(model, attribute)
 
     # Convert sklearn n_jobs to xgboost nthread
     if "n_jobs" in dmatrix_attributes:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -991,6 +991,12 @@ class TreeEnsemble:
                     self.model_output = "probability_doubled" # with predict_proba we need to double the outputs to match
                 else:
                     self.model_output = "probability"
+            # Some properties of the sklearn API are passed to a DMatrix object in xgboost
+            # We need to make sure we do the same here - gh3313
+            properties_to_pass = ["missing", "n_jobs", "enable_categorical", "feature_types"]
+            for prop in properties_to_pass:
+                if hasattr(model, prop):
+                    setattr(self, f"dmatrix_{prop}", getattr(model, prop))
         elif safe_isinstance(model, "xgboost.sklearn.XGBRegressor"):
             self.original_model = model.get_booster()
             self.model_type = "xgboost"
@@ -1002,6 +1008,12 @@ class TreeEnsemble:
             self.tree_limit = getattr(model, "best_ntree_limit", None)
             if xgb_loader.num_class > 0:
                 self.num_stacked_models = xgb_loader.num_class
+            # Some properties of the sklearn API are passed to a DMatrix object in xgboost
+            # We need to make sure we do the same here - gh3313
+            properties_to_pass = ["missing", "n_jobs", "enable_categorical", "feature_types"]
+            for prop in properties_to_pass:
+                if hasattr(model, prop):
+                    setattr(self, f"dmatrix_{prop}", getattr(model, prop))
         elif safe_isinstance(model, "xgboost.sklearn.XGBRanker"):
             self.original_model = model.get_booster()
             self.model_type = "xgboost"
@@ -1013,6 +1025,12 @@ class TreeEnsemble:
             self.tree_limit = getattr(model, "best_ntree_limit", None)
             if xgb_loader.num_class > 0:
                 self.num_stacked_models = xgb_loader.num_class
+            # Some properties of the sklearn API are passed to a DMatrix object in xgboost
+            # We need to make sure we do the same here - gh3313
+            properties_to_pass = ["missing", "n_jobs", "enable_categorical", "feature_types"]
+            for prop in properties_to_pass:
+                if hasattr(model, prop):
+                    setattr(self, f"dmatrix_{prop}", getattr(model, prop))
         elif safe_isinstance(model, "lightgbm.basic.Booster"):
             assert_import("lightgbm")
             self.model_type = "lightgbm"

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1669,7 +1669,7 @@ def get_dmatrix_properties(model: xgboost.sklearn.XGBModel):
         if value is not None:
             dmatrix_attributes[attribute] = value
     return dmatrix_attributes
-    
+
 def get_xgboost_json(model):
     """ This gets a JSON dump of an XGBoost model while ensuring the features names are their indexes.
     """

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1661,7 +1661,10 @@ class IsoTree(SingleTree):
             self.features = np.where(self.features >= 0, tree_features[self.features], self.features)
 
 
-def get_dmatrix_properties(model: xgboost.sklearn.XGBModel):
+def get_dmatrix_properties(model):
+    """
+    Retrieves properties from an xgboost.sklearn.XGBModel instance that should be passed to the xgboost.core.DMatrix object before calling predict on the model
+    """
     properties_to_pass = ["missing", "n_jobs", "enable_categorical", "feature_types"]
     dmatrix_attributes = {}
     for attribute in properties_to_pass:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -355,7 +355,12 @@ class TreeExplainer(Explainer):
             if self.model.model_type == "xgboost":
                 import xgboost
                 if not isinstance(X, xgboost.core.DMatrix):
-                    X = xgboost.DMatrix(X)
+                    # Retrieve any DMatrix properties if they have been set on the class
+                    dmatrix_props = [p for p in dir(self) if p.startswith("dmatrix_")]
+                    dmatrix_kwargs = {p.split("dmatrix_")[-1]: getattr(self, p) for p in dmatrix_props}
+                    if "n_jobs" in dmatrix_kwargs:
+                        dmatrix_kwargs["nthread"] = dmatrix_kwargs.pop("n_jobs")
+                    X = xgboost.DMatrix(X, **dmatrix_kwargs)
                 if tree_limit == -1:
                     tree_limit = 0
                 try:

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1198,14 +1198,15 @@ class TestExplainerXGBoost:
         assert expected_diff < 1e-4, "SHAP values don't sum to model output!"
 
     def test_xgboost_dmatrix_propagation(self):
+        """
+        Test that xgboost sklearn attributues are properly passed to the DMatrix
+        initiated during shap value calculation. see GH #3313
+        """
         xgboost = pytest.importorskip("xgboost")
 
-        def sigmoid(x):
-            return 1 / (1 + np.exp(-x))
+        X, y = shap.datasets.adult(n_points=100)
 
-        X, y = shap.datasets.adult()
-
-        # Randomly set some features of X to NaN to test propagation of missing param
+        # Randomly add missing data to the input where missing data is encoded as 1e-8
         X_nan = X.copy()
         X_nan.loc[
             X_nan.sample(frac=0.3, random_state=42).index,
@@ -1214,12 +1215,11 @@ class TestExplainerXGBoost:
 
         clf = xgboost.XGBClassifier(missing=1e-8, random_state=42)
         clf.fit(X_nan, y)
-        pred_probs = clf.predict_proba(X_nan)[:, 1]
+        margin = clf.predict(X_nan, output_margin=True)
         explainer = shap.TreeExplainer(clf)
         shap_values = explainer.shap_values(X_nan)
         # check that SHAP values sum to model output
-        expected_diff = np.max((pred_probs - sigmoid(explainer.expected_value + shap_values.sum(axis=1))).abs())
-        assert expected_diff < 1e-5, "SHAP values don't sum to model output!"
+        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
 
     def test_xgboost_direct(self):
         xgboost = pytest.importorskip("xgboost")


### PR DESCRIPTION
## Overview

Closes #3313 

Description of the changes proposed in this pull request:
- Changed the TreeEnsemble class to keep track of xgboost sklearn specific class parameters that may be useful for propogating to DMatrices later on
- Adapted the shap_values calculation method of the TreeExplainer to use DMatrix kwargs if they have been set on the explainer class


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
