### PR TITLE
ENH: Add support for Explanation.display_data in bar plot

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -88,7 +88,7 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
         # TODO: check other attributes for equality? like feature names perhaps? probably clustering as well.
 
     # unpack the Explanation object
-    features = cohort_exps[0].data
+    features = cohort_exps[0].display_data if cohort_exps[0].display_data is not None else cohort_exps[0].data
     feature_names = cohort_exps[0].feature_names
     if clustering is None:
         partition_tree = getattr(cohort_exps[0], "clustering", None)


### PR DESCRIPTION
Closes: #3387

For `shap.plots.bar` if attribute `.display_data` given then use that otherwise use `.data`.

## Overview

I noticed that `shap.plots.bar` doesn't make use of `explanation.display_data` if it exists which I've found to be really useful in other shap plots e.g. the waterfall or scatter plots. For example when you have categorical features that you have encoded but would like the plot to show the "unencoded" feature value.

The change in the code is basically taken straight from the waterfall plot code.



## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
