### PR TITLE
Deprecate the legacy bar plot, add migration guide to new Explainer API

### DIFF
--- a/docs/api_examples.rst
+++ b/docs/api_examples.rst
@@ -10,6 +10,12 @@ corresponding example notebook here that demonstrates its API usage. The source 
 are `available on GitHub <https://github.com/shap/shap/tree/master/notebooks/api_examples>`_.
 
 
+.. toctree::
+    :glob:
+    :maxdepth: 1
+
+    example_notebooks/api_examples/migrating-to-new-api.ipynb
+
 .. _explainers_examples:
 
 explainers

--- a/notebooks/api_examples/migrating-to-new-api.ipynb
+++ b/notebooks/api_examples/migrating-to-new-api.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Migrating to the new \"Explanation\" API\n",
+    "\n",
+    "This notebook explains some of the differences between the old- and new-style shap API.\n",
+    "\n",
+    "In short:\n",
+    "\n",
+    "```python\n",
+    "shap_values = explainer.shap_values(X)  # Old style\n",
+    "shap_values = explainer(X)              # New style\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an example dataset and model\n",
+    "import xgboost\n",
+    "\n",
+    "import shap\n",
+    "\n",
+    "X, y = shap.datasets.adult(n_points=100)\n",
+    "model = xgboost.XGBClassifier().fit(X, y)\n",
+    "explainer = shap.TreeExplainer(model, X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In older versions of shap, explanations are represented as simple numpy arrays and\n",
+    "calculated using the `.shap_values()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-0.54854601,  0.01639348, -0.46476041,  0.85896822, -1.36168788,\n",
+       "        -0.64692199,  0.0254638 , -0.58422904, -0.02344483,  0.        ,\n",
+       "         0.1224989 ,  0.01079906],\n",
+       "       [-0.83802091,  0.01562196,  0.78349799, -1.10456323, -0.68524691,\n",
+       "        -0.84828204,  0.03734176, -0.86151311, -0.02564897,  0.        ,\n",
+       "        -0.56183428,  0.00415988]])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "shap_values = explainer.shap_values(X)\n",
+    "shap_values[:2]  # a numpy array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In newer versions of shap, explanations are represented with the `Explanation` object,\n",
+    "and are created by calling the explainer directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       ".values =\n",
+       "array([[-0.54854601,  0.01639348, -0.46476041,  0.85896822, -1.36168788,\n",
+       "        -0.64692199,  0.0254638 , -0.58422904, -0.02344483,  0.        ,\n",
+       "         0.1224989 ,  0.01079906],\n",
+       "       [-0.83802091,  0.01562196,  0.78349799, -1.10456323, -0.68524691,\n",
+       "        -0.84828204,  0.03734176, -0.86151311, -0.02564897,  0.        ,\n",
+       "        -0.56183428,  0.00415988]])\n",
+       "\n",
+       ".base_values =\n",
+       "array([-2.70354599, -2.70354599])\n",
+       "\n",
+       ".data =\n",
+       "array([[27.,  4., 10.,  0.,  1.,  1.,  4.,  0.,  0.,  0., 44., 39.],\n",
+       "       [27.,  4., 13.,  4., 10.,  0.,  4.,  0.,  0.,  0., 40., 39.]])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "shap_values = explainer(X)\n",
+    "shap_values[:2]  # a shap.Explanation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Explanation` object tracks more information, such as the background dataset and the feature names.\n",
+    "\n",
+    "The new-style plotting functions like `shap.plots.beeswarm` require `Explanation` objections."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "shap",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/api_examples/migrating-to-new-api.ipynb
+++ b/notebooks/api_examples/migrating-to-new-api.ipynb
@@ -6,14 +6,7 @@
    "source": [
     "# Migrating to the new \"Explanation\" API\n",
     "\n",
-    "This notebook explains some of the differences between the old- and new-style shap API.\n",
-    "\n",
-    "In short:\n",
-    "\n",
-    "```python\n",
-    "shap_values = explainer.shap_values(X)  # Old style\n",
-    "shap_values = explainer(X)              # New style\n",
-    "```"
+    "This notebook demonstrates some of the differences between the old- and new-style shap API."
    ]
   },
   {
@@ -22,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create an example dataset and model\n",
+    "# An example dataset and model\n",
     "import xgboost\n",
     "\n",
     "import shap\n",
@@ -36,13 +29,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In older versions of shap, explanations are represented as simple numpy arrays and\n",
-    "calculated using the `.shap_values()` method:"
+    "To summarise the main change:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shap_values = explainer.shap_values(X)  # Old style\n",
+    "explanation = explainer(X)  # New style"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Old style\n",
+    "\n",
+    "In versions of shap before `v0.36.0`, explanations are represented as simple numpy arrays and\n",
+    "calculated using the `.shap_values()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -56,7 +68,7 @@
        "        -0.56183428,  0.00415988]])"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -70,13 +82,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In newer versions of shap, explanations are represented with the `Explanation` object,\n",
+    "## New style\n",
+    "\n",
+    "As of shap `v0.36.0`, explanations are represented with the `Explanation` object,\n",
     "and are created by calling the explainer directly:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -98,23 +112,26 @@
        "       [27.,  4., 13.,  4., 10.,  0.,  4.,  0.,  0.,  0., 40., 39.]])"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "shap_values = explainer(X)\n",
-    "shap_values[:2]  # a shap.Explanation"
+    "explanation = explainer(X)\n",
+    "explanation[:2]  # a shap.Explanation object"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Explanation` object tracks more information, such as the background dataset and the feature names.\n",
+    "The `Explanation` object is a much richer representation that includes the shap values\n",
+    "as well as supporting contextual information such as the background dataset and the\n",
+    "feature names.\n",
     "\n",
-    "The new-style plotting functions like `shap.plots.beeswarm` require `Explanation` objections."
+    "The new-style plotting functions like `shap.plot.bar` and `shap.plots.beeswarm` require\n",
+    "`Explanation` objections rather than numpy arrays."
    ]
   }
  ],

--- a/notebooks/api_examples/migrating-to-new-api.ipynb
+++ b/notebooks/api_examples/migrating-to-new-api.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Migrating to the new \"Explanation\" API\n",
     "\n",
-    "This notebook demonstrates some of the differences between the old- and new-style shap API."
+    "This notebook demonstrates some of the changes to the shap API that were introduced in shap `v0.36.0`."
    ]
   },
   {
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To summarise the main change:"
+    "To summarise the main change in the API:"
    ]
   },
   {
@@ -46,10 +46,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Old style\n",
+    "## Calculating explanations\n",
     "\n",
-    "In versions of shap before `v0.36.0`, explanations are represented as simple numpy arrays and\n",
-    "calculated using the `.shap_values()` method:"
+    "### Old style\n",
+    "\n",
+    "In versions of shap before `v0.36.0`, explanations are represented as simple numpy arrays and calculated using the `.shap_values()` method of an explainer:"
    ]
   },
   {
@@ -82,10 +83,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## New style\n",
+    "Similarly, legacy plotting functions like `shap.summary_plot` expected the `shap_values` as a numpy array."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### New style\n",
     "\n",
-    "As of shap `v0.36.0`, explanations are represented with the `Explanation` object,\n",
-    "and are created by calling the explainer directly:"
+    "As of shap `v0.36.0`, explanations are now represented with the `Explanation` object, and are created by calling the explainer directly as a function:"
    ]
   },
   {
@@ -126,12 +133,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Explanation` object is a much richer representation that includes the shap values\n",
-    "as well as supporting contextual information such as the background dataset and the\n",
-    "feature names.\n",
+    "The `shap.Explanation` object is a much richer representation that includes the shap values (accessible with the `.values` attribute) as well as supporting contextual information such as the background dataset and the feature names.\n",
     "\n",
-    "The new-style plotting functions like `shap.plot.bar` and `shap.plots.beeswarm` require\n",
-    "`Explanation` objections rather than numpy arrays."
+    "The new-style plotting functions like `shap.plot.bar` and `shap.plots.beeswarm` accept these `Explanation` objections rather than numpy arrays."
    ]
   }
  ],

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -1,3 +1,5 @@
+import warnings
+
 import matplotlib.pyplot as pl
 import numpy as np
 import pandas as pd
