### PR TITLE
BUG: fix issue with tight tolerances when calling check_additivity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ test = [
   # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
   # See GH #3707, #3768, 3922
   "numpy<2.0",
-  "hypothesis",
 ]
 
 test_notebooks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ test = [
   # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
   # See GH #3707, #3768, 3922
   "numpy<2.0",
+  "hypothesis",
 ]
 
 test_notebooks = [

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -457,8 +457,6 @@ class TreeExplainer(Explainer):
         approximate: bool = False,
         check_additivity: bool = True,
         from_call: bool = False,
-        abs_tol: float = 1e-2,
-        rel_tol: float = 1e-2,
     ):
         """Estimate the SHAP values for a set of samples.
 
@@ -485,13 +483,6 @@ class TreeExplainer(Explainer):
             Run a validation check that the sum of the SHAP values equals the output of the model. This
             check takes only a small amount of time, and will catch potential unforeseen errors.
             Note that this check only runs right now when explaining the margin of the model.
-
-        abs_tol : float
-            absolute tolerance value for checking the difference between shap calculations and model
-            output when calling `check_additivity=True`
-
-        rel_tol : float
-            relative tolerance value for handling very small numbers when calling `check_sum`
 
         Returns
         -------
@@ -582,7 +573,7 @@ class TreeExplainer(Explainer):
                     out = phi[:, :-1]
 
                 if check_additivity and model_output_vals is not None:
-                    self.assert_additivity(out, model_output_vals, abs_tol, rel_tol)
+                    self.assert_additivity(out, model_output_vals)
                 if isinstance(out, list):
                     out = np.stack(out, axis=-1)
                 return out
@@ -639,7 +630,7 @@ class TreeExplainer(Explainer):
 
         out = self._get_shap_output(phi, flat_output)
         if check_additivity and self.model.model_output == "raw":
-            self.assert_additivity(out, self.model.predict(X), abs_tol, rel_tol)
+            self.assert_additivity(out, self.model.predict(X))
 
         # This statements handles the case of multiple outputs
         # e.g. a multi-class classification problem, multi-target regression problem
@@ -800,10 +791,12 @@ class TreeExplainer(Explainer):
                 out = np.stack([phi[:, :-1, :-1, i] for i in range(self.model.num_outputs)], axis=-1)
         return out
 
-    def assert_additivity(self, phi, model_output, abs_tol, rel_tol):
-        def check_sum(sum_val, model_output, abs_tol, rel_tol):
+    def assert_additivity(self, phi, model_output):
+        def check_sum(sum_val, model_output):
             diff = np.abs(sum_val - model_output)
-            if not np.allclose(sum_val, model_output, atol=abs_tol, rtol=rel_tol):
+            # TODO: add arguments for passing custom 'atol' and 'rtol' values to 'np.allclose'
+            # would require change to interface i.e. '__call__' methods
+            if not np.allclose(sum_val, model_output, atol=1e-2, rtol=1e-2):
                 ind = np.argmax(diff)
                 err_msg = (
                     "Additivity check failed in TreeExplainer! Please ensure the data matrix you passed to the "
@@ -821,9 +814,9 @@ class TreeExplainer(Explainer):
 
         if isinstance(phi, list):
             for i in range(len(phi)):
-                check_sum(self.expected_value[i] + phi[i].sum(-1), model_output[:, i], abs_tol, rel_tol)
+                check_sum(self.expected_value[i] + phi[i].sum(-1), model_output[:, i])
         else:
-            check_sum(self.expected_value + phi.sum(-1), model_output, abs_tol, rel_tol)
+            check_sum(self.expected_value + phi.sum(-1), model_output)
 
     @staticmethod
     def supports_model_with_masker(model, masker):


### PR DESCRIPTION
* Closes #3992

* modified the `check_sum` function to use `np.allclose` for comparing `sum_val` and `model_outputs` because the relative error function that was being used was sensitive to very small differences (values very close to zero) between the model outputs and calculated SHAP sums

* added two variables `abs_tol` and `rel_tol` to allow for customization of the absolute and relative tolerance values when calling `explainer.shap_values`

* added a portable regression test that reproduces the error locally

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
