### PR TITLE
Fix/check for attribute to extract colors

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -451,7 +451,7 @@ def beeswarm(
                 rasterized=len(shaps) > 500,
             )
         else:
-            if safe_isinstance(color, "matplotlib.colors.Colormap"):
+            if safe_isinstance(color, "matplotlib.colors.Colormap") and hasattr(color, "colors"):
                 color = color.colors
             ax.scatter(
                 shaps,

--- a/tests/plots/test_beeswarm.py
+++ b/tests/plots/test_beeswarm.py
@@ -21,6 +21,27 @@ from shap.plots.colors import (
 from shap.utils._exceptions import DimensionError
 
 
+@pytest.fixture(
+    params=[
+        blue_rgb,
+        gray_rgb,
+        light_blue_rgb,
+        light_red_rgb,
+        red_blue,
+        red_blue_circle,
+        red_blue_no_bounds,
+        red_blue_transparent,
+        red_rgb,
+        red_transparent_blue,
+        red_white_blue,
+        transparent_blue,
+        transparent_red,
+    ]
+)
+def color(request):
+    return request.param
+
+
 def test_beeswarm_input_is_explanation():
     """Checks an error is raised if a non-Explanation object is passed as input."""
     with pytest.raises(
@@ -84,25 +105,17 @@ def test_beeswarm_basic_explanation_works():
     shap.plots.beeswarm(explanation, show=False)
 
 
-@pytest.mark.parametrize(
-    "color",
-    [
-        blue_rgb,
-        gray_rgb,
-        light_blue_rgb,
-        light_red_rgb,
-        red_blue,
-        red_blue_circle,
-        red_blue_no_bounds,
-        red_blue_transparent,
-        red_rgb,
-        red_transparent_blue,
-        red_white_blue,
-        transparent_blue,
-        transparent_red,
-    ],
-)
 def test_beeswarm_works_with_colors(color):
     # GH 3901
     explanation = shap.Explanation([[1.0, 2.0, 3.0]])
+    shap.plots.beeswarm(explanation, show=False, color_bar=True, color=color)
+
+
+def test_beeswarm_colors_values_with_data(color):
+    np.random.seed(42)
+
+    explanation = shap.Explanation(
+        values=np.random.randn(100, 5),
+        data=np.array([["cat"] * 5] * 100),
+    )
     shap.plots.beeswarm(explanation, show=False, color_bar=True, color=color)


### PR DESCRIPTION
## Overview
Adds further checks to avoid AttributeError.

The `beeswarm` function checks the if the given `color` is of type `matplotlib.colors.Colormap` in one else path of the function and access the attribute `colors` if that check is true (it is in line [454](https://github.com/shap/shap/blob/cadb4d0300eb2c9104a48a604910d114ffd0a84c/shap/plots/_beeswarm.py#L454)). However, not all subtypes of `matplotlib.colors.Colormap` have that attribute (see this [discussion])(https://stackoverflow.com/questions/59395038/why-the-structure-of-matplotlibs-color-maps-differ). Therefore this PR just add a further attribute check as well as a test, assuming that the type check should persist.
## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
