### PR TITLE
Add maintainer guide to docs to explain versioning and releasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,13 @@ conda activate shap
 
 ### Installing from source
 
+To build from source, you need a compiler to build the C extension. For example
+on linux, you can install gcc with:
+
+```bash
+sudo apt install build-essential
+```
+
 Pip-install the project with the `--editable` flag, which ensures that any
 changes you make to the source code are immediately reflected in your
 environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
   - [Notebook linting and formatting](#notebook-linting-and-formatting)
 - [Maintainer guide](#maintainer-guide)
   - [Versioning](#versioning)
-  - [Releases](#releases)
+  - [Making releases](#making-releases)
   - [Release notes from PR labels](#release-notes-from-pr-labels)
 
 ## Introduction
@@ -267,9 +267,11 @@ Prefer relative links over absolute paths.
 
 ### Notebook linting and formatting
 
-We use `ruff` and `black-jupyter` to perform code linting and auto-formatting on our notebooks.
-Assuming you have set up `pre-commit` as described [above](#code-checks-with-precommit), these checks will
-run automatically whenever you commit any changes.
+We use `ruff` to perform code linting and auto-formatting on our notebooks.
+Assuming you have set up `pre-commit` as described
+[above](#code-checks-with-precommit), these checks will run automatically
+whenever you commit any changes.
+
 To run the code-quality checks manually, you can do, e.g.:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@
   - [General Jupyter guidelines](#general-jupyter-guidelines)
   - [Links / Cross-references](#links--cross-references)
   - [Notebook linting and formatting](#notebook-linting-and-formatting)
+- [Maintainer guide](#maintainer-guide)
+  - [Versioning](#versioning)
+  - [Releases](#releases)
+  - [Release notes from PR labels](#release-notes-from-pr-labels)
 
 ## Introduction
 
@@ -262,3 +266,50 @@ pre-commit run --files notebook1.ipynb notebook2.ipynb
 ```
 
 replacing `notebook1.ipynb` and `notebook2.ipynb` with any notebook(s) you have modified.
+
+## Maintainer guide
+
+We try to use automation to make the release process reliable, transparent and
+reproducible.
+
+### Versioning
+
+We use `setuptools-scm` to source the version number from the git history
+automatically. At build time, the version number is determined from the git tag.
+
+### Releases
+
+When a new GitHub [release](https://github.com/shap/shap/releases) is made, the
+wheels will be built and published to GitHub automatically by the `build_wheels`
+GitHub action. This can be triggered manually at any time to do a dry-run of
+cibuildwheel.
+
+The conda package is managed in a separate repo:
+https://github.com/conda-forge/shap-feedstock . The conda-forge bot will
+automatically make a PR to this repo to update the conda package, typically
+within a few hours of the PyPSA package being published.
+
+Suggested release checklist:
+
+```
+- [ ] Dry-run cibuildwheel & test
+- [ ] Make GitHub release & tag
+- [ ] Confirm PyPI wheels published
+- [ ] Conda forge published
+```
+
+### Release notes from PR labels
+
+The PR titles and labels are used to help draft release notes automatically.The
+draft notes are configured in [.github/release.yml](.github/release.yml). See
+the [GitHub docs][auto_release_notes] for more info.
+
+It's helpful to assign labels such as `BREAKING`, `bug`, `enhancement` or
+`skip-changelog` to each PR, so that the change will show up in the notes under
+the right section. It also helps to ensure each PR has a descriptive name.
+
+The notes can be edited (both before and after release) to remove information
+that is unlikely to be of high interest to users, such as maintenance updates.
+
+[auto_release_notes]:
+    https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,12 +98,16 @@ conda activate shap
 
 ### Installing from source
 
-To build from source, you need a compiler to build the C extension. For example
-on linux, you can install gcc with:
+To build from source, you need a compiler to build the C extension.
 
-```bash
-sudo apt install build-essential
-```
+- On linux, you can install gcc with:
+
+  ```bash
+  sudo apt install build-essential
+  ```
+
+- Or on Windows, one way of getting a compiler is to [install
+  mingw64](https://www.mingw-w64.org/downloads/).
 
 Pip-install the project with the `--editable` flag, which ensures that any
 changes you make to the source code are immediately reflected in your
@@ -329,9 +333,18 @@ within a few hours of the PyPSA package being published.
 ### Release notes from PR labels
 
 Release notes can be automatically drafted by Github using the titles and labels
-of PRs that were merged since the previous release. The draft notes are
-configured in [.github/release.yml](.github/release.yml). See the [GitHub
-docs][auto_release_notes] for more info.
+of PRs that were merged since the previous release. See the GitHub docs on
+[automatically generated release notes][auto_release_notes] for more
+information.
+
+The generated notes will follow the template defined in
+[.github/release.yml](.github/release.yml), arranging PRs into subheadings by
+label and excluding PRs made by bots. See the [docs][auto_release_notes] for the
+available configuration options.
+
+[auto_release_notes]:
+    https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
 
 It's helpful to assign labels such as `BREAKING`, `bug`, `enhancement` or
 `skip-changelog` to each PR, so that the change will show up in the notes under
@@ -339,6 +352,3 @@ the right section. It also helps to ensure each PR has a descriptive name.
 
 The notes can be edited (both before and after release) to remove information
 that is unlikely to be of high interest to users, such as maintenance updates.
-
-[auto_release_notes]:
-    https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,24 +270,40 @@ replacing `notebook1.ipynb` and `notebook2.ipynb` with any notebook(s) you have 
 ## Maintainer guide
 
 We try to use automation to make the release process reliable, transparent and
-reproducible.
+reproducible. This also helps us make releases more frequently.
 
 ### Versioning
 
 We use `setuptools-scm` to source the version number from the git history
 automatically. At build time, the version number is determined from the git tag.
 
-### Releases
+shap uses a PEP 440-compliant versioning scheme of `MAJOR.MINOR.PATCH`. Like
+[numpy](numpy_versioning), shap does *not* use semantic versioning, and has
+never made a `major` release. Most releases increment `minor`, typically made
+every month or two. `patch` releases are sometimes made for any important
+bugfixes.
+
+Breaking changes are done with care, given that shap is a very popular package.
+When breaking changes are made, the PR should be tagged with the `BREAKING`
+label to ensure it is highlighted in the release notes. Deprecation cycless are
+used to mitigate the impact on downstream users.
+
+GitHub milestones can be used to track any actions that need to be completed for
+a given release, such as those relating to deprecation cycles.
+
+[numpy_versioning]: https://numpy.org/doc/stable/dev/depending_on_numpy.html
+
+
+### Making releases
+
+In the run-up to a release, create a GitHub issue for the release such as [[Meta
+issue] Release 0.43.0](https://github.com/shap/shap/issues/3289). This can be
+used to co-ordinate with other maintainers and agree to make a release.
 
 When a new GitHub [release](https://github.com/shap/shap/releases) is made, the
 wheels will be built and published to GitHub automatically by the `build_wheels`
-GitHub action. This can be triggered manually at any time to do a dry-run of
-cibuildwheel.
-
-The conda package is managed in a separate repo:
-https://github.com/conda-forge/shap-feedstock . The conda-forge bot will
-automatically make a PR to this repo to update the conda package, typically
-within a few hours of the PyPSA package being published.
+GitHub action. This workflow can also be triggered manually at any time to do a
+dry-run of cibuildwheel.
 
 Suggested release checklist:
 
@@ -298,11 +314,17 @@ Suggested release checklist:
 - [ ] Conda forge published
 ```
 
+The conda package is managed in a separate repo:
+https://github.com/conda-forge/shap-feedstock . The conda-forge bot will
+automatically make a PR to this repo to update the conda package, typically
+within a few hours of the PyPSA package being published.
+
 ### Release notes from PR labels
 
-The PR titles and labels are used to help draft release notes automatically.The
-draft notes are configured in [.github/release.yml](.github/release.yml). See
-the [GitHub docs][auto_release_notes] for more info.
+Release notes can be automatically drafted by Github using the titles and labels
+of PRs that were merged since the previous release.The draft notes are
+configured in [.github/release.yml](.github/release.yml). See the [GitHub
+docs][auto_release_notes] for more info.
 
 It's helpful to assign labels such as `BREAKING`, `bug`, `enhancement` or
 `skip-changelog` to each PR, so that the change will show up in the notes under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,7 +329,7 @@ within a few hours of the PyPSA package being published.
 ### Release notes from PR labels
 
 Release notes can be automatically drafted by Github using the titles and labels
-of PRs that were merged since the previous release.The draft notes are
+of PRs that were merged since the previous release. The draft notes are
 configured in [.github/release.yml](.github/release.yml). See the [GitHub
 docs][auto_release_notes] for more info.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,7 +292,7 @@ bugfixes.
 
 Breaking changes are done with care, given that shap is a very popular package.
 When breaking changes are made, the PR should be tagged with the `BREAKING`
-label to ensure it is highlighted in the release notes. Deprecation cycless are
+label to ensure it is highlighted in the release notes. Deprecation cycles are
 used to mitigate the impact on downstream users.
 
 GitHub milestones can be used to track any actions that need to be completed for


### PR DESCRIPTION
This PR aims to formalise our guidelines for maintainers for things like releases and versioning. I hope this will make our process more transparent, and make it easier for new maintainers to join the team.

This is also perhaps a good opportunity to check if we agree what our current process actually should be. So, I'd be grateful for a review and discussion from ideally at least two others.

Related:
- #3405 
- #3402 

Nb. I've written the "versioning" section assuming setuptools-scm, in preparation for #3402.