### PR TITLE
MAINT: Improved isolation and cleanup of matplotlib tests 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     pass
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -63,3 +64,12 @@ def global_random_seed():
     `np.random.RandomState` rather than use the global numpy random state.
     """
     np.random.seed(0)
+
+
+@pytest.fixture(autouse=True)
+def mpl_test_cleanup():
+    """Run tests in a mpl context manager and close figures after each test."""
+    plt.switch_backend("Agg")  # Non-interactive backend
+    with plt.rc_context():
+        yield
+    plt.close("all")

--- a/tests/explainers/__init__.py
+++ b/tests/explainers/__init__.py
@@ -1,5 +1,1 @@
 """This modules tests all the explainer types."""
-
-import matplotlib
-
-matplotlib.use("Agg")

--- a/tests/plots/conftest.py
+++ b/tests/plots/conftest.py
@@ -1,5 +1,7 @@
 """Shared pytest fixtures"""
 
+from contextlib import ExitStack
+
 import matplotlib.pyplot as plt
 import pytest
 
@@ -7,8 +9,18 @@ import shap
 
 
 @pytest.fixture(autouse=True)
-def close_matplotlib_plots_after_tests():
-    plt.close("all")
+def mpl_test_cleanup():
+    """Run tests in a context manager and close figures after each test."""
+    # Adapted from matplotlib test suite in cartopy
+    with ExitStack() as stack:
+        # At exit, close all open figures and switch backend back to original.
+        stack.callback(plt.switch_backend, plt.get_backend())
+        stack.callback(plt.close, "all")
+
+        # Run each test in a context manager so that state does not leak out
+        plt.switch_backend("Agg")
+        stack.enter_context(plt.rc_context())
+        yield
 
 
 @pytest.fixture()

--- a/tests/plots/conftest.py
+++ b/tests/plots/conftest.py
@@ -1,26 +1,8 @@
 """Shared pytest fixtures"""
 
-from contextlib import ExitStack
-
-import matplotlib.pyplot as plt
 import pytest
 
 import shap
-
-
-@pytest.fixture(autouse=True)
-def mpl_test_cleanup():
-    """Run tests in a context manager and close figures after each test."""
-    # Adapted from matplotlib test suite in cartopy
-    with ExitStack() as stack:
-        # At exit, close all open figures and switch backend back to original.
-        stack.callback(plt.switch_backend, plt.get_backend())
-        stack.callback(plt.close, "all")
-
-        # Run each test in a context manager so that state does not leak out
-        plt.switch_backend("Agg")
-        stack.enter_context(plt.rc_context())
-        yield
 
 
 @pytest.fixture()

--- a/tests/plots/test_beeswarm.py
+++ b/tests/plots/test_beeswarm.py
@@ -48,6 +48,6 @@ def test_beeswarm(explainer):
     """
     fig = plt.figure()
     shap_values = explainer(explainer.data)
-    shap.plots.beeswarm(shap_values)
+    shap.plots.beeswarm(shap_values, show=False)
     plt.tight_layout()
     return fig

--- a/tests/plots/test_decision.py
+++ b/tests/plots/test_decision.py
@@ -1,12 +1,9 @@
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import sklearn
 
 import shap
-
-matplotlib.use("Agg")
 
 
 @pytest.fixture
@@ -84,12 +81,7 @@ def test_decision_multioutput(values_features):
     fig = plt.figure()
     adult_rfc_shap_values_list = [adult_rfc_shap_values.values[:, :, i] for i in range(adult_rfc_shap_values.shape[2])]
     base_values_list = list(adult_rfc_shap_values.base_values[0, :])
-    shap.multioutput_decision_plot(
-        base_values_list,
-        adult_rfc_shap_values_list,
-        row_index=0,
-        features=X,
-    )
+    shap.multioutput_decision_plot(base_values_list, adult_rfc_shap_values_list, row_index=0, features=X, show=False)
     plt.tight_layout()
     return fig
 

--- a/tests/plots/test_dependence.py
+++ b/tests/plots/test_dependence.py
@@ -39,4 +39,5 @@ def test_dependence_use_line_collection_bug():
         feature_expected_value=True,
         ice=False,
         shap_values=shap_values[:1, :],
+        show=False,
     )

--- a/tests/plots/test_dependence_string_features.py
+++ b/tests/plots/test_dependence_string_features.py
@@ -1,12 +1,9 @@
 from typing import Any
 
-import matplotlib
 import numpy as np
 import pandas as pd
 
 import shap
-
-matplotlib.use("Agg")
 
 
 def test_dependence_one_string_feature():

--- a/tests/plots/test_force.py
+++ b/tests/plots/test_force.py
@@ -1,13 +1,11 @@
 from contextlib import nullcontext as does_not_raise
 
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from pytest import param
 
-matplotlib.use("Agg")
-import shap  # noqa: E402
+import shap
 
 
 @pytest.mark.parametrize(

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -1,9 +1,6 @@
-import matplotlib
 import numpy as np
 
 import shap
-
-matplotlib.use("Agg")
 
 
 def test_random_single_image():

--- a/tests/plots/test_summary.py
+++ b/tests/plots/test_summary.py
@@ -135,4 +135,4 @@ def test_summary_plot_with_multiclass_model():
 
     explainer = shap.TreeExplainer(model)  # Background dataset not passed
     shap_values = explainer.shap_values(X)  # Has shape (20, 3, 2)
-    shap.summary_plot(shap_values, X, feature_names=["foo", "bar", "baz"])
+    shap.summary_plot(shap_values, X, feature_names=["foo", "bar", "baz"], show=False)

--- a/tests/plots/test_violin.py
+++ b/tests/plots/test_violin.py
@@ -56,7 +56,7 @@ def test_violin(explainer):
     """Make sure the violin plot is unchanged."""
     fig = plt.figure()
     shap_values = explainer.shap_values(explainer.data)
-    shap.plots.violin(shap_values)
+    shap.plots.violin(shap_values, show=False)
     plt.tight_layout()
     return fig
 

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -29,7 +29,7 @@ def test_waterfall(explainer):
     """Test the new waterfall plot."""
     fig = plt.figure()
     shap_values = explainer(explainer.data)
-    shap.plots.waterfall(shap_values[0])
+    shap.plots.waterfall(shap_values[0], show=False)
     plt.tight_layout()
     return fig
 
@@ -39,7 +39,7 @@ def test_waterfall_legacy(explainer):
     """Test the old waterfall plot."""
     shap_values = explainer.shap_values(explainer.data)
     fig = plt.figure()
-    shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0])
+    shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0], show=False)
     plt.tight_layout()
     return fig
 


### PR DESCRIPTION
Improved isolation of matplotlib tests:
- Call `plt.close()` _after_ each test, rather than before
- Moves the matplotlib fixture to the top level, as there are some plotting tests outside of `tests/plots`
- Set the matplotlib backend in the fixture, rather than as an import-level side-effect in various places.
- Ensures `show=False` is passed, to fix test warnings about plotting in a non-interactive environment 

