### PR TITLE
ENH: 2x import time speedup via lazy importing of pytorch

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -6,18 +6,13 @@ from packaging import version
 from .._explainer import Explainer
 from .deep_utils import _check_additivity
 
-torch = None
-
 
 class PyTorchDeep(Explainer):
 
     def __init__(self, model, data):
-        # try and import pytorch
-        global torch
-        if torch is None:
-            import torch
-            if version.parse(torch.__version__) < version.parse("0.4"):
-                warnings.warn("Your PyTorch version is older than 0.4 and not supported.")
+        import torch
+        if version.parse(torch.__version__) < version.parse("0.4"):
+            warnings.warn("Your PyTorch version is older than 0.4 and not supported.")
 
         # check if we have multiple inputs
         self.multi_input = False
@@ -102,6 +97,7 @@ class PyTorchDeep(Explainer):
                     pass
 
     def gradient(self, idx, inputs):
+        import torch
         self.model.zero_grad()
         X = [x.requires_grad_() for x in inputs]
         outputs = self.model(*X)
@@ -133,6 +129,7 @@ class PyTorchDeep(Explainer):
             return grads
 
     def shap_values(self, X, ranked_outputs=None, output_rank_order="max", check_additivity=True):
+        import torch
         # X ~ self.model_input
         # X_data ~ self.data
 
@@ -247,6 +244,7 @@ def add_interim_values(module, input, output):
     """The forward hook used to save interim tensors, detached
     from the graph. Used to calculate the multipliers
     """
+    import torch
     try:
         del module.x
     except AttributeError:
@@ -297,6 +295,7 @@ def passthrough(module, grad_input, grad_output):
 
 
 def maxpool(module, grad_input, grad_output):
+    import torch
     pool_to_unpool = {
         'MaxPool1d': torch.nn.functional.max_unpool1d,
         'MaxPool2d': torch.nn.functional.max_unpool2d,
@@ -336,6 +335,7 @@ def linear_1d(module, grad_input, grad_output):
 
 
 def nonlinear_1d(module, grad_input, grad_output):
+    import torch
     delta_out = module.y[: int(module.y.shape[0] / 2)] - module.y[int(module.y.shape[0] / 2):]
 
     delta_in = module.x[: int(module.x.shape[0] / 2)] - module.x[int(module.x.shape[0] / 2):]

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -15,7 +15,6 @@ from ..explainers.tf_utils import (
 
 keras = None
 tf = None
-torch = None
 
 
 class GradientExplainer(Explainer):
@@ -381,12 +380,9 @@ class _PyTorchGradient(Explainer):
 
     def __init__(self, model, data, batch_size=50, local_smoothing=0):
 
-        # try and import pytorch
-        global torch
-        if torch is None:
-            import torch
-            if version.parse(torch.__version__) < version.parse("0.4"):
-                warnings.warn("Your PyTorch version is older than 0.4 and not supported.")
+        import torch
+        if version.parse(torch.__version__) < version.parse("0.4"):
+            warnings.warn("Your PyTorch version is older than 0.4 and not supported.")
 
         # check if we have multiple inputs
         self.multi_input = False
@@ -439,6 +435,7 @@ class _PyTorchGradient(Explainer):
             self.gradients = [None for i in range(outputs.shape[1])]
 
     def gradient(self, idx, inputs):
+        import torch
         self.model.zero_grad()
         X = [x.requires_grad_() for x in inputs]
         outputs = self.model(*X)
@@ -469,6 +466,7 @@ class _PyTorchGradient(Explainer):
 
     def shap_values(self, X, nsamples=200, ranked_outputs=None, output_rank_order="max", rseed=None, return_variances=False):
 
+        import torch
         # X ~ self.model_input
         # X_data ~ self.data
 

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -11,11 +11,6 @@ from ..utils._exceptions import DimensionError
 from ._masker import Masker
 
 try:
-    import torch  # noqa: F401
-except ImportError as e:
-    record_import_error("torch", "torch could not be imported!", e)
-
-try:
     import cv2
 except ImportError as e:
     record_import_error("cv2", "cv2 could not be imported!", e)

--- a/shap/models/_model.py
+++ b/shap/models/_model.py
@@ -1,12 +1,7 @@
 import numpy as np
 
 from .._serializable import Deserializer, Serializable, Serializer
-from ..utils import record_import_error, safe_isinstance
-
-try:
-    import torch  # noqa: F401
-except ImportError as e:
-    record_import_error("torch", "torch could not be imported!", e)
+from ..utils import safe_isinstance
 
 
 class Model(Serializable):


### PR DESCRIPTION
## Overview

Closes #3528

Implements lazy importing for pytorch

## Timing

Created a profile in a local environment with the dev dependencies installed:

```bash
python -X importtime -c "import shap" > profile.log
```

### Before: 2.293s

Visualising with [tuna](https://github.com/nschloe/tuna):

![image](https://github.com/shap/shap/assets/71127464/3283d2a1-5112-4675-82ef-40dc1a20e8ce)

### After: 1.122s

![image](https://github.com/shap/shap/assets/71127464/ba75412c-be66-4b73-9253-761f5442a3f6)


## Discussion

At present pytorch is imported lazily in _some_ of the modules, but not all, so there is no net speedup. This PR implements lazy loading of torch everywhere it is used.

Presently some lazy importing is done via global variables, such as:

```python
foo = None

def bar():
    if foo is None:
        import foo
```

This seems needlessly complex, as `import foo` will be a simple lookup in sys.modules if foo has already been imported. So, I propose just importing the relevant modules at the top of each function in which it is used:

```python
def bar():
   import foo
```

## Alternatives considered

### LazyLoader

The standard library has [LazyLoader](https://docs.python.org/3/library/importlib.html#importlib.util.LazyLoader), which can be used to postpone the execution of the loader of a module until the module has an attribute accessed.

However, this has some downsides and is discouraged unless really necessary:

>  For projects where startup time is not essential then use of this class is heavily discouraged due to error messages created during loading being postponed and thus occurring out of context.

There are a significant number of open issues relating to DeepExplainer, so I think it is wise to keep complexity to an absolute minimum and avoid complex approaches like this.

### Lazy subpackages

We could copy scipy's approach and import entire subpackages of shap lazily, with some `getattr` magic. This would probably be a bit more complex to implement. However, it could offer significant speedups. I don't think it's a priority for now.

https://peps.python.org/pep-0562/

