### PR TITLE
Fix broken link and update plot description

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ shap.plots.text(shap_values[0, :, "POSITIVE"])
 Deep SHAP is a high-speed approximation algorithm for SHAP values in deep learning models that builds on a connection with [DeepLIFT](https://arxiv.org/abs/1704.02685) described in the SHAP NIPS paper. The implementation here differs from the original DeepLIFT by using a distribution of background samples instead of a single reference value, and using Shapley equations to linearize components such as max, softmax, products, divisions, etc. Note that some of these enhancements have also been since integrated into DeepLIFT. TensorFlow models and Keras models using the TensorFlow backend are supported (there is also preliminary support for PyTorch):
 
 ```python
-# ...include code from https://github.com/keras-team/keras/blob/master/examples/mnist_cnn.py
+# ...include code from https://github.com/keras-team/keras/blob/master/examples/demo_mnist_convnet.py
 
 import shap
 import numpy as np

--- a/notebooks/image_examples/image_classification/Front Page DeepExplainer MNIST Example.ipynb
+++ b/notebooks/image_examples/image_classification/Front Page DeepExplainer MNIST Example.ipynb
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot above shows the explanations for each class on four predictions. Note that the explanations are ordered for the classes 0-9 going left to right along the rows."
+    "The plot above shows the explanations for each class on five predictions. Note that the explanations are ordered for the classes 0-9 going left to right along the rows."
    ]
   }
  ],


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

- Updated a broken link in the readme from:
  [https://github.com/keras-team/keras/blob/master/examples/mnist_cnn.py]
  to:
  [https://github.com/keras-team/keras/blob/master/examples/demo_mnist_convnet.py].

- Adjusted the plot description, replacing "four" with "five," to accurately reflect that the explanations now show each class on five predictions.



## Checklist

~- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.~
~- [ ] Unit tests added (if fixing a bug or adding a new feature)~
