### PR TITLE
fix: OpChain repr for kwargs-only operations

### DIFF
--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -319,12 +319,12 @@ class OpChain:
 
     def __repr__(self):
         out = self._root_name
-        for o in self._ops:
-            op, args, kwargs = o
+        for op in self._ops:
+            op_name, args, kwargs = op
             args = args or tuple()
             kwargs = kwargs or {}
 
-            out += f".{op}"
+            out += f".{op_name}"
             has_args = len(args) > 0
             has_kwargs = len(kwargs) > 0
             if has_args or has_kwargs:

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -321,15 +321,14 @@ class OpChain:
         out = self._root_name
         for o in self._ops:
             op, args, kwargs = o
-            out += "."
-            out += op
-            if (args is not None and len(args) > 0) or (kwargs is not None and len(kwargs) > 0):
-                out += "("
-                if args is not None and len(args) > 0:
-                    out += ", ".join([str(v) for v in args])
-                if kwargs is not None and len(kwargs) > 0:
-                    out += ", " + ", ".join([str(k) + "=" + str(kwargs[k]) for k in kwargs.keys()])
-                out += ")"
+            args = args or tuple()
+            kwargs = kwargs or {}
+
+            out += f".{op}"
+            has_args = len(args) > 0
+            has_kwargs = len(kwargs) > 0
+            if has_args or has_kwargs:
+                out += "(" + ", ".join([repr(v) for v in args] + [f"{k}={v!r}" for k, v in kwargs.items()]) + ")"
         return out
 
 

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -72,3 +72,17 @@ def test_sample_can_be_zipped():
 
     assert (new_arr1 == new_combined["arr1"]).all()
     assert (new_arr2 == new_combined["arr2"]).all()
+
+
+def test_opchain_repr():
+    """Ensures OpChain repr is working properly"""
+    opchain = (
+        shap.utils.OpChain("shap.DummyExplanation")
+        .foo.foo(0, "big_blue_bear")
+        .foo(0, v1=10)
+        .foo(k1="alpha", k2="beta")
+        .baz
+    )
+    expected_repr = "shap.DummyExplanation.foo.foo(0, 'big_blue_bear').foo(0, v1=10).foo(k1='alpha', k2='beta').baz"
+
+    assert repr(opchain) == expected_repr


### PR DESCRIPTION
## Overview

Previously, if an `OpChain` Op had only kwargs, then the repr would be wrong, as in `Explanation.mean(axis=0)` would get rendered as `shap.Explanation.mean(, axis=0)`

![image](https://github.com/user-attachments/assets/df0729ed-a2df-4d62-9abf-809c48384cc1)

This PR fixes the above bug, adds tests to prevent regression. And also some general refactor to be more pythonic. 


## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
