### PR TITLE
Fix PySpark loaded models

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1444,7 +1444,7 @@ class SingleTree:
                     self.values[index] = [node.prediction()]  # prediction for the node
                 else:
                     self.values[index] = [e for e in node.impurityStats().stats()] #for gini: NDarray(numLabel): 1 per label: number of item for each label which went through this node
-                self.node_sample_weight[index] = node.impurityStats().count()  # weighted count of element through this node
+                self.node_sample_weight[index] = sum([e for e in node.impurityStats().stats()])  # weighted count of element through this node
 
                 if node.subtreeDepth() == 0:
                     return index


### PR DESCRIPTION
## Overview

fix https://github.com/shap/shap/issues/884 , fix https://github.com/shap/shap/issues/2480, fix https://github.com/shap/shap/issues/3383

# ISSUE:
Running PySpark GBT models sometimes causes the shap package to fail with the error message:
```python
The background dataset you provided does not cover all the leaves in the model, so TreeExplainer cannot run with the feature_perturbation="tree_path_dependent" option! " Try providing a larger background dataset, no background dataset, or using feature_perturbation="interventional"."
```
Using `feature_perturbation="interventional"` as suggested does not work with pyspark models as the predict function is not implemented for pyspark models

```python
# lines 1082 to 1085 in shap/shap/explainers/_tree.py
if self.model_type == "pyspark":
  #import pyspark
  # TODO: support predict for pyspark
   raise NotImplementedError("Predict with pyspark isn't implemented. Don't run 'interventional' as feature_perturbation.")
```

The `feature_perturbation="tree_path_dependent"` is failing due to a check in the code that is meant to ensure that background dataset lands in every leaf.

```python
# lines 1031 to 1033 in shap/shap/explainers/_tree.py
# ensure that the passed background dataset lands in every leaf
if np.min(self.trees[i].node_sample_weight) <= 0:
    self.fully_defined_weighting = False
```

This should by right pass in all cases, considering that no background dataset is required for `feature_perturbation="tree_path_dependent"`.

In some cases for pyspark gbt models, `fully_defined_weighting` is incorrectly set to False. `fully_defined_weighting` is determined by the values of `node_sample_weight`, which is determined by the code below:

```python
# line 1199 in shap/shap/explainers/_tree.py
self.node_sample_weight[index] = node.impurityStats().count() #weighted count of element trough this node
```

`node.impurityStats()` returns a `GiniCalculator`, and the method `.count()` should return a float instead of int.
See [source](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/mllib/tree/impurity/Gini.scala)

![image](https://github.com/shap/shap/assets/140796546/c802d27b-87e3-4c75-b882-78571c291f04)

However, if you create a pyspark GBT model and obtain the values for `node.impurityStats().count()`,
you will notice that the values has been rounded down to int.

`node.impurityStats().count()` should return the same values as `sum([e for e in node.impurityStats().stats()])` if you follow the image above. It is however rounding down the values, and in some cases values greater than 0 and less than 1 are rounded down to 0.

This causes the `self.fully_defined_weighting` to return False, even when the values are clearly not zero.

# SOLUTION

Avoid using `node.impurityStats().count()`. Replace with `sum([e for e in node.impurityStats().stats()])` which does exactly the same, but retain the value as float.