### PR TITLE
Bump cibuildwheel to 2.16.5

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
       # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.14.0
+        run: pipx install cibuildwheel==2.16.5
+      - name: Print all build identifiers
+        run: cibuildwheel --print-build-identifiers
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -63,7 +65,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.14.0
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           only: ${{ matrix.only }}
 


### PR DESCRIPTION
Closes #3539

- Bumps cibuildwheel to latest version. Should now build python 3.12, and fix the build on Windows.
- Adds a debugging step to print build IDs

Example build: https://github.com/shap/shap/actions/runs/8144602339