### PR TITLE
Remove unnecessary `safe_isinstance` calls

### DIFF
--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -5,7 +5,7 @@ from tqdm.auto import tqdm
 
 from shap import Explanation, links
 from shap.maskers import FixedComposite, Image, Text
-from shap.utils import MaskedModel, partition_tree_shuffle, safe_isinstance
+from shap.utils import MaskedModel, partition_tree_shuffle
 
 from ._result import BenchmarkResult
 
@@ -82,7 +82,7 @@ class ExplanationError:
         """ Run this benchmark on the given explanation.
         """
 
-        if safe_isinstance(explanation, "numpy.ndarray"):
+        if isinstance(explanation, np.ndarray):
             attributions = explanation
         elif isinstance(explanation, Explanation):
             attributions = explanation.values

--- a/shap/benchmark/_sequential.py
+++ b/shap/benchmark/_sequential.py
@@ -8,7 +8,7 @@ from tqdm.auto import tqdm
 
 from shap import Explanation, links
 from shap.maskers import FixedComposite, Image, Text
-from shap.utils import MaskedModel, safe_isinstance
+from shap.utils import MaskedModel
 
 from ._result import BenchmarkResult
 
@@ -89,7 +89,7 @@ class SequentialPerturbation:
 
     def __call__(self, name, explanation, *model_args, percent=0.01, indices=[], y=None, label=None, silent=False, debug_mode=False, batch_size=10):
         # if explainer is already the attributions
-        if safe_isinstance(explanation, "numpy.ndarray"):
+        if isinstance(explanation, np.ndarray):
             attributions = explanation
         elif isinstance(explanation, Explanation):
             attributions = explanation.values
@@ -102,7 +102,7 @@ class SequentialPerturbation:
             label = "Score %d" % len(self.score_values)
 
         # convert dataframes
-        # if safe_isinstance(X, "pandas.core.series.Series") or safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        # if isinstance(X, (pd.Series, pd.DataFrame)):
         #     X = X.values
 
         # convert all single-sample vectors to matrices
