### PR TITLE
refactor: Slight logic and docs cleanup of the clustering functions

### DIFF
--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -106,10 +106,10 @@ def xgboost_distances_r2(
     learning_rate: float = 0.6,
     early_stopping_rounds: Optional[int] = 2,
     subsample: Optional[float] = 1.0,
-    max_estimators: Optional[int] = 10000,
+    max_estimators: Optional[int] = 10_000,
     random_state: Union[int, np.random.RandomState] = 0,
-):
-    """Compute reducancy distances scaled from 0-1 among all the feature in X relative to the label y.
+) -> np.ndarray:
+    """Compute redundancy distances scaled from 0-1 among all the features in X relative to the label y.
 
     Distances are measured by training univariate XGBoost models of y for all the features, and then
     predicting the output of these models using univariate XGBoost models of other features. If one
@@ -184,10 +184,13 @@ def hclust(
     metric: str = "auto",
     random_state: Union[int, np.random.RandomState] = 0,
 ) -> np.ndarray:
-    """Fit a hierarcical clustering model for features X relative to target variable y.
+    """Fit a hierarchical clustering model for features X relative to target variable y.
 
-    For more information on clutering methods see:
+    For more information on clustering methods, see:
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html
+
+    For more information on scipy distance metrics, see:
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.pdist.html
 
     Parameters
     ----------

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -124,9 +124,10 @@ def xgboost_distances_r2(
     X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y, random_state=random_state)
 
     # fit an XGBoost model on each of the features
+    num_features = X.shape[1]
     train_preds_list = []
     test_preds_list = []
