### PR TITLE
Support returning the actual matplotlib Figure

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -342,6 +342,8 @@ def bar(shap_values, max_display=10, order=Explanation.abs, clustering=None, clu
 
     if show:
         pl.show()
+    else:
+        return pl.gcf()
 
 
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):


### PR DESCRIPTION
## Overview

I'm using SHAP in software (as opposed to a Jupyter notebook). One use case I would like to do is display the SHAP bar chart from an Explanation object. With Force plots, there is an HTML method that returns raw HTML. I've implemented a simple alternative to adding the HTML method everywhere.

In essence, if show=False, return the actual current matplotlib Figure. This means that the calling function can then manipulate the actual figure. This approach also means that a lot of the styling / color options that are part of the library can be made directly on the Figure itself, instead of passing through to the actual plot.

If this approach is acceptable, I'd suggest modifying all the other plot functions as well to behave similarly.

Please let me know your thoughts! cc @CloseChoice 
