### PR TITLE
Fix force_plot contribution threshold for negative contributions

### DIFF
--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -134,12 +134,6 @@ def draw_labels(fig, ax, out_value, features, feature_type, offset_text, total_e
         else:
             box_end_ = box_size.get_points()[1][0]
 
-        # If the feature goes over the side of the plot, we remove that label
-        # and stop drawing labels
-        if box_end_ > ax.get_xlim()[1]:
-            text_out_val.remove()
-            break
-
         # Create end line
         if (sign * box_end_) > (sign * val):
             x, y = np.array([[val, val], [0, -0.18]])


### PR DESCRIPTION
## Overview

Closes #2889

Removes redundant logic that controls the display of labels, so that the `contribution_threshold` parameter works as expected for both positive and negative values


## Screenshots

For the example in #2889, if `contribution_threshold=0` we expect to see all labels present (even though this is rather visually cluttered, which is why by default a higher threshold is applied).

Before (note labels missing on right hand side):

![image](https://github.com/shap/shap/assets/71127464/ed40a40e-c2d1-42b0-905c-7a187b3eb509)

After:

![image](https://github.com/shap/shap/assets/71127464/0bf337d5-469d-4a75-94f6-0fb4dd93c318)
