### PR TITLE
MAINT: Restore ngboost tests for py311

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
   "lightgbm",
   "catboost",
   "gpboost",
-  "ngboost;python_version<'3.11'",  # FIXME: pending py3.11 support
+  "ngboost;python_version<'3.12'",  # FIXME: pending py3.12 support
   "pyspark",
   "pyod",
   "transformers",


### PR DESCRIPTION
Include ngboost in test suite in python 3.11, now that it officially supports 3.11.

Tangentially related:
- #3305
- https://github.com/stanfordmlgroup/ngboost/pull/346