### PR TITLE
CI: Switch from pip to uv (~5min speedup), fix tensorflow/numpy constraint 

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -69,6 +69,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install libomp
       - name: Install dependencies
+        # Do regular install NOT editable install: see GH #3020
         run: |
           python -m pip install --upgrade uv
           uv pip install --system '.[${{ matrix.extras }},plots]'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,26 +65,24 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache python libs
-        uses: actions/cache@v4
-        if: matrix.extras == 'test'
-        with:
-          path: |
-            # Only cache a subset of libraries, ensuring cache size remains under 10GB. See GH dsgibbons#42
-            ${{ env.pythonLocation }}/**/site-packages/pyspark*
-            ${{ env.pythonLocation }}/**/site-packages/nvidia*
-            ${{ env.pythonLocation }}/**/site-packages/torch*
-            ${{ env.pythonLocation }}/**/site-packages/functorch*
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
+      # - name: Cache python libs
+      #   uses: actions/cache@v4
+      #   if: matrix.extras == 'test'
+      #   with:
+      #     path: |
+      #       # Only cache a subset of libraries, ensuring cache size remains under 10GB. See GH dsgibbons#42
+      #       ${{ env.pythonLocation }}/**/site-packages/pyspark*
+      #       ${{ env.pythonLocation }}/**/site-packages/nvidia*
+      #       ${{ env.pythonLocation }}/**/site-packages/torch*
+      #       ${{ env.pythonLocation }}/**/site-packages/functorch*
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          # Use "eager" update strategy in case cached dependencies are outdated
-          # Using regular install NOT editable install: see GH #3020
-          pip install --upgrade --upgrade-strategy eager '.[${{ matrix.extras }},plots]'
+          python -m pip install --upgrade uv
+          uv pip install --system '.[${{ matrix.extras }},plots]'
       - name: Test with pytest
         # Ensure we avoid adding current working directory to sys.path:
         # - Use "pytest" over "python -m pytest"
@@ -122,8 +120,8 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy==1.24.0 '.[test-core,plots]'
+          python -m pip install --upgrade uv
+          uv pip install --system numpy==1.24.0 '.[test-core,plots]'
       - name: Test with pytest
         run: pytest --durations=20 --import-mode=append
 
@@ -139,7 +137,7 @@ jobs:
           python-version: 3.12
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install '.[test-core]'
+          python -m pip install --upgrade uv
+          uv pip install --system '.[test-core]'
       - name: Run mypy
         run: mypy shap tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,17 +65,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Cache python libs
-      #   uses: actions/cache@v4
-      #   if: matrix.extras == 'test'
-      #   with:
-      #     path: |
-      #       # Only cache a subset of libraries, ensuring cache size remains under 10GB. See GH dsgibbons#42
-      #       ${{ env.pythonLocation }}/**/site-packages/pyspark*
-      #       ${{ env.pythonLocation }}/**/site-packages/nvidia*
-      #       ${{ env.pythonLocation }}/**/site-packages/torch*
-      #       ${{ env.pythonLocation }}/**/site-packages/functorch*
-      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: '.*tree_shap_paper.*|.*user_studies.*'
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.2
+  rev: v0.5.5
   hooks:
   - id: ruff
     types_or: [python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ test = [
   "tensorflow",
   "sentencepiece",
   "opencv-python",
+  # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
+  # See GH #3707 and #3768
+  "numpy<2.0; python_version < '3.12'",
 ]
 
 test_notebooks = [


### PR DESCRIPTION
## Overview

Switches CI jobs to use `uv` rather than `pip` to install dependencies. This speeds up all CI jobs by an average of 1min 40sec, and up to **5 minutes faster** on the slowest job (windows)!

## Discussion

[uv](https://github.com/astral-sh/uv) is *"An extremely fast Python package installer and resolver, written in Rust"*. It is becoming increasingly popular and dominant, following the success of the `ruff` linter by the same team.

Implementation notes:
1. I have disabled caching, as it does not lead to any speedup. 
   - I experimented with adding caching over at #3769 , and it does not lead to any improvement. This means we can just keep things simple.
   - Related: https://github.com/actions/setup-python/issues/822
1. We use the `--system` flag to install directly into system python, as recommended in CI environments. See https://github.com/astral-sh/uv/issues/1386
1. As part of this PR I encountered an unrelated issue of incompatible tensorflow and numpy versions, explained in https://github.com/shap/shap/issues/3707#issuecomment-2252511284 . To protect against this, I've added a new conditional numpy constraint into the test dependencies.

## Timings comparison

Comparison of timings of the "install dependencies" stage, versus the latest run on `master`:

| job  name     | Old (pip) | New (uv)   |
| -------- | ------- |------- |
| run_tests (ubuntu-latest, 3.9, test)           |  2m 14s  |  59s  |
| run_tests (ubuntu-latest, 3.10, test)         | 2m 53s   |  57s  |
| run_tests (ubuntu-latest, 3.11, test)         | 2m 44s   | 50s   |
| run_tests (ubuntu-latest, 3.12, test)         | 3m 53s   |  54s  |
| run_tests (windows-latest, 3.11, test)       |  10m 12s  | 4m 38s  |
| run_tests (macos-latest, 3.11, test)           |  1m48s  | 32s   |
| run_tests (ubuntu-latest, 3.12, test-core) | 46s        | 14s   |
| run tests (oldest supported numpy)        | 43s         | 20s  |
| run mypy                                                  | 42s        | 15s  |