### PR TITLE
FIX: Update .save() and .load() methods to remove AttributeError in Explainer and Serializer

### DIFF
--- a/shap/_serializable.py
+++ b/shap/_serializable.py
@@ -79,11 +79,13 @@ class Serializer:
             pickle.dump("custom_encoder", self.out_stream)
             encoder(value, self.out_stream)
         elif encoder == ".save" or (isinstance(value, Serializable) and encoder == "auto"):
-            try:
+            if hasattr(value, "save"):
+                # If it can save, use the original serializable.save logic
                 log.debug("encoder_name = %s", "serializable.save")
                 pickle.dump("serializable.save", self.out_stream)
                 value.save(self.out_stream)
-            except AttributeError:
+            else:
+                # If it can't, use the cloudpickle fallback logic directly
                 log.debug("encoder_name = %s", "cloudpickle.dump (fallback)")
                 pickle.dump("cloudpickle.dump", self.out_stream)
                 cloudpickle.dump(value, self.out_stream)
@@ -93,7 +95,6 @@ class Serializer:
                 pickle.dump("pickle.dump", self.out_stream)
                 pickle.dump(value, self.out_stream)
             else:
-                print(f"Value: {value}")
                 log.debug("encoder_name = %s", "cloudpickle.dump")
                 pickle.dump("cloudpickle.dump", self.out_stream)
                 cloudpickle.dump(value, self.out_stream)

--- a/shap/_serializable.py
+++ b/shap/_serializable.py
@@ -79,18 +79,21 @@ class Serializer:
             pickle.dump("custom_encoder", self.out_stream)
             encoder(value, self.out_stream)
         elif encoder == ".save" or (isinstance(value, Serializable) and encoder == "auto"):
-            log.debug("encoder_name = %s", "serializable.save")
-            pickle.dump("serializable.save", self.out_stream)
-            if len(inspect.getfullargspec(value.save)[0]) == 3:  # backward compat for MLflow, can remove 4/1/2021
-                value.save(self.out_stream, value)
-            else:
+            try:
+                log.debug("encoder_name = %s", "serializable.save")
+                pickle.dump("serializable.save", self.out_stream)
                 value.save(self.out_stream)
+            except AttributeError:
+                log.debug("encoder_name = %s", "cloudpickle.dump (fallback)")
+                pickle.dump("cloudpickle.dump", self.out_stream)
+                cloudpickle.dump(value, self.out_stream)
         elif encoder == "auto":
             if isinstance(value, (int, float, str)):
                 log.debug("encoder_name = %s", "pickle.dump")
                 pickle.dump("pickle.dump", self.out_stream)
                 pickle.dump(value, self.out_stream)
             else:
+                print(f"Value: {value}")
                 log.debug("encoder_name = %s", "cloudpickle.dump")
                 pickle.dump("cloudpickle.dump", self.out_stream)
                 cloudpickle.dump(value, self.out_stream)

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -505,7 +505,7 @@ class Explainer(Serializable):
         super().save(out_file)
         with Serializer(out_file, "shap.Explainer", version=0) as s:
             s.save("model", self.model, model_saver)
-            if hasattr(self, 'masker'):
+            if hasattr(self, "masker"):
                 s.save("masker", self.masker, masker_saver)
             s.save("link", self.link)
 

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -8,8 +8,6 @@ import scipy.sparse
 from .. import explainers, links, maskers, models
 from .._explanation import Explanation
 from .._serializable import Deserializer, Serializable, Serializer
-from ..maskers import Masker
-from ..models import Model
 from ..utils import safe_isinstance, show_progress
 from ..utils._exceptions import InvalidAlgorithmError
 from ..utils.transformers import is_transformers_lm
@@ -505,12 +503,14 @@ class Explainer(Serializable):
         super().save(out_file)
         with Serializer(out_file, "shap.Explainer", version=0) as s:
             s.save("model", self.model, model_saver)
-            if hasattr(self, 'masker'):
+            if hasattr(self, "masker"):
                 s.save("masker", self.masker, masker_saver)
+            if hasattr(self, "data"):
+                s.save("data", self.data)
             s.save("link", self.link)
 
     @classmethod
