### PR TITLE
Remove deprecated use_line_collection on dependence_plot

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -181,7 +181,7 @@ def partial_dependence(ind, model, data, xmin="percentile(0)", xmax="percentile(
             markerline, stemlines, _ = ax1.stem(
                 shap_values.data[:,ind], shap_values.base_values + shap_values.values[:, ind],
                 bottom=shap_values.base_values,
-                markerfmt="o", basefmt=" ", use_line_collection=True
+                markerfmt="o", basefmt=" ",
             )
             stemlines.set_edgecolors([red_rgb if v > 0 else blue_rgb for v in vals])
             pl.setp(stemlines, 'zorder', -1)

--- a/tests/plots/test_dependence.py
+++ b/tests/plots/test_dependence.py
@@ -1,5 +1,6 @@
 import matplotlib
 import numpy as np
+import pytest
 
 matplotlib.use('Agg')
 import shap  # pylint: disable=wrong-import-position
@@ -14,3 +15,28 @@ def test_random_dependence_no_interaction():
     """ Make sure a dependence plot does not crash when we are not showing interactions.
     """
     shap.dependence_plot(0, np.random.randn(20, 5), np.random.randn(20, 5), show=False, interaction_index=None)
+
+def test_dependence_use_line_collection_bug():
+    """ Make sure a dependence plot does not crash.
+    """
+    # GH 3368
+    sklearn = pytest.importorskip("sklearn")
+
+    X, y = shap.datasets.california(n_points=10)
+
+    X2 = shap.utils.sample(X, 2)
+
+    model = sklearn.linear_model.LinearRegression()
+    model.fit(X, y)
+
+    explainer = shap.Explainer(model.predict, X2)
+    shap_values = explainer(X2)
+    shap.partial_dependence_plot(
+        "MedInc",
+        model.predict,
+        X2,
+        model_expected_value=True,
+        feature_expected_value=True,
+        ice=False,
+        shap_values=shap_values[:1, :],
+    )


### PR DESCRIPTION
## Overview

Closes #3368  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
as far as I can see `use_line_collection` was just used internally by [matplotlib for performance reasons](https://matplotlib.org/3.7.3/api/_as_gen/matplotlib.pyplot.stem.html). This keyword is removed in matplotlib 3.8 causing an error in [one of our Notebook](https://shap.readthedocs.io/en/latest/example_notebooks/overviews/An%20introduction%20to%20explainable%20AI%20with%20Shapley%20values.html) (cell 4). This PR fixes this by removing the keyword in our dependence_plot. 

Tested this with matplotlib 3.7 and 3.8 and with both versions I am able to recover the expected plot in the notebook.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
