### PR TITLE
BUG: TreeExplainer numerical sensitivity

### DIFF
--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -709,7 +709,8 @@ inline void build_merged_tree(TreeEnsemble &out_tree, const ExplanationDataset &
 // Independent Tree SHAP functions below here
 // ------------------------------------------
 struct Node {
-    short cl, cr, cd, pnode, feat, pfeat; // uint_16
+    short cl, cr, cd, pnode; // uint_16
+    long feat, pfeat;
     float thres, value;
     char from_flag;
 };
@@ -746,7 +747,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 //     }
     int ns_ctr = 0;
     std::fill_n(feat_hist, num_feats, 0);
-    short node = 0, feat, cl, cr, cd, pnode, pfeat = -1;
+    short node = 0, cl, cr, cd, pnode;
+    long feat, pfeat = -1;
     short next_xnode = -1, next_rnode = -1;
     short next_node = -1, from_child = -1;
     float thres, pos_x = 0, neg_x = 0, pos_r = 0, neg_r = 0;

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1898,3 +1898,15 @@ def test_consistency_approximate(expected_result, approximate):
     explanations_shap_values_approx = exp.shap_values(arr, approximate=approximate)
     np.testing.assert_allclose(explanations_call_approx.values, explanations_shap_values_approx)
     np.testing.assert_allclose(explanations_call_approx.values, expected_result)
+
+
+@pytest.mark.parametrize("n_rows", [3, 5])
+def test_gh_3948(n_rows):
+    rng = np.random.default_rng(0)
+    X = rng.integers(low=0, high=2, size=(n_rows, 90_000)).astype(np.float64)
+    y = rng.integers(low=0, high=2, size=n_rows)
+    clf = sklearn.ensemble.RandomForestClassifier(n_estimators=1, random_state=0)
+    clf.fit(X, y)
+    clf.predict_proba(X)
+    exp = shap.TreeExplainer(clf, X)
+    exp.shap_values(X)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1901,11 +1901,12 @@ def test_consistency_approximate(expected_result, approximate):
 
 
 @pytest.mark.parametrize("n_rows", [3, 5])
-def test_gh_3948(n_rows):
+@pytest.mark.parametrize("n_estimators", [1, 100])
+def test_gh_3948(n_rows, n_estimators):
     rng = np.random.default_rng(0)
     X = rng.integers(low=0, high=2, size=(n_rows, 90_000)).astype(np.float64)
     y = rng.integers(low=0, high=2, size=n_rows)
-    clf = sklearn.ensemble.RandomForestClassifier(n_estimators=1, random_state=0)
+    clf = sklearn.ensemble.RandomForestClassifier(n_estimators=n_estimators, random_state=0)
     clf.fit(X, y)
     clf.predict_proba(X)
     exp = shap.TreeExplainer(clf, X)


### PR DESCRIPTION
* Fixes gh-3948

* I drafted the regression test in the matching issue which fails before and passes after the patch discovered by @arhall0 (added as co-author here), that seems to indicate some types were set a bit too small. `pytest --import-mode=append` (full suite) also passes locally on this branch.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
