### PR TITLE
MAINT: Simplify pre-commit hook specification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,13 @@ ci:
   autoupdate_schedule: monthly
 
 exclude: '.*tree_shap_paper.*|.*user_studies.*'
+
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.292
   hooks:
   - id: ruff
+    types_or: [python, pyi, jupyter]
     args: [ --fix, --exit-non-zero-on-fix ]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -22,21 +24,9 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
 
-# Notebook linting checks
-# Careful: When using pre-commit, ruff's "include" and "exclude" config is ignored.
-# See: https://github.com/shap/shap/issues/3036
-
 - repo: https://github.com/psf/black
   rev: 23.9.1
   hooks:
   - id: black-jupyter
     name: black (notebooks)
     files:  notebooks/.*.ipynb
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.292
-  hooks:
-  - id: ruff
-    name: ruff (notebooks)
-    types_or: [jupyter]
-    files: notebooks/.*.ipynb
-    args: [ --fix, --exit-non-zero-on-fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,13 +129,17 @@ ignore = [
 ]
 
 # Careful: when running on pre-commit, ruff's "include" and "exclude" config
-# options are ignored! So, use the "per-file-ignores" config to disable linting
-# for specific files.
+# options are ignored! So, instead of "exclude", use the "per-file-ignores"
+# config to always disable linting for specific files.
+include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 
 [tool.ruff.per-file-ignores]
 # Don't apply linting/formatting to vendored code
 "shap/explainers/other/_maple.py" = ["ALL"]
 "shap/plots/colors/_colorconv.py" = ["ALL"]
+
+# Ignore notebooks in user_studies, which are not maintained
+"docs/user_studies/*.ipynb" = ["ALL"]
 
 # Ignore SHAP Paper, as it is an unmaintained record of a published paper
 "notebooks/tabular_examples/tree_based_models/tree_shap_paper/*"  = ["ALL"]


### PR DESCRIPTION
## Overview

Simplifies the configuration of pre-commit hooks, now that all notebooks can be linted.

Previously we used regular expressions to only lint specific notebooks. Now though, we have all notebooks passing Ruff and Black! 🎉

So, we can remove the regular expressions and just run Ruff a single time on both `.py` and `.ipynb` files.
