### PR TITLE
Fix comment for beeswarm plot in intro notebook

### DIFF
--- a/notebooks/overviews/An introduction to explainable AI with Shapley values.ipynb
+++ b/notebooks/overviews/An introduction to explainable AI with Shapley values.ipynb
@@ -428,7 +428,7 @@
     }
    ],
    "source": [
-    "# the waterfall_plot shows how we get from explainer.expected_value to model.predict(X)[sample_ind]\n",
+    "# the beeswarm plot displays SHAP values for each feature across all examples, with colors indicating how the SHAP values correlate with feature values\n",
     "shap.plots.beeswarm(shap_values_ebm)"
    ]
   },

--- a/notebooks/overviews/An introduction to explainable AI with Shapley values.ipynb
+++ b/notebooks/overviews/An introduction to explainable AI with Shapley values.ipynb
@@ -428,7 +428,8 @@
     }
    ],
    "source": [
-    "# the beeswarm plot displays SHAP values for each feature across all examples, with colors indicating how the SHAP values correlate with feature values\n",
+    "# the beeswarm plot displays SHAP values for each feature across all examples,\n",
+    "# with colors indicating how the SHAP values correlate with feature values\n",
     "shap.plots.beeswarm(shap_values_ebm)"
    ]
   },


### PR DESCRIPTION
## Overview

One code comment in the notebook is repeated twice by mistake (referring to the waterfall_plot). This PR fixes this small glitch in the doc.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
