### PR TITLE
MAINT: Skip sentiment analysis test on MacOS runners

### DIFF
--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -1,5 +1,7 @@
 """Tests for the Deep explainer."""
 
+import platform
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -241,6 +243,7 @@ def test_tf_keras_imdb_lstm(random_seed):
     np.testing.assert_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
 
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Skipping on MacOS due to memory error on GH runners")
 def test_tf_deep_imbdb_transformers():
     # GH 3522
     transformers = pytest.importorskip("transformers")

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -1,7 +1,5 @@
 """Tests for the Deep explainer."""
 
-import platform
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -243,12 +241,14 @@ def test_tf_keras_imdb_lstm(random_seed):
     np.testing.assert_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
 
-@pytest.mark.skipif(platform.system() == "Darwin", reason="Skipping on MacOS due to memory error on GH runners")
-def test_tf_deep_imbdb_transformers():
+def test_tf_deep_imbdb_transformers(monkeypatch):
     # GH 3522
     transformers = pytest.importorskip("transformers")
 
     from shap import models
+
+    # Disable upper limit for memory allocations (see GH #3929)
+    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.0")
 
     # data from datasets imdb dataset
     short_data = ["I lov", "Worth", "its a", "STAR ", "First", "I had", "Isaac", "It ac", "Techn", "Hones"]

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -243,7 +243,7 @@ def test_tf_keras_imdb_lstm(random_seed):
     np.testing.assert_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
 
-@pytest.mark.skipif(platform.system() == "Darwin", reason="Skipping on MacOS due to memory error on GH runners")
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Skipping on MacOS due to memory error, see GH #3929")
 def test_tf_deep_imbdb_transformers():
     # GH 3522
     transformers = pytest.importorskip("transformers")

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -1,5 +1,7 @@
 """Tests for the Deep explainer."""
 
+import platform
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -241,14 +243,12 @@ def test_tf_keras_imdb_lstm(random_seed):
     np.testing.assert_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
 
-def test_tf_deep_imbdb_transformers(monkeypatch):
+@pytest.mark.skipif(platform.system() == "Darwin", reason="Skipping on MacOS due to memory error on GH runners")
+def test_tf_deep_imbdb_transformers():
     # GH 3522
     transformers = pytest.importorskip("transformers")
 
     from shap import models
-
-    # Disable upper limit for memory allocations (see GH #3929)
-    monkeypatch.setenv("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.0")
 
     # data from datasets imdb dataset
     short_data = ["I lov", "Worth", "its a", "STAR ", "First", "I had", "Isaac", "It ac", "Techn", "Hones"]

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -1,5 +1,6 @@
 """Tests for the Deep explainer."""
 
+import os
 import platform
 
 import numpy as np
@@ -243,7 +244,10 @@ def test_tf_keras_imdb_lstm(random_seed):
     np.testing.assert_allclose(sums, diff, atol=1e-02), "Sum of SHAP values does not match difference!"
 
 
-@pytest.mark.skipif(platform.system() == "Darwin", reason="Skipping on MacOS due to memory error, see GH #3929")
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and os.getenv("GITHUB_ACTIONS") == "true",
+    reason="Skipping on GH MacOS runners due to memory error, see GH #3929",
+)
 def test_tf_deep_imbdb_transformers():
     # GH 3522
     transformers = pytest.importorskip("transformers")


### PR DESCRIPTION
## Summary

Closes #3929

Skip failing test on MacOS.

## Discussion

I tried setting `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0` but that did not fix the test. Another option other than setting this limit might be to use a sentiment analysis pipeline that uses less memory.

However, I'd be inclined to merge this fix first to fix the CI, and then possibly make further improvements later.