### PR TITLE
MAINT: Increase operations limit of stale action

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -54,6 +54,6 @@ jobs:
           # If an issue or PR is marked with the "todo" label, never mark it as stale.
           exempt-issue-labels: todo
           exempt-pr-labels: todo
-          # Each run is limited to operations_per_turn=30.
-          # So, process the oldest issues first:
+          operations-per-run: 500
+          # Process the oldest issues first:
           ascending: true


### PR DESCRIPTION
## Summary

Increases the operations-per-run from 30 to 500.

## Discussion

The GitHub API is limited to 1000 operations per hour, so a limit of 500 means we never come near the limit. See: https://github.com/actions/stale/tree/main?tab=readme-ov-file#operations-per-run

At present the stale action only processes about a dozen items per run. This was useful at first so that we could watch how the action worked whilst avoiding changing too much at once. Now we can see it working, it would be useful to update the issue backlog (e.g. removing `stale` labels upon activity) in a more timely manner.

