### PR TITLE
update workflows to run copy over latest bundle js if changes were made

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,6 +12,7 @@ on:
       - "shap/**"
       - "tests/**"
       - "data/**"
+      - "javascript/**"  # Include JS changes that affect bundle.js
       - ".github/workflows/run_tests.yml"
       - "pyproject.toml"
       - "setup.py"
@@ -47,10 +48,30 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            js:
+              - 'javascript/**'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      # Build JavaScript bundle if JS files have changed
+      - name: Set up Node.js
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/Hydrogen
+      - name: Build JavaScript bundle conditionally
+        if: steps.filter.outputs.js == 'true'
+        shell: bash
+        run: |
+          cd javascript
+          npm ci
+          npm run build
+          cp build/bundle.js ../shap/plots/resources/bundle.js
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       # Build JavaScript bundle if JS files have changed
       - name: Set up Node.js
-        if: github.event_name == 'pull_request'
+        if: steps.filter.outputs.js == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: lts/Hydrogen

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -1,5 +1,6 @@
 # Ensure that the javascript package can be built with webpack
 # Runs on any PRs that modify the javascript directory
+# Also verifies that the built bundle matches the committed bundle
 
 name: test_js
 
@@ -27,3 +28,20 @@ jobs:
       working-directory: ./javascript
     - run: npm run test
       working-directory: ./javascript
+
+    # Check if the built bundle matches the committed bundle (ignoring whitespace)
+    - name: Compare built bundle with committed bundle
+      run: |
+        # Normalize whitespace in both files for comparison
+        # Remove empty lines and all whitespace, then compare
+        sed '/^[[:space:]]*$/d; s/[[:space:]]//g' javascript/build/bundle.js | tr -d '\n' > /tmp/new_bundle_normalized.js
+        sed '/^[[:space:]]*$/d; s/[[:space:]]//g' shap/plots/resources/bundle.js | tr -d '\n' > /tmp/committed_bundle_normalized.js
+
+        if diff -q /tmp/new_bundle_normalized.js /tmp/committed_bundle_normalized.js > /dev/null; then
+          echo "✅ Bundle matches the committed version"
+        else
+          echo "❌ Built bundle differs from committed version"
+          echo "The bundle.js file needs to be updated."
+          echo "Run: cd javascript && npm run build && cp build/bundle.js ../shap/plots/resources/bundle.js"
+          exit 1
+        fi


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:
We need to copy over the bundle.js from javascript after building it. This PR makes sure that it is checked that the code in the javascript directory matches the bundle.js package and therefore keeps them in sync. It also makes sure the python tests run with the current code in the javascript folder, previously they could get out of sync.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
~- [ ] Unit tests added (if fixing a bug or adding a new feature)~
