### PR TITLE
FIX : Add libomp for lightgbm Compilation (macOS Workflow)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix-macos-ci
   pull_request:
     branches:
       - master

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,6 +76,9 @@ jobs:
             ${{ env.pythonLocation }}/**/site-packages/torch*
             ${{ env.pythonLocation }}/**/site-packages/functorch*
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
+      - name: Install libomp (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install libomp
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix-macos-ci
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Overview

Closes #3631 <!--Add issue number here, or delete as appropriate-->

This pull request resolves the lightgbm compilation error on macOS by ensuring libomp is installed.

You can view the successful execution of this change in the Actions runs on my forked branch [here](https://github.com/bewygs/shap/actions/runs/8886311208/job/24399502982).

## Description of the changes

Added a step to install libomp via Homebrew for macOS GitHub Actions workflow.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
