### PR TITLE
MAINT: Enable "no response" bot

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,21 @@
+name: No Response bot
+# Close issues where the original author doesn't resond to a request for information
+# For more info see https://github.com/lee-dohm/no-response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          responseRequiredLabel: "awaiting feedback"
+          # TODO: use default time (14 days) after an initial implementation period 
+          daysUntilClose: 30  

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           token: ${{ github.token }}
           responseRequiredLabel: "awaiting feedback"
-          # TODO: use default time (14 days) after an initial implementation period 
-          daysUntilClose: 30  
+          # TODO: use default time (14 days) after an initial implementation period
+          daysUntilClose: 30


### PR DESCRIPTION
## Overview

Closes #3422

Add the "no response" bot, to close issues with the "awaiting feedback" label where the original author has not replied. For more info about the bot see: https://github.com/lee-dohm/no-response

This is probably less impactful that the "stale bot" over on #3424 , so we should probably focus on that first.

## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
