### PR TITLE
MAINT: enable mypy on tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -140,4 +140,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install '.[test-core]'
       - name: Run mypy
-        run: mypy shap
+        run: mypy shap tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ check_untyped_defs = true
 disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
-exclude = ["shap/benchmark/*"]
+exclude = ["shap/benchmark/*", "tests/benchmark/*"]
 
 [[tool.mypy.overrides]]
 # Disable some checks from certain shap modules
@@ -125,6 +125,7 @@ module = [
   "lime.*",
   "numba",
   "pandas",
+  "pyod.*",
   "pyspark.*",
   "scipy.*",
   "sklearn.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ disallow_untyped_defs = false
 disallow_incomplete_defs = false
 exclude = ["shap/benchmark/*", "tests/benchmark/*"]
 
+plugins = ["numpy.typing.mypy_plugin"]
+
 [[tool.mypy.overrides]]
 # Disable some checks from certain shap modules
 # TODO: get these passing!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ module = [
   "cloudpickle",
   "cv2",
   "IPython.*",
+  "lightgbm.*",
   "lime.*",
   "numba",
   "pandas",

--- a/shap/plots/colors/_colorconv.py
+++ b/shap/plots/colors/_colorconv.py
@@ -625,7 +625,7 @@ _integer_types = (
     np.longlong,
     np.ulonglong,
 )  # 64 bits
-_integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max) for t in _integer_types}
+_integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max) for t in _integer_types}  # type:ignore
 dtype_range: dict[Any, Tuple[Union[bool, int], Union[bool, int]]] = {
     np.bool_: (False, True),
     bool: (False, True),

--- a/tests/explainers/other/test_ubjson.py
+++ b/tests/explainers/other/test_ubjson.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from typing import Any
 
 import numpy as np
 
@@ -34,6 +35,7 @@ def test_decode_simple_key_value_pair():
 
 
 def test_decode_object():
+    expected_value: dict[str, Any]
     regression_loss = b"L\x00\x00\x00\x00\x00\x00\x00\x0ereg_loss_param{L\x00\x00\x00\x00\x00\x00\x00\x10scale_pos_weightSL\x00\x00\x00\x00\x00\x00\x00\x011}"
     fp = BytesIO(regression_loss)
     key_type = fp.read(1)

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -253,7 +253,7 @@ def test_tf_keras_imdb_lstm(random_seed):
     diff = sess.run(mod.layers[-1].output, feed_dict={mod.layers[0].input: testx})[0, :] - sess.run(
         mod.layers[-1].output, feed_dict={mod.layers[0].input: background}
     ).mean(0)
-    np.testing.testing_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
+    np.testing.assert_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
 
 def test_tf_deep_imbdb_transformers():
@@ -667,12 +667,7 @@ def test_pytorch_multiple_inputs(torch_device, disconnected, activation):
     from torch.nn import functional as F
     from torch.utils.data import DataLoader, TensorDataset
 
-    if activation == "relu":
-        activation_func = nn.ReLU()
-    elif activation == "selu":
-        activation_func = nn.SELU()
-    else:
-        raise ValueError(f"Unknown activation function: {activation}")
+    activation_func = {"relu": nn.ReLU(), "selu": nn.SELU()}[activation]
 
     class Net(nn.Module):
         """Testing model."""

--- a/tests/plots/test_dependence_string_features.py
+++ b/tests/plots/test_dependence_string_features.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -52,11 +54,13 @@ def test_approximate_interactions():
 
 
 def _create_sample_dataset(string_features):
+    sex_values: list[Any]
     if "Sex" in string_features:
         sex_values = ["Male", "Female", "Male", "Male", "Female", "Female"]
     else:
         sex_values = [0, 1, 0, 0, 1, 1]
 
+    blood_values: list[Any]
     if "Blood group" in string_features:
         blood_values = ["A", "B", "A", "O", "O", "O"]
     else:


### PR DESCRIPTION
Run mypy on `./tests` as well as `./shap`.

- Excludes the `tests/benchmark` dir, as it is not currently working :(
- Fixes a numpy bug in `test_tf_keras_imdb_lstm` , a test which is currently skipped. (The first genuine bug mypy has found!)
- Adds a few type hints to help mypy pass
- Adds the numpy mypy plugin, which should help when working with arrays.