### PR TITLE
update transformers version for macos, link github issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ test = [
   "ngboost",
   "pyspark",
   "pyod",
-  "transformers<4.49.0; sys_platform == 'darwin'",  # Version constraint for macOS
+  "transformers<=4.49.0; sys_platform == 'darwin'",  # see GH #4036
   "transformers; sys_platform != 'darwin'",  # No constraint for other platforms
   "tf-keras",
   "protobuf==3.20.3",  # See GH #3046


### PR DESCRIPTION
## Overview

Supports #4036 <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
We update the transformers version for the macos runner to the latest version that still works and link the correct github issue in pyproject.toml



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- ~[ ] Unit tests added (if fixing a bug or adding a new feature)~
