### PR TITLE
ENH: Add GELU support for PyTorch.

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -405,6 +405,7 @@ op_handler["Tanh"] = nonlinear_1d
 op_handler["Softplus"] = nonlinear_1d
 op_handler["Softmax"] = nonlinear_1d
 op_handler["SELU"] = nonlinear_1d
+op_handler["GELU"] = nonlinear_1d
 
 op_handler["MaxPool1d"] = maxpool
 op_handler["MaxPool2d"] = maxpool

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -647,7 +647,7 @@ def test_pytorch_single_output(torch_device):
     )
 
 
-@pytest.mark.parametrize("activation", ["relu", "selu"])
+@pytest.mark.parametrize("activation", ["relu", "selu", "gelu"])
 @pytest.mark.parametrize("torch_device", TORCH_DEVICES)
 @pytest.mark.parametrize("disconnected", [True, False])
 def test_pytorch_multiple_inputs(torch_device, disconnected, activation):
@@ -659,7 +659,7 @@ def test_pytorch_multiple_inputs(torch_device, disconnected, activation):
     from torch.nn import functional as F
     from torch.utils.data import DataLoader, TensorDataset
 
-    activation_func = {"relu": nn.ReLU(), "selu": nn.SELU()}[activation]
+    activation_func = {"relu": nn.ReLU(), "selu": nn.SELU(), "gelu": nn.GELU()}[activation]
 
     class Net(nn.Module):
         """Testing model."""


### PR DESCRIPTION
## Overview

Closes #3719; contributes to #3505, #3465, #3438.

Description of the changes proposed in this pull request:
- Implement PyTorch GELU support by adding `op_handler['GELU'] = nonlinear_1d`.
- Added GELU to PyTorch "multiple inputs" testcase.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
