### PR TITLE
MAINT: Add numba lower version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   'tqdm>=4.27.0',
   'packaging>20.9',
   'slicer==0.0.8',
-  'numba',
+  'numba>0.52',
   'cloudpickle'
 ]
 classifiers = [
@@ -57,7 +57,12 @@ docs = [
   "requests",
   "ipywidgets",  # For tqdm in notebooks
 ]
-test-core = ["pytest", "pytest-mpl", "pytest-cov", "mypy"]
+test-core = [
+  "pytest",
+  "pytest-mpl",
+  "pytest-cov",
+  "mypy",
+]
 test = [
   "pytest",
   "pytest-mpl",


### PR DESCRIPTION
Fixes build, closes #3817

Discussion of the root cause of the issue: https://github.com/numba/numba/issues/9708#issuecomment-2296824946