### PR TITLE
Fix CatboostClassifier explanations with feature interactions on windows

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import scipy.special
+import os
 from packaging import version
 
 from .. import maskers
@@ -1837,10 +1838,11 @@ class CatBoostTreeModelLoader:
         # cb_model.save_model("cb_model.json", format="json")
         # self.loaded_cb_model = json.load(open("cb_model.json", "r"))
         import tempfile
-        tmp_file = tempfile.NamedTemporaryFile()
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)
         cb_model.save_model(tmp_file.name, format="json")
         self.loaded_cb_model = json.load(open(tmp_file.name))
         tmp_file.close()
+        os.unlink(tmp_file.name)
 
         # load the CatBoost oblivious trees specific parameters
         self.num_trees = len(self.loaded_cb_model['oblivious_trees'])

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1,4 +1,5 @@
 import json
+import os
 import struct
 import time
 import warnings
@@ -6,7 +7,6 @@ import warnings
 import numpy as np
 import pandas as pd
 import scipy.special
-import os
 from packaging import version
 
 from .. import maskers

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1835,14 +1835,11 @@ class XGBTreeModelLoader:
 
 class CatBoostTreeModelLoader:
     def __init__(self, cb_model):
-        # cb_model.save_model("cb_model.json", format="json")
-        # self.loaded_cb_model = json.load(open("cb_model.json", "r"))
         import tempfile
-        tmp_file = tempfile.NamedTemporaryFile(delete=False)
-        cb_model.save_model(tmp_file.name, format="json")
-        self.loaded_cb_model = json.load(open(tmp_file.name))
-        tmp_file.close()
-        os.unlink(tmp_file.name)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, "model.json")
+            cb_model.save_model(tmp_file, format="json")
+            self.loaded_cb_model = json.load(open(tmp_file))
 
         # load the CatBoost oblivious trees specific parameters
         self.num_trees = len(self.loaded_cb_model['oblivious_trees'])

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -387,7 +387,7 @@ def test_catboost_categorical():
 
 
 def test_catboost_interactions():
-    # GH 3187
+    # GH 3324
     catboost = pytest.importorskip("catboost")
 
     X, y = shap.datasets.adult(n_points=50)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -386,6 +386,24 @@ def test_catboost_categorical():
     )
 
 
+def test_catboost_interactions():
+    # GH 3187
+    catboost = pytest.importorskip("catboost")
+
+    X, y = shap.datasets.adult(n_points=50)
+
+    model = catboost.CatBoostClassifier(depth=1, iterations=10).fit(X, y)
+    predicted = model.predict(X, prediction_type="RawFormulaVal")
+
+    ex_cat = shap.TreeExplainer(model)
+
+    # catboost explanations
+    explanation = ex_cat(X, interactions=True)
+    assert (
+        np.abs(explanation.values.sum(axis=(1, 2)) + explanation.base_values - predicted).max()
+        < 1e-4
+    )
+
 # TODO: Test tree_limit argument
 
 


### PR DESCRIPTION
## Overview

Closes #3324  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
- handle delete manually so that catboost interactions can work for windows


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
