### PR TITLE
Expose arg `s` for marker size in `beeswarm`

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -29,7 +29,7 @@ from ._utils import (
 def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
              clustering=None, cluster_threshold=0.5, color=None,
              axis_color="#333333", alpha=1, show=True, log_scale=False,
-             color_bar=True, plot_size="auto", color_bar_label=labels["FEATURE_VALUE"]):
+             color_bar=True, s=16, plot_size="auto", color_bar_label=labels["FEATURE_VALUE"]):
     """Create a SHAP beeswarm plot, colored by feature values when they are provided.
 
     Parameters
@@ -49,6 +49,9 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
 
     color_bar : bool
         Whether to draw the color bar (legend).
+
+    s : int
+        What size to make the markers. For further information see `s` in ``matplotlib.pyplot.scatter``.
 
     plot_size : "auto" (default), float, (float, float), or None
         What size to make the plot. By default, the size is auto-scaled based on the
@@ -381,7 +384,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
             # plot the nan fvalues in the interaction feature as grey
             nan_mask = np.isnan(fvalues)
             pl.scatter(shaps[nan_mask], pos + ys[nan_mask], color="#777777",
-                        s=16, alpha=alpha, linewidth=0,
+                        s=s, alpha=alpha, linewidth=0,
                         zorder=3, rasterized=len(shaps) > 500)
 
             # plot the non-nan fvalues colored by the trimmed feature value
@@ -391,12 +394,12 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
             cvals[cvals_imp > vmax] = vmax
             cvals[cvals_imp < vmin] = vmin
             pl.scatter(shaps[np.invert(nan_mask)], pos + ys[np.invert(nan_mask)],
-                        cmap=color, vmin=vmin, vmax=vmax, s=16,
+                        cmap=color, vmin=vmin, vmax=vmax, s=s,
                         c=cvals, alpha=alpha, linewidth=0,
                         zorder=3, rasterized=len(shaps) > 500)
         else:
 
-            pl.scatter(shaps, pos + ys, s=16, alpha=alpha, linewidth=0, zorder=3,
+            pl.scatter(shaps, pos + ys, s=s, alpha=alpha, linewidth=0, zorder=3,
                         color=color if colored_feature else "#777777", rasterized=len(shaps) > 500)
 
 

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -50,7 +50,7 @@ def beeswarm(shap_values, max_display=10, order=Explanation.abs.mean(0),
     color_bar : bool
         Whether to draw the color bar (legend).
 
-    s : int
+    s : float
         What size to make the markers. For further information see `s` in ``matplotlib.pyplot.scatter``.
 
     plot_size : "auto" (default), float, (float, float), or None


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

With a relatively large number of points, the data points can get crowded and cause significant overlap, which can lead to misinterpretation of the data.

This PR solves this problem by exposing the argument `s` (marker size) in ``pl.scatter`` for convenience.

Before
<img width="918" alt="Screenshot 2024-02-29 at 11 58 38 PM" src="https://github.com/shap/shap/assets/28705891/2b6272ab-80d0-45ae-b595-b8c1e192efca">


After
<img width="815" alt="Screenshot 2024-02-29 at 11 58 57 PM" src="https://github.com/shap/shap/assets/28705891/d9899142-a382-45bc-baba-e76820fa2db6">


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
