### PR TITLE
Fix use of Falcon language model for text generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,6 @@ test = [
   "tensorflow<2.16;python_version<'3.12'",  # FIXME: pending keras 3.0 support, pending tf py3.12 support
   "sentencepiece",
   "opencv-python",
-  "accelerate",
-  "bitsandbytes"
 ]
 
 test_notebooks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ test = [
   "tensorflow<2.16;python_version<'3.12'",  # FIXME: pending keras 3.0 support, pending tf py3.12 support
   "sentencepiece",
   "opencv-python",
+  "accelerate",
+  "bitsandbytes"
 ]
 
 test_notebooks = [

--- a/shap/models/_teacher_forcing.py
+++ b/shap/models/_teacher_forcing.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import scipy.special
 
@@ -282,6 +284,8 @@ class TeacherForcing(Model):
                     inputs["position_ids"] = (inputs["attention_mask"].long().cumsum(-1) - 1)
                     inputs["position_ids"].masked_fill_(inputs["attention_mask"] == 0, 0)
                     # model inference
+                    expected_parameters = list(inspect.signature(self.similarity_model.forward).parameters)
+                    inputs = {k: v for k, v in inputs.items() if k in expected_parameters}
                     outputs = self.similarity_model(**inputs, return_dict=True)
                 logits = outputs.logits.detach().cpu().numpy().astype('float64')
         elif self.similarity_model_type == "tf":

--- a/tests/models/test_teacher_forcing_logits.py
+++ b/tests/models/test_teacher_forcing_logits.py
@@ -13,7 +13,7 @@ def test_falcon():
     try:
         tokenizer = transformers.AutoTokenizer.from_pretrained(name)
         model = transformers.AutoModelForCausalLM.from_pretrained(
-            name, trust_remote_code=True, load_in_8bit=True, device_map="auto"
+            name, trust_remote_code=True, load_in_8bit=False, low_cpu_mem_usage=False
         )
     except requests.exceptions.RequestException:
         pytest.xfail(reason="Connection error to transformers model")


### PR DESCRIPTION
## Overview

Closes #3589 <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
- the falcon model does not need `position_ids` so we check the function signature dynamically now and only hand over the expected arguments to avoid errors
- add test with tiny falcon model (<10MB). Admittedly we can improve what we test but this test works for now. Fails on master but works on this branch.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
