### PR TITLE
Fix potential TypeError in numeric feature branch by adding string conversion for feature names #4150

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -140,7 +140,7 @@ def waterfall(shap_values, max_display=10, show=True):
         else:
             if np.issubdtype(type(features[order[i]]), np.number):
                 yticklabels[rng[i]] = (
-                    format_value(float(features[order[i]]), "%0.03f") + " = " + feature_names[order[i]]
+                    format_value(float(features[order[i]]), "%0.03f") + " = " + str(feature_names[order[i]])
                 )
             else:
                 yticklabels[rng[i]] = str(features[order[i]]) + " = " + str(feature_names[order[i]])

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.neighbors import KNeighborsClassifier
 from sklearn.tree import DecisionTreeRegressor
 
 import shap
@@ -90,3 +91,29 @@ def test_waterfall_plot_for_decision_tree_explanation():
     explainer = shap.TreeExplainer(model)
     explanation = explainer(X)
     shap.plots.waterfall(explanation[0], show=False)
+
+
+def test_waterfall_plot_for_data_with_number_columns():
+    model = KNeighborsClassifier()
+
+    def f(x):
+        return model.predict_proba(x)[:, 1]
+
+    X = pd.DataFrame(
+        [
+            [1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 1],
+            [0, 0, 0, 1, 0],
+            [0, 0, 1, 0, 0],
+            [0, 1, 0, 0, 0],
+        ]
+    )
+    y = pd.Series([0, 1, 2, 3, 4, 3, 2, 1])
+    model.fit(X, y)
+    med = X.median().values.reshape((1, X.shape[1]))
+    explainer = shap.Explainer(f, med)
+    shap_values = explainer(X)
+    shap.plots.waterfall(shap_values[0], show=False)

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -94,6 +94,7 @@ def test_waterfall_plot_for_decision_tree_explanation():
 
 
 def test_waterfall_plot_for_data_with_number_columns():
+    #GH 4150
     model = KNeighborsClassifier()
 
     def f(x):


### PR DESCRIPTION
## Overview

Closes #4150 

Description of the changes proposed in this pull request:
In line 143 of shap/plots/_waterfall.py, the built-in `str()` function is called on the return value of `feature_names[order[i]]`. For more details, see:
> https://github.com/shap/shap/issues/4150

I have already proposed a feasible solution to this problem. Please approve it.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
