### PR TITLE
MAINT: Add numpy compatibility linter rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: '.*tree_shap_paper.*|.*user_studies.*'
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.7
+  rev: v0.4.10
   hooks:
   - id: ruff
     types_or: [python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ select = [
   "E",  # pycodestyle
   "W",  # warning
   "D",  # pydocstyle
+  "NP201",  # Numpy 2.0 compatibility
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ select = [
   "E",  # pycodestyle
   "W",  # warning
   "D",  # pydocstyle
-  "NP201",  # Numpy 2.0 compatibility
+  "NPY",  # Numpy
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [
@@ -157,6 +157,7 @@ ignore = [
   "D400",  # First line should end with a period
   "D401",  # First line of docstring should be in imperative mood: "A basic partial dependence plot function."
   "D404",  # First word of the docstring should not be "This"
+  "NPY002",  # Allow numpy RandomState objects in tests
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
Supports #3707

Adds numpy linter rule [NPY201](https://docs.astral.sh/ruff/rules/numpy2-deprecation/) , as recommended by numpy migration guide. It currently passes with no issues.