### PR TITLE
Ci warning matplotlib vert bool future deprecation

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -29,6 +29,7 @@ from ._utils import (
     sort_inds,
 )
 
+# TODO: simplify this when we drop support for matplotlib 3.9
 if version.parse(matplotlib.__version__) >= version.parse("3.10"):
     ORIENTATION_KWARG = {"orientation": "horizontal"}
 else:

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Literal
 
+import matplotlib
 import matplotlib.pyplot as pl
 import numpy as np
 import pandas as pd
@@ -12,6 +13,7 @@ import scipy.cluster
 import scipy.sparse
 import scipy.spatial
 from matplotlib.figure import Figure
+from packaging import version
 from scipy.stats import gaussian_kde
 
 from .. import Explanation
@@ -26,6 +28,11 @@ from ._utils import (
     merge_nodes,
     sort_inds,
 )
+
+if version.parse(matplotlib.__version__) >= version.parse("3.10"):
+    ORIENTATION_KWARG = {"orientation": "horizontal"}
+else:
+    ORIENTATION_KWARG = {"vert": False}
 
 
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
@@ -981,7 +988,7 @@ def summary_legacy(
                 shap_values[:, feature_order],
                 range(len(feature_order)),
                 points=200,
-                vert=False,
+                **ORIENTATION_KWARG,
                 widths=0.7,
                 showmeans=False,
                 showextrema=False,

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -31,9 +31,9 @@ from ._utils import (
 
 # TODO: simplify this when we drop support for matplotlib 3.9
 if version.parse(matplotlib.__version__) >= version.parse("3.10"):
-    ORIENTATION_KWARG = {"orientation": "horizontal"}
+    ORIENTATION_KWARG = dict(orientation="horizontal")
 else:
-    ORIENTATION_KWARG = {"vert": False}
+    ORIENTATION_KWARG = dict(vert=False)  # type: ignore[dict-item]
 
 
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
@@ -989,7 +989,7 @@ def summary_legacy(
                 shap_values[:, feature_order],
                 range(len(feature_order)),
                 points=200,
-                **ORIENTATION_KWARG,
+                **ORIENTATION_KWARG,  # type: ignore[arg-type]
                 widths=0.7,
                 showmeans=False,
                 showextrema=False,

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -2,14 +2,22 @@
 
 import warnings
 
+import matplotlib
 import matplotlib.pyplot as pl
 import numpy as np
 import pandas as pd
+from packaging import version
 from scipy.stats import gaussian_kde
 
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels
+
+# TODO: simplify this when we drop support for matplotlib 3.9
+if version.parse(matplotlib.__version__) >= version.parse("3.10"):
+    ORIENTATION_KWARG = {"orientation": "horizontal"}
+else:
+    ORIENTATION_KWARG = {"vert": False}
 
 
 # TODO: remove unused title argument / use title argument
@@ -249,7 +257,7 @@ def violin(
                 shap_values[:, feature_order],
                 range(len(feature_order)),
                 points=200,
-                vert=False,
+                **ORIENTATION_KWARG,
                 widths=0.7,
                 showmeans=False,
                 showextrema=False,

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -15,9 +15,9 @@ from ._labels import labels
 
 # TODO: simplify this when we drop support for matplotlib 3.9
 if version.parse(matplotlib.__version__) >= version.parse("3.10"):
-    ORIENTATION_KWARG = {"orientation": "horizontal"}
+    ORIENTATION_KWARG = dict(orientation="horizontal")
 else:
-    ORIENTATION_KWARG = {"vert": False}
+    ORIENTATION_KWARG = dict(vert=False)  # type: ignore[dict-item]
 
 
 # TODO: remove unused title argument / use title argument
@@ -257,7 +257,7 @@ def violin(
                 shap_values[:, feature_order],
                 range(len(feature_order)),
                 points=200,
-                **ORIENTATION_KWARG,
+                **ORIENTATION_KWARG,  # type: ignore[arg-type]
                 widths=0.7,
                 showmeans=False,
                 showextrema=False,


### PR DESCRIPTION
## Overview

Closes #3975 

MAINT: 

Housekeeping PR to ensure CI warnings related to a deprecation change matplotlib are addressed by ensuring that the right kwargs are used in the violinplot function, depending on which version of matplotlib is installed.

If matplotlib version 3.10 or higher is installed: orientation="horizontal" is used. If the package version is lower then vert=False is used. Solution follows guidance outlined [here](https://github.com/shap/shap/issues/3975#issue-2806773008)



## Checklist

- [ x] All [pre-commit checks](https://pre-commit.com/#install) pass.