### PR TITLE
MAINT: Bump GH action versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           only: ${{ matrix.only }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: bdist_files
@@ -100,7 +100,7 @@ jobs:
           python -m pip install build
           python -m build --sdist
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sdist_files
           path: dist/*.tar.gz
@@ -110,12 +110,12 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bdist_files
           path: dist
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdist_files
           path: dist
@@ -133,12 +133,12 @@ jobs:
     # Only publish tagged releases to PyPI
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bdist_files
           path: dist
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: sdist_files
           path: dist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: bdist_files
+          name: bdist_files_${{ matrix.only }}
 
   build_sdist:
     name: Build source distribution
@@ -112,8 +112,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: bdist_files
           path: dist
+          pattern: bdist_files_*
+          merge-multiple: true
 
       - uses: actions/download-artifact@v4
         with:
@@ -135,8 +136,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: bdist_files
           path: dist
+          pattern: bdist_files_*
+          merge-multiple: true
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,12 +60,12 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.19.1
         with:
           only: ${{ matrix.only }}
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -96,7 +96,7 @@ jobs:
           --import-mode=append
       - name: Upload mpl test report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mpl-results-${{ matrix.python-version }}-${{ runner.os }}-${{ matrix.extras }}
           path: mpl-results/


### PR DESCRIPTION
Bumps `upload-artifact` and `download-artifact` GitHub actions from deprecated `v3` to the newer `v4`.

NOTE: The [upload-artifact action](https://github.com/actions/upload-artifact) has some breaking changes as described in the readme. I have followed the migration guide:
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

Test run of the build-wheels action on this branch:
https://github.com/shap/shap/actions/runs/9683432793