### PR TITLE
Remove deprecation warning for permutation explainer

### DIFF
--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -1,4 +1,3 @@
-import warnings
 
 import numpy as np
 
@@ -208,7 +207,6 @@ class PermutationExplainer(Explainer):
             attribute of the explainer). For models with vector outputs this returns a list
             of such matrices, one for each output.
         """
-        warnings.warn("shap_values() is deprecated; use __call__().", DeprecationWarning)
 
         explanation = self(X, max_evals=npermutations * X.shape[1], main_effects=main_effects)
         return explanation.values


### PR DESCRIPTION
Supports #3507

Removes the deprecation warning for the permutation explainer