### PR TITLE
refactor: raise error during init if masker is None for PermutationExplainer

### DIFF
--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -47,6 +47,9 @@ class PermutationExplainer(Explainer):
         # setting seed for random generation: if seed is not None, then shap values computation should be reproducible
         np.random.seed(seed)
 
+        if masker is None:
+            raise ValueError("masker cannot be None.")
+
         super().__init__(model, masker, link=link, linearize_link=linearize_link, feature_names=feature_names)
 
         if not isinstance(self.model, Model):

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -2,8 +2,28 @@
 """
 
 import pytest
+import sklearn
 
 import shap
+
+
+def test_explainer_to_permutationexplainer():
+    """Checks that Explainer maps to PermutationExplainer as expected."""
+
+    X_train, X_test, y_train, _ = sklearn.model_selection.train_test_split(*shap.datasets.adult(), test_size=0.1, random_state=0)
+    lr = sklearn.linear_model.LogisticRegression(solver="liblinear")
+    lr.fit(X_train, y_train)
+
+    explainer = shap.Explainer(lr.predict_proba, masker=X_train)
+    assert isinstance(explainer, shap.PermutationExplainer)
+
+    # ensures a proper error message is raised if a masker is not provided (GH #3310)
+    with pytest.raises(
+        ValueError,
+        match=r"masker cannot be None",
+    ):
+        explainer = shap.Explainer(lr.predict_proba)
+        _ = explainer(X_test)
 
 
 def test_wrapping_for_text_to_text_teacher_forcing_model():


### PR DESCRIPTION
## Overview

Closes #3310  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:

* Raise ValueError earlier on during `__init__` rather than during `__call__`. See #3310 for more context.


## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
