### PR TITLE
MAINT: xfail on transformers connection errors

### DIFF
--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pytest
+from requests.exceptions import RequestException
 
 import shap
 
@@ -14,8 +15,11 @@ def test_method_get_teacher_forced_logits_for_encoder_decoder_model():
     transformers = pytest.importorskip("transformers")
 
     name = "hf-internal-testing/tiny-random-BartModel"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
-    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(name)
+    try:
+        tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+        model = transformers.AutoModelForSeq2SeqLM.from_pretrained(name)
+    except (OSError, RequestException):
+        pytest.xfail(reason="Connection error to transformers model")
 
     wrapped_model = shap.models.TeacherForcing(model, tokenizer, device='cpu')
 
@@ -34,8 +38,12 @@ def test_method_get_teacher_forced_logits_for_decoder_model():
     transformers = pytest.importorskip("transformers")
 
     name = "hf-internal-testing/tiny-random-gpt2"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
-    model = transformers.AutoModelForCausalLM.from_pretrained(name)
+    try:
+        tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+        model = transformers.AutoModelForCausalLM.from_pretrained(name)
+    except (OSError, RequestException):
+        pytest.xfail(reason="Connection error to transformers model")
+
     model.config.is_decoder = True
 
     wrapped_model = shap.models.TeacherForcing(model, tokenizer, device='cpu')

--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -12,12 +12,13 @@ def test_method_get_teacher_forced_logits_for_encoder_decoder_model():
     """
 
     transformers = pytest.importorskip("transformers")
+    requests = pytest.importorskip("requests")
 
     name = "hf-internal-testing/tiny-random-BartModel"
     try:
         tokenizer = transformers.AutoTokenizer.from_pretrained(name)
         model = transformers.AutoModelForSeq2SeqLM.from_pretrained(name)
-    except OSError:  # OSError includes requests.exceptions.RequestException
+    except requests.exceptions.RequestException:
         pytest.xfail(reason="Connection error to transformers model")
 
     wrapped_model = shap.models.TeacherForcing(model, tokenizer, device='cpu')
@@ -35,12 +36,13 @@ def test_method_get_teacher_forced_logits_for_decoder_model():
     """
 
     transformers = pytest.importorskip("transformers")
+    requests = pytest.importorskip("requests")
 
     name = "hf-internal-testing/tiny-random-gpt2"
     try:
         tokenizer = transformers.AutoTokenizer.from_pretrained(name)
         model = transformers.AutoModelForCausalLM.from_pretrained(name)
-    except OSError:  # OSError includes requests.exceptions.RequestException
+    except requests.exceptions.RequestException:
         pytest.xfail(reason="Connection error to transformers model")
 
     model.config.is_decoder = True

--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-from requests.exceptions import RequestException
 
 import shap
 
@@ -18,7 +17,7 @@ def test_method_get_teacher_forced_logits_for_encoder_decoder_model():
     try:
         tokenizer = transformers.AutoTokenizer.from_pretrained(name)
         model = transformers.AutoModelForSeq2SeqLM.from_pretrained(name)
-    except (OSError, RequestException):
+    except OSError:  # OSError includes requests.exceptions.RequestException
         pytest.xfail(reason="Connection error to transformers model")
 
     wrapped_model = shap.models.TeacherForcing(model, tokenizer, device='cpu')
@@ -41,7 +40,7 @@ def test_method_get_teacher_forced_logits_for_decoder_model():
     try:
         tokenizer = transformers.AutoTokenizer.from_pretrained(name)
         model = transformers.AutoModelForCausalLM.from_pretrained(name)
-    except (OSError, RequestException):
+    except OSError:  # OSError includes requests.exceptions.RequestException
         pytest.xfail(reason="Connection error to transformers model")
 
     model.config.is_decoder = True


### PR DESCRIPTION
## Overview

Label a test as XFAIL if a connection error to `transformers` occurs.

## Discussion

A recent CI job failed on `master` due to a connection error when downloading a model from `transformers`:
https://github.com/shap/shap/actions/runs/7798964523/attempts/1

I have seen this happen a few times previously. I don't think this should cause the whole CI workflow to fail, as it seems to be indicative of a flaky network connection rather than a genuine issue with shap. So, suggest marking such failures as "XFAIL" (and thus allowing the overall suite to pass), to avoid this phenomenon making our test suite "flaky".