### PR TITLE
MAINT: Incrementally update mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,24 +95,39 @@ Documentation = 'https://shap.readthedocs.io/en/latest/index.html'
 "Release Notes" = 'https://shap.readthedocs.io/en/latest/release_notes.html'
 
 [tool.mypy]
+check_untyped_defs = true
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
-check_untyped_defs = false
 exclude = ["shap/benchmark/*"]
 
 [[tool.mypy.overrides]]
+# Disable some checks from certain shap modules
+# TODO: get these passing!
 module = [
-    "catboost",
-    "cloudpickle",
-    "lime.*",
-    "numba",
-    "pandas",
-    "scipy.*",
-    "sklearn.*",
-    "slicer",
-    "tensorflow.*",
-    "tqdm.*",
+  "shap._explanation",
+  "shap.actions.*",
+  "shap.explainers.*",
+  "shap.maskers.*",
+  "shap.models.*",
+  "shap.plots.*",
+  "shap.utils.*",
+]
+check_untyped_defs = false
+
+[[tool.mypy.overrides]]
+# Ignore missing types for 3rd party libraries
+module = [
+  "catboost",
+  "cloudpickle",
+  "lime.*",
+  "numba",
+  "pandas",
+  "scipy.*",
+  "sklearn.*",
+  "slicer",
+  "tensorflow.*",
+  "tqdm.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,16 +118,21 @@ check_untyped_defs = false
 [[tool.mypy.overrides]]
 # Ignore missing types for 3rd party libraries
 module = [
-  "catboost",
+  "catboost.*",
   "cloudpickle",
+  "cv2",
+  "IPython.*",
   "lime.*",
   "numba",
   "pandas",
+  "pyspark.*",
   "scipy.*",
   "sklearn.*",
   "slicer",
   "tensorflow.*",
+  "torch.*",
   "tqdm.*",
+  "xgboost.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,26 @@ Documentation = 'https://shap.readthedocs.io/en/latest/index.html'
 "Release Notes" = 'https://shap.readthedocs.io/en/latest/release_notes.html'
 
 [tool.mypy]
-ignore_missing_imports = true
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 check_untyped_defs = false
 exclude = ["shap/benchmark/*"]
+
+[[tool.mypy.overrides]]
+module = [
+    "catboost",
+    "cloudpickle",
+    "lime.*",
+    "numba",
+    "pandas",
+    "scipy.*",
+    "sklearn.*",
+    "slicer",
+    "tensorflow.*",
+    "tqdm.*",
+]
+ignore_missing_imports = true
 
 [tool.setuptools]
 packages = [

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -1,7 +1,7 @@
 import json
 import random
 import string
-from typing import Optional, Union, cast
+from typing import Literal, Optional, Union, cast
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -27,7 +27,7 @@ def image(
     true_labels: Optional[list] = None,
     width: Optional[int] = 20,
     aspect: Optional[float] = 0.2,
-    hspace: Optional[float] = 0.2,
+    hspace: Optional[float] | Literal["auto"] = 0.2,
     labelpad: Optional[float] = None,
     cmap: Optional[Union[str, Colormap]] = colors.red_transparent_blue,
     show: Optional[bool] = True,

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -27,7 +27,7 @@ def image(
     true_labels: Optional[list] = None,
     width: Optional[int] = 20,
     aspect: Optional[float] = 0.2,
-    hspace: Optional[float] | Literal["auto"] = 0.2,
+    hspace: Union[Optional[float], Literal["auto"]] = 0.2,
     labelpad: Optional[float] = None,
     cmap: Optional[Union[str, Colormap]] = colors.red_transparent_blue,
     show: Optional[bool] = True,


### PR DESCRIPTION
A slight marginal update to the mypy config:
- `ignore missing imports` only for explicit 3rd party libraries, but not globally. That way, incorrect shap imports should be flagged.
- Enable `check-uptyped-defs` globally and then opt-out for specific modules that current fail (which is most!), to set us up to progressively get it passing by module