### PR TITLE
MAINT: Enable type checking for subset of shap.plots, update to PEP604

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,14 @@ plugins = ["numpy.typing.mypy_plugin"]
 module = [
   "shap.explainers.*",
   "shap.maskers.*",
-  "shap.plots.*",
+  "shap.plots._beeswarm",
+  "shap.plots._benchmark",
+  "shap.plots._force_matplotlib",
+  "shap.plots._force",
+  "shap.plots._heatmap",
+  "shap.plots._scatter.*",
+  "shap.plots._text",
+  "shap.plots._waterfall",
 ]
 check_untyped_defs = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ select = [
   "NPY",  # Numpy
   "SIM101",  # flake8-simplify
   "FA",  # future annotations
+  "TCH",  # Move type only imports to type-checking condition.
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ select = [
   "D",  # pydocstyle
   "NPY",  # Numpy
   "SIM101",  # flake8-simplify
+  "FA",  # future annotations
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import copy
 import operator
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -170,7 +172,7 @@ class Explanation(metaclass=MetaExplanation):
         )
 
     @property
-    def shape(self) -> tuple[Union[int, None], ...]:
+    def shape(self) -> tuple[int | None, ...]:
         """Compute the shape over potentially complex data nesting."""
         # TODO: check if the return type should actually be tuple[int, ...]
         return _compute_shape(self._s.values)
@@ -309,7 +311,7 @@ class Explanation(metaclass=MetaExplanation):
             out += "\n\n.data =\n" + self.data.__repr__()
         return out
 
-    def __getitem__(self, item) -> "Explanation":
+    def __getitem__(self, item) -> Explanation:
         """This adds support for OpChain indexing."""
         new_self = None
         if not isinstance(item, tuple):
@@ -422,7 +424,7 @@ class Explanation(metaclass=MetaExplanation):
     def __len__(self):
         return self.shape[0]
 
-    def __copy__(self) -> "Explanation":
+    def __copy__(self) -> Explanation:
         new_exp = Explanation(
             self.values,
             self.base_values,
@@ -558,7 +560,7 @@ class Explanation(metaclass=MetaExplanation):
         else:
             raise DimensionError("Only axis = 1 is supported for grouping right now...")
 
-    def hstack(self, other: "Explanation") -> "Explanation":
+    def hstack(self, other: Explanation) -> Explanation:
         """Stack two explanations column-wise."""
         assert self.shape[0] == other.shape[0], "Can't hstack explanations with different numbers of rows!"
         assert (
@@ -791,7 +793,7 @@ def _first_item(x):
     return None
 
 
-def _compute_shape(x) -> tuple[Union[int, None], ...]:
+def _compute_shape(x) -> tuple[int | None, ...]:
     if not hasattr(x, "__len__") or isinstance(x, str):
         return tuple()
     elif not scipy.sparse.issparse(x) and len(x) > 0 and isinstance(_first_item(x), str):

--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 import copy
 import queue
 import warnings
-from typing import Union
 
 from ..utils._exceptions import ConvergenceError, InvalidAction
 from ._action import Action
 
 
 class ActionOptimizer:
-    def __init__(self, model, actions: list[Union[Action, list[Action]]]):
+    def __init__(self, model, actions: list[Action | list[Action]]):
         self.model = model
         warnings.warn("Note that ActionOptimizer is still in an alpha state and is subject to API changes.")
         # actions go into mutually exclusive groups

--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -1,4 +1,4 @@
-from typing import Union
+from __future__ import annotations
 
 from ..._explanation import Explanation
 from .._explainer import Explainer
@@ -96,7 +96,7 @@ class DeepExplainer(Explainer):
         self.expected_value = self.explainer.expected_value
         self.explainer.framework = framework
 
-    def __call__(self, X: Union[list, "np.ndarray", "pd.DataFrame", "torch.tensor"]) -> Explanation:  # type: ignore  # noqa: F821
+    def __call__(self, X: list | np.ndarray | pd.DataFrame | torch.tensor) -> Explanation:  # type: ignore  # noqa: F821
         """Return an explanation object for the model applied to X.
 
         Parameters

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import io
 import json
 import os
 import time
 import warnings
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -1977,7 +1978,7 @@ class XGBTreeModelLoader:
         if feature_types is not None:
             cat_feature_indices: np.ndarray = np.where(np.asarray(feature_types) == "c")[0]
             if len(cat_feature_indices) == 0:
-                self.cat_feature_indices: Optional[np.ndarray] = None
+                self.cat_feature_indices: np.ndarray | None = None
             else:
                 self.cat_feature_indices = cat_feature_indices
         else:

--- a/shap/models/_teacher_forcing.py
+++ b/shap/models/_teacher_forcing.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import inspect
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import scipy.special
@@ -83,8 +85,8 @@ class TeacherForcing(Model):
                 self.similarity_tokenizer.pad_token = self.similarity_tokenizer.eos_token
             self.model_agnostic = True
         # initializing target which is the target sentence/ids for every new row of explanation
-        self.output: Optional[np.ndarray] = None
-        self.output_names: Optional[list[Any]] = None
+        self.output: np.ndarray | None = None
+        self.output_names: list[Any] | None = None
 
         self.similarity_model_type = None
         if safe_isinstance(self.similarity_model, "transformers.PreTrainedModel"):

--- a/shap/models/_text_generation.py
+++ b/shap/models/_text_generation.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 import numpy as np
 
@@ -48,7 +48,7 @@ class TextGeneration(Model):
         self.device = device
         if self.device is None:
             self.device = getattr(self.inner_model, "device", None)
-        self.model_type: Optional[str]  # Type hint for mypy
+        self.model_type: str | None  # Type hint for mypy
         if safe_isinstance(model, "transformers.PreTrainedModel"):
             self.model_agnostic = False
             self.model_type = "pt"

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -974,7 +974,7 @@ def summary_legacy(
             for i in range(nbins - 1, -1, -1):
                 y = ys[i, :] / scale
                 c = (
-                    pl.get_cmap(color)(i / (nbins - 1)) if color in pl.cm.datad else color
+                    pl.get_cmap(color)(i / (nbins - 1)) if color in pl.colormaps else color
                 )  # if color is a cmap, use it, otherwise use a color
                 pl.fill_between(x_points, pos - y, pos + y, facecolor=c, edgecolor="face")
         pl.xlim(shap_min, shap_max)
@@ -1029,7 +1029,7 @@ def summary_legacy(
         color_bar
         and features is not None
         and plot_type != "bar"
-        and (plot_type != "layered_violin" or color in pl.cm.datad)
+        and (plot_type != "layered_violin" or color in pl.colormaps)
     ):
         import matplotlib.cm as cm
 

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -94,7 +94,7 @@ def __decision_plot_matplotlib(
 
     # if there is a single observation and feature values are supplied, print them.
     if (cumsum.shape[0] == 1) and (features is not None):
-        renderer = pl.gcf().canvas.get_renderer()
+        renderer = pl.gcf().canvas.get_renderer()  # type: ignore
         inverter = pl.gca().transData.inverted()
         y_pos = y_pos + 0.5
         for i in range(feature_display_count):
@@ -141,12 +141,12 @@ def __decision_plot_matplotlib(
 
         # place the colorbar
         pl.ylim(0, feature_display_count + 0.25)
-        ax_cb = ax.inset_axes([xlim[0], feature_display_count, xlim[1] - xlim[0], 0.25], transform=ax.transData)
+        ax_cb = ax.inset_axes((xlim[0], feature_display_count, xlim[1] - xlim[0], 0.25), transform=ax.transData)
         cb = pl.colorbar(m, ticks=[0, 1], orientation="horizontal", cax=ax_cb)
         cb.set_ticklabels([])
         cb.ax.tick_params(labelsize=11, length=0)
         cb.set_alpha(alpha)
-        cb.outline.set_visible(False)
+        cb.outline.set_visible(False)  # type: ignore
 
         # re-activate the main axis for drawing.
         pl.sca(ax)

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -1,6 +1,6 @@
 """Visualize cumulative SHAP values."""
 
-from typing import Optional, Union
+from __future__ import annotations
 
 import matplotlib.cm as cm
 import matplotlib.pyplot as pl
@@ -210,9 +210,9 @@ class DecisionPlotResult:
 
 
 def decision(
-    base_value: Union[float, np.ndarray],
+    base_value: float | np.ndarray,
     shap_values: np.ndarray,
-    features: Optional[Union[np.ndarray, pd.Series, pd.DataFrame, list]] = None,
+    features: np.ndarray | pd.Series | pd.DataFrame | list | None = None,
     feature_names=None,
     feature_order="importance",
     feature_display_range=None,
@@ -232,7 +232,7 @@ def decision(
     new_base_value=None,
     legend_labels=None,
     legend_location="best",
-) -> Optional[DecisionPlotResult]:
+) -> DecisionPlotResult | None:
     """Visualize model decisions using cumulative SHAP values.
 
     Each plotted line explains a single model prediction. If a single prediction is plotted, feature values will be
@@ -414,7 +414,7 @@ def decision(
         a[:, feature_count:] = shap_values[:, idx_triu[0], idx_triu[1]] * 2
         shap_values = a
         # names
-        b: list[Optional[str]] = [None] * shap_values.shape[1]
+        b: list[str | None] = [None] * shap_values.shape[1]
         b[:feature_count] = feature_names
         for i, row, col in zip(range(feature_count, shap_values.shape[1]), idx_triu[0], idx_triu[1]):
             b[i] = f"{feature_names[row]} *\n{feature_names[col]}"
@@ -569,7 +569,7 @@ def decision(
     return DecisionPlotResult(base_value_saved, shap_values, feature_names, feature_idx, xlim)
 
 
-def multioutput_decision(base_values, shap_values, row_index, **kwargs) -> Union[DecisionPlotResult, None]:
+def multioutput_decision(base_values, shap_values, row_index, **kwargs) -> DecisionPlotResult | None:
     """Decision plot for multioutput models.
 
     Plots all outputs for a single observation. By default, the plotted base value will be the mean of base_values

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -59,7 +59,7 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
     # pl.title(feature_names[ind])
     cb = pl.colorbar()
     cb.set_label("SHAP value for\n" + fname, size=13)
-    cb.outline.set_visible(False)
+    cb.outline.set_visible(False)  # type: ignore
 
     pl.gcf().set_size_inches(7.5, 5)
     bbox = cb.ax.get_window_extent().transformed(pl.gcf().dpi_scale_trans.inverted())

--- a/shap/plots/_group_difference.py
+++ b/shap/plots/_group_difference.py
@@ -40,8 +40,8 @@ def group_difference(
     for i in range(200):
         r = np.random.rand(shap_values.shape[0]) > gmean
         vs.append(shap_values[r].mean(0) - shap_values[~r].mean(0))
-    vs = np.array(vs)
-    xerr = np.vstack([np.percentile(vs, 95, axis=0), np.percentile(vs, 5, axis=0)])
+    vs_ = np.array(vs)
+    xerr = np.vstack([np.percentile(vs_, 95, axis=0), np.percentile(vs_, 5, axis=0)])
 
     # See if we were passed a single model output vector and not a matrix of SHAP values
     if len(shap_values.shape) == 1:

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import random
 import string
-from typing import Literal, Optional, Union, cast
+from typing import Literal, cast
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -21,16 +23,16 @@ from . import colors
 
 
 def image(
-    shap_values: Union[Explanation, np.ndarray, list[np.ndarray]],
-    pixel_values: Optional[np.ndarray] = None,
-    labels: Optional[Union[list[str], np.ndarray]] = None,
-    true_labels: Optional[list] = None,
-    width: Optional[int] = 20,
-    aspect: Optional[float] = 0.2,
-    hspace: Union[Optional[float], Literal["auto"]] = 0.2,
-    labelpad: Optional[float] = None,
-    cmap: Optional[Union[str, Colormap]] = colors.red_transparent_blue,
-    show: Optional[bool] = True,
+    shap_values: Explanation | np.ndarray | list[np.ndarray],
+    pixel_values: np.ndarray | None = None,
+    labels: list[str] | np.ndarray | None = None,
+    true_labels: list | None = None,
+    width: int | None = 20,
+    aspect: float | None = 0.2,
+    hspace: float | Literal["auto"] | None = 0.2,
+    labelpad: float | None = None,
+    cmap: str | Colormap | None = colors.red_transparent_blue,
+    show: bool | None = True,
 ):
     """Plots SHAP values for image inputs.
 

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import json
 import random
 import string
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import matplotlib.pyplot as pl
 import numpy as np
-from matplotlib.colors import Colormap
 
 try:
     from IPython.display import HTML, display
@@ -20,6 +19,9 @@ from .._explanation import Explanation
 from ..utils import ordinal_str
 from ..utils._legacy import kmeans
 from . import colors
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 
 
 def image(

--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -59,7 +59,7 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
         _, pval = scipy.stats.ttest_ind(ys[:i], ys[i:])
         pvals.append(pval)
     min_pval = np.min(pvals)
-    min_pval_ind = np.argmin(pvals) * inc + inc
+    min_pval_ind = float(np.argmin(pvals) * inc + inc)
 
     if min_pval < 0.05 / shap_values.shape[1]:
         pl.axvline(min_pval_ind, linestyle="dashed", color="#666666", alpha=0.2)
@@ -73,7 +73,7 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     pl.gca().spines["right"].set_visible(False)
     pl.gca().spines["top"].set_visible(False)
     cb = pl.colorbar()
-    cb.outline.set_visible(False)
+    cb.outline.set_visible(False)  # type: ignore
     bbox = cb.ax.get_window_extent().transformed(pl.gcf().dpi_scale_trans.inverted())
     cb.ax.set_aspect((bbox.height - 0.7) * 20)
     cb.set_label(truncate_text(feature_names[ind], 30), size=13)

--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -1,3 +1,5 @@
+import typing
+
 import matplotlib.pyplot as pl
 import numpy as np
 import pandas as pd
@@ -105,6 +107,7 @@ def partial_dependence(
 
         # fig, ax1 = pl.subplots(figsize)
         ax2 = ax1.twinx()
+        ax2 = typing.cast(pl.Axes, ax2)  # fix for matplotlib typing
 
         # the histogram of the data
         if hist:

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -128,8 +128,8 @@ def dendrogram_coords(leaf_positions, partition_tree):
     Note that scipy can compute these coords as well, but it does not allow you to easily specify
     a specific leaf order, hence this reimplementation.
     """
-    xout = []
-    yout = []
+    xout: list[list[float]] = []
+    yout: list[list[float]] = []
     _dendrogram_coords_rec(partition_tree.shape[0] - 1, leaf_positions, partition_tree, xout, yout)
 
     return np.array(xout), np.array(yout)

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -256,7 +256,7 @@ def violin(
                 showmedians=False,
             )
 
-            for pc in parts["bodies"]:
+            for pc in parts["bodies"]:  # type: ignore
                 pc.set_facecolor(color)
                 pc.set_edgecolor("none")
                 pc.set_alpha(alpha)
@@ -341,7 +341,7 @@ def violin(
         cb.set_label(color_bar_label, size=12, labelpad=0)
         cb.ax.tick_params(labelsize=11, length=0)
         cb.set_alpha(1)
-        cb.outline.set_visible(False)
+        cb.outline.set_visible(False)  # type: ignore
         # bbox = cb.ax.get_window_extent().transformed(pl.gcf().dpi_scale_trans.inverted())
         # cb.ax.set_aspect((bbox.height - 0.9) * 20)
         # cb.draw_all()

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -320,7 +320,7 @@ def violin(
             for i in range(nbins - 1, -1, -1):
                 y = ys[i, :] / scale
                 c = (
-                    pl.get_cmap(color)(i / (nbins - 1)) if color in pl.cm.datad else color
+                    pl.get_cmap(color)(i / (nbins - 1)) if color in pl.colormaps else color
                 )  # if color is a cmap, use it, otherwise use a color
                 pl.fill_between(x_points, pos - y, pos + y, facecolor=c, edgecolor="face")
         pl.xlim(shap_min, shap_max)
@@ -330,7 +330,7 @@ def violin(
         color_bar
         and features is not None
         and plot_type != "bar"
-        and (plot_type != "layered_violin" or color in pl.cm.datad)
+        and (plot_type != "layered_violin" or color in pl.colormaps)
     ):
         import matplotlib.cm as cm
 

--- a/shap/plots/colors/_colorconv.py
+++ b/shap/plots/colors/_colorconv.py
@@ -416,7 +416,7 @@ def get_xyz_coords(illuminant, observer):
     """
     illuminant = illuminant.upper()
     try:
-        return illuminants[illuminant][observer]
+        return illuminants[illuminant][observer]  # type: ignore
     except KeyError:
         raise ValueError(
             "Unknown illuminant/observer combination\
@@ -843,8 +843,8 @@ def convert(image, dtype, force_copy=False, uniform=False):
         imin_in = np.iinfo(dtype_in).min
         imax_in = np.iinfo(dtype_in).max
     if kind_out in "ui":
-        imin_out = np.iinfo(dtype_out).min
-        imax_out = np.iinfo(dtype_out).max
+        imin_out = np.iinfo(dtype_out).min  # type: ignore
+        imax_out = np.iinfo(dtype_out).max  # type: ignore
 
     # any -> binary
     if kind_out == "b":

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import itertools as it
 import warnings
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -106,10 +108,10 @@ def xgboost_distances_r2(
     X,
     y,
     learning_rate: float = 0.6,
-    early_stopping_rounds: Optional[int] = 2,
-    subsample: Optional[float] = 1.0,
-    max_estimators: Optional[int] = 10_000,
-    random_state: Union[int, np.random.RandomState] = 0,
+    early_stopping_rounds: int | None = 2,
+    subsample: float | None = 1.0,
+    max_estimators: int | None = 10_000,
+    random_state: int | np.random.RandomState = 0,
 ) -> np.ndarray:
     """Compute redundancy distances scaled from 0-1 among all the features in X relative to the label y.
 
@@ -193,10 +195,10 @@ def xgboost_distances_r2(
 
 def hclust(
     X: _ArrayLike,
-    y: Optional[_ArrayLike] = None,
+    y: _ArrayLike | None = None,
     linkage: Literal["single", "complete", "average"] = "single",
     metric: str = "auto",
-    random_state: Union[int, np.random.RandomState] = 0,
+    random_state: int | np.random.RandomState = 0,
 ) -> np.ndarray:
     """Fit a hierarchical clustering model for features X relative to target variable y.
 

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools as it
 import warnings
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,9 @@ from numba import njit
 
 from ..utils._exceptions import DimensionError
 from ._show_progress import show_progress
-from ._types import _ArrayLike
+
+if TYPE_CHECKING:
+    from ._types import _ArrayLike
 
 
 def partition_tree(X, metric="correlation"):

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import copy
 import os
 import re
 import sys
 from contextlib import contextmanager
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -201,7 +203,7 @@ def sample(X: _ArrayT, nsamples: int = 100, random_state: int = 0) -> _ArrayT:
     return sklearn.utils.shuffle(X, n_samples=nsamples, random_state=random_state)
 
 
-def safe_isinstance(obj: Any, class_path_str: Union[str, list[str]]) -> bool:
+def safe_isinstance(obj: Any, class_path_str: str | list[str]) -> bool:
     """Acts as a safe version of isinstance without having to explicitly
     import packages which may not exist in the users environment.
 
@@ -291,7 +293,7 @@ class OpChain:
                 obj = getattr(obj, op)
         return obj
 
-    def __call__(self, *args, **kwargs) -> "OpChain":
+    def __call__(self, *args, **kwargs) -> OpChain:
         """Update the args for the previous operation."""
         new_self = OpChain(self._root_name)
         new_self._ops = copy.copy(self._ops)
@@ -305,7 +307,7 @@ class OpChain:
         new_self._ops.append(["__getitem__", [item], {}])
         return new_self
 
-    def __getattr__(self, name: str) -> "OpChain":
+    def __getattr__(self, name: str) -> OpChain:
         # Don't chain special attributes
         if name.startswith("__") and name.endswith("__"):
             return None  # type: ignore

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -5,14 +5,15 @@ import os
 import re
 import sys
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
 import scipy.special
 import sklearn
 
-from ._types import _ArrayT
+if TYPE_CHECKING:
+    from ._types import _ArrayT
 
 import_errors: dict[str, tuple[str, Exception]] = {}
 

--- a/shap/utils/_types.py
+++ b/shap/utils/_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TypeVar, Union
 
 import numpy as np


### PR DESCRIPTION
## Overview

Supports #3730

Gets mypy passing on about half the modules in shap.plots with `check-untyped-defs=True`.

## Discussion

Also updates types hints to use the nice PEP604-style annotations:
- `X | Y` rather than `Union[X, Y]`
- `X | None` rather than `Optional[X]`.
 
This is made possible even with python 3.9 support with `__future__` imports.

As a supporting change, enables two typing-related linting rules.
