### PR TITLE
feat: change OpHistoryItem data structure to dataclass

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -21,6 +21,8 @@ op_chain_root = OpChain("shap.Explanation")
 
 @dataclass
 class OpHistoryItem:
+    """An operation that has been applied to an Explanation object."""
+
     name: str
     prev_shape: tuple[int, ...]
     args: tuple[Any, ...] = ()

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import copy
 import operator
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -16,6 +17,15 @@ from .utils._exceptions import DimensionError
 from .utils._general import OpChain
 
 op_chain_root = OpChain("shap.Explanation")
+
+
+@dataclass
+class OpHistoryItem:
+    name: str
+    prev_shape: tuple[int, ...]
+    args: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    collapsed_instances: bool = False
 
 
 class MetaExplanation(type):
@@ -100,7 +110,7 @@ class Explanation(metaclass=MetaExplanation):
         clustering=None,
         compute_time=None,
     ):
-        self.op_history = []
+        self.op_history: list[OpHistoryItem] = []
 
         self.compute_time = compute_time
 
@@ -172,10 +182,12 @@ class Explanation(metaclass=MetaExplanation):
         )
 
     @property
-    def shape(self) -> tuple[int | None, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Compute the shape over potentially complex data nesting."""
-        # TODO: check if the return type should actually be tuple[int, ...]
-        return _compute_shape(self._s.values)
+        shap_values_shape = _compute_shape(self._s.values)
+        # impl: `Explanation.values` always corresponds to the shap values, which is a numpy array, so the
+        # shape will always be of tuple[int, ...] type, not tuple[int|None, ...].
+        return cast(tuple[int, ...], shap_values_shape)
 
     @property
     def values(self):
@@ -417,7 +429,7 @@ class Explanation(metaclass=MetaExplanation):
         if new_self is None:
             new_self = copy.copy(self)
         new_self._s = new_self._s.__getitem__(item)
-        new_self.op_history.append({"name": "__getitem__", "args": (item,), "prev_shape": self.shape})
+        new_self.op_history.append(OpHistoryItem(name="__getitem__", args=(item,), prev_shape=self.shape))
 
         return new_self
 
@@ -447,7 +459,7 @@ class Explanation(metaclass=MetaExplanation):
     def _apply_binary_operator(self, other, binary_op, op_name):
         new_exp = self.__copy__()
         new_exp.op_history = copy.copy(self.op_history)
-        new_exp.op_history.append({"name": op_name, "args": (other,), "prev_shape": self.shape})
+        new_exp.op_history.append(OpHistoryItem(name=op_name, args=(other,), prev_shape=self.shape))
         if isinstance(other, Explanation):
             new_exp.values = binary_op(new_exp.values, other.values)
             if new_exp.data is not None:
@@ -489,10 +501,10 @@ class Explanation(metaclass=MetaExplanation):
     #     """
     #     new_self = copy.copy(self)
     #     new_self.values = np.abs(new_self.values)
-    #     new_self.op_history.append({
-    #         "name": "abs",
-    #         "prev_shape": self.shape
-    #     })
+    #     new_self.op_history.append(OpHistoryItem(
+    #         name="abs",
+    #         prev_shape=self.shape,
+    #     ))
     #     return new_self
 
     def _numpy_func(self, fname, **kwargs):
@@ -534,7 +546,12 @@ class Explanation(metaclass=MetaExplanation):
                 new_self.clustering = None
 
         new_self.op_history.append(
-            {"name": fname, "kwargs": kwargs, "prev_shape": self.shape, "collapsed_instances": axis == 0}
+            OpHistoryItem(
+                name=fname,
+                kwargs=kwargs,
+                prev_shape=self.shape,
+                collapsed_instances=axis == 0,
+            ),
         )
 
         return new_self
@@ -682,7 +699,12 @@ class Explanation(metaclass=MetaExplanation):
             new_self.data = np.percentile(new_self.data, q, axis)
         # new_self.data = None
         new_self.op_history.append(
-            {"name": "percentile", "args": (axis,), "prev_shape": self.shape, "collapsed_instances": axis == 0}
+            OpHistoryItem(
+                name="percentile",
+                args=(axis,),
+                prev_shape=self.shape,
+                collapsed_instances=axis == 0,
+            ),
         )
         return new_self
 

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -6,6 +6,7 @@ import pandas as pd
 import scipy
 
 from .. import Cohorts, Explanation
+from .._explanation import OpHistoryItem
 from ..utils import format_value, ordinal_str
 from ..utils._exceptions import DimensionError
 from . import colors
@@ -124,7 +125,7 @@ def bar(
                 "The clustering provided by the Explanation object does not seem to be a "
                 "partition tree, which is all shap.plots.bar supports."
             )
-    op_history = cohort_exps[0].op_history
+    op_history: list[OpHistoryItem] = cohort_exps[0].op_history
     values = np.array([cohort_exps[i].values for i in range(len(cohort_exps))])
 
     if len(values[0]) == 0:
@@ -132,7 +133,7 @@ def bar(
 
     # we show the data on auto only when there are no transforms (excluding getitem calls)
     if show_data == "auto":
-        transforms = [t for t in op_history if t.get("name") != "__getitem__"]
+        transforms = [op for op in op_history if op.name != "__getitem__"]
         show_data = len(transforms) == 0
 
     # TODO: Rather than just show the "1st token", "2nd token", etc. it would be better to show the "Instance 0's 1st but", etc
@@ -142,19 +143,19 @@ def bar(
     # build our auto xlabel based on the transform history of the Explanation object
     xlabel = "SHAP value"
     for op in op_history:
-        if op["name"] == "abs":
-            xlabel = "|" + xlabel + "|"
-        elif op["name"] == "__getitem__":
+        if op.name == "abs":
+            xlabel = f"|{xlabel}|"
+        elif op.name == "__getitem__":
             pass  # no need for slicing to effect our label, it will be used later to find the sizes of cohorts
         else:
-            xlabel = str(op["name"]) + "(" + xlabel + ")"
+            xlabel = f"{op.name}({xlabel})"
 
     # find how many instances are in each cohort (if they were created from an Explanation object)
     cohort_sizes = []
     for exp in cohort_exps:
         for op in exp.op_history:
-            if op.get("collapsed_instances", False):  # see if this if the first op to collapse the instances
-                cohort_sizes.append(op["prev_shape"][0])
+            if op.collapsed_instances:  # see if this if the first op to collapse the instances
+                cohort_sizes.append(op.prev_shape[0])
                 break
 
     # unwrap any pandas series

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -6,7 +7,6 @@ import pandas as pd
 import scipy
 
 from .. import Cohorts, Explanation
-from .._explanation import OpHistoryItem
 from ..utils import format_value, ordinal_str
 from ..utils._exceptions import DimensionError
 from . import colors
@@ -18,6 +18,9 @@ from ._utils import (
     merge_nodes,
     sort_inds,
 )
+
+if TYPE_CHECKING:
+    from .._explanation import OpHistoryItem
 
 
 # TODO: improve the bar chart to look better like the waterfall plot with numbers inside the bars when they fit

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -22,7 +22,7 @@ def convert_ordering(ordering, shap_values):
     if issubclass(type(ordering), OpChain):
         ordering = ordering.apply(Explanation(shap_values))
     if issubclass(type(ordering), Explanation):
-        if "argsort" in [op["name"] for op in ordering.op_history]:
+        if any("argsort" in op.name for op in ordering.op_history):
             ordering = ordering.values
         else:
             ordering = ordering.argsort.flip.values

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -22,7 +22,7 @@ def convert_ordering(ordering, shap_values):
     if issubclass(type(ordering), OpChain):
         ordering = ordering.apply(Explanation(shap_values))
     if issubclass(type(ordering), Explanation):
-        if any("argsort" in op.name for op in ordering.op_history):
+        if any(op.name == "argsort" for op in ordering.op_history):
             ordering = ordering.values
         else:
             ordering = ordering.argsort.flip.values


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

1. I'm proposing to use a dataclass structure for an OpHistory item instead of a dictionary. For several reasons: 1) it removes the need for "attribute"/"item" access via a string, a la `op.get('name')`, so we use the safer `op.name` instead. 2) it makes clear what attributes of an OpHistory item are mandatory, and what are optional. E.g. "name" should always be present based on the code, but "collapsed_instances" is not (defaults to False if not provided).
1. Side note: Chiming in on the TODO left from the ([review comment](https://github.com/shap/shap/pull/3732/files#r1662223509))  from PR #3732, I think specifically for `Explanation.shape`, it should return a `tuple[int,...]`, not a `tuple[int|None,...]`. Because the `Explanation.shape` calculates the shape of the underlying `Explanation.values` array, which should never contain a string, nor is it ever sparse. The reason why I'm addressing this TODO here is because `OpHistoryItem.shape` requires a type hint for `prev_shape` attribute.

### Discussion

I'm assuming the OpHistory is an internal implementation detail (because `Explanation.op_history` is not even a documented attribute), so this change shouldn't break anyone's code, in theory. I.e., this isn't breaking change territory.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
