### PR TITLE
MAINT: reduce test times of 3 longest tests

### DIFF
--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -35,8 +35,9 @@ def test_wrapping_for_text_to_text_teacher_forcing_model():
     def f(x): # pylint: disable=unused-argument
         pass
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
-    model = transformers.AutoModelForCausalLM.from_pretrained("gpt2")
+    name = "hf-internal-testing/tiny-random-BartForCausalLM"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    model = transformers.AutoModelForCausalLM.from_pretrained(name)
     wrapped_model = shap.models.TeacherForcing(f, similarity_model=model, similarity_tokenizer=tokenizer)
     masker = shap.maskers.Text(tokenizer, mask_token="...")
 
@@ -49,7 +50,6 @@ def test_wrapping_for_topk_lm_model():
     """
 
     transformers = pytest.importorskip("transformers")
-
     tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
     model = transformers.AutoModelForCausalLM.from_pretrained("gpt2")
     wrapped_model = shap.models.TopKLM(model, tokenizer)

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -50,8 +50,10 @@ def test_wrapping_for_topk_lm_model():
     """
 
     transformers = pytest.importorskip("transformers")
-    tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
-    model = transformers.AutoModelForCausalLM.from_pretrained("gpt2")
+
+    name = "hf-internal-testing/tiny-random-BartForCausalLM"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    model = transformers.AutoModelForCausalLM.from_pretrained(name)
     wrapped_model = shap.models.TopKLM(model, tokenizer)
     masker = shap.maskers.Text(tokenizer, mask_token="...")
 

--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -215,7 +215,7 @@ def test_pytorch_mnist_cnn():
         else:
             e = shap.GradientExplainer(model, next_x[inds, :, :, :])
         test_x, _ = next(iter(test_loader))
-        shap_values = e.shap_values(test_x[:1], nsamples=5000)
+        shap_values = e.shap_values(test_x[:1], nsamples=1000)
 
         if not interim:
             # unlike deepLIFT, Integrated Gradients aren't necessarily consistent for interim layers

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1444,7 +1444,7 @@ class TestExplainerLightGBM:
 
         # train lightgbm model
         X_train, X_test, Y_train, _ = sklearn.model_selection.train_test_split(
-            *shap.datasets.adult(),
+            *shap.datasets.adult(n_points=500),
             test_size=0.2,
             random_state=0,
         )

--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -13,8 +13,9 @@ def test_method_get_teacher_forced_logits_for_encoder_decoder_model():
 
     transformers = pytest.importorskip("transformers")
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained("sshleifer/distilbart-xsum-12-6")
-    model = transformers.AutoModelForSeq2SeqLM.from_pretrained("sshleifer/distilbart-xsum-12-6")
+    name = "hf-internal-testing/tiny-random-BartModel"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(name)
 
     wrapped_model = shap.models.TeacherForcing(model, tokenizer, device='cpu')
 

--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -33,7 +33,7 @@ def test_method_get_teacher_forced_logits_for_decoder_model():
 
     transformers = pytest.importorskip("transformers")
 
-    name = "hf-internal-testing/tiny-random-BartForCausalLM"
+    name = "hf-internal-testing/tiny-random-gpt2"
     tokenizer = transformers.AutoTokenizer.from_pretrained(name)
     model = transformers.AutoModelForCausalLM.from_pretrained(name)
     model.config.is_decoder = True

--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -33,8 +33,9 @@ def test_method_get_teacher_forced_logits_for_decoder_model():
 
     transformers = pytest.importorskip("transformers")
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained("gpt2")
-    model = transformers.AutoModelForCausalLM.from_pretrained("gpt2")
+    name = "hf-internal-testing/tiny-random-BartForCausalLM"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    model = transformers.AutoModelForCausalLM.from_pretrained(name)
     model.config.is_decoder = True
 
     wrapped_model = shap.models.TeacherForcing(model, tokenizer, device='cpu')

--- a/tests/models/test_text_generation.py
+++ b/tests/models/test_text_generation.py
@@ -17,8 +17,9 @@ def test_call_function_text_generation():
     torch = pytest.importorskip("torch")
     transformers = pytest.importorskip("transformers")
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained("sshleifer/distilbart-xsum-12-6")
-    model = transformers.AutoModelForSeq2SeqLM.from_pretrained("sshleifer/distilbart-xsum-12-6")
+    name = "hf-internal-testing/tiny-random-BartModel"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(name)
 
     # Define function
     def f(x):


### PR DESCRIPTION
## Overview

Closes #3045  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
- use smaller models for longrunning tests where possible
- remove download of gpt2 model entirely (just the tokenizer is downloaded, ~2MB)
- reduce number of calculated shap values (hopefully the test does not become flaky with this change)
- reduced testtimes (tested on my local machine): 
   - tests/explainers/test_gradient.py::test_pytorch_mnist_cnn: 33.42s / 6.39s
   - total test time: [541.37s](https://github.com/shap/shap/actions/runs/6443885950/job/17496282816?pr=3317#step:6:195) vs [839s](https://github.com/shap/shap/actions/runs/6440320191/job/17489006493?pr=3316#step:6:202) for ubuntu latest python 3.11


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- ~[ ] Unit tests added (if fixing a bug or adding a new feature)~