@@ -202,7 +202,7 @@ class SequentialPerturbation:
         Will be deprecated once MaskedModel is in complete support
         '''
         # if explainer is already the attributions
-        if safe_isinstance(explanation, "numpy.ndarray"):
+        if isinstance(explanation, np.ndarray):
             attributions = explanation
         elif isinstance(explanation, Explanation):
             attributions = explanation.values
@@ -211,7 +211,7 @@ class SequentialPerturbation:
             label = "Score %d" % len(self.score_values)
 
         # convert dataframes
-        if safe_isinstance(X, "pandas.core.series.Series") or safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values
 
         # convert all single-sample vectors to matrices

--- a/shap/benchmark/framework.py
+++ b/shap/benchmark/framework.py
@@ -2,8 +2,7 @@ import itertools as it
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-from shap.utils import safe_isinstance
+import pandas as pd
 
 from . import perturbation
 
@@ -17,9 +16,9 @@ def update(model, attributions, X, y, masker, sort_order, perturbation_method, s
 
 def get_benchmark(model, attributions, X, y, masker, metrics):
     # convert dataframes
-    if safe_isinstance(X, "pandas.core.series.Series") or safe_isinstance(X, "pandas.core.frame.DataFrame"):
+    if isinstance(X, (pd.Series, pd.DataFrame)):
         X = X.values
-    if safe_isinstance(masker, "pandas.core.series.Series") or safe_isinstance(masker, "pandas.core.frame.DataFrame"):
+    if isinstance(masker, (pd.Series, pd.DataFrame)):
         masker = masker.values
 
     # record scores per metric

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 import sklearn.utils
 from tqdm.auto import tqdm
 
@@ -395,7 +396,7 @@ def local_accuracy(X_train, y_train, X_test, y_test, attr_test, model_generator,
     return metric(yp_test, strip_list(attr_test).sum(1))
 
 def to_array(*args):
-    return [a.values if str(type(a)).endswith("'pandas.core.frame.DataFrame'>") else a for a in args]
+    return [a.values if isinstance(a, pd.DataFrame) else a for a in args]
 
 def const_rand(size, seed=23980):
     """ Generate a random array with a fixed seed.

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -133,9 +133,7 @@ class AdditiveExplainer(Explainer):
 #             raise ValueError("The passed model must be a recognized object or a function!")
 
 #         # convert dataframes
-#         if safe_isinstance(data, "pandas.core.series.Series"):
-#             data = data.values
-#         elif safe_isinstance(data, "pandas.core.frame.DataFrame"):
+#         if isinstance(data, (pd.Series, pd.DataFrame)):
 #             data = data.values
 #         self.data = data
 
@@ -169,20 +167,15 @@ class AdditiveExplainer(Explainer):
 #         """
 
 #         # convert dataframes
-#         if str(type(X)).endswith("pandas.core.series.Series'>"):
-#             X = X.values
-#         elif str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+#         if isinstance(X, (pd.Series, pd.DataFrame)):
 #             X = X.values
 
-#         #assert str(type(X)).endswith("'numpy.ndarray'>"), "Unknown instance type: " + str(type(X))
+#         # assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
 #         assert len(X.shape) == 1 or len(X.shape) == 2, "Instance must have 1 or 2 dimensions!"
 
 #         # convert dataframes
-#         if safe_isinstance(X, "pandas.core.series.Series"):
+#         if isinstance(X, (pd.Series, pd.DataFrame)):
 #             X = X.values
-#         elif safe_isinstance(X, "pandas.core.frame.DataFrame"):
-#             X = X.values
-
 
 #         phi = np.zeros(X.shape)
 #         tmp = np.zeros(X.shape)

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -2,6 +2,7 @@ import copy
 import time
 
 import numpy as np
+import pandas as pd
 import scipy.sparse
 
 from .. import explainers, links, maskers, models
@@ -78,8 +79,10 @@ class Explainer(Serializable):
         self.feature_names = feature_names
 
         # wrap the incoming masker object as a shap.Masker object
-        if safe_isinstance(masker, "pandas.core.frame.DataFrame") or \
-                ((safe_isinstance(masker, "numpy.ndarray") or scipy.sparse.issparse(masker)) and len(masker.shape) == 2):
+        if (
+            isinstance(masker, pd.DataFrame)
+            or ((isinstance(masker, np.ndarray) or scipy.sparse.issparse(masker)) and len(masker.shape) == 2)
+        ):
             if algorithm == "partition":
                 self.masker = maskers.Partition(masker)
             else:
@@ -232,7 +235,7 @@ class Explainer(Serializable):
                     pass
 
             # convert DataFrames to numpy arrays
-            if safe_isinstance(args[i], "pandas.core.frame.DataFrame"):
+            if isinstance(args[i], pd.DataFrame):
                 feature_names[i] = list(args[i].columns)
                 args[i] = args[i].to_numpy()
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -84,7 +84,7 @@ class KernelExplainer(Explainer):
 
         if feature_names is not None:
             self.data_feature_names=feature_names
-        elif safe_isinstance(data, "pandas.core.frame.DataFrame"):
+        elif isinstance(data, pd.DataFrame):
             self.data_feature_names = list(data.columns)
 
         # convert incoming inputs to standardized iml objects
@@ -135,7 +135,7 @@ class KernelExplainer(Explainer):
 
         start_time = time.time()
 
-        if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, pd.DataFrame):
             feature_names = list(X.columns)
         else:
             feature_names = getattr(self, "data_feature_names", None)
@@ -153,7 +153,7 @@ class KernelExplainer(Explainer):
         return Explanation(
             v,
             base_values=ev_tiled,
-            data=X.to_numpy() if safe_isinstance(X, "pandas.core.frame.DataFrame") else X,
+            data=X.to_numpy() if isinstance(X, pd.DataFrame) else X,
             feature_names=feature_names,
             compute_time=time.time() - start_time,
         )
@@ -194,9 +194,9 @@ class KernelExplainer(Explainer):
         """
 
         # convert dataframes
-        if str(type(X)).endswith("pandas.core.series.Series'>"):
+        if isinstance(X, pd.Series):
             X = X.values
-        elif str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+        elif isinstance(X, pd.DataFrame):
             if self.keep_index:
                 index_value = X.index.values
                 index_name = X.index.name

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -1,11 +1,11 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 from scipy.sparse import issparse
 from tqdm.auto import tqdm
 
 from .. import links, maskers
-from ..utils import safe_isinstance
 from ..utils._exceptions import (
     DimensionError,
     InvalidFeaturePerturbationError,
@@ -73,7 +73,7 @@ class LinearExplainer(Explainer):
         # wrap the incoming masker object as a shap.Masker object before calling
         # parent class constructor, which does the same but without respecting
         # the user-provided feature_perturbation choice
-        if safe_isinstance(masker, "pandas.core.frame.DataFrame") or ((safe_isinstance(masker, "numpy.ndarray") or issparse(masker)) and len(masker.shape) == 2):
+        if isinstance(masker, pd.DataFrame) or ((isinstance(masker, np.ndarray) or issparse(masker)) and len(masker.shape) == 2):
             if self.feature_perturbation == "correlation_dependent":
                 masker = maskers.Impute(masker)
             else:
@@ -102,7 +102,7 @@ class LinearExplainer(Explainer):
         data = getattr(self.masker, "data", None)
 
         # convert DataFrame's to numpy arrays
-        if safe_isinstance(type(data), 'pandas.core.frame.DataFrame'):
+        if isinstance(data, pd.DataFrame):
             data = data.values
 
         # get the mean and covariance of the model
@@ -111,19 +111,19 @@ class LinearExplainer(Explainer):
             self.cov = self.masker.cov
         elif isinstance(data, dict) and len(data) == 2:
             self.mean = data["mean"]
-            if safe_isinstance(self.mean, "pandas.core.series.Series"):
+            if isinstance(self.mean, pd.Series):
                 self.mean = self.mean.values
 
             self.cov = data["cov"]
-            if safe_isinstance(self.cov, "pandas.core.frame.DataFrame"):
+            if isinstance(self.cov, pd.DataFrame):
                 self.cov = self.cov.values
-        elif type(data) is tuple and len(data) == 2:
+        elif isinstance(data, tuple) and len(data) == 2:
             self.mean = data[0]
-            if safe_isinstance(self.mean, "pandas.core.series.Series"):
+            if isinstance(self.mean, pd.Series):
                 self.mean = self.mean.values
 
             self.cov = data[1]
-            if safe_isinstance(self.cov, "pandas.core.frame.DataFrame"):
+            if isinstance(self.cov, pd.DataFrame):
                 self.cov = self.cov.values
         elif data is None:
             raise ValueError("A background data distribution must be provided!")
@@ -296,12 +296,9 @@ class LinearExplainer(Explainer):
             X = X.reshape(1, -1)
 
         # convert dataframes
-        if str(type(X)).endswith("pandas.core.series.Series'>"):
-            X = X.values
-        elif str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+        if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values
 
-        #assert str(type(X)).endswith("'numpy.ndarray'>"), "Unknown instance type: " + str(type(X))
         if len(X.shape) not in (1, 2):
             raise DimensionError("Instance must have 1 or 2 dimensions! Not: %s" %len(X.shape))
 
@@ -358,12 +355,10 @@ class LinearExplainer(Explainer):
         """
 
         # convert dataframes
-        if str(type(X)).endswith("pandas.core.series.Series'>"):
-            X = X.values
-        elif str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+        if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values
 
-        #assert str(type(X)).endswith("'numpy.ndarray'>"), "Unknown instance type: " + str(type(X))
+        # assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 1 or len(X.shape) == 2, "Instance must have 1 or 2 dimensions!"
 
         if self.feature_perturbation == "correlation_dependent":

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -67,9 +67,9 @@ class PartitionExplainer(Explainer):
                          output_names = output_names, feature_names=feature_names)
 
         # convert dataframes
-        # if safe_isinstance(masker, "pandas.core.frame.DataFrame"):
+        # if isinstance(masker, pd.DataFrame):
         #     masker = TabularMasker(masker)
-        # elif safe_isinstance(masker, "numpy.ndarray") and len(masker.shape) == 2:
+        # elif isinstance(masker, np.ndarray) and len(masker.shape) == 2:
         #     masker = TabularMasker(masker)
         # elif safe_isinstance(masker, "transformers.PreTrainedTokenizer"):
         #     masker = TextMasker(masker)

--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 from .._explanation import Explanation
-from ..utils import safe_isinstance
 from ..utils._legacy import convert_to_instance, match_instance_to_data
 from ._kernel import KernelExplainer
 
@@ -50,7 +49,7 @@ class SamplingExplainer(KernelExplainer):
 
     def __call__(self, X, y=None, nsamples=2000):
 
-        if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, pd.DataFrame):
             feature_names = list(X.columns)
             X = X.values
         else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -113,7 +113,7 @@ class TreeExplainer(Explainer):
         """
         if feature_names is not None:
             self.data_feature_names = feature_names
-        elif safe_isinstance(data, "pandas.core.frame.DataFrame"):
+        elif isinstance(data, pd.DataFrame):
             self.data_feature_names = list(data.columns)
 
         masker = data
@@ -149,7 +149,7 @@ class TreeExplainer(Explainer):
             raise InvalidFeaturePerturbationError("feature_perturbation = \"independent\" is not a valid option value, please use " \
                 "feature_perturbation = \"interventional\" instead. See GitHub issue #882.")
 
-        if safe_isinstance(data, "pandas.core.frame.DataFrame"):
+        if isinstance(data, pd.DataFrame):
             self.data = data.values
         elif isinstance(data, DenseData):
             self.data = data.data
@@ -225,7 +225,7 @@ class TreeExplainer(Explainer):
 
         start_time = time.time()
 
-        if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, pd.DataFrame):
             feature_names = list(X.columns)
         else:
             feature_names = getattr(self, "data_feature_names", None)
@@ -250,7 +250,7 @@ class TreeExplainer(Explainer):
 
         # cf. GH issue dsgibbons#66, this conversion to numpy array should be done AFTER
         # calculation of shap values
-        if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, pd.DataFrame):
             X = X.values
 
         return Explanation(
@@ -269,9 +269,7 @@ class TreeExplainer(Explainer):
         if tree_limit < 0 or tree_limit > self.model.values.shape[0]:
             tree_limit = self.model.values.shape[0]
         # convert dataframes
-        if safe_isinstance(X, "pandas.core.series.Series"):
-            X = X.values
-        elif safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values
         flat_output = False
         if len(X.shape) == 1:
@@ -1275,9 +1273,7 @@ class TreeEnsemble:
             tree_limit = -1 if self.tree_limit is None else self.tree_limit
 
         # convert dataframes
-        if safe_isinstance(X, "pandas.core.series.Series"):
-            X = X.values
-        elif safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values
         flat_output = False
         if len(X.shape) == 1:

--- a/shap/explainers/other/_lime.py
+++ b/shap/explainers/other/_lime.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from .._explainer import Explainer
 
@@ -30,7 +31,7 @@ class LimeTabular(Explainer):
         assert mode in ["classification", "regression"]
         self.mode = mode
 
-        if str(type(data)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(data, pd.DataFrame):
             data = data.values
         self.data = data
         self.explainer = lime.lime_tabular.LimeTabularExplainer(data, mode=mode)
@@ -52,7 +53,7 @@ class LimeTabular(Explainer):
     def attributions(self, X, nsamples=5000, num_features=None):
         num_features = X.shape[1] if num_features is None else num_features
 
-        if str(type(X)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(X, pd.DataFrame):
             X = X.values
 
         out = [np.zeros(X.shape) for j in range(self.out_dim)]

--- a/shap/explainers/other/_maple.py
+++ b/shap/explainers/other/_maple.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from sklearn.model_selection import train_test_split
 
 from .._explainer import Explainer
@@ -21,7 +22,7 @@ class Maple(Explainer):
     def __init__(self, model, data):
         self.model = model
 
-        if str(type(data)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(data, pd.DataFrame):
             data = data.values
         self.data = data
         self.data_mean = self.data.mean(0)
@@ -46,7 +47,7 @@ class Maple(Explainer):
             If true, this multiplies the learned coefficients by the mean-centered input. This makes these
             values roughly comparable to SHAP values.
         """
-        if str(type(X)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(X, pd.DataFrame):
             X = X.values
 
         out = [np.zeros(X.shape) for j in range(self.out_dim)]
@@ -91,7 +92,7 @@ class TreeMaple(Explainer):
         else:
             raise NotImplementedError("The passed model is not yet supported by TreeMapleExplainer: " + str(type(model)))
 
-        if str(type(data)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(data, pd.DataFrame):
             data = data.values
         self.data = data
         self.data_mean = self.data.mean(0)
@@ -117,7 +118,7 @@ class TreeMaple(Explainer):
             If true, this multiplies the learned coefficients by the mean-centered input. This makes these
             values roughly comparable to SHAP values.
         """
-        if str(type(X)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(X, pd.DataFrame):
             X = X.values
 
         out = [np.zeros(X.shape) for j in range(self.out_dim)]

--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -4,6 +4,7 @@ It is primarily for illustration since it is slower than the 'tree'
 module which uses a compiled C++ implementation.
 """
 import numpy as np
+import pandas as pd
 
 #import numba
 from ..utils._exceptions import ExplainerError
@@ -39,12 +40,10 @@ from ..utils._exceptions import ExplainerError
 #             return self.trees.predict(X, num_iteration=tree_limit, pred_contrib=True)
 
 #         # convert dataframes
-#         if str(type(X)).endswith("pandas.core.series.Series'>"):
-#             X = X.values
-#         elif str(type(X)).endswith("pandas.core.frame.DataFrame'>"):
+#         if isinstance(X, (pd.Series, pd.DataFrame)):
 #             X = X.values
 
-#         assert str(type(X)).endswith("'numpy.ndarray'>"), "Unknown instance type: " + str(type(X))
+#         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
 #         assert len(X.shape) == 1 or len(X.shape) == 2, "Instance must have 1 or 2 dimensions!"
 
 #         n_outputs = self.trees[0].values.shape[1]
@@ -180,12 +179,10 @@ class TreeExplainer:
             return self.trees.predict(X, num_iteration=tree_limit, pred_contrib=True)
 
         # convert dataframes
-        if str(type(X)).endswith("pandas.core.series.Series'>"):
-            X = X.values
-        elif str(type(X)).endswith("pandas.core.frame.DataFrame'>"):
+        if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values
 
-        assert str(type(X)).endswith("'numpy.ndarray'>"), "Unknown instance type: " + str(type(X))
+        assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 1 or len(X.shape) == 2, "Instance must have 1 or 2 dimensions!"
 
         n_outputs = self.trees[0].values.shape[1]

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -6,7 +6,7 @@ from numba import njit
 
 from .. import utils
 from .._serializable import Deserializer, Serializer
-from ..utils import MaskedModel, safe_isinstance
+from ..utils import MaskedModel
 from ..utils._exceptions import DimensionError, InvalidClusteringError
 from ._masker import Masker
 
@@ -44,7 +44,7 @@ class Tabular(Masker):
         """
 
         self.output_dataframe = False
-        if safe_isinstance(data, "pandas.core.frame.DataFrame"):
+        if isinstance(data, pd.DataFrame):
             self.feature_names = data.columns
             data = data.values
             self.output_dataframe = True
@@ -70,7 +70,7 @@ class Tabular(Masker):
         if clustering is not None:
             if isinstance(clustering, str):
                 self.clustering = utils.hclust(data, metric=clustering)
-            elif safe_isinstance(clustering, "numpy.ndarray"):
+            elif isinstance(clustering, np.ndarray):
                 self.clustering = clustering
             else:
                 raise InvalidClusteringError(

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as pl
 import numpy as np
+import pandas as pd
 import scipy
 
 from .. import Cohorts, Explanation
@@ -131,7 +132,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 
 
     # unwrap any pandas series
-    if str(type(features)) == "<class 'pandas.core.series.Series'>":
+    if isinstance(features, pd.Series):
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values
@@ -375,7 +376,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):
 
     # unwrap pandas series
-    if str(type(features)) == "<class 'pandas.core.series.Series'>":
+    if isinstance(features, pd.Series):
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -5,6 +5,7 @@ import warnings
 
 import matplotlib.pyplot as pl
 import numpy as np
+import pandas as pd
 import scipy.cluster
 import scipy.sparse
 import scipy.spatial
@@ -121,7 +122,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
 
     idx2cat = None
     # convert from a DataFrame or other types
-    if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         # feature index to category flag
@@ -517,7 +518,7 @@ def summary_legacy(shap_values, features=None, feature_names=None, max_display=N
 
     idx2cat = None
     # convert from a DataFrame or other types
-    if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         # feature index to category flag

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -5,6 +5,7 @@ from typing import Union
 import matplotlib.cm as cm
 import matplotlib.pyplot as pl
 import numpy as np
+import pandas as pd
 
 from ..utils import hclust_ordering
 from ..utils._legacy import LogitLink, convert_to_link
@@ -374,11 +375,11 @@ def decision(
     feature_count = shap_values.shape[1]
 
     # code taken from force_plot. convert features from other types.
-    if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns.to_list()
         features = features.values
-    elif str(type(features)) == "<class 'pandas.core.series.Series'>":
+    elif isinstance(features, pd.Series):
         if feature_names is None:
             feature_names = features.index.to_list()
         features = features.values
@@ -611,7 +612,7 @@ def multioutput_decision(base_values, shap_values, row_index, **kwargs) -> Union
         features = kwargs["features"]
         if isinstance(features, np.ndarray) and (features.ndim == 2):
             kwargs["features"] = features[[row_index]]
-        elif str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
+        elif isinstance(features, pd.DataFrame):
             kwargs["features"] = features.iloc[row_index]
 
     return decision(base_values_mean, shap_values[:, row_index, :], **kwargs)

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -11,6 +11,7 @@ import warnings
 from collections.abc import Sequence
 
 import numpy as np
+import pandas as pd
 import scipy.sparse
 
 try:
@@ -138,11 +139,11 @@ def force(
         return visualize(shap_values)
 
     # convert from a DataFrame or other types
-    if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = list(features.columns)
         features = features.values
-    elif str(type(features)) == "<class 'pandas.core.series.Series'>":
+    elif isinstance(features, pd.Series):
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values

--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as pl
 import numpy as np
+import pandas as pd
 import scipy.stats
 
 from . import colors
@@ -36,7 +37,7 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
         Names of the features (length # features)
     """
 
-    if str(type(features)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         features = features.values

--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -42,7 +42,7 @@ def partial_dependence(ind, model, data, xmin="percentile(0)", xmax="percentile(
 
     # convert from DataFrames if we got any
     use_dataframe = False
-    if str(type(features)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         features = features.values
@@ -176,7 +176,7 @@ def partial_dependence(ind, model, data, xmin="percentile(0)", xmax="percentile(
             #         model_expected_value = model(pd.DataFrame(features, columns=feature_names)).mean()
             #     else:
             #         model_expected_value = model(features).mean()
-            # if str(type(shap_value_features)).endswith("'pandas.core.frame.DataFrame'>"):
+            # if isinstance(shap_value_features, pd.DataFrame):
             #     shap_value_features = shap_value_features.values
             markerline, stemlines, _ = ax1.stem(
                 shap_values.data[:,ind], shap_values.base_values + shap_values.values[:, ind],

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -3,6 +3,7 @@ import warnings
 import matplotlib
 import matplotlib.pyplot as pl
 import numpy as np
+import pandas as pd
 
 from .._explanation import Explanation
 from ..utils import approximate_interactions, convert_name
@@ -172,7 +173,7 @@ def scatter(shap_values, color="#1E88E5", hist=True, axis_color="#333333", cmap=
                         "passing shap_values_arr[0] instead to explain the first output class of a multi-output model.")
 
     # convert from DataFrames if we got any
-    if str(type(features)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         features = features.values
@@ -546,11 +547,11 @@ def dependence_legacy(ind, shap_values=None, features=None, feature_names=None, 
                         "passing shap_values[0] instead to explain the first output class of a multi-output model.")
 
     # convert from DataFrames if we got any
-    if str(type(features)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         features = features.values
-    if str(type(display_features)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(display_features, pd.DataFrame):
         if feature_names is None:
             feature_names = display_features.columns
         display_features = display_features.values

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -5,6 +5,7 @@ import warnings
 
 import matplotlib.pyplot as pl
 import numpy as np
+import pandas as pd
 from scipy.stats import gaussian_kde
 
 from ..utils._exceptions import DimensionError
@@ -111,7 +112,7 @@ def violin(shap_values, features=None, feature_names=None, max_display=None, plo
             color = colors.blue_rgb
 
     # convert from a DataFrame or other types
-    if str(type(features)) == "<class 'pandas.core.frame.DataFrame'>":
+    if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
         features = features.values

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -1,9 +1,10 @@
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 
 from .. import Explanation
-from ..utils import format_value, safe_isinstance
+from ..utils import format_value
 from . import colors
 from ._labels import labels
 
@@ -75,7 +76,7 @@ def waterfall(shap_values, max_display=10, show=True):
     values = shap_values.values
 
     # unwrap pandas series
-    if safe_isinstance(features, "pandas.core.series.Series"):
+    if isinstance(features, pd.Series):
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values
@@ -382,7 +383,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             "The waterfall_plot can currently only plot a single explanation but a matrix of explanations was passed!")
 
     # unwrap pandas series
-    if safe_isinstance(features, "pandas.core.series.Series"):
+    if isinstance(features, pd.Series):
         if feature_names is None:
             feature_names = list(features.index)
         features = features.values

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,12 +1,12 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 import scipy.cluster
 import scipy.spatial
 import sklearn
 from numba import njit
 
-from ._general import safe_isinstance
 from ._show_progress import show_progress
 
 
@@ -140,7 +140,7 @@ def xgboost_distances_r2(X, y, learning_rate=0.6, early_stopping_rounds=2, subsa
     return dist
 
 def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
-    if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+    if isinstance(X, pd.DataFrame):
         X = X.values
 
     if metric == "auto":
@@ -169,7 +169,7 @@ def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
     else:
         if y is not None:
             warnings.warn("Ignoring the y argument passed to shap.utils.hclust since the given clustering metric is not based on label fitting!")
-        if safe_isinstance(X, "pandas.core.frame.DataFrame"):
+        if isinstance(X, pd.DataFrame):
             bg_no_nan = X.values.copy()
         else:
             bg_no_nan = X.copy()

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -5,6 +5,7 @@ import sys
 from contextlib import contextmanager
 
 import numpy as np
+import pandas as pd
 import scipy.special
 import sklearn
 
@@ -105,7 +106,7 @@ def approximate_interactions(index, shap_values, X, feature_names=None):
     """
 
     # convert from DataFrames if we got any
-    if str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(X, pd.DataFrame):
         if feature_names is None:
             feature_names = X.columns
         X = X.values

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -29,7 +29,7 @@ def kmeans(X, k, round_values=True):
     """
 
     group_names = [str(i) for i in range(X.shape[1])]
-    if str(type(X)).endswith("'pandas.core.frame.DataFrame'>"):
+    if isinstance(X, pd.DataFrame):
         group_names = X.columns
         X = X.values
 
@@ -208,11 +208,11 @@ class DenseDataWithIndex(DenseData):
 def convert_to_data(val, keep_index=False):
     if isinstance(val, Data):
         return val
-    elif type(val) == np.ndarray:
+    elif isinstance(val, np.ndarray):
         return DenseData(val, [str(i) for i in range(val.shape[1])])
-    elif str(type(val)).endswith("'pandas.core.series.Series'>"):
+    elif isinstance(val, pd.Series):
         return DenseData(val.values.reshape((1,len(val))), list(val.index))
-    elif str(type(val)).endswith("'pandas.core.frame.DataFrame'>"):
+    elif isinstance(val, pd.DataFrame):
         if keep_index:
             return DenseDataWithIndex(val.values, list(val.columns), val.index.values, val.index.name)
         else:


### PR DESCRIPTION
## Overview

<s>Closes #XXXX</s>  <!--Add issue number here, or delete as appropriate-->

Just a simple refactoring PR. There should not be any noticeable effect on the user-facing API.

Description of the changes proposed in this pull request:

* Prefer usage of the builtin `isinstance` instead of `safe_isinstance` for pandas and numpy, since they are core dependencies of shap (they are already imported at top-level).



## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
