### PR TITLE
Add tests for layernorm and add op_handler functions

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -382,6 +382,7 @@ op_handler["Dropout3d"] = passthrough
 op_handler["Dropout2d"] = passthrough
 op_handler["Dropout"] = passthrough
 op_handler["AlphaDropout"] = passthrough
+op_handler["Identity"] = passthrough
 
 op_handler["Conv1d"] = linear_1d
 op_handler["Conv2d"] = linear_1d
@@ -400,6 +401,7 @@ op_handler["BatchNorm1d"] = linear_1d
 op_handler["BatchNorm2d"] = linear_1d
 op_handler["BatchNorm3d"] = linear_1d
 
+op_handler["LayerNorm"] = nonlinear_1d
 op_handler["LeakyReLU"] = nonlinear_1d
 op_handler["ReLU"] = nonlinear_1d
 op_handler["ELU"] = nonlinear_1d


### PR DESCRIPTION
## Overview

Partially closes #3438  by adding support for LayerNorm and testing it

Description of the changes proposed in this pull request:

Adds LayerNorm to the op_handler dictionary with nonlinear_1d as well as Identity as passthrough. I've kept the structure of the tests as similar as possible to previous ones for consistency.


## Checklist

- [ x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ x] Unit tests added (if fixing a bug or adding a new feature)
