### PR TITLE
MAINT: Add nsamples argument to KernelExplainer call()

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -156,7 +156,7 @@ class KernelExplainer(Explainer):
                 tensor_as_np_array = sess.run(symbolic_tensor)
         return tensor_as_np_array
 
-    def __call__(self, X, l1_reg="num_features(10)", silent=False):
+    def __call__(self, X, l1_reg="num_features(10)", silent=False, nsamples="auto"):
         start_time = time.time()
 
         if isinstance(X, pd.DataFrame):
@@ -164,7 +164,7 @@ class KernelExplainer(Explainer):
         else:
             feature_names = getattr(self, "data_feature_names", None)
 
-        v = self.shap_values(X, l1_reg=l1_reg, silent=silent)
+        v = self.shap_values(X, l1_reg=l1_reg, silent=silent, nsamples=nsamples)
         if isinstance(v, list):
             v = np.stack(v, axis=-1)  # put outputs at the end
 

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -248,7 +248,8 @@ def test_linear(random_seed):
         return x[:, 0] + 2.0 * x[:, 1]
 
     explainer = shap.KernelExplainer(f, x)
-    explanation = explainer(x, l1_reg="num_features(2)", silent=True)
+    nsamples = nsamples = 2 * x.shape[1] + 128
+    explanation = explainer(x, l1_reg="num_features(2)", silent=True, nsamples=nsamples)
     phi = explanation.values
     assert phi.shape == x.shape
 


### PR DESCRIPTION
## Overview
- Closes https://github.com/shap/shap/issues/4031 
- Currently, when calling `KernelExplainer.__call__()`, we cannot specify the `nsamples` parameter. As a result, it always defaults to "auto", which is calculated as: `nsamples = 2 * X.shape[1] + 2048`. 
- Add a `nsamples` argument to `KernelExplainer.__call__()` and pass this argument to `shap_values()` to allow users to specify nsamples explicitly.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
```sh
% pytest tests/explainers/test_kernel.py
================================================== test session starts ===================================================
platform darwin -- Python 3.9.6, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/risako/Desktop/shap
configfile: pyproject.toml
collected 22 items                                                                                                       

tests/explainers/test_kernel.py .............s........                                                             [100%]
```
