### PR TITLE
Add actions:write permission to stale bot

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write  # Workaround for https://github.com/actions/stale/issues/1090
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
Another small tweak to the stale bot, to fix an issue with updating the cache. If not fixed, the bot will just process the same lot of issues over and over.

From some manual testing, the stale bot cache is not updating correctly. After deleting the cache, a [first run ](https://github.com/shap/shap/actions/runs/7140741597/job/19446621680) works fine, creating the cache as expected:

```
The saved state was not found, the process starts from the first issue.
...
...
state: persisting info about 26 issue(s)
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/shap/shap --files-from manifest.txt --use-compress-program zstdmt
Cache Size: ~0 MB (348 B)
Cache saved successfully
```

A [second run ](https://github.com/shap/shap/actions/runs/7140762734/job/19446688399) loads the cache ok, but fails to save the updated cache:
```
Cache restored successfully
state: restored with info about 26 issue(s)
...
...
state: persisting info about 41 issue(s)
Warning: Error delete _state: [403] Resource not accessible by integration
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/shap/shap --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: _state, Version: fa41d75081481069cfb6b92a5f83a94c6e06ef3ab2e6b762649ac5f86f46153f
```

It seems to be the same issue as described here, so suggesting updating the permissions with the suggested workaround:
https://github.com/actions/stale/issues/1090