### PR TITLE
Add pre commit hook to check notebook order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
   - id: end-of-file-fixer
 
 - repo: https://github.com/stefsmeets/nbcheckorder/
-    rev: v0.2.0
-    hooks:
-      - id: nbcheckorder
+  rev: v0.2.0
+  hooks:
+  - id: nbcheckorder

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,23 @@ repos:
   rev: v0.2.0
   hooks:
   - id: nbcheckorder
+    # TODO: get passing on all notebooks
+    exclude: |
+      (?x)^(
+        docs/notebooks/plots/bar.ipynb|
+        notebooks/api_examples/plots/decision_plot.ipynb|
+        notebooks/api_examples/plots/heatmap.ipynb|
+        notebooks/api_examples/plots/scatter.ipynb|
+        notebooks/api_examples/plots/text.ipynb|
+        notebooks/api_examples/plots/violin.ipynb|
+        notebooks/image_examples/image_captioning/Image.Captioning.using.Azure.Cognitive.Services.ipynb|
+        notebooks/image_examples/image_captioning/Image.Captioning.using.Open.Source.ipynb|
+        notebooks/image_examples/image_classification/Image.Multi.Class.ipynb|
+        notebooks/tabular_examples/model_agnostic/Census.income.classification.with.scikit-learn.ipynb|
+        notebooks/tabular_examples/model_agnostic/Squashing.Effect.ipynb|
+        notebooks/tabular_examples/tree_based_models/Fitting.a.Linear.Simulation.with.XGBoost.ipynb|
+        notebooks/tabular_examples/tree_based_models/Perfomance.Comparison.ipynb|
+        notebooks/text_examples/sentiment_analysis/Emotion.classification.multiclass.example.ipynb|
+        notebooks/text_examples/sentiment_analysis/Keras.LSTM.for.IMDB.Sentiment.Classification.ipynb|
+        notebooks/text_examples/sentiment_analysis/Positive.vs..Negative.Sentiment.Classification.ipynb
+      )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
   - id: mixed-line-ending
   - id: trailing-whitespace
   - id: end-of-file-fixer
+
+- repo: https://github.com/stefsmeets/nbcheckorder/
+    rev: v0.2.0
+    hooks:
+      - id: nbcheckorder


### PR DESCRIPTION
Add pre commit hook, to help ensure notebook cells are executed cleanly in order.

This should help ensure we remember to "restart and run all cells", which helps us ensure the notebooks are reproducible and don't contain hidden state.