-    def load(cls, in_file, model_loader=Model.load, masker_loader=Masker.load, instantiate=True):
+    def load(cls, in_file, model_loader=None, masker_loader=None, instantiate=True):
         """Load an Explainer from the given file stream.
 
         Parameters
@@ -524,7 +524,10 @@ class Explainer(Serializable):
         kwargs = super().load(in_file, instantiate=False)
         with Deserializer(in_file, "shap.Explainer", min_version=0, max_version=0) as s:
             kwargs["model"] = s.load("model", model_loader)
-            kwargs["masker"] = s.load("masker", masker_loader)
+            if cls.__name__ == "KernelExplainer":
+                kwargs["data"] = s.load("data")
+            else:
+                kwargs["masker"] = s.load("masker", masker_loader)
             kwargs["link"] = s.load("link")
         return kwargs
 

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -505,7 +505,8 @@ class Explainer(Serializable):
         super().save(out_file)
         with Serializer(out_file, "shap.Explainer", version=0) as s:
             s.save("model", self.model, model_saver)
-            s.save("masker", self.masker, masker_saver)
+            if hasattr(self, 'masker'):
+                s.save("masker", self.masker, masker_saver)
             s.save("link", self.link)
 
     @classmethod

--- a/tests/explainers/common.py
+++ b/tests/explainers/common.py
@@ -2,6 +2,7 @@ import tempfile
 
 import numpy as np
 import pytest
+from sklearn.linear_model import LogisticRegression
 
 import shap
 
@@ -20,6 +21,18 @@ def basic_xgboost_scenario(max_samples=None, dataset=shap.datasets.adult):
     # train an XGBoost model (but any other model type would also work)
     # Specify some hyperparameters for consitency between xgboost v1.X and v2.X
     model = xgboost.XGBClassifier(tree_method="exact", base_score=0.5)
+    model.fit(X, y)
+
+    return model, X
+
+
+def basic_sklearn_scenario():
+    """Creates a basic scikit-learn logistic regression model and data."""
+    X = np.random.randn(20, 5)
+    y = np.zeros(20)
+    y[10:] = 1
+
+    model = LogisticRegression()
     model.fit(X, y)
 
     return model, X
@@ -98,4 +111,5 @@ def test_serialization(explainer_type, model, masker, data, rtol=1e-05, atol=1e-
     assert np.allclose(shap_values_original.base_values, shap_values_new.base_values, rtol=rtol, atol=atol)
     assert np.allclose(shap_values_original[0].values, shap_values_new[0].values, rtol=rtol, atol=atol)
     assert isinstance(explainer_original, type(explainer_new))
-    assert isinstance(explainer_original.masker, type(explainer_new.masker))
+    if hasattr(explainer_original, "masker"):
+        assert isinstance(explainer_original.masker, type(explainer_new.masker))

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -8,6 +8,8 @@ import sklearn
 
 import shap
 
+from . import common
+
 
 def sigm(x):
     return np.exp(x) / (1 + np.exp(x))
@@ -386,3 +388,8 @@ def test_explainer_non_number_dtype(dt):
     explainer = shap.KernelExplainer(model=rf.predict_proba, data=X, random_state=seed)
     shap_values = explainer(X)
     np.testing.assert_allclose(shap_values.values.max(), 0.26548, rtol=1e-2)
+
+
+def test_serialization():
+    model, data = common.basic_sklearn_scenario()
+    common.test_serialization(shap.explainers.KernelExplainer, model.predict, data, data)


### PR DESCRIPTION
## Overview

Closes #4154  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:

1. shap/_serializable.py: The Serializer.save method is now more robust. It uses an if hasattr(value, 'save') check to safely attempt using an object's .save() method, and falls back to the cloudpickle saver if the method doesn't exist. This also removes an obsolete compatibility check for an old version of MLflow mentioned in the comments.

2. shap/explainers/_explainer.py:.

- The save() method now uses hasattr() to conditionally save attributes like .masker or .data based on the explainer type.

- The load() method is updated with symmetrical logic to correctly load these conditional attributes, fixing the entire save/load cycle.

3. tests/explainers/: Test coverage for this feature has been added.

- A new common.basic_sklearn_scenario() helper was created to provide a consistent test case.

- A new test_serialization() function was added to test_kernel.py to specifically validate this fix.

These three changes ensure Explainer.save() and Explainer.load() work as expected for a wider range of common use cases, as has been brought up in past forums and/or stale issues.

Additionally, I noticed the documentation for KernelExplainer mentions a .masker attribute, but this appears to be outdated. This PR fixes the save method to be compatible with the explainer's actual implementation, which does not use a formal masker.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
