### PR TITLE
MAINT: Address pyod isolation forest test warning

### DIFF
--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -468,6 +468,7 @@ def test_pyod_isolation_forest():
     from pyod.models.iforest import IForest
 
     X, _ = shap.datasets.california(n_points=500)
+    X = sklearn.utils.check_array(X)
     for max_features in [1.0, 0.75]:
         iso = IForest(max_features=max_features)
         iso.fit(X)


### PR DESCRIPTION

## Overview

For one task on #3066 relating to the pyod isolation forest test warning:

```
tests/explainers/test_tree.py::test_pyod_isolation_forest
tests/explainers/test_tree.py::test_pyod_isolation_forest
  X has feature names, but IsolationForest was fitted without feature names
```

Isolation forest will use the feature names if a dataframe with column names is passed on fit or inference and will complain when a different format is passed than the fit call.

The test is written with a Dataframe but the pyod package converts to a 2D array in the `fit` call [here](https://github.com/yzhao062/pyod/blob/master/pyod/models/iforest.py#L203). This results in the warning when shap does the explaining. This normalises the input format for the model to a 2D array in all cases.




## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
