### PR TITLE
Bugfix: always force transformers label2id ids to integers

### DIFF
--- a/shap/models/_transformers_pipeline.py
+++ b/shap/models/_transformers_pipeline.py
@@ -19,6 +19,7 @@ class TransformersPipeline(Model):
 
         # self.tokenizer = self.inner_model.model.tokenizer
         self.label2id = self.inner_model.model.config.label2id
+        self.label2id = {k: int(v) for k, v in self.label2id.items()}
         self.id2label = self.inner_model.model.config.id2label
         self.output_shape = (max(self.label2id.values()) + 1,)
         if len(self.output_shape) == 1:

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -26,7 +26,6 @@ def test_explainer_to_permutationexplainer():
         _ = explainer(X_test)
 
 
-
 def test_transformers_label_to_id_mapping_enforces_ints():
     """This tests that when we construct our TransformersPipeline, we enforce that label2id values are ints."""
     pytest.importorskip("torch")

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -43,6 +43,7 @@ def test_transformers_label_to_id_mapping_enforces_ints():
     explainer = shap.Explainer(pipe, seed=1)
 
     # Check that the label2id values are all ints after construction
+    assert isinstance(explainer.model, shap.models.TransformersPipeline)
     assert all(isinstance(v, int) for v in explainer.model.label2id.values())
 
 

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -26,6 +26,25 @@ def test_explainer_to_permutationexplainer():
         _ = explainer(X_test)
 
 
+def test_wrapping_for_text_to_text_teacher_forcing_model():
+    """This tests using the Explainer class to auto wrap a masker in a text to text scenario."""
+    pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+
+    def f(x):
+        pass
+
+    name = "hf-internal-testing/tiny-random-BartForCausalLM"
+    tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    model = transformers.AutoModelForCausalLM.from_pretrained(name)
+    wrapped_model = shap.models.TeacherForcing(f, similarity_model=model, similarity_tokenizer=tokenizer)
+    masker = shap.maskers.Text(tokenizer, mask_token="...")
+
+    explainer = shap.Explainer(wrapped_model, masker, seed=1)
+
+    assert shap.utils.safe_isinstance(explainer.masker, "shap.maskers.OutputComposite")
+
+
 def test_transformers_label_to_id_mapping_enforces_ints():
     """This tests that when we construct our TransformersPipeline, we enforce that label2id values are ints."""
     pytest.importorskip("torch")


### PR DESCRIPTION
## Overview

Description of the changes proposed in this pull request:

In the process of using `shap` I found that some transformer models had `label2id` dictionaries with ids as strings. I.e.:

```python
{
    "label_one": "1",
    "label_two": "2",
    "label_three": "3",
}
```

It doesn't seem like there is a requirement/enforcement on the `transformers` side for integer ids and as such, a simple cast to integer can fix the following `max() + 1` call as the addition results in the following error: `TypeError: can only concatenate str (not "int") to str`.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)