### PR TITLE
uninstall catboost for pipelines if python 3.12 is used

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -58,6 +58,12 @@ jobs:
         run: |
           python -m pip install --upgrade uv
           uv pip install --system '.[${{ matrix.extras }},plots]'
+
+      # See GH 3922: catboost is not compatible with Python 3.2
+      - name: Uninstall catboost if Python 3.12
+        if: matrix.python-version == '3.12'
+        run: pip uninstall -y catboost
+
       - name: Test with pytest
         # Ensure we avoid adding current working directory to sys.path:
         # - Use "pytest" over "python -m pytest"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -62,7 +62,7 @@ jobs:
       # See GH 3922: catboost is not compatible with Python 3.2
       - name: Uninstall catboost if Python 3.12
         if: matrix.python-version == '3.12'
-        run: pip uninstall -y catboost
+        run: pip uninstall -y catboost ngboost
 
       - name: Test with pytest
         # Ensure we avoid adding current working directory to sys.path:


### PR DESCRIPTION
## Overview

Closes #3910 <!--Add issue number here, or delete as appropriate-->

Supports #3922
Description of the changes proposed in this pull request:
catboost and ngboost still have issues with python 3.12, so uninstall them temporarily in the corresponding pipeline


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
