### PR TITLE
MAINT: Include ngboost tests for python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
   "lightgbm",
   "catboost;python_version<'3.12'",  # FIXME: pending py3.12 support
   "gpboost",
-  "ngboost;python_version<'3.12'",  # FIXME: pending py3.12 support
+  "ngboost",
   "pyspark",
   "pyod",
   "transformers",


### PR DESCRIPTION
Following the recent ngboost release `v0.5.0` which adds support for python 3.12, we can re-add that dependency to our test suite :

https://github.com/stanfordmlgroup/ngboost/pull/346