### PR TITLE
MAINT: Supress ci warning for sklearn: 'force_all_finite' was renamed to 'ensure_all_finite'  #3969

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ filterwarnings = [
   "ignore:.*distutils Version classes are deprecated.*:DeprecationWarning:.*pandas.*",
   "ignore:.*typing.io is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*is_datetime64tz_dtype is deprecated.*:DeprecationWarning:.*pyspark.*",
+  "ignore:.*'force_all_finite' was renamed to 'ensure_all_finite' in 1.6.*:FutureWarning:.*sklearn.*",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
MAINT: Supress ci warning for sklearn: 'force_all_finite' was renamed to 'ensure_all_finite'  #3969

A small housekeeping PR to ensure supress CI warnings related to a deprecation change in Sklearn.

We don't use the `force_all_finite argument`, and this warning is likely from `lightgbm` and will be fixed in a upcoming version.
The reason we are seeing this warning is because the `lightGBM` package is using this. I can see in the repo that this has been fixed now, but the most recent release (`4.5.0`) was released in last July.  [The commits that fix this](https://github.com/microsoft/LightGBM/commit/7eae66a7bd0cf5e4bb081f23b61ad11b4f66d706) were introduced in October and are not released yet.