### PR TITLE
MAINT: Enable trusted publishing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -109,6 +109,11 @@ jobs:
     name: Publish wheels to TestPyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/shap
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -125,7 +130,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
-          password: ${{ secrets.TEST_PYPI_TOKEN  }}
           repository-url: https://test.pypi.org/legacy/
 
   publish_pypi:
@@ -134,6 +138,11 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish tagged releases to PyPI
     if: startsWith(github.ref, 'refs/tags')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/shap
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -148,5 +157,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Enables the Trusted Publishing workflow when uploading the package to PyPI and TestPyPI, and removes the use of the API token which will be no longer needed.

Closes #3979

## Discussion

The current upload workflow is broken, as the PyPI token is associated with an account that does not have 2FA authentication enabled. As such, uploads are now blocked.

This PR enables the [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) workflow. For this to work, GitHub needs to be configured as a Trusted Publisher on PyPI and TestPyPI settings; so this PR is in draft until that is completed. EDIT: that change has now been configured.