### PR TITLE
refactor: remove boston dataset as promised

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -134,7 +134,6 @@ datasets
 
     shap.datasets.a1a
     shap.datasets.adult
-    shap.datasets.boston
     shap.datasets.california
     shap.datasets.communitiesandcrime
     shap.datasets.corrgroups60

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -4,7 +4,6 @@ from urllib.request import urlretrieve
 import numpy as np
 import pandas as pd
 import sklearn.datasets
-from sklearn.utils import deprecated
 
 import shap
 
@@ -32,23 +31,6 @@ def imagenet50(display=False, resolution=224, n_points=None): # pylint: disable=
         y = shap.utils.sample(y, n_points, random_state=0)
 
     return X, y
-
-@deprecated()
-def boston(display=False, n_points=None):
-    """Return the boston housing data in a nice package (DEPRECATED).
-
-    This dataset is deprecated and will be removed in the next version (0.43.0).
-    Please use :func:`shap.datasets.california` instead.
-    """
-    d = sklearn.datasets.load_boston()
-    df = pd.DataFrame(data=d.data, columns=d.feature_names) # pylint: disable=E1101
-    target = d.target # pylint: disable=E1101
-
-    if n_points is not None:
-        df = shap.utils.sample(df, n_points, random_state=0)
-        target = shap.utils.sample(target, n_points, random_state=0)
-
-    return df, target
 
 
 def california(display=False, n_points=None): # pylint: disable=unused-argument


### PR DESCRIPTION
## Overview

Closes #XXXX  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:

* Remove the `shap.datasets.boston` Boston dataset, which has been marked deprecated since the previous major version 0.42, and slated for removal in 0.43.0.


## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
