### PR TITLE
MAINT: Remove deprecated unused code `_build_delta_masked_inputs` and `Explainer._compute_main_effects`

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -1,6 +1,5 @@
 import copy
 import time
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -500,34 +499,6 @@ class Explainer(Serializable):
         This is an abstract static method meant to be implemented by each subclass.
         """
         return False
-
-    @staticmethod
-    def _compute_main_effects(fm, expected_value, inds):
-        """A utility method to compute the main effects from a MaskedModel."""
-        warnings.warn(
-            "This function is not used within the shap library and will therefore be removed in an upcoming release. "
-            "If you rely on this function, please open an issue: https://github.com/shap/shap/issues.",
-            DeprecationWarning,
-        )
-
-        # mask each input on in isolation
-        masks = np.zeros(2 * len(inds) - 1, dtype=int)
-        last_ind = -1
-        for i in range(len(inds)):
-            if i > 0:
-                masks[2 * i - 1] = -last_ind - 1  # turn off the last input
-            masks[2 * i] = inds[i]  # turn on this input
-            last_ind = inds[i]
-
-        # compute the main effects for the given indexes
-        main_effects = fm(masks) - expected_value
-
-        # expand the vector to the full input size
-        expanded_main_effects = np.zeros(len(fm))
-        for i, ind in enumerate(inds):
-            expanded_main_effects[ind] = main_effects[i]
-
-        return expanded_main_effects
 
     def save(self, out_file, model_saver=".save", masker_saver=".save"):
         """Write the explainer to the given file stream."""

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -757,7 +757,7 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
     warnings.warn(
         "This function is not used within the shap library and will therefore be removed in an upcoming release. "
         "If you rely on this function, please open an issue: https://github.com/shap/shap/issues.",
-        DeprecationWarning,
+        FutureWarning,
     )
     M = len(tokens)
     if len(shap_values) != M:

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -1,5 +1,4 @@
 import copy
-import warnings
 from typing import Any
 
 import numpy as np
@@ -304,84 +303,6 @@ def _convert_delta_mask_to_full(masks, full_masks):
         if masks[masks_pos] != MaskedModel.delta_mask_noop_value:
             full_masks[i, masks[masks_pos]] = ~full_masks[i, masks[masks_pos]]
         masks_pos += 1
-
-
-# @njit # TODO: figure out how to jit this function, or most of it
-def _build_delta_masked_inputs(
-    masks,
-    batch_positions,
-    num_mask_samples,
-    num_varying_rows,
-    delta_indexes,
-    varying_rows,
-    args,
-    masker,
-    variants,
-    variants_column_sums,
-):
-    warnings.warn(
-        "This function is not used within the shap library and will therefore be removed in an upcoming release. "
-        "If you rely on this function, please open an issue: https://github.com/shap/shap/issues.",
-        DeprecationWarning,
-    )
-    all_masked_inputs: list[list[Any]] = [[] for _ in args]
-    dpos = 0
-    i = -1
-    masks_pos = 0
-    while masks_pos < len(masks):
-        i += 1
-
-        dpos = 0
-        delta_indexes[0] = masks[masks_pos]
-
-        # update the masked inputs
-        while delta_indexes[dpos] < 0:  # negative values mean keep going
-            delta_indexes[dpos] = -delta_indexes[dpos] - 1  # -value + 1 is the original index that needs flipped
-            masker(delta_indexes[dpos], *args)
-            dpos += 1
-            delta_indexes[dpos] = masks[masks_pos + dpos]
-        masked_inputs = masker(delta_indexes[dpos], *args).copy()
-
-        masks_pos += dpos + 1
-
-        num_mask_samples[i] = len(masked_inputs)
-        # print(i, dpos, delta_indexes[dpos])
-        # see which rows have been updated, so we can only evaluate the model on the rows we need to
-        if i == 0:
-            varying_rows[i, :] = True
-            # varying_rows.append(np.arange(num_mask_samples[i]))
-            num_varying_rows[i] = num_mask_samples[i]
-
-        else:
-            # only one column was changed
-            if dpos == 0:
-                varying_rows[i, :] = variants[:, delta_indexes[dpos]]
-                # varying_rows.append(_variants_row_inds[delta_indexes[dpos]])
-                num_varying_rows[i] = variants_column_sums[delta_indexes[dpos]]
-
-            # more than one column was changed
-            else:
-                varying_rows[i, :] = np.any(variants[:, delta_indexes[: dpos + 1]], axis=1)
-                # varying_rows.append(np.any(variants[:,delta_indexes[:dpos+1]], axis=1))
-                num_varying_rows[i] = varying_rows[i, :].sum()
-
-        batch_positions[i + 1] = batch_positions[i] + num_varying_rows[i]
-
-        # subset the masked input to only the rows that vary
-        if num_varying_rows[i] != num_mask_samples[i]:
-            if len(args) == 1:
-                masked_inputs = masked_inputs[varying_rows[i, :]]
-            else:
-                masked_inputs = [v[varying_rows[i, :]] for v in zip(*masked_inputs)]
-
-        # wrap the masked inputs if they are not already in a tuple
-        if len(args) == 1:
-            masked_inputs = (masked_inputs,)
-
-        for j in range(len(masked_inputs)):
-            all_masked_inputs[j].append(masked_inputs[j])
-
-    return all_masked_inputs, i + 1  # i + 1 is the number of output rows after averaging
 
 
 def _upcast_array(arr: np.ndarray) -> np.ndarray:

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1150,7 +1150,8 @@ class TestExplainerXGBoost:
         X, y = shap.datasets.adult(n_points=100)
 
         # Randomly add missing data to the input where missing data is encoded as 1e-8
-        X_nan = X.copy()
+        # Cast all columns to float to allow imputing a float value
+        X_nan = X.copy().astype(float)
         X_nan.loc[
             X_nan.sample(frac=0.3, random_state=42).index,
             X_nan.columns.to_series().sample(frac=0.5, random_state=42),


### PR DESCRIPTION
## Overview

Supports #3507 

Removes unused functions which have previously been deprecated:

- `shap/utils/_masked_models.py:_build_delta_masked_inputs()`
- `shap/explainers/_explainer.py:Explainer._compute_main_effects()`