### PR TITLE
MAINT: Remove redundant test fixture

### DIFF
--- a/tests/explainers/conftest.py
+++ b/tests/explainers/conftest.py
@@ -1,9 +1,6 @@
-import sys
-
 import pytest
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Integer division bug in HuggingFace on Windows")
 @pytest.fixture(scope="session")
 def basic_translation_scenario():
     """Create a basic transformers translation model and tokenizer."""


### PR DESCRIPTION
Removes a mark applied to a test fixture, which has no effect as consequently is quite misleading. From the docs:

https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

> Applying a mark to a fixture function never had any effect, but it is a common user error.