### PR TITLE
Improve base_score assignment

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -2112,7 +2112,7 @@ class XGBTreeModelLoader:
             try:
                 base_score = ast.literal_eval(base_score)
                 if not isinstance(base_score, (list, float, int, tuple, np.ndarray)):
-                    raise ValueError   
+                    raise ValueError
             except ValueError as e:
                 emsg = f"Expected the base_score to contain a list or float, received {base_score}"
                 raise ValueError(emsg) from e

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import io
 import json
 import os
@@ -7,7 +8,6 @@ import time
 import warnings
 from typing import Any
 
-import ast
 import numpy as np
 import pandas as pd
 import scipy.sparse

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -2111,8 +2111,11 @@ class XGBTreeModelLoader:
         if isinstance(base_score, str):
             try:
                 base_score = ast.literal_eval(base_score)
-            except Exception:
-                pass
+                if not isinstance(base_score, (list, float, int, tuple, np.ndarray)):
+                    raise ValueError   
+            except ValueError as e:
+                emsg = f"Expected the base_score to contain a list or float, received {base_score}"
+                raise ValueError(emsg) from e
         if isinstance(base_score, (list, tuple, np.ndarray)):
             base_score = base_score[0]
         base_score = float(base_score)


### PR DESCRIPTION
Refactor base_score assignment to handle string and collection types. in xgboost 310, the base_score return an array instead of a simple float

## Overview

Description of the changes proposed in this pull request:
BUG is reported in the issue #4184  due to changes in xgboost base_score return data type.

Diff of the file in xgboost is here: [Xgboost base_score](https://github.com/dmlc/xgboost/pull/11651/files#diff-92691cadfd8852da44fa622dceb9ada7c352a0b8a62e158ee2e87a95feeab6baR85-R87
)
from:

 Line 86 float base_score{ObjFunction::DefaultBaseScore()};

to

Line 86  common::ParamArray<float, true> base_score{"base_score", ObjFunction::DefaultBaseScore()};



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
