### PR TITLE
CI: Implement caching for uv package installer

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -102,14 +102,16 @@ jobs:
       - name: Prune uv cache
         # See https://github.com/astral-sh/uv/pull/5391
         run: |
+          CACHE_DIR=$(uv cache dir)
+          echo "** uv cache dir: $CACHE_DIR"
           echo "** Before:"
-          du -sh ~/.cache/uv
-          ls ~/.cache/uv
+          du -sh $CACHE_DIR 2>/dev/null || echo "Directory not found"
+          ls $CACHE_DIR
           echo "** pruning.."
           uv cache prune --ci
           echo "** after:"
-          du -sh ~/.cache/uv
-          ls ~/.cache/uv
+          du -sh $CACHE_DIR 2>/dev/null || echo "Directory not found"
+          ls $CACHE_DIR
 
 
   test_oldest_supported_numpy:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -72,6 +72,7 @@ jobs:
         run: python -m pip install --upgrade uv
       - name: Get uv cache dir
         id: uv-cache-dir
+        shell: bash
         run: echo "dir=$(uv cache dir)" >> $GITHUB_OUTPUT
       - name: Cache built wheels
         uses: actions/cache@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -105,19 +105,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Prune uv cache
         # See https://github.com/astral-sh/uv/pull/5391
-        if: matrix.os != 'windows-latest'  # TODO: remove when debugging commands not needed
-        run: |
-          CACHE_DIR=$(uv cache dir)
-          echo "** uv cache dir: $CACHE_DIR"
-          echo "** Before:"
-          du -sh $CACHE_DIR 2>/dev/null || echo "Directory not found"
-          ls $CACHE_DIR
-          pip cache info
-          echo "** pruning.."
-          uv cache prune --ci
-          echo "** after:"
-          du -sh $CACHE_DIR 2>/dev/null || echo "Directory not found"
-          ls $CACHE_DIR
+        run: uv cache prune --ci
 
 
   test_oldest_supported_numpy:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,26 +65,24 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache python libs
-        uses: actions/cache@v4
-        if: matrix.extras == 'test'
-        with:
-          path: |
-            # Only cache a subset of libraries, ensuring cache size remains under 10GB. See GH dsgibbons#42
-            ${{ env.pythonLocation }}/**/site-packages/pyspark*
-            ${{ env.pythonLocation }}/**/site-packages/nvidia*
-            ${{ env.pythonLocation }}/**/site-packages/torch*
-            ${{ env.pythonLocation }}/**/site-packages/functorch*
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
+      # - name: Cache python libs
+      #   uses: actions/cache@v4
+      #   if: matrix.extras == 'test'
+      #   with:
+      #     path: |
+      #       # Only cache a subset of libraries, ensuring cache size remains under 10GB. See GH dsgibbons#42
+      #       ${{ env.pythonLocation }}/**/site-packages/pyspark*
+      #       ${{ env.pythonLocation }}/**/site-packages/nvidia*
+      #       ${{ env.pythonLocation }}/**/site-packages/torch*
+      #       ${{ env.pythonLocation }}/**/site-packages/functorch*
+      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          # Use "eager" update strategy in case cached dependencies are outdated
-          # Using regular install NOT editable install: see GH #3020
-          pip install --upgrade --upgrade-strategy eager '.[${{ matrix.extras }},plots]'
+          python -m pip install --upgrade uv
+          uv pip install --system '.[${{ matrix.extras }},plots]'
       - name: Test with pytest
         # Ensure we avoid adding current working directory to sys.path:
         # - Use "pytest" over "python -m pytest"
@@ -122,8 +120,8 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy==1.24.0 '.[test-core,plots]'
+          python -m pip install --upgrade uv
+          uv pip install --system numpy==1.24.0 '.[test-core,plots]'
       - name: Test with pytest
         run: pytest --durations=20 --import-mode=append
 
@@ -139,7 +137,7 @@ jobs:
           python-version: 3.12
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install '.[test-core]'
+          python -m pip install --upgrade uv
+          uv pip install --system '.[test-core]'
       - name: Run mypy
         run: mypy shap tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Prune uv cache
         # See https://github.com/astral-sh/uv/pull/5391
         run: |
