### PR TITLE
MAINT: simpler numpy pin for py3.12

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -58,12 +58,6 @@ jobs:
         run: |
           python -m pip install --upgrade uv
           uv pip install --system '.[${{ matrix.extras }},plots]'
-
-      # See GH 3922: catboost is not compatible with Python 3.2
-      - name: Uninstall catboost if Python 3.12
-        if: matrix.python-version == '3.12'
-        run: pip uninstall -y catboost ngboost
-
       - name: Test with pytest
         # Ensure we avoid adding current working directory to sys.path:
         # - Use "pytest" over "python -m pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ test = [
   "sentencepiece",
   "opencv-python",
   # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
-  # See GH #3707 and #3768
-  "numpy<2.0; python_version < '3.12'",
+  # See GH #3707, #3768, 3922
+  "numpy<2.0",
 ]
 
 test_notebooks = [


### PR DESCRIPTION
Follow-on refactor for #3923, which fixed #3910.

Temporary solution to support #3922