### PR TITLE
fix: resolve threading warnings of regex library

### DIFF
--- a/shap/benchmark/experiments.py
+++ b/shap/benchmark/experiments.py
@@ -376,7 +376,7 @@ def run_remote_experiments(experiments, thread_hosts, rate_limit=10):
 
     for host in thread_hosts:
         worker = Thread(target=__thread_worker, args=(q, host))
-        worker.setDaemon(True)
+        worker.daemon = True
         worker.start()
 
     for experiment in experiments:


### PR DESCRIPTION
## Overview
Small PR - resolves the deprecation warnings of `threading`:
```python
DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead worker.setDaemon(True)
```



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
