### PR TITLE
Fix text masking with certain tokenizers

### DIFF
--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -112,9 +112,11 @@ class Text(Masker):
         self._update_s_cache(s)
 
         # if we have a fixed prefix or suffix then we need to grow the mask to account for that
-        if self.keep_prefix > 0 or self.keep_suffix > 0:
+        if self.keep_prefix > 0:
             mask = mask.copy()
             mask[:self.keep_prefix] = True
+        if self.keep_suffix > 0:
+            mask = mask.copy()
             mask[-self.keep_suffix:] = True
 
         if self.output_type == "string":

--- a/tests/maskers/test_text.py
+++ b/tests/maskers/test_text.py
@@ -95,7 +95,6 @@ def test_sentencepiece_tokenizer_output():
     # since we expect output wrapped in a tuple hence the indexing [0][0] to extract the string
     assert sentencepiece_tokenizer_output_processed[0][0] == expected_sentencepiece_tokenizer_output_processed
 
-@pytest.mark.skip(reason="fails on travis and I don't know why yet...Ryan might need to take a look since this API will change soon anyway")
 def test_keep_prefix_suffix_tokenizer_parsing():
     """ Checks parsed keep prefix and keep suffix for different tokenizers.
     """

--- a/tests/maskers/test_text.py
+++ b/tests/maskers/test_text.py
@@ -105,18 +105,22 @@ def test_keep_prefix_suffix_tokenizer_parsing():
     tokenizer_mt = AutoTokenizer.from_pretrained("Helsinki-NLP/opus-mt-en-es")
     tokenizer_gpt = AutoTokenizer.from_pretrained("gpt2")
     tokenizer_bart = AutoTokenizer.from_pretrained("sshleifer/distilbart-xsum-12-6")
+    tokenizer_mistral = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1")
 
     masker_mt = shap.maskers.Text(tokenizer_mt)
     masker_gpt = shap.maskers.Text(tokenizer_gpt)
     masker_bart = shap.maskers.Text(tokenizer_bart)
+    masker_mistral = shap.maskers.Text(tokenizer_mistral)
 
     masker_mt_expected_keep_prefix, masker_mt_expected_keep_suffix = 0, 1
     masker_gpt_expected_keep_prefix, masker_gpt_expected_keep_suffix = 0, 0
     masker_bart_expected_keep_prefix, masker_bart_expected_keep_suffix = 1, 1
+    masker_mistral_expected_keep_prefix, masker_mistral_expected_keep_suffix = 1, 0
 
     assert masker_mt.keep_prefix == masker_mt_expected_keep_prefix and masker_mt.keep_suffix == masker_mt_expected_keep_suffix and \
            masker_gpt.keep_prefix == masker_gpt_expected_keep_prefix and masker_gpt.keep_suffix == masker_gpt_expected_keep_suffix and \
-           masker_bart.keep_prefix == masker_bart_expected_keep_prefix and masker_bart.keep_suffix == masker_bart_expected_keep_suffix
+           masker_bart.keep_prefix == masker_bart_expected_keep_prefix and masker_bart.keep_suffix == masker_bart_expected_keep_suffix and \
+           masker_mistral.keep_prefix == masker_mistral_expected_keep_prefix and masker_mistral.keep_suffix == masker_mistral_expected_keep_suffix
 
 
 def test_text_infill_with_collapse_mask_token():
@@ -127,6 +131,9 @@ def test_text_infill_with_collapse_mask_token():
 
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     masker = shap.maskers.Text(tokenizer, mask_token='...', collapse_mask_token=True)
+
+    tokenizer_mistral = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1")
+    masker_mistral = shap.maskers.Text(tokenizer_mistral, mask_token='...', collapse_mask_token=True)
 
     s = "This is a test string to be infilled"
 
@@ -140,19 +147,25 @@ def test_text_infill_with_collapse_mask_token():
     mask_ex4 = np.array([False, False, False, False, False, False, False, False, False])
 
     text_infilled_ex1 = masker(mask_ex1, s)[0][0]
+    text_infilled_ex1_mist = masker_mistral(np.append(True, mask_ex1), s)[0][0]
     expected_text_infilled_ex1 = "This is a test string ..."
 
     text_infilled_ex2 = masker(mask_ex2, s)[0][0]
+    text_infilled_ex2_mist = masker_mistral(np.append(True, mask_ex2), s)[0][0]
     expected_text_infilled_ex2 = "This is a ... to be infilled"
 
     text_infilled_ex3 = masker(mask_ex3, s)[0][0]
+    text_infilled_ex3_mist = masker_mistral(np.append(True, mask_ex3), s)[0][0]
     expected_text_infilled_ex3 = "... test string to be infilled"
 
     text_infilled_ex4 = masker(mask_ex4, s)[0][0]
+    text_infilled_ex4_mist = masker_mistral(np.append(True, mask_ex4), s)[0][0]
     expected_text_infilled_ex4 = "..."
 
     assert  text_infilled_ex1 == expected_text_infilled_ex1 and text_infilled_ex2 == expected_text_infilled_ex2 and \
-            text_infilled_ex3 == expected_text_infilled_ex3 and text_infilled_ex4 == expected_text_infilled_ex4
+            text_infilled_ex3 == expected_text_infilled_ex3 and text_infilled_ex4 == expected_text_infilled_ex4 and \
+            text_infilled_ex1_mist == expected_text_infilled_ex1 and text_infilled_ex2_mist == expected_text_infilled_ex2 and \
+            text_infilled_ex3_mist== expected_text_infilled_ex3 and text_infilled_ex4_mist == expected_text_infilled_ex4
 
 def test_serialization_text_masker():
     """ Make sure text serialization works.


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:
Fixed a bug in text masker for a tokenizer where keep_prefix is >0 but keep_sufix is 0. In this case, the full mask is overwritten to True. This PR contains the (small) fix and some tests.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
