### PR TITLE
Enable type checking for shap/actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ plugins = ["numpy.typing.mypy_plugin"]
 # Disable some checks from certain shap modules
 # TODO: get these passing!
 module = [
-  "shap.actions.*",
   "shap.explainers.*",
   "shap.maskers.*",
   "shap.models.*",

--- a/shap/actions/_action.py
+++ b/shap/actions/_action.py
@@ -1,6 +1,9 @@
 class Action:
     """Abstract action class."""
 
+    def __init__(self, cost):
+        self.cost = cost
+
     def __lt__(self, other_action):
         return self.cost < other_action.cost
 

--- a/shap/actions/_action.py
+++ b/shap/actions/_action.py
@@ -3,6 +3,11 @@ class Action:
 
     def __init__(self, cost):
         self.cost = cost
+        self._group_index = 0
+        self._grouped_index = 0
+
+    def __call__(self, *args):
+        raise NotImplementedError
 
     def __lt__(self, other_action):
         return self.cost < other_action.cost

--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -1,6 +1,7 @@
 import copy
 import queue
 import warnings
+from typing import Any
 
 from ..utils._exceptions import ConvergenceError, InvalidAction
 from ._action import Action
@@ -9,9 +10,9 @@ from ._action import Action
 class ActionOptimizer:
     def __init__(self, model, actions):
         self.model = model
-        warnings.warn("Note that ActionOptimizer is still in an alpha state and is subjust to API changes.")
+        warnings.warn("Note that ActionOptimizer is still in an alpha state and is subject to API changes.")
         # actions go into mutually exclusive groups
-        self.action_groups = []
+        self.action_groups: list[Any] = []
         for group in actions:
             if issubclass(type(group), Action):
                 group._group_index = len(self.action_groups)

--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -1,24 +1,24 @@
 import copy
 import queue
 import warnings
-from typing import Any
+from typing import Union
 
 from ..utils._exceptions import ConvergenceError, InvalidAction
 from ._action import Action
 
 
 class ActionOptimizer:
-    def __init__(self, model, actions):
+    def __init__(self, model, actions: list[Union[Action, list[Action]]]):
         self.model = model
         warnings.warn("Note that ActionOptimizer is still in an alpha state and is subject to API changes.")
         # actions go into mutually exclusive groups
-        self.action_groups: list[Any] = []
+        self.action_groups: list[list[Action]] = []
         for group in actions:
-            if issubclass(type(group), Action):
+            if isinstance(group, Action):
                 group._group_index = len(self.action_groups)
                 group._grouped_index = 0
                 self.action_groups.append([copy.copy(group)])
-            elif issubclass(type(group), list):
+            elif isinstance(group, list):
                 group = sorted([copy.copy(v) for v in group], key=lambda a: a.cost)
                 for i, v in enumerate(group):
                     v._group_index = len(self.action_groups)
@@ -29,9 +29,8 @@ class ActionOptimizer:
 
     def __call__(self, *args, max_evals=10000):
         # init our queue with all the least costly actions
-        q = queue.PriorityQueue()
-        for i in range(len(self.action_groups)):
-            group = self.action_groups[i]
+        q: queue.PriorityQueue[tuple[float, list[Action]]] = queue.PriorityQueue()
+        for group in self.action_groups:
             q.put((group[0].cost, [group[0]]))
 
         nevals = 0

--- a/tests/actions/_optimizer.py
+++ b/tests/actions/_optimizer.py
@@ -92,4 +92,4 @@ def test_run_out_of_group():
 
 def test_bad_action():
     with pytest.raises(InvalidAction):
-        shap.ActionOptimizer(None, [None])
+        shap.ActionOptimizer(None, [None])  # type: ignore


### PR DESCRIPTION
## Overview

Supports https://github.com/shap/shap/issues/3730

Gets mypy passing on shap/actions/ with check-untyped-defs=True, and adds a couple of type hints.

## Discussion

This was the first time I've read this module. I'm not clear what the original context or purpose was, and it might even be "dead code". If we can confirm with Scott, perhaps we might want to remove this from a future release. But for now, I've added a few hints which hopefully improve the clarity and get it passing on mypy.