### PR TITLE
MAINT: fixup string literal concatenation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ line-length = 120
 select = [
   "F",  # pyflakes
   "I",  # isort
+  "ISC",  # string literal concatenation.
   "UP",  # pyupgrade
   "E",  # pycodestyle
   "W",  # warning

--- a/shap/_serializable.py
+++ b/shap/_serializable.py
@@ -119,12 +119,12 @@ class Deserializer:
         if serializer_version < self.serializer_min_version:
             raise ValueError(
                 f"The file being loaded was saved with a serializer version of {serializer_version}, "
-                + f"but the current deserializer in SHAP requires at least version {self.serializer_min_version}."
+                f"but the current deserializer in SHAP requires at least version {self.serializer_min_version}."
             )
         if serializer_version > self.serializer_max_version:
             raise ValueError(
                 f"The file being loaded was saved with a serializer version of {serializer_version}, "
-                + f"but the current deserializer in SHAP only support up to version {self.serializer_max_version}."
+                f"but the current deserializer in SHAP only support up to version {self.serializer_max_version}."
             )
 
         # confirm the block name
@@ -133,7 +133,7 @@ class Deserializer:
         if block_name != self.block_name:
             raise ValueError(
                 f"The next data block in the file being loaded was supposed to be {self.block_name}, "
-                + f"but the next block found was {block_name}."
+                f"but the next block found was {block_name}."
             )
 
         # confirm the block version
@@ -142,12 +142,12 @@ class Deserializer:
         if block_version < self.block_min_version:
             raise ValueError(
                 f"The file being loaded was saved with a block version of {block_version}, "
-                + f"but the current deserializer in SHAP requires at least version {self.block_min_version}."
+                f"but the current deserializer in SHAP requires at least version {self.block_min_version}."
             )
         if block_version > self.block_max_version:
             raise ValueError(
                 f"The file being loaded was saved with a block version of {block_version}, "
-                + f"but the current deserializer in SHAP only support up to version {self.block_max_version}."
+                f"but the current deserializer in SHAP only support up to version {self.block_max_version}."
             )
         return self
 
@@ -170,7 +170,7 @@ class Deserializer:
         if loaded_name != name:
             raise ValueError(
                 f"The next data item in the file being loaded was supposed to be {name}, "
-                + f"but the next block found was {loaded_name}."
+                f"but the next block found was {loaded_name}."
             )  # We should eventually add support for skipping over unused data items in old formats...
 
         value = self._load_data_value(decoder)

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -140,13 +140,13 @@ class GPUTreeExplainer(TreeExplainer):
             this returns a list of tensors, one for each output.
 
         """
-        assert self.model.model_output == "raw", (
-            'Only model_output = "raw" is supported for ' "SHAP interaction values right now!"
-        )
-        assert self.feature_perturbation != "interventional", (
-            'feature_perturbation="interventional" is not yet supported for '
-            + 'interaction values. Use feature_perturbation="tree_path_dependent" instead.'
-        )
+        if self.model.model_output != "raw":
+            raise ValueError('Only model_output = "raw" is supported for SHAP interaction values right now!')
+        if self.feature_perturbation == "interventional":
+            raise ValueError(
+                'feature_perturbation="interventional" is not yet supported for interaction values. '
+                'Use feature_perturbation="tree_path_dependent" instead.'
+            )
         transform = "identity"
 
         X, y, X_missing, flat_output, tree_limit, _ = self._validate_inputs(X, y, tree_limit, False)

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1421,7 +1421,7 @@ class TreeEnsemble:
             elif self.objective == "binary_crossentropy":
                 transform = "logistic_nlogloss"
             else:
-                emsg = 'model_output = "log_loss" is not yet supported when model.objective = ' f'"{self.objective}"!'
+                emsg = f'model_output = "log_loss" is not yet supported when model.objective = "{self.objective}"!'
                 raise NotImplementedError(emsg)
         else:
             emsg = (

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -79,7 +79,7 @@ class Image(Masker):
         if np.prod(x.shape) != np.prod(self.input_shape):
             raise DimensionError(
                 "The length of the image to be masked must match the shape given in the "
-                + "ImageMasker constructor: "
+                "ImageMasker constructor: "
                 + " * ".join([str(i) for i in x.shape])
                 + " != "
                 + " * ".join([str(i) for i in self.input_shape])

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -214,19 +214,15 @@ def image_to_text(shap_values):
     for i in range(model_output.shape[0]):
         output_text_html += (
             "<div style='display:inline; text-align:center;'>"
-            + f"<div id='{uuid}_output_flat_value_label_"
-            + str(i)
-            + "'"
-            + "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>"
-            + "</div>"
-            + f"<div id='{uuid}_output_flat_token_"
-            + str(i)
-            + "'"
-            + "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
-            + f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
-            + f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
-            + f'onclick="onMouseClickFlat_{uuid}(this.id)" '
-            + ">"
+            f"<div id='{uuid}_output_flat_value_label_{i}'"
+            "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>"
+            "</div>"
+            f"<div id='{uuid}_output_flat_token_{i}'"
+            "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
+            f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
+            f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
+            f'onclick="onMouseClickFlat_{uuid}(this.id)" '
+            ">"
             + model_output[i]
             .replace("<", "&lt;")
             .replace(">", "&gt;")

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -134,7 +134,7 @@ def scatter(
     if len(shap_values.shape) != 1:
         raise Exception(
             "The passed Explanation object has multiple columns, please pass a single feature column to "
-            + "shap.plots.dependence like: shap_values[:,column]"
+            "shap.plots.dependence like: shap_values[:,column]"
         )
 
     # this unpacks the explanation object for the code that was written earlier

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -1148,16 +1148,10 @@ def heatmap(shap_values):
 
     javascript_values = (
         "<script> "
-        + f"colors_{uuid} = "
-        + colors_json
-        + "\n"
-        + f" shap_values_{uuid} = "
-        + shap_values_json
-        + "\n"
-        + f" token_id_to_node_id_mapping_{uuid} = "
-        + token_id_to_node_id_mapping_json
-        + "\n"
-        + "</script> \n "
+        f"colors_{uuid} = {colors_json}\n"
+        f" shap_values_{uuid} = {shap_values_json}\n"
+        f" token_id_to_node_id_mapping_{uuid} = {token_id_to_node_id_mapping_json}\n"
+        "</script> \n "
     )
 
     def generate_tree(shap_values):
@@ -1218,11 +1212,11 @@ def heatmap(shap_values):
         else:
             input_text_html += (
                 f'<div id="{uuid}_input_node_{input_index}_content"'
-                + "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
-                + f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
-                + f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
-                + f'onclick="onMouseClickFlat_{uuid}(this.id)" '
-                + ">"
+                "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
+                f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
+                f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
+                f'onclick="onMouseClickFlat_{uuid}(this.id)" '
+                ">"
             )
             input_text_html += (
                 content[TREE_NODE_KEY_TOKENS]
@@ -1246,19 +1240,15 @@ def heatmap(shap_values):
     for i in range(len(model_output)):
         output_text_html += (
             "<div style='display:inline; text-align:center;'>"
-            + f"<div id='{uuid}_output_flat_value_label_"
-            + str(i)
-            + "'"
-            + "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>"
-            + "</div>"
-            + f"<div id='{uuid}_output_flat_token_"
-            + str(i)
-            + "'"
-            + "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
-            + f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
-            + f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
-            + f'onclick="onMouseClickFlat_{uuid}(this.id)" '
-            + ">"
+            f"<div id='{uuid}_output_flat_value_label_{i}'"
+            "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>"
+            "</div>"
+            f"<div id='{uuid}_output_flat_token_{i}'"
+            "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
+            f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
+            f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
+            f'onclick="onMouseClickFlat_{uuid}(this.id)" '
+            ">"
             + model_output[i]
             .replace("<", "&lt;")
             .replace(">", "&gt;")

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -384,8 +384,8 @@ def process_shap_values(tokens, values, grouping_threshold, separator, clusterin
         if clustering is None:
             raise ValueError(
                 "The length of the attribution values must match the number of "
-                + "tokens if shap_values.clustering is None! When passing hierarchical "
-                + "attributions the clustering is also required."
+                "tokens if shap_values.clustering is None! When passing hierarchical "
+                "attributions the clustering is also required."
             )
 
         # compute the groups, lower_values, and max_values
@@ -765,8 +765,8 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
         if partition_tree is None:
             raise ValueError(
                 "The length of the attribution values must match the number of "
-                + "tokens if partition_tree is None! When passing hierarchical "
-                + "attributions the partition_tree is also required."
+                "tokens if partition_tree is None! When passing hierarchical "
+                "attributions the partition_tree is also required."
             )
 
         # compute the groups, lower_values, and max_values

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -97,7 +97,7 @@ def violin(
     if plot_type is None:
         plot_type = "violin"
     if plot_type not in {"violin", "layered_violin"}:
-        emsg = "plot_type: Expected one of ('violin','layered_violin'), received " f"{plot_type} instead."
+        emsg = f"plot_type: Expected one of ('violin','layered_violin'), received {plot_type} instead."
         raise ValueError(emsg)
 
     assert len(shap_values.shape) != 1, "Violin summary plots need a matrix of shap_values, not a vector."

--- a/shap/utils/transformers.py
+++ b/shap/utils/transformers.py
@@ -118,8 +118,8 @@ def parse_prefix_suffix_for_tokenizer(tokenizer):
         else:
             raise Exception(
                 "The given tokenizer produces one token when applied to the empty string, but "
-                + "does not have a .special_tokens_map['eos_token'] or .special_tokens_map['bos_token'] "
-                + "property (and .decode) to specify if it is an eos (end) of bos (beginning) token!"
+                "does not have a .special_tokens_map['eos_token'] or .special_tokens_map['bos_token'] "
+                "property (and .decode) to specify if it is an eos (end) of bos (beginning) token!"
             )
     else:
         assert len(null_tokens) % 2 == 0, "An odd number of boundary tokens are added to the null string!"

--- a/tests/plots/test_bar.py
+++ b/tests/plots/test_bar.py
@@ -30,7 +30,7 @@ def test_input_shap_values_type(unsupported_inputs):
 def test_input_shap_values_type_2():
     """Check that a DimensionError is raised if the cohort Explanation objects have different shape."""
     rs = np.random.RandomState(42)
-    emsg = "When passing several Explanation objects, they must all have " "the same number of feature columns!"
+    emsg = "When passing several Explanation objects, they must all have the same number of feature columns!"
     with pytest.raises(DimensionError, match=emsg):
         shap.plots.bar(
             {

--- a/tests/plots/test_beeswarm.py
+++ b/tests/plots/test_beeswarm.py
@@ -32,7 +32,7 @@ def test_beeswarm_wrong_features_shape():
         )
         shap.plots.beeswarm(expln, show=False)
 
-    emsg = "The shape of the shap_values matrix does not match the shape of " "the provided data matrix."
+    emsg = "The shape of the shap_values matrix does not match the shape of the provided data matrix."
     with pytest.raises(DimensionError, match=emsg):
         expln = shap.Explanation(
             values=rs.randn(20, 5),

--- a/tests/plots/test_violin.py
+++ b/tests/plots/test_violin.py
@@ -35,7 +35,7 @@ def test_violin_wrong_features_shape():
             show=False,
         )
 
-    emsg = "The shape of the shap_values matrix does not match the shape of " "the provided data matrix."
+    emsg = "The shape of the shap_values matrix does not match the shape of the provided data matrix."
     with pytest.raises(DimensionError, match=emsg):
         expln = shap.Explanation(
             values=rs.randn(20, 5),


### PR DESCRIPTION
## Overview

Gets ruff rule ["ISC"](https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/) passing, which checks for implicit string concatentation.

## Discussion

This involved fixing a few remnant string literal formatting issues from `ruff format`. The linting rule also highlighted a few places in `_text.py` where f-strings could be used more widely for a tidier implementation.

Example of changes:

```python
old = "foo" " bar"
new = "foo bar"
```



