### PR TITLE
refactor: plot utils and colors

### DIFF
--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal, Union, overload
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -239,3 +239,40 @@ def sort_inds(partition_tree, leaf_values, pos=None, inds=None):
     sort_inds(partition_tree, leaf_values, right, inds)
 
     return inds
+
+
+# Various ways to specify a desired axis limit in plots
+AxisLimitSpec = Union[Explanation, str, float, None]
+
+
+def parse_axis_limit(ax_limit: AxisLimitSpec, ax_values: np.ndarray, *, is_shap_axis: bool) -> float | None:
+    """Handle axis limits in "percentile(float)" format or from Explanation objects.
+
+    Parameters
+    ----------
+    ax_limit : LimitSpec
+        Represents one of the lower or upper bounds of an xlim / ylim of a plot.
+        Can be in "percentile(float)" format, a float or an :class:`.Explanation` object that has been aggregated
+        into a single value, e.g. ``explanation[:, "feature_name"].percentile(20)``.
+
+    ax_values : np.ndarray
+        The values represented by the axis in question. Usually the SHAP values or the feature values. Only used if
+        ``ax_limit`` is a string of the "percentile(float)" form.
+
+    is_shap_axis : bool
+        Whether the ``ax_limit`` is describing the axis representing SHAP values, or not. Only relevant when
+        ``ax_limit`` is an :class:`.Explanation` object. It is assumed that when False, the axis is representing
+        the feature values instead of the SHAP values.
+
+    """
+    if isinstance(ax_limit, str):
+        try:
+            percentage = float(ax_limit.removeprefix("percentile(").removesuffix(")"))
+        except ValueError as e:
+            raise ValueError("Only strings of the format `percentile(x)` are supported.") from e
+        return np.nanpercentile(ax_values, percentage)
+    if isinstance(ax_limit, Explanation):
+        # Extract relevant attributes, depending on whether the axis is a SHAP-value axis or not
+        return float(ax_limit.values) if is_shap_axis else float(ax_limit.data)
+    # Else, should be float or None
+    return ax_limit

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -242,7 +242,7 @@ def sort_inds(partition_tree, leaf_values, pos=None, inds=None):
 
 
 # Various ways to specify a desired axis limit in plots
-AxisLimitSpec = Union[Explanation, str, float, None]
+AxisLimitSpec: TypeAlias = Union[Explanation, str, float, None]
 
 
 def parse_axis_limit(ax_limit: AxisLimitSpec, ax_values: np.ndarray, *, is_shap_axis: bool) -> float | None:

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Union, overload
+from typing import TYPE_CHECKING, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
+from typing_extensions import TypeAlias
 
 from .. import Explanation
 from ..utils import OpChain
@@ -13,13 +14,8 @@ if TYPE_CHECKING:
     from matplotlib.colors import Colormap
 
 
-@overload
-def convert_color(color: Literal["shap_red", "shap_blue"]) -> np.ndarray: ...
-@overload
-def convert_color(color: str) -> np.ndarray | str | Colormap: ...
-
-
 def convert_color(color: str) -> np.ndarray | Colormap | str:
+    """Converts a color specification alias into its actual representation"""
     if color == "shap_red":
         return colors.red_rgb
     if color == "shap_blue":

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -1,19 +1,32 @@
-import matplotlib.pyplot as pl
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, overload
+
+import matplotlib.pyplot as plt
 import numpy as np
 
 from .. import Explanation
 from ..utils import OpChain
 from . import colors
 
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 
-def convert_color(color):
+
+@overload
+def convert_color(color: Literal["shap_red", "shap_blue"]) -> np.ndarray: ...
+@overload
+def convert_color(color: str) -> np.ndarray | str | Colormap: ...
+
+
+def convert_color(color: str) -> np.ndarray | Colormap | str:
     if color == "shap_red":
         return colors.red_rgb
     if color == "shap_blue":
         return colors.blue_rgb
 
     try:
-        return pl.get_cmap(color)
+        return plt.get_cmap(color)
     except ValueError:
         return color
 

--- a/shap/plots/colors/__init__.py
+++ b/shap/plots/colors/__init__.py
@@ -15,15 +15,17 @@ from ._colors import (
 )
 
 __all__ = [
+    # Colors
     "blue_rgb",
     "gray_rgb",
     "light_blue_rgb",
     "light_red_rgb",
+    "red_rgb",
+    # Colormaps
     "red_blue",
     "red_blue_circle",
     "red_blue_no_bounds",
     "red_blue_transparent",
-    "red_rgb",
     "red_transparent_blue",
     "red_white_blue",
     "transparent_blue",

--- a/shap/plots/colors/_colors.py
+++ b/shap/plots/colors/_colors.py
@@ -6,7 +6,7 @@ from matplotlib.colors import LinearSegmentedColormap
 from ._colorconv import lab2rgb, lch2lab
 
 
-def lch2rgb(x):
+def lch2rgb(x: list[float]) -> np.ndarray:
     return lab2rgb(lch2lab([[x]]))[0][0]
 
 
@@ -44,9 +44,10 @@ for pos, l, c, h in zip(np.linspace(0, 1, nsteps), l_vals, c_vals, h_vals):  # n
     alphas.append((pos, 1.0, 1.0))
 
 red_blue = LinearSegmentedColormap("red_blue", {"red": reds, "green": greens, "blue": blues, "alpha": alphas})
-red_blue.set_bad(gray_rgb, 1.0)
-red_blue.set_over(gray_rgb, 1.0)
-red_blue.set_under(gray_rgb, 1.0)  # "under" is incorrectly used instead of "bad" in the scatter plot
+red_blue.set_bad(gray_rgb.tolist(), 1.0)
+red_blue.set_over(gray_rgb.tolist(), 1.0)
+# "under" is incorrectly used instead of "bad" in the scatter plot
+red_blue.set_under(gray_rgb.tolist(), 1.0)
 
 red_blue_no_bounds = LinearSegmentedColormap(
     "red_blue_no_bounds", {"red": reds, "green": greens, "blue": blues, "alpha": alphas}


### PR DESCRIPTION
## Overview

Just some tidying up before I start work proper on the overhaul of the `partial_dependence_plot` plotting function (as part of the visualization overhaul).

Changes:

* Add some type hints to the `colors` module
* Migrate the recently added `LimitSpec` type and `_parse_limit` helper functions (added in #3811) to the `shap/plots/_utils.py` module. (Discussion below)
* Renamed the `LimitSpec` -> `AxisLimitSpec`, and `_parse_limit` -> `parse_axis_limit` (only because it is now in the utils module instead of only in `_scatter.py`, and this naming makes it clearer what these are used for).
* Made the `is_shap_axis` parameter a kw-only. Discussion for why is in the previous [PR review](https://github.com/shap/shap/pull/3811#discussion_r1729783962).


## Discussion

I'm proposing to migrate the recently added `LimitSpec` type and `_parse_limit` helper functions (added in #3811) to the `shap/plots/_utils.py` module. Reason is because the same functionality is also used in `partial_dependence_plot`, so thought we could refactor this out into the general utils module. (ps: I'll work on the pdp overhaul next, just wanted to get this out of the way)

In light of this, I've renamed the 2 objects, & added some docstrings. To be kinder to our future selfs :)

@connortann let me know what you think since these 2 were introduced by you. Open for discussion, because FWIW: I didn't see similar parsing axis-limit functionality being required in other plotting functions (but I only glanced briefly), so I guess it would also be okay duplicating the functions in `_scatter.py` and `_partial_dependence.py` respectively.