### PR TITLE
fix for shap.maskers.Impute class

### DIFF
--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -331,6 +331,8 @@ class LinearImpute:
             Array to impute missing values for, should be masked
             using missing_value.
         """
+        if len(data.shape) != 2:
+            raise NotImplementedError(f"Currently only 2 dimensional data can by processed with the LinearImpute class. You provided {len(data.shape)}. If this is crucial to you, feel free to open an issue: https://github.com/shap/shap/issues.")
         self.data = pd.DataFrame(data)
         self.data = self.data.replace(self.missing_value, np.NaN)
         interpolated = self.data.interpolate(
@@ -376,7 +378,7 @@ class Impute(Tabular):
         methods = ["linear", "mean", "median", "mode", "knn"]
         if isinstance(method, str):
             if method not in methods:
-                raise NotImplementedError("Given imputation method is not supported.")
+                raise NotImplementedError(f"Given imputation method is not supported. Please provide one of the following methods: {', '.join(methods)}")
             elif method == "knn":
                 impute = KNNImputer(missing_values=0)
             elif method == "linear":

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -299,7 +299,7 @@ class Partition(Tabular):
         super().__init__(data, max_samples=max_samples, clustering=clustering)
 
 
-class Impute(Masker): # we should inherit from Tabular once we add support for arbitrary masking
+class Impute(Tabular):
     """ This imputes the values of missing features using the values of the observed features.
 
     Unlike Independent, Gaussian imputes missing values based on correlations with observed data points.

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -308,6 +308,39 @@ class Partition(Tabular):
         super().__init__(data, max_samples=max_samples, clustering=clustering)
 
 
+class LinearImpute():
+    """ Simple class for imputing missing values using pandas.Series.interpolate.
+    """
+
+    def __init__(self, missing_value=0):
+        """ Build a linear imputer for Impute classes when method=linear
+
+        Parameters
+        ----------
+        missing_value : int, numpy.NaN
+            The missing value to impute.
+        """
+        self.missing_value = missing_value
+
+    def fit(self, data):
+        """ Linearly impute missing values in the data and return as array.
+        
+        Parameters
+        ----------
+        data : numpy.ndarray
+            Array to impute missing values for, should be masked
+            using missing_value.
+        """
+        self.data = pd.Series(data)
+        self.data = self.data.replace(self.missing_value, np.NaN)
+        interpolated = self.data.interpolate(
+            method="linear",
+            limit_direction="both"
+        )
+
+        return interpolated.values()
+
+
 class Impute(Tabular):
     """ This imputes the values of missing features using the values of the observed features.
 
@@ -340,12 +373,14 @@ class Impute(Tabular):
                 mode - SimpleImputer with elements replaced by most frequent of feature in data.
                 knn - KNNImputer with elements replaced by mean value within 5 NNs of feature in data.
         """
-        methods = ["mean", "median", "mode", "knn"]
+        methods = ["linear", "mean", "median", "mode", "knn"]
         if isinstance(method, str):
             if method not in methods:
                 raise NotImplementedError("Given imputation method is not supported.")
             elif method == "knn":
                 impute = KNNImputer(missing_values=0)
+            elif method == "linear":
+                impute = LinearImpute(missing_value=0)
             else:
                 impute = SimpleImputer(missing_values=0, strategy=method)
         else:

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -308,7 +308,7 @@ class Partition(Tabular):
         super().__init__(data, max_samples=max_samples, clustering=clustering)
 
 
-class LinearImpute():
+class LinearImpute:
     """ Simple class for imputing missing values using pandas.Series.interpolate.
     """
 
@@ -324,7 +324,7 @@ class LinearImpute():
 
     def fit(self, data):
         """ Linearly impute missing values in the data and return as array.
-        
+
         Parameters
         ----------
         data : numpy.ndarray

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -331,7 +331,7 @@ class LinearImpute:
             Array to impute missing values for, should be masked
             using missing_value.
         """
