### PR TITLE
ENH: support rng for summary_plot

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -531,7 +531,7 @@ def summary_legacy(
     cmap=colors.red_blue,
     show_values_in_legend=False,
     use_log_scale=False,
-    rng=None,
+    seed=None,
 ):
     """Create a SHAP beeswarm plot, colored by feature values when they are provided.
 
@@ -766,10 +766,10 @@ def summary_legacy(
             shaps = shap_values[:, i]
             values = None if features is None else features[:, i]
             inds = np.arange(len(shaps))
-            if rng is None:
+            if seed is None:
                 np.random.shuffle(inds)
             else:
-                rng.shuffle(inds)
+                seed.shuffle(inds)
             if values is not None:
                 values = values[inds]
             shaps = shaps[inds]
@@ -786,10 +786,10 @@ def summary_legacy(
             # curr_bin = []
             nbins = 100
             quant = np.round(nbins * (shaps - np.min(shaps)) / (np.max(shaps) - np.min(shaps) + 1e-8))
-            if rng is None:
+            if seed is None:
                 tmp_x = np.random.randn(N)
             else:
-                tmp_x = rng.standard_normal(N)
+                tmp_x = seed.standard_normal(N)
             inds = np.argsort(quant + tmp_x * 1e-6)
             layer = 0
             last_bin = -1
@@ -874,10 +874,10 @@ def summary_legacy(
                 rng = shap_max - shap_min
                 xs = np.linspace(np.min(shaps) - rng * 0.2, np.max(shaps) + rng * 0.2, 100)
                 if np.std(shaps) < (global_high - global_low) / 100:
-                    if rng is None:
+                    if seed is None:
                         tmp_y = np.random.randn(len(shaps))
                     else:
-                        tmp_y = rng.standard_normal(len(shaps))
+                        tmp_y = seed.standard_normal(len(shaps))
                     ds = gaussian_kde(shaps + tmp_y * (global_high - global_low) / 100)(xs)
                 else:
                     ds = gaussian_kde(shaps)(xs)
@@ -1017,10 +1017,10 @@ def summary_legacy(
                         ys[i, :] = ys[i - 1, :]
                     continue
                 # save kde of them: note that we add a tiny bit of gaussian noise to avoid singular matrix errors
-                if rng is None:
+                if seed is None:
                     tmp_z = np.random.normal(loc=0, scale=0.001, size=shaps.shape[0])
                 else:
-                    tmp_z = rng.normal(loc=0, scale=0.001, size=shaps.shape[0])
+                    tmp_z = seed.normal(loc=0, scale=0.001, size=shaps.shape[0])
                 ys[i, :] = gaussian_kde(shaps + tmp_z)(x_points)
                 # scale it up so that the 'size' of each y represents the size of the bin. For continuous data this will
                 # do nothing, but when we've gone with the unqique option, this will matter - e.g. if 99% are male and 1%

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -531,6 +531,7 @@ def summary_legacy(
     cmap=colors.red_blue,
     show_values_in_legend=False,
     use_log_scale=False,
+    rng=None,
 ):
     """Create a SHAP beeswarm plot, colored by feature values when they are provided.
 
