### PR TITLE
MAINT: Pin tensorflow to <2.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ test = [
   "torch==2.2.0; sys_platform == 'darwin'",  # see GH #3524
   "torch; sys_platform != 'darwin'",
   "torchvision",
-  "tensorflow;python_version<'3.12'",  # FIXME: pending py3.12 support
+  "tensorflow<2.16;python_version<'3.12'",  # FIXME: pending keras 3.0 support, pending tf py3.12 support
   "sentencepiece",
   "opencv-python",
 ]


### PR DESCRIPTION
## Overview

Supports #3562 , pins tensorflow to the most recent passing version for now.

Hopefully fixes CI as short-term patch