### PR TITLE
CI: remove the disk-space job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,22 +44,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Overview

After having migrated to use `uv`, I think it's likely that we don't need the clean-disk-space job and can save several more minutes of CI time. This PR reverts #3331 , dropping that job.

Most test jobs are now much faster: in the region of 5-9 minutes, which is almost halved compared to the previous pip workflow. The tests on windows remain the clear bottleneck.

## Discussion

We never got to the bottom of what caused the disk space issue, but I think it's likely due to the face that pip will sometimes download many different wheels for the same package to determine which are compatible. uv does not have this flaw, so I think it's likely we will not encounter the disk space issue.

That said, after merging this PR we should keep an eye out for CI failures due to disk space, and if issue #3330 occurs again we can always re-instate the fix.