### PR TITLE
MAINT: Include ipywidgets in dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
   "sphinx_github_changelog==1.2.1",
   "myst-parser==2.0.0",
   "requests",
+  "ipywidgets",  # For tqdm in notebooks
 ]
 test-core = ["pytest", "pytest-mpl", "pytest-cov", "mypy"]
 test = [


### PR DESCRIPTION
Small change to fix a warning that can appear in some notebooks about missing dependencies when tqdm is used.