### PR TITLE
ENH add nsamples parameter to KernelExplainer __call__ method

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -200,6 +200,7 @@ class KernelExplainer(Explainer):
         X: npt.NDArray[Any] | pd.DataFrame | scipy.sparse.spmatrix,
         l1_reg: str | float | bool = "num_features(10)",
         silent: bool = False,
+        nsamples: str | int = "auto",
     ) -> Explanation:
         start_time = time.time()
 
@@ -208,7 +209,7 @@ class KernelExplainer(Explainer):
         else:
             feature_names = getattr(self, "data_feature_names", None)  # type: ignore[assignment]
 
-        v = self.shap_values(X, l1_reg=l1_reg, silent=silent)
+        v = self.shap_values(X, l1_reg=l1_reg, silent=silent, nsamples=nsamples)
         if isinstance(v, list):
             v = np.stack(v, axis=-1)  # put outputs at the end
 


### PR DESCRIPTION
## Overview

Hi everyone! Thanks for your great work on this project. 

I noticed that the `call` method of the Kernel Explainer does not currently expose the `nsamples` argument. Is there a particular reason for this limitation?

I'm proposing a simple fix to allow `nsamples` to be passed through.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