@@ -765,7 +766,10 @@ def summary_legacy(
             shaps = shap_values[:, i]
             values = None if features is None else features[:, i]
             inds = np.arange(len(shaps))
-            np.random.shuffle(inds)
+            if rng is None:
+                np.random.shuffle(inds)
+            else:
+                rng.shuffle(inds)
             if values is not None:
                 values = values[inds]
             shaps = shaps[inds]
@@ -782,7 +786,11 @@ def summary_legacy(
             # curr_bin = []
             nbins = 100
             quant = np.round(nbins * (shaps - np.min(shaps)) / (np.max(shaps) - np.min(shaps) + 1e-8))
-            inds = np.argsort(quant + np.random.randn(N) * 1e-6)
+            if rng is None:
+                tmp_x = np.random.randn(N)
+            else:
+                tmp_x = rng.standard_normal(N)
+            inds = np.argsort(quant + tmp_x * 1e-6)
             layer = 0
             last_bin = -1
             ys = np.zeros(N)
@@ -866,7 +874,11 @@ def summary_legacy(
                 rng = shap_max - shap_min
                 xs = np.linspace(np.min(shaps) - rng * 0.2, np.max(shaps) + rng * 0.2, 100)
                 if np.std(shaps) < (global_high - global_low) / 100:
-                    ds = gaussian_kde(shaps + np.random.randn(len(shaps)) * (global_high - global_low) / 100)(xs)
+                    if rng is None:
+                        tmp_y = np.random.randn(len(shaps))
+                    else:
+                        tmp_y = rng.standard_normal(len(shaps))
+                    ds = gaussian_kde(shaps + tmp_y * (global_high - global_low) / 100)(xs)
                 else:
                     ds = gaussian_kde(shaps)(xs)
                 ds /= np.max(ds) * 3
@@ -1005,7 +1017,11 @@ def summary_legacy(
                         ys[i, :] = ys[i - 1, :]
                     continue
                 # save kde of them: note that we add a tiny bit of gaussian noise to avoid singular matrix errors
-                ys[i, :] = gaussian_kde(shaps + np.random.normal(loc=0, scale=0.001, size=shaps.shape[0]))(x_points)
+                if rng is None:
+                    tmp_z = np.random.normal(loc=0, scale=0.001, size=shaps.shape[0])
+                else:
+                    tmp_z = rng.normal(loc=0, scale=0.001, size=shaps.shape[0])
+                ys[i, :] = gaussian_kde(shaps + tmp_z)(x_points)
                 # scale it up so that the 'size' of each y represents the size of the bin. For continuous data this will
                 # do nothing, but when we've gone with the unqique option, this will matter - e.g. if 99% are male and 1%
                 # female, we want the 1% to appear a lot smaller.

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -565,13 +565,18 @@ def summary_legacy(
     show_values_in_legend: bool
         Flag to print the mean of the SHAP values in the multi-output bar plot. Set to False
         by default.
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None,
+        the legacy behavior of using global NumPy random state will be
+        used. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
     """
     # handle randomization machinery in conformance with SPEC 7
     if rng is not None:
         rng = np.random.default_rng(rng)
     else:
-        global_seed_set = np.random.mtrand._rand._bit_generator._seed_seq is None
+        global_seed_set = np.random.mtrand._rand._bit_generator._seed_seq is None  # type: ignore
         if global_seed_set:
             msg = (
                 "The NumPy global RNG was seeded by calling `np.random.seed`. "

--- a/tests/plots/test_summary_plot.py
+++ b/tests/plots/test_summary_plot.py
@@ -44,7 +44,7 @@ def test_summary_plot_seed_insulated(explainer):
     # see i.e., https://scientific-python.org/specs/spec-0007/
     shap_values = explainer(explainer.data)
     rng = np.random.default_rng(167089660)
-    state_before = np.random.get_state()[1] # type: ignore[index]
+    state_before = np.random.get_state()[1]  # type: ignore[index]
     shap.summary_plot(shap_values, show=False, seed=rng)
-    state_after = np.random.get_state()[1] # type: ignore[index]
+    state_after = np.random.get_state()[1]  # type: ignore[index]
     assert_array_equal(state_after, state_before)

--- a/tests/plots/test_summary_plot.py
+++ b/tests/plots/test_summary_plot.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
 import shap
@@ -34,3 +35,16 @@ def test_summary_plot(explainer):
     shap.plots.beeswarm(shap_values, show=False)
     plt.tight_layout()
     return fig
+
+
+def test_summary_plot_seed_insulated(explainer):
+    # ensure that it is possible for downstream
+    # projects to avoid mutating global NumPy
+    # random state
+    # see i.e., https://scientific-python.org/specs/spec-0007/
+    shap_values = explainer(explainer.data)
+    rng = np.random.default_rng(167089660)
+    state_before = np.random.get_state()[1]
+    shap.summary_plot(shap_values, show=False, rng=rng)
+    state_after = np.random.get_state()[1]
+    assert_array_equal(state_after, state_before)

--- a/tests/plots/test_summary_plot.py
+++ b/tests/plots/test_summary_plot.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy.testing import assert_array_equal
 import pytest
+from numpy.testing import assert_array_equal
 
 import shap
 

--- a/tests/plots/test_summary_plot.py
+++ b/tests/plots/test_summary_plot.py
@@ -44,7 +44,7 @@ def test_summary_plot_seed_insulated(explainer):
     # see i.e., https://scientific-python.org/specs/spec-0007/
     shap_values = explainer(explainer.data)
     rng = np.random.default_rng(167089660)
-    state_before = np.random.get_state()[1]
-    shap.summary_plot(shap_values, show=False, rng=rng)
-    state_after = np.random.get_state()[1]
+    state_before = np.random.get_state()[1] # type: ignore[index]
+    shap.summary_plot(shap_values, show=False, seed=rng)
+    state_after = np.random.get_state()[1] # type: ignore[index]
     assert_array_equal(state_after, state_before)

--- a/tests/plots/test_summary_plot.py
+++ b/tests/plots/test_summary_plot.py
@@ -37,11 +37,14 @@ def test_summary_plot(explainer):
     return fig
 
 
-@pytest.mark.parametrize("rng", [
-    np.random.default_rng(167089660),
-    17,
-    np.random.SeedSequence(entropy=60767),
-])
+@pytest.mark.parametrize(
+    "rng",
+    [
+        np.random.default_rng(167089660),
+        17,
+        np.random.SeedSequence(entropy=60767),
+    ],
+)
 def test_summary_plot_seed_insulated(explainer, rng):
     # ensure that it is possible for downstream
     # projects to avoid mutating global NumPy

--- a/tests/plots/test_summary_plot.py
+++ b/tests/plots/test_summary_plot.py
@@ -37,14 +37,26 @@ def test_summary_plot(explainer):
     return fig
 
 
-def test_summary_plot_seed_insulated(explainer):
+@pytest.mark.parametrize("rng", [
+    np.random.default_rng(167089660),
+    17,
+    np.random.SeedSequence(entropy=60767),
+])
+def test_summary_plot_seed_insulated(explainer, rng):
     # ensure that it is possible for downstream
     # projects to avoid mutating global NumPy
     # random state
     # see i.e., https://scientific-python.org/specs/spec-0007/
     shap_values = explainer(explainer.data)
-    rng = np.random.default_rng(167089660)
     state_before = np.random.get_state()[1]  # type: ignore[index]
-    shap.summary_plot(shap_values, show=False, seed=rng)
+    shap.summary_plot(shap_values, show=False, rng=rng)
     state_after = np.random.get_state()[1]  # type: ignore[index]
     assert_array_equal(state_after, state_before)
+
+
+def test_summary_plot_warning(explainer):
+    # enforce FutureWarning for usage of global random
+    # state as we prepare for SPEC 7 adoption
+    shap_values = explainer(explainer.data)
+    with pytest.warns(FutureWarning, match="NumPy global RNG"):
+        shap.summary_plot(shap_values, show=False)


### PR DESCRIPTION
* Some folks on my team are having issues writing tests downstream of `shap` because `summary_plot` mutates the NumPy legacy random machinery global state, which is hard to work around in a large testsuite. It would be great if a heavily-used project in the ML space like `shap` could start to adopt support for local random `Generator` objects per the community document at https://scientific-python.org/specs/spec-0007/. This PR is a lot cruder than that approach, but appears to allow preservation of the current global state behavior while allowing the option of using the modern non-global approach for downstream developers that need it.

* This patch adds a regression test that fails when not using the optional `rng` argument, and passes when it is used to scope to a local random state. If there is a preference for using the full SPEC 7 approach (and that may very well be the best idea), I may ask one of my team members to help out a bit, since they will benefit from it.

* The full testsuite passed locally via `pytest --import-mode=append`

Maybe I'll cc @mdhaber @tupui -- not expecting a review, but because they also work in stats/ML space and were involved in the SPEC.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
