### PR TITLE
ENH: Add support for numpy 2, and test against numpy 1.X and 2.X

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -103,3 +103,22 @@ jobs:
           if-no-files-found: ignore
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+
+
+  oldest_supported_numpy:
+    # As recommended by https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+    # Package is built with numpy 2.X, and tested against numpy 1.X
+    name: Test oldest supported numpy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install oldest-supported-numpy '.[test-core,plots]'
+      - name: Test with pytest
+        run: pytest --durations=20 --import-mode=append

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -105,10 +105,12 @@ jobs:
         uses: codecov/codecov-action@v3
 
 
-  oldest_supported_numpy:
-    # As recommended by https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
-    # Package is built with numpy 2.X, and tested against numpy 1.X
-    name: Test oldest supported numpy
+  test_oldest_supported_numpy:
+    # Package is built with numpy 2.X, and tested against numpy 1.X.
+    # This job is recommended by https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
+    # The "oldest supported numpy" is determined by SPEC 0:
+    # https://scientific-python.org/specs/spec-0000/
+    name: run tests (oldest supported numpy)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +121,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install oldest-supported-numpy '.[test-core,plots]'
+          pip install numpy==1.24.0 '.[test-core,plots]'
       - name: Test with pytest
         run: pytest --durations=20 --import-mode=append

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "oldest-supported-numpy", "packaging>20.9"]
+# Note for maintainers: this numpy constraint is specific to wheels for PyPI. See:
+# https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-abi-handling
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "numpy>=2.0", "packaging>20.9"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  'numpy<2.0.0',  # wait till dependent libraries are compatible with numpy 2.0, see GH #3707
+  'numpy',
   'scipy',
   'scikit-learn',
   'pandas',

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -1,4 +1,4 @@
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 
 #include <Python.h>
 #include <numpy/arrayobject.h>

--- a/shap/cext/_cext_gpu.cc
+++ b/shap/cext/_cext_gpu.cc
@@ -1,4 +1,4 @@
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
 
 #include <Python.h>
 #include <numpy/arrayobject.h>


### PR DESCRIPTION
## Overview

Adds support for numpy 2.0. Closes #3707

## Changes

- Changes the build-time dependency to be numpy 2.0, rather than oldest-supported-numpy
- Adds a CI job to test against the oldest supported numpy (`1.24.0`)

## References

- https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice
- https://numpy.org/doc/stable/dev/depending_on_numpy.html#build-time-dependency
- https://scientific-python.org/specs/spec-0000/