### PR TITLE
MAINT: Improved build messages when building from source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,11 +96,7 @@ def compile_cuda_module(host_args):
     return 'build', '_cext_gpu'
 
 
-def run_setup(
-    *,
-    with_binary,
-    with_cuda,
-):
+def run_setup(*, with_binary, with_cuda):
     ext_modules = []
     if with_binary:
         compile_args = []

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ import numpy as np
 from packaging.version import Version, parse
 from setuptools import Extension, setup
 
+_BUILD_ATTEMPTS = 0
+
 # This is copied from @robbuckley's fix for Panda's
 # For mac, ensure extensions are built for macos 10.9 when compiling on a
 # 10.9 system or above, overriding distuitls behavior which is to target
@@ -136,27 +138,31 @@ def run_setup(
     setup(ext_modules=ext_modules)
 
 
-def try_run_setup(**kwargs):
+def try_run_setup(*, with_binary, with_cuda):
     """ Fails gracefully when various install steps don't work.
     """
+    global _BUILD_ATTEMPTS
+    _BUILD_ATTEMPTS += 1
 
     try:
-        run_setup(**kwargs)
+        print(f"Attempting to build SHAP: {with_binary=}, {with_cuda=} (Attempt {_BUILD_ATTEMPTS})")
+        run_setup(with_binary=with_binary, with_cuda=with_cuda)
     except Exception as e:
         print("Exception occurred during setup,", str(e))
-        exc_msg = str(e).lower()
 
-        if "cuda module" in exc_msg:
-            kwargs["with_cuda"] = False
+        if with_cuda:
+            with_cuda = False
             print("WARNING: Could not compile cuda extensions.")
-        elif kwargs["with_binary"]:
-            kwargs["with_binary"] = False
+            print("Retrying SHAP build without cuda extension...")
+        elif with_binary:
+            with_binary = False
             print("WARNING: The C extension could not be compiled, sklearn tree models not supported.")
+            print("Retrying SHAP build without binary extension...")
         else:
             print("ERROR: Failed to build!")
-            return
+            raise
 
-        try_run_setup(**kwargs)
+        try_run_setup(with_binary=with_binary, with_cuda=with_cuda)
 
 
 # we seem to need this import guard for appveyor


### PR DESCRIPTION
## Overview

An attempt to make the log messages a bit more informative when building from source:

- Upon failure, make it explicit that the build is being retried with different settings
- Show the attempt number when attempting build

## Example

Example output when the build fails (in this case from adding `raise ValueError("EXAMPLE BUILD ERROR")` around line 100):

<details>

```
(shap) connor:shap$ pip install -e .
Obtaining file:///home/connor/projects/shap
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [50 lines of output]
      Attempting to build SHAP: with_binary=True, with_cuda=True (Attempt 1)
      Exception occurred during setup, EXAMPLE BUILD ERROR
      WARNING: Could not compile cuda extensions.
      Retrying SHAP build without cuda extension...
      Attempting to build SHAP: with_binary=True, with_cuda=False (Attempt 2)
      Exception occurred during setup, EXAMPLE BUILD ERROR
      WARNING: The C extension could not be compiled, sklearn tree models not supported.
      Retrying SHAP build without binary extension...
      Attempting to build SHAP: with_binary=False, with_cuda=False (Attempt 3)
      Exception occurred during setup, EXAMPLE BUILD ERROR
      ERROR: Failed to build!
      Traceback (most recent call last):
        File "<string>", line 150, in try_run_setup
        File "<string>", line 104, in run_setup
```

</details>

## Discussion

This still has room for improvement. I note two quite significant issues in particular. These are probably out-of-scope for this PR, but I thought I would mention them:

1. If the build fails with cuda (Attempt 1)  but succeeds without CUDA (attempt 2), I don't think anything is shown to the user, so it's not obvious that the CUDA extension was not built. For most users this is probably fine, but it might be surprising if someone is expecting CUDA to be built.
2. When `gcc` is not available the exception is not caught, and so we never progress to try building without the binary extension. Consequently, the "Attempt 3" seems perhaps a bit useless.

To illustrate the second point, here's an example output in an environment that doesn't have gcc available:

<details>

```
(shap) connor:shap$ pip install -e .
Obtaining file:///home/connor/projects/shap
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: numpy in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (1.26.2)
Requirement already satisfied: scipy in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (1.11.4)
Requirement already satisfied: scikit-learn in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (1.3.2)
Requirement already satisfied: pandas in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (2.1.3)
Requirement already satisfied: tqdm>=4.27.0 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (4.66.1)
Requirement already satisfied: packaging>20.9 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (23.2)
Requirement already satisfied: slicer==0.0.7 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (0.0.7)
Requirement already satisfied: numba in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (0.58.1)
Requirement already satisfied: cloudpickle in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from shap==0.43.0) (3.0.0)
Requirement already satisfied: llvmlite<0.42,>=0.41.0dev0 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from numba->shap==0.43.0) (0.41.1)
Requirement already satisfied: python-dateutil>=2.8.2 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from pandas->shap==0.43.0) (2.8.2)
Requirement already satisfied: pytz>=2020.1 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from pandas->shap==0.43.0) (2023.3.post1)
Requirement already satisfied: tzdata>=2022.1 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from pandas->shap==0.43.0) (2023.3)
Requirement already satisfied: joblib>=1.1.1 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from scikit-learn->shap==0.43.0) (1.3.2)
Requirement already satisfied: threadpoolctl>=2.0.0 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from scikit-learn->shap==0.43.0) (3.2.0)
Requirement already satisfied: six>=1.5 in /home/connor/miniforge3/envs/shap/lib/python3.11/site-packages (from python-dateutil>=2.8.2->pandas->shap==0.43.0) (1.16.0)
Building wheels for collected packages: shap
  Building editable for shap (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building editable for shap (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [124 lines of output]
      Attempting to build SHAP: with_binary=True, with_cuda=True (Attempt 1)
      The nvcc binary could not be located in your $PATH. Either add it to your path, or set $CUDAHOME to enable CUDA.
      Exception occurred during setup, Error building cuda module: TypeError('cannot unpack non-iterable NoneType object')
      WARNING: Could not compile cuda extensions.
      Retrying SHAP build without cuda extension...
      Attempting to build SHAP: with_binary=True, with_cuda=False (Attempt 2)
      running editable_wheel
      creating /tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info
      writing /tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/dependency_links.txt
      writing requirements to /tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/requires.txt
      writing top-level names to /tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/top_level.txt
      writing manifest file '/tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/SOURCES.txt'
      reading manifest file '/tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/SOURCES.txt'
      adding license file 'LICENSE'
      writing manifest file '/tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap.egg-info/SOURCES.txt'
      creating '/tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap-0.43.0.dist-info'
      creating /tmp/pip-wheel-0ms099q0/.tmp-xqvzmxte/shap-0.43.0.dist-info/WHEEL
      running build_py
      running build_ext
      building 'shap._cext' extension
      creating /tmp/tmpfj7g183l.build-temp/shap
      creating /tmp/tmpfj7g183l.build-temp/shap/cext
      gcc -pthread -B /home/connor/miniforge3/envs/shap/compiler_compat -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /home/connor/miniforge3/envs/shap/include -fPIC -O2 -isystem /home/connor/miniforge3/envs/shap/include -fPIC -I/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/numpy/core/include -I/home/connor/miniforge3/envs/shap/include/python3.11 -c shap/cext/_cext.cc -o /tmp/tmpfj7g183l.build-temp/shap/cext/_cext.o
      Traceback (most recent call last):
        File "<string>", line 118, in run_setup
      TypeError: cannot unpack non-iterable NoneType object

      The above exception was the direct cause of the following exception:

      Traceback (most recent call last):
        File "<string>", line 149, in try_run_setup
        File "<string>", line 136, in run_setup
      Exception: Error building cuda module: TypeError('cannot unpack non-iterable NoneType object')

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/spawn.py", line 57, in spawn
          proc = subprocess.Popen(cmd, env=env)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/connor/miniforge3/envs/shap/lib/python3.11/subprocess.py", line 1026, in __init__
          self._execute_child(args, executable, preexec_fn, close_fds,
        File "/home/connor/miniforge3/envs/shap/lib/python3.11/subprocess.py", line 1950, in _execute_child
          raise child_exception_type(errno_num, err_msg, err_filename)
      FileNotFoundError: [Errno 2] No such file or directory: 'gcc'

      The above exception was the direct cause of the following exception:

      Traceback (most recent call last):
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/unixccompiler.py", line 185, in _compile
          self.spawn(compiler_so + cc_args + [src, '-o', obj] + extra_postargs)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/ccompiler.py", line 1041, in spawn
          spawn(cmd, dry_run=self.dry_run, **kwargs)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/spawn.py", line 63, in spawn
          raise DistutilsExecError(
      distutils.errors.DistutilsExecError: command 'gcc' failed: No such file or directory

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 156, in run
          self._create_wheel_file(bdist_wheel)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 345, in _create_wheel_file
          files, mapping = self._run_build_commands(dist_name, unpacked, lib, tmp)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 268, in _run_build_commands
          self._run_build_subcommands()
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/command/editable_wheel.py", line 295, in _run_build_subcommands
          self.run_command(name)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 963, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/command/build_ext.py", line 88, in run
          _build_ext.run(self)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 345, in run
          self.build_extensions()
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 467, in build_extensions
          self._build_extensions_serial()
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 493, in _build_extensions_serial
          self.build_extension(ext)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/command/build_ext.py", line 249, in build_extension
          _build_ext.build_extension(self, ext)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 548, in build_extension
          objects = self.compiler.compile(
                    ^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/ccompiler.py", line 600, in compile
          self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
        File "/tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/unixccompiler.py", line 187, in _compile
          raise CompileError(msg)
      distutils.errors.CompileError: command 'gcc' failed: No such file or directory
      /tmp/pip-build-env-hfmt40bi/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py:988: _DebuggingTips: Problem in editable installation.
      !!

              ********************************************************************************
              An error happened while installing `shap` in editable mode.

              The following steps are recommended to help debug this problem:

              - Try to install the project normally, without using the editable mode.
                Does the error still persist?
                (If it does, try fixing the problem before attempting the editable mode).
              - If you are using binary extensions, make sure you have all OS-level
                dependencies installed (e.g. compilers, toolchains, binary libraries, ...).
              - Try the latest version of setuptools (maybe the error was already fixed).
              - If you (or your project dependencies) are using any setuptools extension
                or customization, make sure they support the editable mode.

              After following the steps above, if the problem still persists and
              you think this is related to how setuptools handles editable installations,
              please submit a reproducible example
              (see https://stackoverflow.com/help/minimal-reproducible-example) to:

                  https://github.com/pypa/setuptools/issues

              See https://setuptools.pypa.io/en/latest/userguide/development_mode.html for details.
              ********************************************************************************

      !!
        cmd_obj.run()
      error: command 'gcc' failed: No such file or directory
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building editable for shap
Failed to build shap
ERROR: Could not build wheels for shap, which is required to install pyproject.toml-based projects
```
</details>