### PR TITLE
MAINT: Enable type checking for shap.models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ plugins = ["numpy.typing.mypy_plugin"]
 module = [
   "shap.explainers.*",
   "shap.maskers.*",
-  "shap.models.*",
   "shap.plots.*",
 ]
 check_untyped_defs = false

--- a/shap/models/_model.py
+++ b/shap/models/_model.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 
 from .._serializable import Deserializer, Serializable, Serializer
@@ -10,7 +12,7 @@ class Model(Serializable):
     def __init__(self, model=None):
         """Wrap a callable model as a SHAP Model object."""
         if isinstance(model, Model):
-            self.inner_model = model.inner_model
+            self.inner_model: Any = model.inner_model
         else:
             self.inner_model = model
 

--- a/shap/models/_teacher_forcing.py
+++ b/shap/models/_teacher_forcing.py
@@ -1,4 +1,5 @@
 import inspect
+from typing import Any, Optional
 
 import numpy as np
 import scipy.special
@@ -82,8 +83,8 @@ class TeacherForcing(Model):
                 self.similarity_tokenizer.pad_token = self.similarity_tokenizer.eos_token
             self.model_agnostic = True
         # initializing target which is the target sentence/ids for every new row of explanation
-        self.output = None
-        self.output_names = None
+        self.output: Optional[np.ndarray] = None
+        self.output_names: Optional[list[Any]] = None
 
         self.similarity_model_type = None
         if safe_isinstance(self.similarity_model, "transformers.PreTrainedModel"):
@@ -132,7 +133,7 @@ class TeacherForcing(Model):
             start_batch_idx += self.batch_size
         return output_batch
 
-    def update_output_names(self, output):
+    def update_output_names(self, output: np.ndarray):
         """The function updates output tokens.
 
         It mimics the caching mechanism to update the output tokens for every
@@ -244,6 +245,7 @@ class TeacherForcing(Model):
 
         """
         # set output ids for which scores are to be extracted
+        assert self.output is not None
         if self.output.dtype.type is np.str_:
             output_ids = self.get_outputs(self.output)[0]
         else:

--- a/shap/models/_text_generation.py
+++ b/shap/models/_text_generation.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from .._serializable import Deserializer, Serializer
@@ -46,6 +48,7 @@ class TextGeneration(Model):
         self.device = device
         if self.device is None:
             self.device = getattr(self.inner_model, "device", None)
+        self.model_type: Optional[str]  # Type hint for mypy
         if safe_isinstance(model, "transformers.PreTrainedModel"):
             self.model_agnostic = False
             self.model_type = "pt"

--- a/shap/models/_topk_lm.py
+++ b/shap/models/_topk_lm.py
@@ -149,6 +149,7 @@ class TopKLM(Model):
             Computes log odds for corresponding top-k token ids.
 
         """
+        assert self.topk_token_ids is not None
 
         # pass logits through softmax, get the token corresponding score and convert back to log odds (as one vs all)
         def calc_logodds(arr):
@@ -181,7 +182,7 @@ class TopKLM(Model):
         self.tokenizer.padding_side = "right"
         return inputs
 
-    def generate_topk_token_ids(self, X):
+    def generate_topk_token_ids(self, X) -> np.ndarray:
         """Generates top-k token ids for Causal/Masked LM.
 
         Parameters


### PR DESCRIPTION
## Overview

Supports #3730

Gets mypy passing on shap/models with check-untyped-defs=True, and adds a couple of type hints.