### PR TITLE
Add VERSION type stub for version management

### DIFF
--- a/stubs/_kernel_lib.pyi
+++ b/stubs/_kernel_lib.pyi
@@ -9,3 +9,4 @@ def _exp_val(
     y: list[float] | np.ndarray,
     ey: list[float] | np.ndarray,
 ) -> tuple[np.ndarray, int]: ...
+VERSION: str

--- a/stubs/_kernel_lib.pyi
+++ b/stubs/_kernel_lib.pyi
@@ -9,4 +9,5 @@ def _exp_val(
     y: list[float] | np.ndarray,
     ey: list[float] | np.ndarray,
 ) -> tuple[np.ndarray, int]: ...
+
 VERSION: str


### PR DESCRIPTION
### Description of the changes proposed in this pull request:
- Added a `VERSION: str` variable to the `_exp_val` function file.
- This variable is intended to store versioning or metadata information for easier tracking.

---

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
