### PR TITLE
BUG: fix additivity check failure uint32 overflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ version_file = "shap/_version.py"
 local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
-addopts = "--mpl"
+addopts = "--mpl -m 'not xslow'"
 testpaths = ["tests"]
 filterwarnings = [
   # Ignore warnings that are entirely from 3rd party libs outside our control
@@ -205,6 +205,7 @@ filterwarnings = [
   "ignore:.*is_datetime64tz_dtype is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*'force_all_finite' was renamed to 'ensure_all_finite' in 1.6.*:FutureWarning:.*sklearn.*",
 ]
+markers = ["xslow: mark test as extremely slow (not run unless explicitly requested)"]
 
 [tool.ruff]
 # Careful: when running on pre-commit, ruff's "include" and "exclude" config

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -1275,7 +1275,7 @@ inline void dense_tree_path_dependent(const TreeEnsemble& trees, const Explanati
 
     // build explanation for each sample
     for (unsigned i = 0; i < data.num_X; ++i) {
-        instance_out_contribs = out_contribs + i * (data.M + 1) * trees.num_outputs;
+        instance_out_contribs = out_contribs + static_cast<unsigned long long>(i) * (data.M + 1) * trees.num_outputs;
         data.get_x_instance(instance, i);
 
         // aggregate the effect of explaining each tree

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1979,6 +1979,7 @@ def test_sklearn_tree_explainer_with_missing_values(X, y, expected_shap_values):
     np.testing.assert_allclose(shap_values, expected_shap_values)
 
 
+@pytest.mark.xslow
 def test_overflow_tree_path_dependent():
     """GH #4002
     Test SHAP values computation for `feature_perturbation='tree_path_dependent'` with large number of features."""

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1977,3 +1977,19 @@ def test_sklearn_tree_explainer_with_missing_values(X, y, expected_shap_values):
 
     # Verify SHAP values match expected values
     np.testing.assert_allclose(shap_values, expected_shap_values)
+
+
+def test_overflow_tree_path_dependent():
+    """GH #4002
+    Test SHAP values computation for `feature_perturbation='tree_path_dependent'` with large number of features."""
+    seed = 0
+    n_rows = 2_000
+    rng = np.random.default_rng(seed)
+    X = rng.integers(low=0, high=2, size=(n_rows, 1_100_000)).astype(np.float64)
+    y = rng.integers(low=0, high=2, size=n_rows)
+
+    clf = sklearn.ensemble.RandomForestClassifier(random_state=seed)
+    clf.fit(X, y)
+    clf.predict_proba(X)
+    exp = shap.Explainer(clf, algorithm='tree', feature_perturbation='tree_path_dependent')
+    exp(X)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1991,5 +1991,5 @@ def test_overflow_tree_path_dependent():
     clf = sklearn.ensemble.RandomForestClassifier(random_state=seed)
     clf.fit(X, y)
     clf.predict_proba(X)
-    exp = shap.Explainer(clf, algorithm='tree', feature_perturbation='tree_path_dependent')
+    exp = shap.Explainer(clf, algorithm="tree", feature_perturbation="tree_path_dependent")
     exp(X)


### PR DESCRIPTION
* related to shap#4002

* addresses issue for 'tree_path_dependent'

* adds regression test that reproduces error before fix

## Overview

Description of the changes proposed in this pull request:

This PR attempts to correct part of shap#4002 for `feature_perturbation='tree_path_dependent'`. The test for this is quite slow; around ~120s on my local machine.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
