### PR TITLE
CI: pin gpboost to 1.6.1 to avoid bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ test = [
   "xgboost",
   "lightgbm",
   "catboost; python_version < '3.13'",  # TODO: pending 3.13 support
-  "gpboost<=1.6.1",
+  "gpboost<=1.6.1",  # TODO: can be relaxed once https://github.com/fabsig/GPBoost/issues/165 is solved
   "ngboost",
   "pyspark",
   "pyod",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ test = [
   "xgboost",
   "lightgbm",
   "catboost; python_version < '3.13'",  # TODO: pending 3.13 support
-  "gpboost",
+  "gpboost<=1.6.1",
   "ngboost",
   "pyspark",
   "pyod",


### PR DESCRIPTION
## Overview

Closes #4157  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- ~[ ] Unit tests added (if fixing a bug or adding a new feature)~
