### PR TITLE
Skip test_random_force_plot_mpl_with_data on macos

### DIFF
--- a/tests/plots/test_force.py
+++ b/tests/plots/test_force.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import nullcontext as does_not_raise
 
 import matplotlib.pyplot as plt
@@ -49,6 +50,9 @@ def test_verify_valid_cmap(cmap, exp_ctx):
         verify_valid_cmap(cmap)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="Since this test is flaky on MacOS, we skip it for now. See GH #4102."
+)
 def test_random_force_plot_mpl_with_data():
     """Test if force plot with matplotlib works."""
     RandomForestRegressor = pytest.importorskip("sklearn.ensemble").RandomForestRegressor


### PR DESCRIPTION
## Overview

Supports #3663 <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
in order to release official support for Python 3.13 we need the tests to pass on all plattforms. As there is no current fix for the flaky tests we skip it on MacOS.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- ~[ ] Unit tests added (if fixing a bug or adding a new feature)~