@@ -74,8 +76,6 @@ def bar(
     See `bar plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/bar.html>`_.
 
     """
-    # assert str(type(shap_values)).endswith("Explanation'>"), "The shap_values parameter must be a shap.Explanation object!"
-
     # convert Explanation objects to dictionaries
     if isinstance(shap_values, Explanation):
         cohorts = {"": shap_values}
@@ -392,6 +392,10 @@ def bar(
 
 
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):
+    warnings.warn(
+        "The behaviour of this function will change in a future version to the new plotting API."
+        " Use `shap.plots.bar` to opt-in to the new behaviour and silence this warning."
+    )
     # unwrap pandas series
     if isinstance(features, pd.Series):
         if feature_names is None:

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -394,7 +394,10 @@ def bar(
 def bar_legacy(shap_values, features=None, feature_names=None, max_display=None, show=True):
     warnings.warn(
         "The behaviour of this function will change in a future version to the new plotting API."
-        " Use `shap.plots.bar` to opt-in to the new behaviour and silence this warning."
+        "\nUse `shap.plots.bar` to opt-in to the new behaviour and silence this warning."
+        "\nFor more information on using the new API, see:\n"
+        "https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/migrating-to-new-api.html",
+        DeprecationWarning,
     )
     # unwrap pandas series
     if isinstance(features, pd.Series):


### PR DESCRIPTION
Supports #3156.

- Adds a deprecation warning to the legacy bar plot.
- Adds a notebook to explain the difference between the old- and new-style API