### PR TITLE
MAINT: Enable verbose upload to test pypi

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
           password: ${{ secrets.TEST_PYPI_TOKEN  }}
           repository-url: https://test.pypi.org/legacy/
 


### PR DESCRIPTION
## Summary

Enable the "verbose: true" option when uploading to TestPyPI

## Discussion

At the moment our workflow to publish to PyPI is failing, due to a change in authentication. I'm looking to change the authentication workflow to Trusted Publishing, and in the meantime enabling verbose logging will help us see what's going wrong.

Without this flag, the `build_wheels` worfklow fails without a clear cause. Enabling verbose logging shows that the current issue relates to missing 2-factor authentication.