-        self.data = pd.Series(data)
+        self.data = pd.DataFrame(data)
         self.data = self.data.replace(self.missing_value, np.NaN)
         interpolated = self.data.interpolate(
             method="linear",

--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -54,7 +54,7 @@ def test_serialization_independent_masker_numpy():
         temp_serialization_file.seek(0)
 
         # deserialize masker
-        new_independent_masker = shap.maskers.Masker.load(temp_serialization_file)
+        new_independent_masker = shap.maskers.Independent.load(temp_serialization_file)
 
     mask = np.ones(X.shape[1]).astype(int)
     mask[0] = 0
@@ -107,7 +107,60 @@ def test_serialization_partion_masker_numpy():
         temp_serialization_file.seek(0)
 
         # deserialize masker
-        new_partition_masker = shap.maskers.Masker.load(temp_serialization_file)
+        new_partition_masker = shap.maskers.Partition.load(temp_serialization_file)
+
+    mask = np.ones(X.shape[1]).astype(int)
+    mask[0] = 0
+    mask[4] = 0
+
+    # comparing masked values
+    assert np.array_equal(original_partition_masker(mask, X[0])[0], new_partition_masker(mask, X[0])[0])
+
+def test_serialization_impute_masker_dataframe():
+    """ Test the serialization of a Partition masker based on a DataFrame.
+    """
+
+    X, _ = shap.datasets.california(n_points=500)
+
+    # initialize partition masker
+    original_partition_masker = shap.maskers.Impute(X)
+
+    with tempfile.TemporaryFile() as temp_serialization_file:
+
+        # serialize partition masker
+        original_partition_masker.save(temp_serialization_file)
+
+        temp_serialization_file.seek(0)
+
+        # deserialize masker
+        new_partition_masker = shap.maskers.Impute.load(temp_serialization_file)
+
+    mask = np.ones(X.shape[1]).astype(int)
+    mask[0] = 0
+    mask[4] = 0
+
+    # comparing masked values
+    assert np.array_equal(original_partition_masker(mask, X[:1].values[0])[1], new_partition_masker(mask, X[:1].values[0])[1])
+
+def test_serialization_impute_masker_numpy():
+    """ Test the serialization of a Partition masker based on a numpy array.
+    """
+
+    X, _ = shap.datasets.california(n_points=500)
+    X = X.values
+
+    # initialize partition masker
+    original_partition_masker = shap.maskers.Impute(X)
+
+    with tempfile.TemporaryFile() as temp_serialization_file:
+
+        # serialize partition masker
+        original_partition_masker.save(temp_serialization_file)
+
+        temp_serialization_file.seek(0)
+
+        # deserialize masker
+        new_partition_masker = shap.maskers.Impute.load(temp_serialization_file)
 
     mask = np.ones(X.shape[1]).astype(int)
     mask[0] = 0


### PR DESCRIPTION
In brief, `Impute` now uses `Tabular` as a parent and uses the sklearn.impute objects for imputation. See #3378 for more discussion (h/t @CloseChoice).

## Overview

Closes #3378

#### Description of the changes proposed in this pull request:

This addresses the `TypeError` generated when `shap.maskers.Impute()` is used in an `Explainer` object. It currently calls `Masker` as a parent instead of `Tabular` and therefore does not have a `__call__` method.

Instead, `Impute` now inherits `Tabular` as a parent (including its `__call__` method and functionality). Upon `Impute.__init__`, an `sklean.impute` object is used for imputing masked data in `Tabular.__call__`. I added four supported keywords to `method`: "mean", "median", "mode", and "knn." The first three refer to the different strategies used by [`sklearn.impute.SimpleImputer`](https://scikit-learn.org/stable/modules/generated/sklearn.impute.SimpleImputer.html#sklearn.impute.SimpleImputer.transform). The last one creates an [`sklearn.impute.KNNImputer`](https://scikit-learn.org/stable/modules/generated/sklearn.impute.KNNImputer.html#sklearn.impute.KNNImputer) object with default inputs instead. There are more Scikit-Learn imputers (e.g. [`sklearn.impute.IterativeImputer`](https://scikit-learn.org/stable/modules/generated/sklearn.impute.IterativeImputer.html#sklearn.impute.IterativeImputer), which is experimental) and many more settings, but if that amount of control is needed, I have added the functionality for `method` to be a pre-initialized `sklearn.impute` object supplied by the user.

## Checklist
I have added two additional tests similar to those for `Independent` and `Partition`. I recognize that there's probably a place for making _all_ of these tabular tests more meaningful for each type of masker.

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
