### PR TITLE
Support for channel-wise partitionshap

### DIFF
--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -153,7 +153,9 @@ class Image(Masker):
         M = int((xmax - xmin) * (ymax - ymin) * (zmax - zmin))
         clustering = np.zeros((M - 1, 4))
         partition_scheme = self.partition_scheme
-        _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q, partition_scheme)
+        _jit_build_partition_tree(
+            xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q, partition_scheme
+        )
         self.clustering = clustering
 
     def save(self, out_file):
@@ -179,7 +181,9 @@ class Image(Masker):
 
 
 @njit
-def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q, partition_scheme):
+def _jit_build_partition_tree(
+    xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q, partition_scheme
+):
     """This partitions an image into a herarchical clustering based on axis-aligned splits."""
     # heapq.heappush(q, (0, xmin, xmax, ymin, ymax, zmin, zmax, -1, False))
 
@@ -216,7 +220,6 @@ def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, 
 
             # Partition scheme 0: xaxis and yaxis fully partitioned before zaxis
             if partition_scheme == 0:
-
                 # split the xaxis if it is the largest dimension
                 if xwidth >= ywidth and xwidth > 1:
                     xmid = xmin + xwidth // 2
@@ -237,7 +240,6 @@ def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, 
 
             # Partition scheme 1: zaxis partitioned first
             if partition_scheme == 1:
-
                 # split the zaxis if it is larger than 1
                 if zwidth > 1:
                     zmid = zmin + zwidth // 2

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -19,7 +19,7 @@ except ImportError as e:
 class Image(Masker):
     """Masks out image regions with blurring or inpainting."""
 
-    def __init__(self, mask_value, shape=None):
+    def __init__(self, mask_value, shape=None, partition_scheme=0):
         """Build a new Image masker with the given masking value.
 
         Parameters
@@ -29,6 +29,10 @@ class Image(Masker):
         shape : None or tuple
             If the mask_value is an auto-generated masker instead of a dataset then the input
             image shape needs to be provided.
+        partition_scheme: 0 or 1
+            Selects partitioning scheme. If the partition_scheme is 0, then all row, column
+            splits are performed before channel splits (default behavior). If the partition_scheme
+            is 1, then all channels are split before splitting along rows and columns.
 
         """
         if shape is None:
@@ -41,6 +45,8 @@ class Image(Masker):
             self.input_shape = shape
 
         self.input_mask_value = mask_value
+
+        self.partition_scheme = partition_scheme
 
         # This is the shape of the masks we expect
         self.shape = (
@@ -146,7 +152,8 @@ class Image(Masker):
         q = numba.typed.List([(0, xmin, xmax, ymin, ymax, zmin, zmax, -1, False)])
         M = int((xmax - xmin) * (ymax - ymin) * (zmax - zmin))
         clustering = np.zeros((M - 1, 4))
-        _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q)
+        partition_scheme = self.partition_scheme
+        _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q, partition_scheme)
         self.clustering = clustering
 
     def save(self, out_file):
@@ -172,7 +179,7 @@ class Image(Masker):
 
 
 @njit
-def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q):
+def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q, partition_scheme):
     """This partitions an image into a herarchical clustering based on axis-aligned splits."""
     # heapq.heappush(q, (0, xmin, xmax, ymin, ymax, zmin, zmax, -1, False))
 
@@ -189,6 +196,10 @@ def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, 
         if ind < 0:
             assert -ind - 1 == xmin * total_ywidth * total_zwidth + ymin * total_zwidth + zmin
 
+        # make sure the partition schme is supported
+        nschemes = [0, 1]
+        assert partition_scheme in nschemes
+
         xwidth = xmax - xmin
         ywidth = ymax - ymin
         zwidth = zmax - zmin
@@ -203,23 +214,47 @@ def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, 
             lzmin = rzmin = zmin
             lzmax = rzmax = zmax
 
-            # split the xaxis if it is the largest dimension
-            if xwidth >= ywidth and xwidth > 1:
-                xmid = xmin + xwidth // 2
-                lxmax = xmid
-                rxmin = xmid
+            # Partition scheme 0: xaxis and yaxis fully partitioned before zaxis
+            if partition_scheme == 0:
 
-            # split the yaxis
-            elif ywidth > 1:
-                ymid = ymin + ywidth // 2
-                lymax = ymid
-                rymin = ymid
+                # split the xaxis if it is the largest dimension
+                if xwidth >= ywidth and xwidth > 1:
+                    xmid = xmin + xwidth // 2
+                    lxmax = xmid
+                    rxmin = xmid
 
