### PR TITLE
DOCS: Formatting and phrasing updates for SHAP return values

### DIFF
--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -44,7 +44,7 @@ class DeepExplainer(Explainer):
             layer argument. layer must be a layer in the model, i.e. model.conv2
 
         data :
-            if framework == 'tensorflow': [numpy.array] or [pandas.DataFrame]
+            if framework == 'tensorflow': [np.array] or [pandas.DataFrame]
             if framework == 'pytorch': [torch.tensor]
             The background dataset to use for integrating out features. Deep integrates
             over these samples. The data passed here must match the input tensors given in the
@@ -94,7 +94,7 @@ class DeepExplainer(Explainer):
         Parameters
         ----------
         X : list,
-            if framework == 'tensorflow': numpy.array, or pandas.DataFrame
+            if framework == 'tensorflow': np.array, or pandas.DataFrame
             if framework == 'pytorch': torch.tensor
             A tensor (or list of tensors) of samples (where X.shape[0] == # samples) on which to
             explain the model's output.
@@ -113,7 +113,7 @@ class DeepExplainer(Explainer):
 
         Returns
         -------
-        array or list
+        np.array or list
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
             The shape of the returned array depends on the number of model outputs:

--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -4,7 +4,7 @@ from .deep_tf import TFDeep
 
 
 class DeepExplainer(Explainer):
-    """ Meant to approximate SHAP values for deep learning models.
+    """Meant to approximate SHAP values for deep learning models.
 
     This is an enhanced version of the DeepLIFT algorithm (Deep SHAP) where, similar to Kernel SHAP, we
     approximate the conditional expectations of SHAP values using a selection of background samples.
@@ -17,6 +17,7 @@ class DeepExplainer(Explainer):
     Examples
     --------
     See :ref:`Deep Explainer Examples <deep_explainer_examples>`
+
     """
 
     def __init__(self, model, data, session=None, learning_phase_flags=None):
@@ -51,8 +52,6 @@ class DeepExplainer(Explainer):
             should only something like 100 or 1000 random background samples, not the whole training
             dataset.
 
-        if framework == 'tensorflow':
-
         session : None or tensorflow.Session
             The TensorFlow session that has the model we are explaining. If None is passed then
             we do our best to find the right session, first looking for a keras session, then
@@ -64,6 +63,7 @@ class DeepExplainer(Explainer):
             batch norm or dropout. If None is passed then we look for tensors in the graph that look like
             learning phase flags (this works for Keras models). Note that we assume all the flags should
             have a value of False during predictions (and hence explanations).
+
         """
         # first, we need to find the framework
         if type(model) is tuple:

--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -114,19 +114,21 @@ class DeepExplainer(Explainer):
         Returns
         -------
         array or list
-            The return type and shape depend on the number of model inputs and outputs:
+            Estimated SHAP values, usually of shape ``(# samples x # features)``.
+
+            The shape of the returned array depends on the number of model outputs:
 
             * one input, one output: matrix of shape ``(#num_samples, *X.shape[1:])``.
             * one input, multiple outputs: matrix of shape ``(#num_samples, *X.shape[1:], #num_outputs)``
             * multiple inputs, one or more outputs: list of matrices, with shapes of one of the above.
 
-            If ranked_outputs is None then this list of tensors matches
+            If ranked_outputs is ``None`` then this list of tensors matches
             the number of model outputs. If ranked_outputs is a positive integer a pair is returned
             (shap_values, indexes), where shap_values is a list of tensors with a length of
             ranked_outputs, and indexes is a matrix that indicates for each sample which output indexes
             were chosen as "top".
 
-           .. versionchanged:: 0.45.0
-              Return type for models with multiple outputs and one input changed from list to np.ndarray.
+            .. versionchanged:: 0.45.0
+                Return type for models with multiple outputs and one input changed from list to np.ndarray.
         """
         return self.explainer.shap_values(X, ranked_outputs, output_rank_order, check_additivity=check_additivity)

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -52,7 +52,7 @@ class GradientExplainer(Explainer):
             is a tuple, the returned shap values will be for the input of the layer argument. layer must
             be a layer in the model, i.e. model.conv2.
 
-        data : [numpy.array] or [pandas.DataFrame] or [torch.tensor]
+        data : [np.array] or [pandas.DataFrame] or [torch.tensor]
             The background dataset to use for integrating out features. Gradient explainer integrates
             over these samples. The data passed here must match the input tensors given in the
             first argument. Single element lists can be passed unwrapped.
@@ -89,7 +89,7 @@ class GradientExplainer(Explainer):
         Parameters
         ----------
         X : list,
-            if framework == 'tensorflow': numpy.array, or pandas.DataFrame
+            if framework == 'tensorflow': np.array, or pandas.DataFrame
             if framework == 'pytorch': torch.tensor
             A tensor (or list of tensors) of samples (where X.shape[0] == # samples) on which to
             explain the model's output.
@@ -108,7 +108,7 @@ class GradientExplainer(Explainer):
         Parameters
         ----------
         X : list,
-            if framework == 'tensorflow': numpy.array, or pandas.DataFrame
+            if framework == 'tensorflow': np.array, or pandas.DataFrame
             if framework == 'pytorch': torch.tensor
             A tensor (or list of tensors) of samples (where X.shape[0] == # samples) on which to
             explain the model's output.

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -131,19 +131,26 @@ class GradientExplainer(Explainer):
 
         Returns
         -------
-        array or list
-            The return type and shape depend on the number of model inputs and outputs:
-              - one input one output: matrix of shape (#num_samples, *X.shape[1:]).
-              - one input multiple outputs: matrix of shape (#num_samples, *X.shape[1:], #num_outputs)
-              - multiple inputs one or more outputs: list of matrices, with shapes of one of the above.
-            If ranked_outputs is None then this list of tensors matches
-            the number of model outputs. If ranked_outputs is a positive integer a pair is returned
-            (shap_values, indexes), where shap_values is a list of tensors with a length of
-            ranked_outputs, and indexes is a matrix that tells for each sample which output indexes
-            were chosen as "top".
+        np.array or list
+            Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
-           .. versionchanged:: 0.45.0
-           Return type for models with multiple outputs and one input changed from list to np.ndarray.
+            The shape of the returned array depends on the number of model outputs:
+
+            * one input, one output: array of shape ``(#num_samples, *X.shape[1:])``.
+            * one input, multiple outputs: array of shape ``(#num_samples, *X.shape[1:], #num_outputs)``
+            * multiple inputs: list of arrays with corresponding shape above.
+
+            If ranked_outputs is ``None`` then this list of tensors matches the
+            number of model outputs. If ranked_outputs is a positive integer a
+            pair is returned ``(shap_values, indexes)``, where shap_values is a
+            list of tensors with a length of ranked_outputs, and indexes is a
+            matrix that tells for each sample which output indexes were chosen
+            as "top".
+
+            .. versionchanged:: 0.45.0
+                Return type for models with multiple outputs and one input changed
+                from list to np.ndarray.
+
         """
         return self.explainer.shap_values(X, nsamples, ranked_outputs, output_rank_order, rseed, return_variances)
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -188,18 +188,21 @@ class KernelExplainer(Explainer):
 
         Returns
         -------
-        array or list
-            The return type and shape depend on the number of model inputs and outputs:
-              - one input one output: matrix of shape (#num_samples, *X.shape[1:]).
-              - one input multiple outputs: matrix of shape (#num_samples, *X.shape[1:], #num_outputs)
-              - multiple inputs one or more outputs: list of matrices, with shapes of one of the above.
-            Each row sums to the difference between the model output for that
-            sample and the expected value of the model output (which is stored as expected_value
-            attribute of the explainer). For models with vector outputs this returns a list
-            of such matrices, one for each output.
+        np.array or list
+            Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
-           .. versionchanged:: 0.45.0
-           Return type for models with multiple outputs and one input changed from list to np.ndarray.
+            Each row sums to the difference between the model output for that
+            sample and the expected value of the model output (which is stored as the ``expected_value``
+            attribute of the explainer).
+
+            The type and shape of the return value depends on the number of model inputs and outputs:
+
+            * one input, one output: array of shape ``(#num_samples, *X.shape[1:])``.
+            * one input, multiple outputs: array of shape ``(#num_samples, *X.shape[1:], #num_outputs)``
+            * multiple inputs: list of arrays of corresponding shape above.
+
+            .. versionchanged:: 0.45.0
+                Return type for models with multiple outputs and one input changed from list to np.ndarray.
         """
 
         # convert dataframes

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -376,17 +376,21 @@ class LinearExplainer(Explainer):
 
         Returns
         -------
-        array
-            Returns a matrix. The shape depends on the number of model outputs:
-              - one output: matrix of shape (#num_samples, *X.shape[1:]).
-              - multiple outputs: matrix of shape (#num_samples, *X.shape[1:], #num_outputs).
-            For models with a single output this returns a matrix of SHAP values
-            (# samples x # features). Each row sums to the difference between the model output for that
-            sample and the expected value of the model output (which is stored as expected_value
-            attribute of the explainer).
+        np.array
+            Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
-           .. versionchanged:: 0.45.0
-           Return type for models with multiple outputs changed from list to np.ndarray.
+            Each row sums to the difference between the model output for that
+            sample and the expected value of the model output (which is stored
+            as the ``expected_value`` attribute of the explainer).
+
+            The shape of the returned array depends on the number of model outputs:
+
+            * one output: array of shape ``(#num_samples, *X.shape[1:])``.
+            * multiple outputs: array of shape ``(#num_samples, *X.shape[1:],
+              #num_outputs)``.
+
+            .. versionchanged:: 0.45.0
+                Return type for models with multiple outputs changed from list to np.ndarray.
         """
 
         # convert dataframes

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -397,15 +397,16 @@ class TreeExplainer(Explainer):
         -------
         array
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
+
+            Each row sums to the difference between the model output for that
+            sample and the expected value of the model output (which is stored
+            as the ``expected_value`` attribute of the explainer).
+
             The shape of the returned array depends on the number of model outputs:
 
             * one output: array of shape ``(#num_samples, *X.shape[1:])``.
             * multiple outputs: array of shape ``(#num_samples, *X.shape[1:],
               #num_outputs)``.
-
-            Each row sums to the difference between the model output for that
-            sample and the expected value of the model output (which is stored
-            as the ``expected_value`` attribute of the explainer).
 
             .. versionchanged:: 0.45.0
                 Return type for models with multiple outputs changed from list to np.ndarray.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -395,7 +395,7 @@ class TreeExplainer(Explainer):
 
         Returns
         -------
-        array
+        np.array
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
             Each row sums to the difference between the model output for that
@@ -555,7 +555,7 @@ class TreeExplainer(Explainer):
 
         Returns
         -------
-        array
+        np.array
             Returns a matrix. The shape depends on the number of model outputs:
 
             * one output: matrix of shape (#num_samples, #features, #features).

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -396,15 +396,19 @@ class TreeExplainer(Explainer):
         Returns
         -------
         array
-            Returns a matrix. The shape depends on the number of model outputs:
-              - one output: matrix of shape (#num_samples, *X.shape[1:]).
-              - multiple outputs: matrix of shape (#num_samples, *X.shape[1:], #num_outputs).
-            Each row sums to the difference between the model output for that
-            sample and the expected value of the model output (which is stored in the ``expected_value``
-            attribute of the explainer when it is constant).
+            Estimated SHAP values, usually of shape ``(# samples x # features)``.
+            The shape of the returned array depends on the number of model outputs:
 
-           .. versionchanged:: 0.45.0
-           Return type for models with multiple outputs changed from list to np.ndarray.
+            * one output: array of shape ``(#num_samples, *X.shape[1:])``.
+            * multiple outputs: array of shape ``(#num_samples, *X.shape[1:],
+              #num_outputs)``.
+
+            Each row sums to the difference between the model output for that
+            sample and the expected value of the model output (which is stored
+            as the ``expected_value`` attribute of the explainer).
+
+            .. versionchanged:: 0.45.0
+                Return type for models with multiple outputs changed from list to np.ndarray.
         """
         # see if we have a default tree_limit in place.
         if tree_limit is None:
@@ -564,8 +568,8 @@ class TreeExplainer(Explainer):
             interaction effects between all pairs of features for that sample.
             For models with vector outputs, this returns a list of tensors, one for each output.
 
-           .. versionchanged:: 0.45.0
-           Return type for models with multiple outputs changed from list to np.ndarray.
+            .. versionchanged:: 0.45.0
+                Return type for models with multiple outputs changed from list to np.ndarray.
         """
 
         assert self.model.model_output == "raw", "Only model_output = \"raw\" is supported for SHAP interaction values right now!"

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -17,11 +17,11 @@ except ImportError as e:
 
 
 class Image(Masker):
-    """ This masks out image regions with blurring or inpainting.
-    """
+    """Masks out image regions with blurring or inpainting."""
 
     def __init__(self, mask_value, shape=None):
-        """ Build a new Image masker with the given masking value.
+        """Build a new Image masker with the given masking value.
+
         Parameters
         ----------
         mask_value : np.array, "blur(kernel_xsize, kernel_xsize)", "inpaint_telea", or "inpaint_ns"
@@ -29,6 +29,7 @@ class Image(Masker):
         shape : None or tuple
             If the mask_value is an auto-generated masker instead of a dataset then the input
             image shape needs to be provided.
+
         """
         if shape is None:
             if isinstance(mask_value, str):


### PR DESCRIPTION
## Overview

A few fixups following #3318

- Update RST formatting for `versionchanged` directive and bullet points
- Rephrase docstrings slightly for clarity (feedback/suggestions welcome)
