### PR TITLE
skip test_random_force_plot_mpl_text_rotation_with_data on MacOS

### DIFF
--- a/tests/plots/test_force.py
+++ b/tests/plots/test_force.py
@@ -9,6 +9,20 @@ from pytest import param
 import shap
 
 
+@pytest.fixture
+def data_explainer_shap_values():
+    RandomForestRegressor = pytest.importorskip("sklearn.ensemble").RandomForestRegressor
+
+    # train model
+    X, y = shap.datasets.california(n_points=500)
+    model = RandomForestRegressor(n_estimators=100)
+    model.fit(X, y)
+
+    # explain the model's predictions using SHAP values
+    explainer = shap.TreeExplainer(model)
+    return X, explainer, explainer.shap_values(X)
+
+
 @pytest.mark.parametrize(
     "cmap, exp_ctx",
     [
@@ -53,18 +67,9 @@ def test_verify_valid_cmap(cmap, exp_ctx):
 @pytest.mark.skipif(
     sys.platform == "darwin", reason="Since this test is flaky on MacOS, we skip it for now. See GH #4102."
 )
-def test_random_force_plot_mpl_with_data():
+def test_random_force_plot_mpl_with_data(data_explainer_shap_values):
     """Test if force plot with matplotlib works."""
-    RandomForestRegressor = pytest.importorskip("sklearn.ensemble").RandomForestRegressor
-
-    # train model
-    X, y = shap.datasets.california(n_points=500)
-    model = RandomForestRegressor(n_estimators=100)
-    model.fit(X, y)
-
-    # explain the model's predictions using SHAP values
-    explainer = shap.TreeExplainer(model)
-    shap_values = explainer.shap_values(X)
+    X, explainer, shap_values = data_explainer_shap_values
 
     # visualize the first prediction's explanation
     shap.force_plot(explainer.expected_value, shap_values[0, :], X.iloc[0, :], matplotlib=True, show=False)
@@ -72,18 +77,12 @@ def test_random_force_plot_mpl_with_data():
         shap.force_plot([1, 1], shap_values, X.iloc[0, :], show=False)
 
 
-def test_random_force_plot_mpl_text_rotation_with_data():
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="Since this test is flaky on MacOS, we skip it for now. See GH #4102."
+)
+def test_random_force_plot_mpl_text_rotation_with_data(data_explainer_shap_values):
     """Test if force plot with matplotlib works when supplied with text_rotation."""
-    RandomForestRegressor = pytest.importorskip("sklearn.ensemble").RandomForestRegressor
-
-    # train model
-    X, y = shap.datasets.california(n_points=500)
-    model = RandomForestRegressor(n_estimators=100)
-    model.fit(X, y)
-
-    # explain the model's predictions using SHAP values
-    explainer = shap.TreeExplainer(model)
-    shap_values = explainer.shap_values(X)
+    X, explainer, shap_values = data_explainer_shap_values
 
     # visualize the first prediction's explanation
     shap.force_plot(


### PR DESCRIPTION
…refactor tests

## Overview

Description of the changes proposed in this pull request:
- skip test_random_force_plot_mpl_text_rotation_with_data on MacOS since it is flaky
- refactor tests that need the same regressor + data to use one common pytest fixture


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
