### PR TITLE
Add Contributing guide to published Sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx_rtd_theme",
     "numpydoc",
-    "nbsphinx",
+    "nbsphinx",     # Allows parsing Jupyter notebooks
+    "myst_parser",  # Allows parsing Markdown, such as CONTRIBUTING.md
     "sphinx_github_changelog",
 ]
 autodoc_default_options = {"members": True, "inherited-members": True}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,2 @@
+```{include} ../../CONTRIBUTING.md
+```

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,2 +1,2 @@
-```{include} ../../CONTRIBUTING.md
-```
+.. include:: ../CONTRIBUTING.md
+   :parser: myst_parser.sphinx_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,5 +51,7 @@ SHAP can be installed from either `PyPI <https://pypi.org/project/shap>`_ or
 
 .. toctree::
    :maxdepth: 1
+   :caption: Development
 
    Release notes <release_notes>
+   Contributing <contributing>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,4 +54,4 @@ SHAP can be installed from either `PyPI <https://pypi.org/project/shap>`_ or
    :caption: Development
 
    Release notes <release_notes>
-   Contributing <contributing>
+   Contributing guide <contributing>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,11 @@ docs = [
   "matplotlib",
   "ipython",
   "numpydoc",
-  "sphinx_rtd_theme==1.2.2",
-  "sphinx==6.2.1",
-  "nbsphinx==0.9.2",
+  "sphinx_rtd_theme==2.0.0",
+  "sphinx==7.2.6",
+  "nbsphinx==0.9.3",
   "sphinx_github_changelog==1.2.1",
+  "myst-parser==2.0.0",
   "requests",
 ]
 test-core = ["pytest", "pytest-mpl", "pytest-cov"]


### PR DESCRIPTION
Add the contributing guide to the Sphinx docs, for better visibility and to help encourage new contributors.

- Adds the `myst-parser` extension to  handle parsing of markdown files
- Updates the pinned versions of related libraries, notably `sphinx-rtd-theme==2.0.0` which was recently released and supports `sphinx==7`
- Adds a stub page `docs/contributing.rst` which includes the contributing guide from the repo's root (even though it's outside the Sphinx source directory)

Screenshot:

![image](https://github.com/shap/shap/assets/71127464/bc057991-6fdf-4423-9af4-bc1cd3008e19)
