### PR TITLE
Rearrange docs for PartitionExplainer

### DIFF
--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -20,15 +20,14 @@ class PartitionExplainer(Explainer):
     The PartitionExplainer has two particularly nice properties:
 
     1) PartitionExplainer is model-agnostic but when using a balanced partition tree only has
-       quadradic exact runtime (in term of the number of input features). This is in contrast to the
+       quadratic exact runtime (in term of the number of input features). This is in contrast to the
        exponential exact runtime of KernelExplainer or SamplingExplainer.
     2) PartitionExplainer always assigns to groups of correlated features the credit that set of features
        would have had if treated as a group. This means if the hierarchical clustering given to
        PartitionExplainer groups correlated features together, then feature correlations are
        "accounted for" in the sense that the total credit assigned to a group of tightly dependent features
-       does net depend on how they behave if their correlation structure was broken during the explanation's
-       perterbation process.
-
+       does not depend on how they behave if their correlation structure was broken during the explanation's
+       perturbation process.
     Note that for linear models the Owen values that PartitionExplainer returns are the same as the standard
     non-hierarchical Shapley values.
     """

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -12,25 +12,30 @@ from ._explainer import Explainer
 
 
 class PartitionExplainer(Explainer):
+    """Uses the Partition SHAP method to explain the output of any function.
+
+    Partition SHAP computes Shapley values recursively through a hierarchy of features, this
+    hierarchy defines feature coalitions and results in the Owen values from game theory.
+    
+    The PartitionExplainer has two particularly nice properties:
+    
+    1) PartitionExplainer is model-agnostic but when using a balanced partition tree only has
+       quadradic exact runtime (in term of the number of input features). This is in contrast to the
+       exponential exact runtime of KernelExplainer or SamplingExplainer.
+    2) PartitionExplainer always assigns to groups of correlated features the credit that set of features
+       would have had if treated as a group. This means if the hierarchical clustering given to
+       PartitionExplainer groups correlated features together, then feature correlations are
+       "accounted for" in the sense that the total credit assigned to a group of tightly dependent features
+       does net depend on how they behave if their correlation structure was broken during the explanation's
+       perterbation process.
+    
+    Note that for linear models the Owen values that PartitionExplainer returns are the same as the standard
+    non-hierarchical Shapley values.
+    """
 
     def __init__(self, model, masker, *, output_names=None, link=links.identity, linearize_link=True,
                  feature_names=None, **call_args):
-        """ Uses the Partition SHAP method to explain the output of any function.
-
-        Partition SHAP computes Shapley values recursively through a hierarchy of features, this
-        hierarchy defines feature coalitions and results in the Owen values from game theory. The
-        PartitionExplainer has two particularly nice properties: 1) PartitionExplainer is
-        model-agnostic but when using a balanced partition tree only has quadradic exact runtime
-        (in term of the number of input features). This is in contrast to the exponential exact
-        runtime of KernelExplainer or SamplingExplainer. 2) PartitionExplainer always assigns to groups of
-        correlated features the credit that set of features would have had if treated as a group. This
-        means if the hierarchical clustering given to PartitionExplainer groups correlated features
-        together, then feature correlations are "accounted for" ... in the sense that the total credit assigned
-        to a group of tightly dependent features does net depend on how they behave if their correlation
-        structure was broken during the explanation's perterbation process. Note that for linear models
-        the Owen values that PartitionExplainer returns are the same as the standard non-hierarchical
-        Shapley values.
-
+        """Build a PartitionExplainer for the given model with the given masker.
 
         Parameters
         ----------

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -16,9 +16,9 @@ class PartitionExplainer(Explainer):
 
     Partition SHAP computes Shapley values recursively through a hierarchy of features, this
     hierarchy defines feature coalitions and results in the Owen values from game theory.
-    
+
     The PartitionExplainer has two particularly nice properties:
-    
+
     1) PartitionExplainer is model-agnostic but when using a balanced partition tree only has
        quadradic exact runtime (in term of the number of input features). This is in contrast to the
        exponential exact runtime of KernelExplainer or SamplingExplainer.
@@ -28,7 +28,7 @@ class PartitionExplainer(Explainer):
        "accounted for" in the sense that the total credit assigned to a group of tightly dependent features
        does net depend on how they behave if their correlation structure was broken during the explanation's
        perterbation process.
-    
+
     Note that for linear models the Owen values that PartitionExplainer returns are the same as the standard
     non-hierarchical Shapley values.
     """


### PR DESCRIPTION
Minor docstring fixups, so that the class will render better on our ReadTheDocs pages.

Before:

![image](https://github.com/shap/shap/assets/71127464/fd760d0e-e8bb-4adf-81db-b88e16359ce3)

After:

![image](https://github.com/shap/shap/assets/71127464/970a5e13-f6ae-439a-a5ff-6ad3cef173fa)
