### PR TITLE
Enable type checking for shap/utils, and improve OpChain docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,6 @@ module = [
   "shap.maskers.*",
   "shap.models.*",
   "shap.plots.*",
-  "shap.utils.*",
 ]
 check_untyped_defs = false
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -17,7 +17,7 @@ op_chain_root = OpChain("shap.Explanation")
 
 
 class MetaExplanation(type):
-    """This metaclass exposes the Explanation object's methods for creating template op chains."""
+    """This metaclass exposes the Explanation object's class methods for creating template op chains."""
 
     def __getitem__(cls, item):
         return op_chain_root.__getitem__(item)
@@ -69,7 +69,16 @@ class MetaExplanation(type):
 
 
 class Explanation(metaclass=MetaExplanation):
-    """A sliceable set of parallel arrays representing a SHAP explanation."""
+    """A sliceable set of parallel arrays representing a SHAP explanation.
+
+    Note
+    ----
+    The *instance* methods such as `.max()` return new Explanation objects with the
+    operation applied.
+
+    The *class* methods such as `Explanation.max` return OpChain objects that represent
+    a set of dot chained operations without actually running them.
+    """
 
     def __init__(
         self,

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -101,7 +101,13 @@ def hclust_ordering(X, metric="sqeuclidean", anchor_first=False):
 
 
 def xgboost_distances_r2(
-    X, y, learning_rate=0.6, early_stopping_rounds=2, subsample=1, max_estimators=10000, random_state=0
+    X,
+    y,
+    learning_rate: float = 0.6,
+    early_stopping_rounds: Optional[int] = 2,
+    subsample: Optional[float] = 1.0,
+    max_estimators: Optional[int] = 10000,
+    random_state: Union[int, np.random.RandomState] = 0,
 ):
     """Compute reducancy distances scaled from 0-1 among all the feature in X relative to the label y.
 
@@ -118,8 +124,8 @@ def xgboost_distances_r2(
     X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y, random_state=random_state)
 
     # fit an XGBoost model on each of the features
-    test_preds_list = []
     train_preds_list = []
+    test_preds_list = []
     for i in range(X.shape[1]):
         model = xgboost.XGBRegressor(
             subsample=subsample,
@@ -176,7 +182,7 @@ def hclust(
     y: Optional[_ArrayLike] = None,
     linkage: Literal["single", "complete", "average"] = "single",
     metric: str = "auto",
-    random_state: int = 0,
+    random_state: Union[int, np.random.RandomState] = 0,
 ) -> np.ndarray:
     """Fit a hierarcical clustering model for features X relative to target variable y.
 
@@ -262,4 +268,4 @@ def hclust(
     elif linkage == "average":
         return scipy.cluster.hierarchy.average(dist)
     else:
-        raise Exception("Unknown linkage: " + str(linkage))
+        raise ValueError("Unknown linkage: " + str(linkage))

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Literal, Optional
 
 import numpy as np
 import pandas as pd
@@ -8,6 +9,7 @@ import sklearn
 from numba import njit
 
 from ._show_progress import show_progress
+from ._types import _ArrayLike
 
 
 def partition_tree(X, metric="correlation"):
@@ -116,8 +118,8 @@ def xgboost_distances_r2(
     X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y, random_state=random_state)
 
     # fit an XGBoost model on each of the features
-    test_preds = []
-    train_preds = []
+    test_preds_list = []
+    train_preds_list = []
     for i in range(X.shape[1]):
         model = xgboost.XGBRegressor(
             subsample=subsample,
@@ -127,10 +129,10 @@ def xgboost_distances_r2(
             early_stopping_rounds=early_stopping_rounds,
         )
         model.fit(X_train[:, i : i + 1], y_train, eval_set=[(X_test[:, i : i + 1], y_test)], verbose=False)
-        train_preds.append(model.predict(X_train[:, i : i + 1]))
-        test_preds.append(model.predict(X_test[:, i : i + 1]))
-    train_preds = np.vstack(train_preds).T
-    test_preds = np.vstack(test_preds).T
+        train_preds_list.append(model.predict(X_train[:, i : i + 1]))
+        test_preds_list.append(model.predict(X_test[:, i : i + 1]))
+    train_preds = np.vstack(train_preds_list).T
+    test_preds = np.vstack(test_preds_list).T
 
     # fit XGBoost models to predict the outputs of other XGBoost models to see how redundant features are
     dist = np.zeros((X.shape[1], X.shape[1]))
@@ -169,7 +171,13 @@ def xgboost_distances_r2(
     return dist
 
 
-def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
+def hclust(
+    X: _ArrayLike,
+    y: Optional[_ArrayLike] = None,
+    linkage: Literal["single", "complete", "average"] = "single",
+    metric: str = "auto",
+    random_state: int = 0,
+) -> np.ndarray:
     """Fit a hierarcical clustering model for features X relative to target variable y.
 
     For more information on clutering methods see:
@@ -217,19 +225,19 @@ def hclust(X, y=None, linkage="single", metric="auto", random_state=0):
         dist_full = xgboost_distances_r2(X, y, random_state=random_state)
 
         # build a condensed upper triangular version by taking the max distance from either direction
-        dist = []
+        dist_list = []
         for i in range(dist_full.shape[0]):
             for j in range(i + 1, dist_full.shape[1]):
                 if i != j:
                     if linkage == "single":
-                        dist.append(min(dist_full[i, j], dist_full[j, i]))
+                        dist_list.append(min(dist_full[i, j], dist_full[j, i]))
                     elif linkage == "complete":
-                        dist.append(max(dist_full[i, j], dist_full[j, i]))
+                        dist_list.append(max(dist_full[i, j], dist_full[j, i]))
                     elif linkage == "average":
-                        dist.append((dist_full[i, j] + dist_full[j, i]) / 2)
+                        dist_list.append((dist_full[i, j] + dist_full[j, i]) / 2)
                     else:
-                        raise Exception("Unsupported linkage type!")
-        dist = np.array(dist)
+                        raise ValueError("Unsupported linkage type!")
+        dist = np.array(dist_list)
 
     else:
         if y is not None:

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -3,13 +3,14 @@ import os
 import re
 import sys
 from contextlib import contextmanager
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
 import scipy.special
 import sklearn
-from numpy.typing import ArrayLike
+
+from ._types import _ArrayT
 
 import_errors: dict[str, tuple[str, Exception]] = {}
 
@@ -163,7 +164,7 @@ def encode_array_if_needed(arr, dtype=np.float64):
         return encoded_array
 
 
-def sample(X: ArrayLike, nsamples: int = 100, random_state: int = 0) -> ArrayLike:
+def sample(X: _ArrayT, nsamples: int = 100, random_state: int = 0) -> _ArrayT:
     """Performs sampling without replacement of the input data ``X``.
 
     This is a simple wrapper over scikit-learn's ``shuffle`` function.
@@ -277,7 +278,7 @@ class OpChain:
     """A way to represent a set of dot chained operations on an object without actually running them."""
 
     def __init__(self, root_name: str = "") -> None:
-        self._ops = []
+        self._ops: list[list[Any]] = []
         self._root_name = root_name
 
     def apply(self, obj):
@@ -304,7 +305,7 @@ class OpChain:
         new_self._ops.append(["__getitem__", [item], {}])
         return new_self
 
-    def __getattr__(self, name: str) -> "OpChain":
+    def __getattr__(self, name: str) -> Optional["OpChain"]:
         # Don't chain special attributes
         if name.startswith("__") and name.endswith("__"):
             return None

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 from contextlib import contextmanager
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -305,10 +305,10 @@ class OpChain:
         new_self._ops.append(["__getitem__", [item], {}])
         return new_self
 
-    def __getattr__(self, name: str) -> Optional["OpChain"]:
+    def __getattr__(self, name: str) -> "OpChain":
         # Don't chain special attributes
         if name.startswith("__") and name.endswith("__"):
-            return None
+            return None  # type: ignore
         new_self = OpChain(self._root_name)
         new_self._ops = copy.copy(self._ops)
         new_self._ops.append([name, None, None])

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -3,16 +3,18 @@ import os
 import re
 import sys
 from contextlib import contextmanager
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
 import scipy.special
 import sklearn
+from numpy.typing import ArrayLike
 
 import_errors: dict[str, tuple[str, Exception]] = {}
 
 
-def assert_import(package_name):
+def assert_import(package_name: str) -> None:
     global import_errors
     if package_name in import_errors:
         msg, e = import_errors[package_name]
@@ -20,12 +22,12 @@ def assert_import(package_name):
         raise e
 
 
-def record_import_error(package_name, msg, e):
+def record_import_error(package_name: str, msg: str, e: ImportError) -> None:
     global import_errors
     import_errors[package_name] = (msg, e)
 
 
-def shapley_coefficients(n):
+def shapley_coefficients(n: int) -> np.ndarray:
     out = np.zeros(n)
     for i in range(n):
         out[i] = 1 / (n * scipy.special.comb(n - 1, i))
@@ -161,7 +163,7 @@ def encode_array_if_needed(arr, dtype=np.float64):
         return encoded_array
 
 
-def sample(X, nsamples=100, random_state=0):
+def sample(X: ArrayLike, nsamples: int = 100, random_state: int = 0) -> ArrayLike:
     """Performs sampling without replacement of the input data ``X``.
 
     This is a simple wrapper over scikit-learn's ``shuffle`` function.
@@ -198,7 +200,7 @@ def sample(X, nsamples=100, random_state=0):
     return sklearn.utils.shuffle(X, n_samples=nsamples, random_state=random_state)
 
 
-def safe_isinstance(obj, class_path_str):
+def safe_isinstance(obj: Any, class_path_str: Union[str, list[str]]) -> bool:
     """Acts as a safe version of isinstance without having to explicitly
     import packages which may not exist in the users environment.
 
@@ -274,7 +276,7 @@ def ordinal_str(n):
 class OpChain:
     """A way to represent a set of dot chained operations on an object without actually running them."""
 
-    def __init__(self, root_name=""):
+    def __init__(self, root_name: str = "") -> None:
         self._ops = []
         self._root_name = root_name
 
@@ -288,7 +290,7 @@ class OpChain:
                 obj = getattr(obj, op)
         return obj
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> "OpChain":
         """Update the args for the previous operation."""
         new_self = OpChain(self._root_name)
         new_self._ops = copy.copy(self._ops)
@@ -302,7 +304,7 @@ class OpChain:
         new_self._ops.append(["__getitem__", [item], {}])
         return new_self
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> "OpChain":
         # Don't chain special attributes
         if name.startswith("__") and name.endswith("__"):
             return None

--- a/shap/utils/_legacy.py
+++ b/shap/utils/_legacy.py
@@ -93,7 +93,6 @@ def match_instance_to_data(instance, data):
                 instance.x[0, group[0]] if len(group) == 1 else "" for group in data.groups
             ]
         assert len(instance.group_display_values) == len(data.groups)
-        instance.groups = data.groups
 
 
 class Model:

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -1,5 +1,6 @@
 import copy
 import warnings
+from typing import Any
 
 import numpy as np
 import scipy.sparse
@@ -78,7 +79,7 @@ class MaskedModel:
         all_outputs = []
         for batch_ind in range(0, len(masks), batch_size):
             mask_batch = masks[batch_ind : batch_ind + batch_size]
-            all_masked_inputs = []
+            all_masked_inputs: list[list[Any]] = []
             num_mask_samples = np.zeros(len(mask_batch), dtype=int)
             last_mask = np.zeros(mask_batch.shape[1], dtype=bool)
             for i, mask in enumerate(mask_batch):
@@ -151,14 +152,14 @@ class MaskedModel:
         averaged_outs = np.zeros((len(batch_positions) - 1,) + outputs.shape[1:])
         max_outs = self._masker_rows if self._masker_rows is not None else max(len(r) for r in varying_rows)
         last_outs = np.zeros((max_outs,) + outputs.shape[1:])
-        varying_rows = np.array(varying_rows)
+        varying_rows_array = np.array(varying_rows)
 
         _build_fixed_output(
             averaged_outs,
             last_outs,
             outputs,
             batch_positions,
-            varying_rows,
+            varying_rows_array,
             num_varying_rows,
             self.link,
             self._linearizing_weights,
@@ -323,7 +324,7 @@ def _build_delta_masked_inputs(
         "If you rely on this function, please open an issue: https://github.com/shap/shap/issues.",
         DeprecationWarning,
     )
-    all_masked_inputs = [[] for a in args]
+    all_masked_inputs: list[list[Any]] = [[] for a in args]
     dpos = 0
     i = -1
     masks_pos = 0

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -324,7 +324,7 @@ def _build_delta_masked_inputs(
         "If you rely on this function, please open an issue: https://github.com/shap/shap/issues.",
         DeprecationWarning,
     )
-    all_masked_inputs: list[list[Any]] = [[] for a in args]
+    all_masked_inputs: list[list[Any]] = [[] for _ in args]
     dpos = 0
     i = -1
     masks_pos = 0

--- a/shap/utils/_types.py
+++ b/shap/utils/_types.py
@@ -5,5 +5,5 @@ import pandas as pd
 import scipy.sparse
 
 # TODO: use TypeAlias (when we drop python 3.9)
-_ArrayLike = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.sparse.csr_matrix]
-_ArrayT = TypeVar("_ArrayT", np.ndarray, pd.DataFrame, pd.Series, scipy.sparse.csr_matrix, list)
+_ArrayLike = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.sparse.spmatrix]
+_ArrayT = TypeVar("_ArrayT", np.ndarray, pd.DataFrame, pd.Series, scipy.sparse.spmatrix, list)

--- a/shap/utils/_types.py
+++ b/shap/utils/_types.py
@@ -1,8 +1,9 @@
-from typing import TypeAlias, TypeVar, Union
+from typing import TypeVar, Union
 
 import numpy as np
 import pandas as pd
 import scipy.sparse
 
-_ArrayLike: TypeAlias = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.sparse.csr_matrix]
+# TODO: use TypeAlias (when we drop python 3.9)
+_ArrayLike = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.sparse.csr_matrix]
 _ArrayT = TypeVar("_ArrayT", np.ndarray, pd.DataFrame, pd.Series, scipy.sparse.csr_matrix, list)

--- a/shap/utils/_types.py
+++ b/shap/utils/_types.py
@@ -1,0 +1,8 @@
+from typing import TypeAlias, TypeVar, Union
+
+import numpy as np
+import pandas as pd
+import scipy.sparse
+
+_ArrayLike: TypeAlias = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.spare.csr_matrix]
+_ArrayT = TypeVar("_ArrayT", np.ndarray, pd.DataFrame, pd.Series, scipy.sparse.csr_matrix, list)

--- a/shap/utils/_types.py
+++ b/shap/utils/_types.py
@@ -4,5 +4,5 @@ import numpy as np
 import pandas as pd
 import scipy.sparse
 
-_ArrayLike: TypeAlias = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.spare.csr_matrix]
+_ArrayLike: TypeAlias = Union[np.ndarray, pd.DataFrame, pd.Series, list, scipy.sparse.csr_matrix]
 _ArrayT = TypeVar("_ArrayT", np.ndarray, pd.DataFrame, pd.Series, scipy.sparse.csr_matrix, list)


### PR DESCRIPTION
Supports https://github.com/shap/shap/issues/3730

Gets mypy passing on shap/utils with check-untyped-defs=True, and adds a couple of type hints.