### PR TITLE
docs: Use uv in readthedocs, RtD AddOn migration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,11 +5,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  commands:
+    # cf. https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv venv
+    - uv pip install .[docs]
+    - >-
+      .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees
+      -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,8 @@ build:
     - uv venv
     - uv pip install .[docs]
     - >-
-      .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees
-      -D language=en docs $READTHEDOCS_OUTPUT/html
+      .venv/bin/python -m sphinx -b linkcheck -D linkcheck_timeout=1
+      docs/ $READTHEDOCS_OUTPUT/linkcheck
+    - >-
+      .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
+      docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,10 +11,7 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - uv pip install .[docs]
-    - >-
-      .venv/bin/python -m sphinx -b linkcheck -D linkcheck_timeout=1
-      docs/ $READTHEDOCS_OUTPUT/linkcheck
+    - uv pip install --no-cache .[docs]
     - >-
       .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
       docs $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

Use `uv` in a custom RtD build (at least, until it's available as a [standard option](https://docs.readthedocs.io/en/stable/config-file/v2.html#packages) in RtD). This is noted in the RtD documentation as a standard recipe: [LINK](https://docs.readthedocs.io/en/stable/config-file/v2.html#packages).

**Impact**: build times are now reduced by 50s, or 26% faster than before.

Before:  
![image](https://github.com/user-attachments/assets/32a4b4f4-a08d-437e-be1a-4c87020a1ae9)

After:  
![image](https://github.com/user-attachments/assets/ded1dd85-c7c1-4330-a5c6-7af849b19f63)

### Discussion

**Side effect**: ReadtheDocs addon will be enabled by default as a result of using build commands (though, it's going to be the default for ALL sphinx projects from 7th October 2024 anyway, even without build command being used). Read more about the migration plan [here](https://about.readthedocs.com/blog/2024/07/addons-by-default).

There is a note there about having to update `conf.py` in the above migration plan (Section [LINK](https://about.readthedocs.com/blog/2024/07/addons-by-default/#how-does-it-affect-my-projects)), I'm not sure whether it applies to us or not, but without it, the doc build still seems to run fine and produce the correct output (?)  
So I've left out that change for now.
