### PR TITLE
MAINT: Update deprecated CodeCov upload action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -102,7 +102,9 @@ jobs:
           path: mpl-results/
           if-no-files-found: ignore
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
 
   test_oldest_supported_numpy:


### PR DESCRIPTION
Updates the codecov action to V4, as the V3 action is deprecated. Related:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
- Continues from #3490

The `codecov-action@v4` has some [breaking changes](https://github.com/codecov/codecov-action/releases/tag/v4.0.0): in particular it requires a token as a repository secret.

EDIT: this PR is now ready as the relevant upload secret has been added as a repo secret.