-    for i in range(X.shape[1]):
+    for i in range(num_features):
         model = xgboost.XGBRegressor(
             subsample=subsample,
             n_estimators=max_estimators,
@@ -141,9 +142,9 @@ def xgboost_distances_r2(
     test_preds = np.vstack(test_preds_list).T
 
     # fit XGBoost models to predict the outputs of other XGBoost models to see how redundant features are
-    dist = np.zeros((X.shape[1], X.shape[1]))
-    for i in show_progress(range(X.shape[1]), total=X.shape[1]):
-        for j in range(X.shape[1]):
+    dist = np.zeros((num_features, num_features))
+    for i in show_progress(range(num_features), total=num_features):
+        for j in range(num_features):
             if i == j:
                 dist[i, j] = 0
                 continue

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -119,6 +119,14 @@ def xgboost_distances_r2(
     then the second feature is redundant with the first with respect to y. A distance of 1 corresponds
     to no redundancy while a distance of 0 corresponds to perfect redundancy (measured using the
     proportion of variance explained). Note these distances are not symmetric.
+
+    Returns
+    -------
+    np.ndarray
+        A square matrix of shape (n_features, n_features) containing the pairwise
+        redundancy distances between features. Each element [i, j] represents the
+        redundancy distance from feature i to feature j with respect to y.
+
     """
     import xgboost
 

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -149,10 +149,12 @@ def xgboost_distances_r2(
                 continue
 
             # skip features that have not variance in their predictions (likely because the feature is a constant)
-            preds_var = np.var(test_preds[:, i])
+            preds_var: float = np.var(test_preds[:, i])
             if preds_var < 1e-4:
                 warnings.warn(
-                    f"No/low signal found from feature {i} (this is typically caused by constant or near-constant features)! Cluster distances can't be computed for it (so setting all distances to 1)."
+                    f"No/low signal found from feature {i} (this is typically caused by constant or "
+                    "near-constant features)! Cluster distances can't be computed for it (so setting "
+                    "all redundancy distances to 1)."
                 )
                 r2 = 0
 
@@ -253,7 +255,8 @@ def hclust(
     else:
         if y is not None:
             warnings.warn(
-                "Ignoring the y argument passed to shap.utils.hclust since the given clustering metric is not based on label fitting!"
+                "Ignoring the y argument passed to shap.utils.hclust since the given clustering metric is "
+                "not based on label fitting!"
             )
         if isinstance(X, pd.DataFrame):
             bg_no_nan = X.values.copy()
@@ -262,8 +265,6 @@ def hclust(
         for i in range(bg_no_nan.shape[1]):
             np.nan_to_num(bg_no_nan[:, i], nan=np.nanmean(bg_no_nan[:, i]), copy=False)
         dist = scipy.spatial.distance.pdist(bg_no_nan.T + np.random.randn(*bg_no_nan.T.shape) * 1e-8, metric=metric)
-    # else:
-    #     raise Exception("Unknown metric: " + str(metric))
 
     # build linkage
     if linkage == "single":

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -146,7 +146,6 @@ def xgboost_distances_r2(
     for i in show_progress(range(num_features), total=num_features):
         for j in range(num_features):
             if i == j:
-                dist[i, j] = 0
                 continue
 
             # skip features that have not variance in their predictions (likely because the feature is a constant)

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -224,6 +224,10 @@ def hclust(
     if isinstance(X, pd.DataFrame):
         X = X.values
 
+    known_linkages = ("single", "complete", "average")
+    if linkage not in known_linkages:
+        raise ValueError(f"Unknown linkage type: {linkage}")
+
     if metric == "auto":
         if y is not None:
             metric = "xgboost_distances_r2"
@@ -245,8 +249,6 @@ def hclust(
                         dist_list.append(max(dist_full[i, j], dist_full[j, i]))
                     elif linkage == "average":
                         dist_list.append((dist_full[i, j] + dist_full[j, i]) / 2)
-                    else:
-                        raise ValueError("Unsupported linkage type!")
         dist = np.array(dist_list)
 
     else:
@@ -271,5 +273,3 @@ def hclust(
         return scipy.cluster.hierarchy.complete(dist)
     elif linkage == "average":
         return scipy.cluster.hierarchy.average(dist)
-    else:
-        raise ValueError("Unknown linkage: " + str(linkage))

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -258,10 +258,7 @@ def hclust(
                 "Ignoring the y argument passed to shap.utils.hclust since the given clustering metric is "
                 "not based on label fitting!"
             )
-        if isinstance(X, pd.DataFrame):
-            bg_no_nan = X.values.copy()
-        else:
-            bg_no_nan = X.copy()
+        bg_no_nan = X.copy()
         for i in range(bg_no_nan.shape[1]):
             np.nan_to_num(bg_no_nan[:, i], nan=np.nanmean(bg_no_nan[:, i]), copy=False)
         dist = scipy.spatial.distance.pdist(bg_no_nan.T + np.random.randn(*bg_no_nan.T.shape) * 1e-8, metric=metric)

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -218,7 +218,7 @@ def hclust(
     metric: str
         Scipy distance metric or "xgboost_distances_r2".
 
-        * If "xgboost_distances_r2", estimate redundancy distances between
+        * If ``xgboost_distances_r2``, estimate redundancy distances between
           features X with respect to target variable y using
           :func:`shap.utils.xgboost_distances_r2`.
         * Otherwise, calculate distances between features using the given
@@ -253,19 +253,19 @@ def hclust(
 
     # build the distance matrix
     if metric == "xgboost_distances_r2":
-        dist_full = xgboost_distances_r2(X_arr, y, random_state=random_state)
+        dist_full: np.ndarray = xgboost_distances_r2(X_arr, y, random_state=random_state)
 
         # build a condensed upper triangular version by taking the max distance from either direction
-        dist_list = []
-        for i in range(dist_full.shape[0]):
-            for j in range(i + 1, dist_full.shape[1]):
-                if i != j:
-                    if linkage == "single":
-                        dist_list.append(min(dist_full[i, j], dist_full[j, i]))
-                    elif linkage == "complete":
-                        dist_list.append(max(dist_full[i, j], dist_full[j, i]))
-                    elif linkage == "average":
-                        dist_list.append((dist_full[i, j] + dist_full[j, i]) / 2)
+        dist_list: list[float] = []
+        for i, j in it.combinations_with_replacement(range(len(dist_full)), 2):
+            if i == j:
+                continue
+            if linkage == "single":
+                dist_list.append(min(dist_full[i, j], dist_full[j, i]))
+            elif linkage == "complete":
+                dist_list.append(max(dist_full[i, j], dist_full[j, i]))
+            elif linkage == "average":
+                dist_list.append((dist_full[i, j] + dist_full[j, i]) / 2)
         dist = np.array(dist_list)
 
     else:

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -160,7 +160,7 @@ def xgboost_distances_r2(
         if i == j:
             continue
 
-        # skip features that have not variance in their predictions (likely because the feature is a constant)
+        # skip features that have no variance in their predictions (likely because the feature is a constant)
         preds_var: float = np.var(test_preds[:, i])
         if preds_var < 1e-4:
             warnings.warn(

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -210,7 +210,7 @@ def hclust(
     ----------
     X: 2d-array-like
         Features to cluster
-    y: array-like | None
+    y: array-like or None
         Target variable
     linkage: str
         Defines the method to calculate the distance between clusters. Must be

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -12,14 +12,15 @@ def test_hclust_runs(linkage):
     X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
     y = np.where(X[:, 0] > 5, 1, 0)
 
-    # just check if clustered ran successfully
+    # just check if clustered ran successfully (using xgboost_distances_r2)
     clustered = hclust(X, y, linkage=linkage, random_state=0)
     assert isinstance(clustered, np.ndarray)
     assert clustered.shape == (1, 4)
 
-    # Check clustering runs if y=None
+    # Check clustering runs if y=None (using scipy metrics)
     clustered = hclust(X, linkage=linkage, random_state=0)
     assert isinstance(clustered, np.ndarray)
+    assert clustered.shape == (1, 4)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -31,6 +31,7 @@ def test_hclust_runs(linkage):
     ],
 )
 def test_hclust_errors_on_input_shapes(X):
+    # hclust only accepts 2-d arrays for X
     with pytest.raises(DimensionError):
         hclust(X, random_state=0)
 

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from shap.utils import hclust
+from shap.utils._exceptions import DimensionError
 
 
 @pytest.mark.parametrize("linkage", ["single", "complete", "average"])
@@ -12,9 +13,28 @@ def test_hclust_runs(linkage):
     y = np.where(X[:, 0] > 5, 1, 0)
 
     # just check if clustered ran successfully
-    clustered = hclust(X, y, linkage=linkage)
+    clustered = hclust(X, y, linkage=linkage, random_state=0)
     assert isinstance(clustered, np.ndarray)
+    assert clustered.shape == (1, 4)
 
     # Check clustering runs if y=None
-    clustered = hclust(X, linkage=linkage)
+    clustered = hclust(X, linkage=linkage, random_state=0)
     assert isinstance(clustered, np.ndarray)
+
+
+@pytest.mark.parametrize(
+    "X",
+    [
+        np.arange(1, 10),
+        list(range(1, 10)),
+    ],
+)
+def test_hclust_errors_on_input_shapes(X):
+    with pytest.raises(DimensionError):
+        hclust(X, random_state=0)
+
+
+def test_hclust_errors_on_unknown_linkages():
+    X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
+    with pytest.raises(ValueError, match=r"Unknown linkage type:"):
+        hclust(X, linkage="random-string", random_state=0)  # type: ignore


### PR DESCRIPTION
## Overview

A general code cleanup and logic improvement for the clustering utils, namely `xgboost_distances_r2` and `hclust` functions.

Description of the changes proposed in this pull request:
* Reduce unnecessary indentation in nested for loops by using itertools `product` and `combinations_with_replacement` where appropriate
* Early exit if linkage is not valid (`xgboost_distances_r2` is potentially time-consuming)
* Add some more tests for hclust
* Some other docstring fixes and improvements (e.g. wrong dtype, add references to scipy docs, clarify return types/shapes of numpy arrays)

I'll highlight some other changes directly as code review snippets.

## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
