### PR TITLE
refactor: Cohorts internals, use @property, add type hinting and expose it in docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,7 @@ Explanation
     :toctree: generated/
 
     shap.Explanation
+    shap.Cohorts
 
 
 .. _explainers_api:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -910,9 +910,10 @@ class Cohorts:
         if not isinstance(cval, dict):
             emsg = "self.cohorts must be a dictionary!"
             raise TypeError(emsg)
-        if not all(isinstance(exp, Explanation) for exp in cval.values()):
-            emsg = "All the arguments to a Cohorts set must be Explanation objects!"
-            raise TypeError(emsg)
+        for exp in cval.values():
+            if not isinstance(exp, Explanation):
+                emsg = f"Arguments to a Cohorts set must be Explanation objects, but found {type(exp)}"
+                raise TypeError(emsg)
 
         cast(dict[str, Explanation], cval)  # type narrowing for mypy
         self._cohorts: dict[str, Explanation] = cval

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import operator
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import numpy as np
 import pandas as pd
@@ -898,7 +898,7 @@ class Cohorts:
 
     def __init__(self, **kwargs: Explanation) -> None:
         self.cohorts = kwargs
-        self._callables = {}
+        self._callables: dict[str, Callable] = {}
 
     @property
     def cohorts(self) -> dict[str, Explanation]:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -915,7 +915,6 @@ class Cohorts:
                 emsg = f"Arguments to a Cohorts set must be Explanation objects, but found {type(exp)}"
                 raise TypeError(emsg)
 
-        cast(dict[str, Explanation], cval)  # type narrowing for mypy
         self._cohorts: dict[str, Explanation] = cval
 
     def __getitem__(self, item) -> Cohorts:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -917,16 +917,16 @@ class Cohorts:
         self._cohorts: dict[str, Explanation] = cval
 
     def __getitem__(self, item) -> Cohorts:
-        new_cohorts = Cohorts()
+        new_cohorts = {}
         for k in self._cohorts:
-            new_cohorts.cohorts[k] = self._cohorts[k].__getitem__(item)
-        return new_cohorts
+            new_cohorts[k] = self._cohorts[k].__getitem__(item)
+        return Cohorts(**new_cohorts)
 
-    def __getattr__(self, name) -> Cohorts:
-        new_cohorts = Cohorts()
+    def __getattr__(self, name: str) -> Cohorts:
+        new_cohorts = {}
         for k in self._cohorts:
-            new_cohorts.cohorts[k] = getattr(self._cohorts[k], name)
-        return new_cohorts
+            new_cohorts[k] = getattr(self._cohorts[k], name)
+        return Cohorts(**new_cohorts)
 
     def __repr__(self):
         return f"<shap._explanation.Cohorts object with {len(self._cohorts)} cohorts of sizes: {[v.shape for v in self._cohorts.values()]}>"

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -911,7 +911,7 @@ class Cohorts:
             raise TypeError(emsg)
         if not all(isinstance(exp, Explanation) for exp in cval.values()):
             emsg = "All the arguments to a Cohorts set must be Explanation objects!"
-            raise ValueError(emsg)
+            raise TypeError(emsg)
 
         cast(dict[str, Explanation], cval)  # type narrowing for mypy
         self._cohorts: dict[str, Explanation] = cval

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -883,12 +883,6 @@ class Cohorts:
             new_cohorts.cohorts[k] = getattr(self._cohorts[k], name)
         return new_cohorts
 
-    def __call__(self, *args, **kwargs) -> "Cohorts":
-        new_cohorts = Cohorts()
-        for k in self._cohorts:
-            new_cohorts.cohorts[k] = self._cohorts[k].__call__(*args, **kwargs)
-        return new_cohorts
-
     def __repr__(self):
         return f"<shap._explanation.Cohorts object with {len(self._cohorts)} cohorts of sizes: {[v.shape for v in self._cohorts.values()]}>"
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -935,7 +935,14 @@ class Cohorts:
         return new_cohorts
 
     def __call__(self, *args, **kwargs) -> Cohorts:
-        """Call the bound methods on the Explanation objects retrieved during attribute access."""
+        """Call the bound methods on the Explanation objects retrieved during attribute access.
+
+        For example,
+        ``Cohorts(...).mean(axis=0)`` would first run ``__getattr__("mean")`` and return a bound method
+        ``Explanation.mean`` for all the :class:`Explanation` objects inside the ``Cohorts``, returned as a
+        new ``Cohorts`` object. Then the ``(axis=0)`` call would be executed on that returned ``Cohorts``
+        object, which is why we need ``__call__`` defined.
+        """
         if not self._callables:
             emsg = "No methods to __call__!"
             raise ValueError(emsg)


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:
- Use `@property` for `Cohorts.cohorts` to enforce that the value passed in is always a dictionary of Explanation objects *before* the value is set. I believe this is the more pythonic way of enforcing this constraint, rather than doing it only in `__init__`. A side effect here of using the property descriptor is that users will no longer be able to `del` the cohorts attribute, but I guess that's not a "normal" thing to do..
- Added docstrings with examples to the Cohorts class. And made `Cohorts` a publicly documented feature (it's already in our public API being exposed in our `__init__.py`).
- <s>One benefit from doing this refactoring is that I spotted a bug in the definition of `Cohorts` (mypy, actually), in that the `Cohorts.__call__()` definition does not make sense. It calls `Explanation.__call__()` which does not exist. See: </s>

<img src="https://github.com/user-attachments/assets/8c6e161a-9ff0-4ed4-ba00-dae9139df4e4" width=300>

(minimized the image because it's not accurate, see follow up comment)

- EDIT: It turns out that `Cohorts.__call__` was actually included here to invoke methods on the individual Explanation objects, not for doing `Explanation.__call__` (which doesn't exist) directly. An example (also included in the newly added tests) would be the following:

```python
exp = shap.Explanation(
    values=rs.uniform(low=-1, high=1, size=e_size),
    data=rs.normal(loc=1, scale=3, size=e_size),
    feature_names=list("abcde"),
)
exp_neg = exp[exp[:, "a"].data < 0]
exp_pos = exp[exp[:, "a"].data >= 0]

ch = shap.Cohorts(col_a_neg=exp_neg, col_a_pos=exp_pos)

# ----------- here is the crux:
new_ch = ch.mean(axis=0)
# This does a `getattr(ch, "mean")` first on the Cohorts object, which results in a bunch of `Explanation.mean` bound methods;
# A Cohorts object is being returned by getattr, hence the subsequent `(axis=0)` is being invoked as a Cohorts.__call__
```

Thus, I've retained the `__call__` magic method on `Cohorts`, but storing the bound methods in a separate private variable, and these would be individually invoked during the `Cohorts.__call__`.

- Added tests to test all of the above mentioned intricacies.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
