### PR TITLE
Fix mypy failure: set plt.subplots squeeze=False in _image.py

### DIFF
--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -121,9 +121,7 @@ def image(
     fig_size = np.array([3 * (len(shap_values) + 1), 2.5 * (x.shape[0] + 1)])
     if fig_size[0] > width:
         fig_size *= width / fig_size[0]
-    fig, axes = pl.subplots(nrows=x.shape[0], ncols=len(shap_values) + 1, figsize=fig_size)
-    if len(axes.shape) == 1:
-        axes = axes.reshape(1, axes.size)
+    fig, axes = pl.subplots(nrows=x.shape[0], ncols=len(shap_values) + 1, figsize=fig_size, squeeze=False)
     for row in range(x.shape[0]):
         x_curr = x[row].copy()
 


### PR DESCRIPTION
Fixes a build failure introduced by the new types hints in matplotlib `3.9.1`.

`_image.py` uses `f, axs = plt.subplots(nrows=nrows, ncols=cols)`. Mypy determines with the new matplotlib type hints that `axs` will be a ndarray (expected in our case) or an Axes object (if `nrows==ncols==1`), and complains that our code will fail in the latter case.

Passing `squeeze=False` to `plt.subplots` ensures that `axs` is always a numpy array.