### PR TITLE
Add support for python 3.12, drop support for 3.8

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,12 +1,12 @@
 codecov:
   notify:
-    after_n_builds: 7
+    after_n_builds: 8
     wait_for_ci: yes
 coverage:
   range: 70..90
 comment:
   require_changes: true
-  after_n_builds: 7
+  after_n_builds: 8
 ignore:
   # Ignore coverage on vendored code
   - "shap/plots/colors/_colorconv.py"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,12 +1,12 @@
 codecov:
   notify:
-    after_n_builds: 8
+    after_n_builds: 7
     wait_for_ci: yes
 coverage:
   range: 70..90
 comment:
   require_changes: true
-  after_n_builds: 8
+  after_n_builds: 7
 ignore:
   # Ignore coverage on vendored code
   - "shap/plots/colors/_colorconv.py"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # The total number of matrix jobs should match codecov.yml `after_n_builds`.
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         extras: ["test"]
         include:
           # Test on windows/mac, just one job each

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # The total number of matrix jobs should match codecov.yml `after_n_builds`.
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         extras: ["test"]
         include:
           # Test on windows/mac, just one job each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ test = [
   "protobuf==3.20.3",  # See GH #3046
   "torch",
   "torchvision",
-  "tensorflow",
+  "tensorflow;python_version<'3.12'",  # FIXME: pending py3.12 support
   "sentencepiece",
   "opencv-python",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
   "pytest-cov",
   "xgboost",
   "lightgbm",
-  "catboost",
+  "catboost;python_version<'3.12'",  # FIXME: pending py3.12 support
   "gpboost",
   "ngboost;python_version<'3.12'",  # FIXME: pending py3.12 support
   "pyspark",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "MIT License"}
 authors = [
   {name = "Scott Lundberg", email = "slund1@cs.washington.edu"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   'numpy',
   'scipy',
@@ -27,7 +27,6 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: Unix",
   "Operating System :: MacOS",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Intended Audience :: Information Technology",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -4,7 +4,7 @@ import struct
 import tempfile
 import time
 import warnings
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -1813,7 +1813,7 @@ class XGBTreeModelLoader:
             self.leaf_child_cnt.append(np.array(tree_json["default_left"], dtype=int))
 
     @staticmethod
-    def read_xgb_params(xgb_model) -> Dict[str, Any]:
+    def read_xgb_params(xgb_model) -> dict[str, Any]:
         import xgboost
         with tempfile.TemporaryDirectory() as tmp_dir:
             if version.parse(xgboost.__version__) >= version.parse("1.6.0"):


### PR DESCRIPTION
## Overview

Closes #3305

- Adds support for 3.12
- Remove support for 3.8
- Excludes catboost and tensorflow from the 3.12 test suite (pending support)

## Discussion

This brings us closer in line with the scientific python standard [SPEC 0](https://scientific-python.org/specs/spec-0000/), which defines the recommended drop schedule for python versions:

> On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)

See previous discussion on drop timelines: https://github.com/shap/shap/issues/3057