### PR TITLE
Stale bot: process oldest issues first

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -17,9 +17,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      # Current latest release v8 has issues with statefullness, so use "main" branch:
-      # https://github.com/actions/stale/issues/792
-      - uses: actions/stale@main
+      - uses: actions/stale@v9
         with:
           # See discussion on generous time limits:
           # https://github.com/shap/shap/discussions/3051

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -53,3 +53,6 @@ jobs:
           # If an issue or PR is marked with the "todo" label, never mark it as stale.
           exempt-issue-labels: todo
           exempt-pr-labels: todo
+          # Each run is limited to operations_per_turn=30.
+          # So, process the oldest issues first:
+          ascending: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -17,7 +17,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      # Current latest release v8 has issues with statefullness, so use "main" branch:
+      # https://github.com/actions/stale/issues/792
+      - uses: actions/stale@main
         with:
           # See discussion on generous time limits:
           # https://github.com/shap/shap/discussions/3051


### PR DESCRIPTION
A suggested tweak to the stale bot, to process the oldest issues first. The "ascending" key controls whether the oldest or newest issues are sorted first:

https://github.com/actions/stale#ascending

Each run is limited to maximum 30 GH API operations, which so far ends up tagging ~5 issues per run. The workflow is currently scheduled to run once per day, and we can also manually trigger it. 

https://github.com/actions/stale#operations-per-run

I think this run limit could be a useful thing to avoid creating too many notifications at once, so we could leave it ticking over in the background rather than processing everything at once.