### PR TITLE
Include catboost tests for py312

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test = [
   "pytest-cov",
   "xgboost",
   "lightgbm",
-  "catboost;python_version<'3.12'",  # FIXME: pending py3.12 support
+  "catboost",
   "gpboost",
   "ngboost",
   "pyspark",


### PR DESCRIPTION
## Overview

Enable catboost tests for python 3.12, following support in recent release:

https://github.com/catboost/catboost/releases/tag/v1.2.3