### PR TITLE
ENH: minor speedups in non-tree KernelExplainer

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -499,6 +499,9 @@ class KernelExplainer(Explainer):
         elif hasattr(i, "dtype") and hasattr(j, "dtype"):
             if np.issubdtype(i.dtype, np.number) and np.issubdtype(j.dtype, np.number):
                 return 0 if np.allclose(i, j, equal_nan=True) else 1
+            if np.issubdtype(i.dtype, np.bool_) and np.issubdtype(j.dtype, np.bool_):
+                return 0 if np.allclose(i, j, equal_nan=True) else 1
+            return 0 if all(i == j) else 1
         else:
             return 0 if i == j else 1
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -495,7 +495,10 @@ class KernelExplainer(Explainer):
     def not_equal(i, j):
         number_types = (int, float, np.number)
         if isinstance(i, number_types) and isinstance(j, number_types):
-            return 0 if np.isclose(i, j, equal_nan=True) else 1
+            return 0 if np.allclose(i, j, equal_nan=True) else 1
+        elif hasattr(i, "dtype") and hasattr(j, "dtype"):
+            if np.issubdtype(i.dtype, np.number) and np.issubdtype(j.dtype, np.number):
+                return 0 if np.allclose(i, j, equal_nan=True) else 1
         else:
             return 0 if i == j else 1
 
@@ -510,8 +513,7 @@ class KernelExplainer(Explainer):
                         varying[i] = False
                         continue
                     x_group = x_group.todense()
-                num_mismatches = np.sum(np.frompyfunc(self.not_equal, 2, 1)(x_group, self.data.data[:, inds]))
-                varying[i] = num_mismatches > 0
+                varying[i] = self.not_equal(x_group, self.data.data[:, inds])
             varying_indices = np.nonzero(varying)[0]
             return varying_indices
         else:

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -360,3 +360,19 @@ def test_kernel_logits_zeros_ones_probs(nsamples):
     pred = rf.predict_proba(X_test_sampled)
 
     np.testing.assert_allclose(sigm(shap_values.values.sum(1) + explainer.expected_value), pred, atol=1e-04)
+
+
+@pytest.mark.parametrize("dt", [np.bool_, np.object_])
+def test_explainer_non_number_dtype(dt):
+    seed = 45479
+    rng = np.random.default_rng(seed)
+    X = rng.choice([True, False], size=(15, 8)).astype(dt)
+    y = rng.choice([True, False], size=(15,)).astype(float)
+    rf = sklearn.ensemble.RandomForestClassifier(random_state=seed)
+    rf.fit(X, y)
+    explainer = shap.KernelExplainer(
+        model=rf.predict_proba,
+        data=X,
+        random_state=seed)
+    shap_values = explainer(X)
+    np.testing.assert_allclose(shap_values.values.max(), 0.26547777777777753)

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -372,4 +372,4 @@ def test_explainer_non_number_dtype(dt):
     rf.fit(X, y)
     explainer = shap.KernelExplainer(model=rf.predict_proba, data=X, random_state=seed)
     shap_values = explainer(X)
-    np.testing.assert_allclose(shap_values.values.max(), 0.26547777777777753)
+    np.testing.assert_allclose(shap_values.values.max(), 0.26548, rtol=1e-2)

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -370,9 +370,6 @@ def test_explainer_non_number_dtype(dt):
     y = rng.choice([True, False], size=(15,)).astype(float)
     rf = sklearn.ensemble.RandomForestClassifier(random_state=seed)
     rf.fit(X, y)
-    explainer = shap.KernelExplainer(
-        model=rf.predict_proba,
-        data=X,
-        random_state=seed)
+    explainer = shap.KernelExplainer(model=rf.predict_proba, data=X, random_state=seed)
     shap_values = explainer(X)
     np.testing.assert_allclose(shap_values.values.max(), 0.26547777777777753)


### PR DESCRIPTION
* A few minor simplifications/adjustments that seem to give about 5-10% better performance for non-tree `KernelExplainer` for the scenario described at gh-3943.

* I don't think we have formal `asv`-style benchmarks in this project, but informal testing with 5 trials each (times in seconds) for the reproducer in the above issue (on an ARM Mac):
  - `master`:     52.803, 50.711, 51.503, 50.613, 51.348
  - this branch:  47.557, 47.128, 48.197, 47.651, 47.216

* This is less impactful than then improvements at gh-3944, but also less intrusive, and the improvements should compound with each other.

* I added postdoc @arhall0 as a co-author on the commit, since they did the initial profiling work to find the ~10% bottleneck.

* Since it appears that we only really need to identify the first point of difference between the arrays, it is probably possible to write an early-break algorithm that is more efficient, but that would probably increase complexity/need for compiled backend, so this is just a start to bump things a little bit.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