-            # split the zaxis only when the other ranges are already width 1
-            else:
-                zmid = zmin + zwidth // 2
-                lzmax = zmid
-                rzmin = zmid
+                # split the yaxis
+                elif ywidth > 1:
+                    ymid = ymin + ywidth // 2
+                    lymax = ymid
+                    rymin = ymid
+
+                # split the zaxis only when the other ranges are already width 1
+                else:
+                    zmid = zmin + zwidth // 2
+                    lzmax = zmid
+                    rzmin = zmid
+
+            # Partition scheme 1: zaxis partitioned first
+            if partition_scheme == 1:
+
+                # split the zaxis if it is larger than 1
+                if zwidth > 1:
+                    zmid = zmin + zwidth // 2
+                    lzmax = zmid
+                    rzmin = zmid
+
+                # split the xaxis if it is larger than the yaxis
+                elif xwidth >= ywidth and xwidth > 1:
+                    xmid = xmin + xwidth // 2
+                    lxmax = xmid
+                    rxmin = xmid
+
+                # split the yaxis
+                elif ywidth > 1:
+                    ymid = ymin + ywidth // 2
+                    lymax = ymid
+                    rymin = ymid
 
             lsize = (lxmax - lxmin) * (lymax - lymin) * (lzmax - lzmin)
             rsize = (rxmax - rxmin) * (rymax - rymin) * (rzmax - rzmin)

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -36,7 +36,7 @@ def image(
     cmap: str | Colormap | None = colors.red_transparent_blue,
     vmax: float | None = None,
     show: bool | None = True,
-    plot_channels: list[int] | None = None
+    plot_channels: list[int] | None = None,
 ):
     """Plots SHAP values for image inputs.
 
@@ -120,7 +120,6 @@ def image(
         for c in plot_channels:
             assert c in list(range(shap_values[0].shape[-1]))
         nchannels = len(plot_channels)
-        
 
     # labels: (rows (images), columns (top_k classes) ) or (1, columns (top_k classes) )
     if labels is not None:
@@ -176,12 +175,12 @@ def image(
             x_curr_gray = x_curr
             x_curr_disp = x_curr
 
-        axes[row*nchannels,0].imshow(x_curr_disp, cmap=plt.get_cmap('gray'))
-        axes[row*nchannels,0].axis('off')
+        axes[row * nchannels, 0].imshow(x_curr_disp, cmap=plt.get_cmap("gray"))
+        axes[row * nchannels, 0].axis("off")
         for c in range(1, nchannels):
-            axes[row*nchannels+c, 0].set_visible(False)
+            axes[row * nchannels + c, 0].set_visible(False)
         if true_labels:
-            axes[row*nchannels, 0].set_title(true_labels[row], **label_kwargs)
+            axes[row * nchannels, 0].set_title(true_labels[row], **label_kwargs)
 
         if len(shap_values[0][row].shape) == 2:
             abs_vals = np.stack([np.abs(shap_values[i]) for i in range(len(shap_values))], 0).flatten()
@@ -194,15 +193,22 @@ def image(
             if labels is not None:
                 # Add labels if there are labels for each sample, or if not, only for the first row
                 if labels.shape[0] > 1 or row == 0:
-                    axes[row*nchannels, i + 1].set_title(labels[row, i], **label_kwargs)
-
+                    axes[row * nchannels, i + 1].set_title(labels[row, i], **label_kwargs)
 
             if plot_channels is not None:
                 for c in range(nchannels):
-                    sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row][..., plot_channels[c]]
-                    axes[row*nchannels+c,i+1].imshow(x_curr_gray, cmap=plt.get_cmap('gray'), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1))
-                    im = axes[row*nchannels+c,i+1].imshow(sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val)
-                    axes[row*nchannels+c,i+1].axis('off')
+                    sv = (
+                        shap_values[i][row]
+                        if len(shap_values[i][row].shape) == 2
+                        else shap_values[i][row][..., plot_channels[c]]
+                    )
+                    axes[row * nchannels + c, i + 1].imshow(
+                        x_curr_gray, cmap=plt.get_cmap("gray"), alpha=0.15, extent=(-1, sv.shape[1], sv.shape[0], -1)
+                    )
+                    im = axes[row * nchannels + c, i + 1].imshow(
+                        sv, cmap=colors.red_transparent_blue, vmin=-max_val, vmax=max_val
+                    )
+                    axes[row * nchannels + c, i + 1].axis("off")
 
             else:
                 sv = shap_values[i][row] if len(shap_values[i][row].shape) == 2 else shap_values[i][row].sum(-1)


### PR DESCRIPTION
## Overview

An updated PR for #1944. Since I am no longer part of the organization that hosted my fork, I had to make a brand new fork on my personal account. I merged my implementation with the latest SHAP code. 

This PR implements "Channel-wise PartitionSHAP" to explore how the superpixels influence the decision **within each image channel**. 

Used in these publications: 

- [Krell et al. 2023](https://www.cambridge.org/core/journals/environmental-data-science/article/aggregation-strategies-to-improve-xai-for-geoscience-models-that-use-correlated-highdimensional-rasters/F6017A23BEF0BD48969225D68DF819A2)
- [Fan et al. 2024](https://journals.ametsoc.org/view/journals/aies/3/3/AIES-D-23-0098.1.xml)

The code includes the implementation (shap/maskers/_image.py) and ability to plot per-channel SHAP values (shap/plots/_image.py)

If this is accepted, I'll next add example to the documentation. 
