### PR TITLE
Unpin numba on 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,7 @@ dependencies = [
   'tqdm>=4.27.0',
   'packaging>20.9',
   'slicer==0.0.8',
-  'numba==0.63.0b1; python_version >= "3.14"',  # todo: remove once numba officially releases support for 3.14
-  'llvmlite==0.46.0b1; python_version >= "3.14"',  # todo: remove once llvmlite officially releases support for 3.14
-  'numba>=0.54; python_version < "3.14"',
+  'numba>=0.54',
   'cloudpickle',
   'typing-extensions',
 ]


### PR DESCRIPTION
## Overview

Unpin numba on 3.14

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