-          echo "** Before:
+          echo "** Before:"
           du -sh ~/.cache/uv
           ls ~/.cache/uv
           echo "** pruning.."

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -68,6 +68,13 @@ jobs:
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp
+      - name: Cache built wheels
+        uses: actions/cache@v4
+        if: matrix.extras == 'test'
+        id: cache-uv
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv
@@ -92,6 +99,17 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Prune uv cache
+        # See https://github.com/astral-sh/uv/pull/5391
+        run: |
+          echo "** Before:
+          du -sh ~/.cache/uv
+          ls ~/.cache/uv
+          echo "** pruning.."
+          uv cache prune --ci
+          echo "** after:"
+          du -sh ~/.cache/uv
+          ls ~/.cache/uv
 
 
   test_oldest_supported_numpy:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -68,12 +68,15 @@ jobs:
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp
+      - name: Get uv cache dir
+        id: uv-cache-dir
+        run: echo "dir=$(uv cache dir)" >> $GITHUB_OUTPUT
       - name: Cache built wheels
         uses: actions/cache@v4
         if: matrix.extras == 'test'
-        id: cache-uv
+        id: uv-cache-restore
         with:
-          path: ~/.cache/uv
+          path: ${{ steps.uv-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,17 +65,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Cache python libs
-      #   uses: actions/cache@v4
-      #   if: matrix.extras == 'test'
-      #   with:
-      #     path: |
-      #       # Only cache a subset of libraries, ensuring cache size remains under 10GB. See GH dsgibbons#42
-      #       ${{ env.pythonLocation }}/**/site-packages/pyspark*
-      #       ${{ env.pythonLocation }}/**/site-packages/nvidia*
-      #       ${{ env.pythonLocation }}/**/site-packages/torch*
-      #       ${{ env.pythonLocation }}/**/site-packages/functorch*
-      #     key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,12 +104,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Prune uv cache
         # See https://github.com/astral-sh/uv/pull/5391
+        if: matrix.os != 'windows-latest'  # TODO: remove when debugging commands not needed
         run: |
           CACHE_DIR=$(uv cache dir)
           echo "** uv cache dir: $CACHE_DIR"
           echo "** Before:"
           du -sh $CACHE_DIR 2>/dev/null || echo "Directory not found"
           ls $CACHE_DIR
+          pip cache info
           echo "** pruning.."
           uv cache prune --ci
           echo "** after:"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp
+      - name: Install uv
+        run: python -m pip install --upgrade uv
       - name: Get uv cache dir
         id: uv-cache-dir
         run: echo "dir=$(uv cache dir)" >> $GITHUB_OUTPUT
@@ -79,9 +81,7 @@ jobs:
           path: ${{ steps.uv-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-0
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv
-          uv pip install --system '.[${{ matrix.extras }},plots]'
+        run: uv pip install --system '.[${{ matrix.extras }},plots]'
       - name: Test with pytest
         # Ensure we avoid adding current working directory to sys.path:
         # - Use "pytest" over "python -m pytest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: '.*tree_shap_paper.*|.*user_studies.*'
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.2
+  rev: v0.5.5
   hooks:
   - id: ruff
     types_or: [python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ test = [
   "tensorflow",
   "sentencepiece",
   "opencv-python",
+  # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
+  # See GH #3707 and #3768
+  "numpy<2.0; python_version < '3.12'",
 ]
 
 test_notebooks = [


### PR DESCRIPTION
Previously caching has given us only marginal improvements at best. Care is also needed to avoid surpassing the repo's cache size limit.

## Timings comparison

Comparison of timings of the "install dependencies" stage, versus the latest run on `master`:

(When caching, times include restoring cache plus then installing pacakages)

| job  name     | Old (pip) | uv, no caching  | uv, with caching  |
| -------- | ------- |------- | ----- |
| run_tests (ubuntu-latest, 3.9, test)           |  2m 14s  |  59s  | 7s + 53s   |
| run_tests (ubuntu-latest, 3.10, test)         | 2m 53s   |  57s  | 12s+48s   |
| run_tests (ubuntu-latest, 3.11, test)         | 2m 44s   | 50s   | 6s+47s   |
| run_tests (ubuntu-latest, 3.12, test)         | 3m 53s   |  54s  |   6s+46s |
| run_tests (windows-latest, 3.11, test)       |  10m 12s  | 4m 38s  | 7m 18s + 1m 4s   |
| run_tests (macos-latest, 3.11, test)           |  1m48s  | 32s   |  20s + 27s  |
| run_tests (ubuntu-latest, 3.12, test-core) | 46s        | 14s   |  (not cached)  |
| run tests (oldest supported numpy)        | 43s         | 20s  |  (not cached)  |
| run mypy                                                  | 42s        | 15s  |  (not cached)  |

Decide to abandon caching, as it does not improve install times.