### PR TITLE
MAINT: Add l1_reg argument to KernelExplainer call()

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -150,7 +150,7 @@ class KernelExplainer(Explainer):
                 tensor_as_np_array = sess.run(symbolic_tensor)
         return tensor_as_np_array
 
-    def __call__(self, X, l1_reg="auto"):
+    def __call__(self, X, l1_reg="auto", silent=False):
 
         start_time = time.time()
 
@@ -159,7 +159,7 @@ class KernelExplainer(Explainer):
         else:
             feature_names = getattr(self, "data_feature_names", None)
 
-        v = self.shap_values(X, l1_reg=l1_reg)
+        v = self.shap_values(X, l1_reg=l1_reg, silent=silent)
         if isinstance(v, list):
             v = np.stack(v, axis=-1) # put outputs at the end
 
@@ -204,6 +204,9 @@ class KernelExplainer(Explainer):
 
             Note: The default behaviour will change in a future version to be ``"num_features(10)"``.
             Pass this value explicitly to silence the DeprecationWarning.
+
+        silent: bool
+            If True, hide tqdm progress bar. Default False.
 
         gc_collect : bool
            Run garbage collection after each explanation round. Sometime needed for memory intensive explanations (default False).

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -234,7 +234,9 @@ def test_linear(random_seed):
     def f(x):
         return x[:, 0] + 2.0*x[:, 1]
 
-    phi = shap.KernelExplainer(f, x).shap_values(x, l1_reg="num_features(2)", silent=True)
+    explainer = shap.KernelExplainer(f, x)
+    explanation = explainer(x, l1_reg="num_features(2)", silent=True)
+    phi = explanation.values
     assert phi.shape == x.shape
 
     # corollary 1


### PR DESCRIPTION
## Overview

Follow-up to #3517 based on discussion. Adds a parameter `l1_reg` to the `__call__` method, so a user can silence the deprecation warning.