### PR TITLE
resolve deprecated obj2sctype in numpy 2.0

### DIFF
--- a/shap/plots/colors/_colorconv.py
+++ b/shap/plots/colors/_colorconv.py
@@ -816,7 +816,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
     #   is a subclass of that type (e.g. `np.floating` will allow
     #   `float32` and `float64` arrays through)
 
-    if np.issubdtype(dtype_in, np.obj2sctype(dtype)):
+    if np.issubdtype(dtype_in, np.dtype(dtype).type):
         if force_copy:
             image = image.copy()
         return image


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

Resolves the error:

AttributeError: `np.obj2sctype` was removed in the NumPy 2.0 release. Use `np.dtype(obj).type` instead.
