### PR TITLE
refactor: Optimize explanation ops

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -455,8 +455,8 @@ class Explanation(metaclass=MetaExplanation):
 
     def _apply_binary_operator(self, other, binary_op, op_name):
         new_exp = self.__copy__()
-        new_exp.op_history = copy.copy(self.op_history)
         new_exp.op_history.append(OpHistoryItem(name=op_name, args=(other,), prev_shape=self.shape))
+
         if isinstance(other, Explanation):
             new_exp.values = binary_op(new_exp.values, other.values)
             if new_exp.data is not None:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -13,6 +13,7 @@ import scipy.spatial
 import sklearn
 from slicer import Alias, Obj, Slicer
 
+from .utils._clustering import hclust_ordering
 from .utils._exceptions import DimensionError
 from .utils._general import OpChain
 
@@ -641,11 +642,7 @@ class Explanation(metaclass=MetaExplanation):
         if axis == 1:
             values = values.T
 
-        # compute a hierarchical clustering and return the optimal leaf ordering
-        D = scipy.spatial.distance.pdist(values, metric)
-        cluster_matrix = scipy.cluster.hierarchy.complete(D)
-        inds = scipy.cluster.hierarchy.leaves_list(scipy.cluster.hierarchy.optimal_leaf_ordering(cluster_matrix, D))
-        return inds
+        return hclust_ordering(X=values, metric=metric)
 
     # =================== Utilities ===================
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -597,7 +597,7 @@ class Explanation(metaclass=MetaExplanation):
         )
         return new_self
 
-    def sample(self, max_samples, replace=False, random_state=0) -> Explanation:
+    def sample(self, max_samples: int, replace: bool = False, random_state: int = 0) -> Explanation:
         """Randomly samples the instances (rows) of the Explanation object.
 
         Parameters
@@ -613,11 +613,10 @@ class Explanation(metaclass=MetaExplanation):
             Random seed to use for sampling, defaults to 0.
 
         """
-        prev_seed = np.random.seed(random_state)
+        rng = np.random.RandomState(random_state)
         length = self.shape[0]
         assert length is not None
-        inds = np.random.choice(length, min(max_samples, length), replace=replace)
-        np.random.seed(prev_seed)
+        inds = rng.choice(length, size=min(max_samples, length), replace=replace)
         return self[list(inds)]
 
     def hclust(self, metric: str = "sqeuclidean", axis: int = 0):

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -91,8 +91,8 @@ class MetaExplanation(type):
 class Explanation(metaclass=MetaExplanation):
     """A sliceable set of parallel arrays representing a SHAP explanation.
 
-    Note
-    ----
+    Notes
+    -----
     The *instance* methods such as `.max()` return new Explanation objects with the
     operation applied.
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -498,13 +498,8 @@ class Explanation(metaclass=MetaExplanation):
         axis = kwargs.get("axis", None)
 
         # collapse the slicer to right shape
-        if axis == 0:
-            new_self = new_self[0]
-        elif axis == 1:
-            new_self = new_self[1]
-        elif axis == 2:
-            new_self = new_self[2]
         if axis in [0, 1, 2]:
+            new_self = new_self[axis]
             new_self.op_history = new_self.op_history[:-1]  # pop off the slicing operation we just used
 
         if self.feature_names is not None and not is_1d(self.feature_names) and axis == 0:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -303,11 +303,11 @@ class Explanation(metaclass=MetaExplanation):
 
     def __repr__(self):
         """Display some basic printable info, but not everything."""
-        out = ".values =\n" + self.values.__repr__()
+        out = f".values =\n{self.values!r}"
         if self.base_values is not None:
-            out += "\n\n.base_values =\n" + self.base_values.__repr__()
+            out += f"\n\n.base_values =\n{self.base_values!r}"
         if self.data is not None:
-            out += "\n\n.data =\n" + self.data.__repr__()
+            out += f"\n\n.data =\n{self.data!r}"
         return out
 
     def __getitem__(self, item) -> Explanation:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -656,9 +656,8 @@ class Explanation(metaclass=MetaExplanation):
 
         """
         assert self.shape[0] == other.shape[0], "Can't hstack explanations with different numbers of rows!"
-        assert np.allclose(
-            self.base_values, other.base_values, atol=1e-6
-        ), "Can't hstack explanations with different base values!"
+        if not np.allclose(self.base_values, other.base_values, atol=1e-6):
+            raise ValueError("Can't hstack explanations with different base values!")
 
         new_exp = Explanation(
             values=np.hstack([self.values, other.values]),

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -656,8 +656,8 @@ class Explanation(metaclass=MetaExplanation):
 
         """
         assert self.shape[0] == other.shape[0], "Can't hstack explanations with different numbers of rows!"
-        assert (
-            np.max(np.abs(self.base_values - other.base_values)) < 1e-6
+        assert np.allclose(
+            self.base_values, other.base_values, atol=1e-6
         ), "Can't hstack explanations with different base values!"
 
         new_exp = Explanation(

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -285,7 +285,7 @@ class OpChain:
         self._root_name = root_name
 
     def apply(self, obj):
-        """Applies all our ops to the given object."""
+        """Applies all our ops to the given object, usually an :class:`.Explanation` instance."""
         for o in self._ops:
             op, args, kwargs = o
             if args is not None:

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -1,11 +1,43 @@
 """This file contains tests for the `shap._explanation` module."""
 
+from textwrap import dedent
+
 import numpy as np
 import pytest
 from pytest import param
 
 import shap
 from shap._explanation import OpHistoryItem
+
+
+def test_explanation_repr():
+    exp = shap.Explanation(values=np.arange(5))
+    assert (
+        exp.__repr__()
+        == dedent(
+            """
+            .values =
+            array([0, 1, 2, 3, 4])
+            """
+        ).strip()
+    )
+
+    exp = shap.Explanation(values=np.arange(5), base_values=0.5, data=np.ones(5))
+    assert (
+        exp.__repr__()
+        == dedent(
+            """
+            .values =
+            array([0, 1, 2, 3, 4])
+
+            .base_values =
+            0.5
+
+            .data =
+            array([1., 1., 1., 1., 1.])
+            """
+        ).strip()
+    )
 
 
 def test_explanation_hstack(random_seed):

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -50,7 +50,7 @@ def test_explanation_hstack_errors(random_seed):
         _ = base_exp.hstack(exp2)
 
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match="Can't hstack explanations with different base values",
     ):
         exp2 = shap.Explanation(


### PR DESCRIPTION
## Overview

A follow-up from the previous cleanup PR #3837 . Here we focus on a few more optimizations related to the Explanation class:

Description of the changes proposed in this pull request:
- Use `shap.utils.hclust_ordering` utility function in `Explanation.hclust` op, instead of duplicating the implementation logic.
- Remove extraneous copying of the `op_history` object during `Explanation._apply_binary_operator` because it's already done in `__copy__`
- Use numpy RandomState instead of setting seeds in the `sample` method
- A few type hints and docstring changes.


## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
