### PR TITLE
Do not overwrite default warning filter or formatter

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -26,8 +26,6 @@ from ..utils._legacy import DenseData
 from ._explainer import Explainer
 from .other._ubjson import decode_ubjson_buffer
 
-warnings.formatwarning = lambda msg, *args, **kwargs: str(msg) + '\n' # ignore everything except the message
-
 try:
     from .. import _cext
 except ImportError as e:

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -1,11 +1,9 @@
 # TODO: heapq in numba does not yet support Typed Lists so we can move to them yet...
 import heapq
-import warnings
 
 import numba.typed
 import numpy as np
 from numba import njit
-from numba.core.errors import NumbaPendingDeprecationWarning
 
 from .._serializable import Deserializer, Serializer
 from ..utils import assert_import, record_import_error, safe_isinstance
@@ -16,8 +14,6 @@ try:
     import torch  # noqa: F401
 except ImportError as e:
     record_import_error("torch", "torch could not be imported!", e)
-
-warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)
 
 try:
     import cv2


### PR DESCRIPTION
## Overview

Closes #3287

- Removes modifications of the default warning formatter
- Removes the global supression of numba deprecation warnings

## Discussion

As per the issue above, the unexpected import-time side-effects can be surprising and cause nefarious bugs. As a general rule, importable libraries should avoid modifying or monkeypatching other libraries.

One consequence of this change is that the warnings produced by SHAP will be the default verbose formatting, rather than the prettier "message-only" format:

![image](https://github.com/shap/shap/assets/71127464/7435bc5c-05b8-48ee-97c1-9e5c5dfb2cfe)

However, whilst I admittedly do prefer the concise formatting, I don't think this preference for formatting has anything to do with shap specifically, so it should be out-of-scope for the shap package to fiddle with generic python behaviour like this. Users are still able to modify the handling of warnings as they see fit.