### PR TITLE
docs(shap_nips.bib): update reference

### DIFF
--- a/docs/references/shap_nips.bib
+++ b/docs/references/shap_nips.bib
@@ -1,9 +1,6 @@
 @incollection{NIPS2017_7062,
 title = {A Unified Approach to Interpreting Model Predictions},
 author = {Lundberg, Scott M and Lee, Su-In},
-booktitle = {Advances in Neural Information Processing Systems 30},
-editor = {I. Guyon and U. V. Luxburg and S. Bengio and H. Wallach and R. Fergus and S. Vishwanathan and R. Garnett},
-pages = {4765--4774},
 year = {2017},
 publisher = {Curran Associates, Inc.},
 url = {http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf}


### PR DESCRIPTION
## Overview
Not sure why with the booktitle, editor and pages the bibtex is interpreted wrongly as:

<img width="2552" height="258" alt="image" src="https://github.com/user-attachments/assets/e77f007f-c43e-4767-a737-f0c741b0d83a" />

---

**After** removing those parts it's "fixed", I do not know if there are others way of fixing it.

<img width="1284" height="164" alt="image" src="https://github.com/user-attachments/assets/13705aff-63b8-4af0-9c98-a2d72b118333" />



Note: this PR is also for reporting the issue, I am not sure about my fix


## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
