### PR TITLE
FIX: Correct Data Type in Docstring for max_display in Waterfall Plot

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -30,8 +30,8 @@ def waterfall(shap_values, max_display=10, show=True):
     shap_values : Explanation
         A one-dimensional :class:`.Explanation` object that contains the feature values and SHAP values to plot.
 
-    max_display : str
-        The maximum number of features to plot (default is 10).
+    max_display : int
+        The maximum number of features to display (default is 10).
 
     show : bool
         Whether ``matplotlib.pyplot.show()`` is called before returning.
@@ -343,8 +343,8 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     feature_names : list
         List of feature names (# features).
 
-    max_display : str
-        The maximum number of features to plot.
+    max_display : int
+        The maximum number of features to display (default is 10).
 
     show : bool
         Whether matplotlib.pyplot.show() is called before returning. Setting this to False allows the plot


### PR DESCRIPTION
## Overview

This is a small PR that corrects the documentation inconsistency in `max_display` parameter of `shap.plots.waterfall` function in `shap/plots/_waterfall.py`. The documentation states it's a string, but it's actually an integer.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- ~~[ ] Unit tests added (if fixing a bug or adding a new feature)~~