### PR TITLE
MAINT: Add timeout to run_tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,7 +43,7 @@ jobs:
             extras: "test-core"
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,6 +43,7 @@ jobs:
             extras: "test-core"
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I noticed one recent test run timeout after 6 hours (having seemingly hung), so I propose adding a timeout to fail after a shorter time.

At present the slowest job (Windows) takes ~18 minutes, so I think 40 mins should provide plenty of leeway.