### PR TITLE
ENH: Specify default clustering as "cosine" if y is None

### DIFF
--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -146,6 +146,8 @@ def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
     if metric == "auto":
         if y is not None:
             metric = "xgboost_distances_r2"
+        else:
+            metric = "cosine"
 
     # build the distance matrix
     if metric == "xgboost_distances_r2":

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -23,10 +23,8 @@ def partition_tree_shuffle(indexes, index_mask, partition_tree):
     ----------
     indexes: np.array
         The output location of the indexes we want shuffled. Note that len(indexes) should equal index_mask.sum().
-
     index_mask: np.array
         A bool mask of which indexes we want to include in the shuffled list.
-
     partition_tree: np.array
         The partition tree we should follow.
     """
@@ -140,6 +138,38 @@ def xgboost_distances_r2(X, y, learning_rate=0.6, early_stopping_rounds=2, subsa
     return dist
 
 def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
+    """Fit a hierarcical clustering model for features X relative to target variable y.
+
+    For more information on clutering methods see:
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html
+
+    Parameters
+    ----------
+    X: np.array
+        Features to cluster
+    y: np.array | None
+        Target variable
+    linkage: str
+        Defines the method to calculate the distance between clusters. Must be
+        one of "single", "complete" or "average".
+    metric: str
+        Scipy distance metric or "xgboost_distances_r2".
+
+        * If "xgboost_distances_r2", estimate redundancy distances between
+          features X with respect to target variable y using
+          :func:`shap.utils.xgboost_distances_r2`.
+        * Otherwise, calculate distances between features using the given
+          distance metric.
+        * If ``auto`` (default), use ``xgboost_distances_r2`` if target variable
+          is provided, or else ``cosine`` distance metric.
+    random_state: int
+        Numpy random state
+
+    Returns
+    -------
+    clustering: np.array
+        The hierarchical clustering encoded as a linkage matrix.
+    """
     if isinstance(X, pd.DataFrame):
         X = X.values
 

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -4,12 +4,17 @@ import pytest
 from shap.utils import hclust
 
 
-def test_hclust_runs():
+@pytest.mark.parametrize("linkage", ["single", "complete", "average"])
+def test_hclust_runs(linkage):
     # GH #3290
     pytest.importorskip('xgboost')
     X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
     y = np.where(X[:, 0] > 5, 1, 0)
 
-    clustered = hclust(X, y)
     # just check if clustered ran successfully
+    clustered = hclust(X, y, linkage=linkage)
+    assert isinstance(clustered, np.ndarray)
+
+    # Check clustering runs if y=None
+    clustered = hclust(X, linkage=linkage)
     assert isinstance(clustered, np.ndarray)


### PR DESCRIPTION
## Overview

Slight tweak to the behaviour of h_clust, so that a valid metric is chosen even if y=None.

This came up in writing a unit test for the bar plots. Previously if y=None, hclust would throw an exception via scipy: `unrecognised metric "auto"`