### PR TITLE
Build python 314

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -100,7 +100,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.2.1
         with:
           only: ${{ matrix.only }}
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
       # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.23.3
+        run: pipx install cibuildwheel==3.2.1
       - name: Print all build identifiers
         run: cibuildwheel --print-build-identifiers
       - id: set-matrix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,7 +302,7 @@ combine = ["shap", "*/site-packages/shap"]
 # skip cp38-musllinux_x86_64 since numpy never provided cp38 musllinux wheels
 #  they introduced musllinux in 1.25 when they already dropped cp38
 # skip *t (free-threaded builds) since dependencies like llvmlite don't support it yet
-skip = ["pp*", "*-musllinux_aarch64", "*t"]
+skip = ["cp314-macosx_x86_64", "cp314t-manylinux_x86_64", "cp314t-macosx_x86_64", "cp314t-win_amd64"]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,7 +301,8 @@ combine = ["shap", "*/site-packages/shap"]
 # skip *-musllinux_aarch64 since numpy doesn't provid those wheels
 # skip cp38-musllinux_x86_64 since numpy never provided cp38 musllinux wheels
 #  they introduced musllinux in 1.25 when they already dropped cp38
-skip = ["pp*", "*-musllinux_aarch64", "cp38-musllinux_x86_64"]
+# skip *t (free-threaded builds) since dependencies like llvmlite don't support it yet
+skip = ["pp*", "*-musllinux_aarch64", "cp38-musllinux_x86_64", "*t"]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,16 +302,16 @@ combine = ["shap", "*/site-packages/shap"]
 # skip cp38-musllinux_x86_64 since numpy never provided cp38 musllinux wheels
 #  they introduced musllinux in 1.25 when they already dropped cp38
 # skip *t (free-threaded builds) since dependencies like llvmlite don't support it yet
-skip = ["pp*", "*-musllinux_aarch64", "cp38-musllinux_x86_64", "*t"]
+skip = ["pp*", "*-musllinux_aarch64", "*t"]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
 test-extras = ["test-core", "plots"]
-# skip tests on cp38-macosx_x86_64 because of https://github.com/catboost/catboost/issues/2371
+# skip tests on cp314-macosx_x86_64 due to llvmlite 0.46.0b1 architecture issues
 # skip tests on emulated architectures, as they are very slow
 # skip tests on *-macosx_arm64 , as cibuildwheel does not support tests on arm64 (yet)
 # skip tests on *-musllinux*" since llvmlite and numba do not provide musllinux wheels
-test-skip = "cp38-macosx_x86_64 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-musllinux*"
+test-skip = "cp314-macosx_x86_64 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
## Overview

Build successfully against python 3.14. 

Due to lacking support for some macos and free-threading architectures we skip building for those, see [here](https://github.com/shap/shap/compare/build-python-314?expand=1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R314). See this [llvmlite issue](https://github.com/numba/llvmlite/issues/1357) for further information.


## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
