### PR TITLE
fix: fix neutral language in SHAP value description

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ shap.plots.scatter(shap_values[:, "Latitude"], color=shap_values)
 </p>
 
 
-To get an overview of which features are most important for a model we can plot the SHAP values of every feature for every sample. The plot below sorts features by the sum of SHAP value magnitudes over all samples, and uses SHAP values to show the distribution of the impacts each feature has on the model output. The color represents the feature value (red high, blue low). This reveals for example that higher median incomes improves the predicted home price.
+To get an overview of which features are most important for a model we can plot the SHAP values of every feature for every sample. The plot below sorts features by the sum of SHAP value magnitudes over all samples, and uses SHAP values to show the distribution of the impacts each feature has on the model output. The color represents the feature value (red high, blue low). This reveals for example that higher median incomes increases the predicted home price.
 
 ```python
 # summarize the effects of all the features


### PR DESCRIPTION
Replace "improves" with "increases" when describing how median income affects house prices, as this is more neutral and accurate terminology. Higher median income increases predicted house prices without implying this is necessarily better or worse.

## Overview
<!-- No issue number needed for this small documentation fix -->
Description of the changes proposed in this pull request:
- Changed wording in documentation from "improves" to "increases" when describing the relationship between median income and predicted house prices
- This provides more neutral and precise terminology that avoids implying a value judgment about whether higher prices are better

## Checklist
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (not applicable for documentation change)