### PR TITLE
MAINT: Bump test-core to use python 312

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -39,7 +39,7 @@ jobs:
           # Run tests with only the core dependencies, to ensure we
           # cover the latest version of numpy/pandas. See GH dsgibbons#46
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             extras: "test-core"
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
A small change to switch the "test-core" CI job to use python 3.12 rather than 3.11. 

The intent of this job is to run the test suite with a minimal set of test dependencies, so that we can test against the very latest compatible version of numpy and pandas without being restricted by e.g. tensorflow compatibility.