### PR TITLE
Implement interventional SHAP interaction values, fix categorical splits & add OpenMP parallelization

### DIFF
--- a/claude_interface/BUG_TRACKER.md
+++ b/claude_interface/BUG_TRACKER.md
@@ -15,7 +15,7 @@
 | `18983ca1` | Add categorical split support to GPU TreeSHAP |
 | `ef45a45c` | Fix `category_in_threshold` 0-based encoding bug + XGBoost `dmatrix_props` for interaction values |
 | `e04629a2` | Add categorical split support to pure Python `tree_shap_recursive` |
-| *(pending)* | Fix zero-weight leaf NaN in path-dependent mode (epsilon weight fix) |
+| `020e5275` | Fix zero-weight leaf NaN in path-dependent mode (epsilon weight fix) |
 
 ---
 
@@ -85,7 +85,7 @@
 | **Affects** | LightGBM multiclass classification with `tree_path_dependent` interaction values |
 | **Root cause** | Two-part issue: (1) `fully_defined_weighting` check (`np.min(node_sample_weight) <= 0`) rejects any model where the background dataset doesn't cover every leaf, blocking path-dependent mode entirely. (2) The underlying reason the check exists: `unwind_path()` in `tree_shap_recursive` divides by `zero_fraction`, which is 0 when a leaf has no background coverage. This causes NaN even when only leaves (not internal nodes) have zero weight. This is a **pre-existing bug** in the path-dependent algorithm affecting ALL tree models with small backgrounds, not just LightGBM multiclass. |
 | **Fix** | After background weight recomputation in `SingleTree.__init__`, replace zero weights with epsilon (1e-6). This gives uncovered nodes negligible probability, preventing division by zero while maintaining near-correct SHAP values. Additivity holds to < 1e-7 precision, and values converge as background size increases. |
-| **Status** | **FIXED** by commit *(pending)* |
+| **Status** | **FIXED** by commit `020e5275` |
 | **Verified** | LightGBM multiclass with 50/150 bg samples: SHAP values finite, interaction symmetry holds, additivity < 1e-6. sklearn DecisionTree with small bg also works. |
 
 ---

--- a/claude_interface/BUG_TRACKER.md
+++ b/claude_interface/BUG_TRACKER.md
@@ -93,8 +93,9 @@
 | **GitHub** | [#292](https://github.com/shap/shap/issues/292), [#248](https://github.com/shap/shap/issues/248), [#1644](https://github.com/shap/shap/issues/1644) |
 | **Severity** | HIGH — crash (`ValueError: could not convert string to float`) |
 | **Affects** | LightGBM with categorical features, path-dependent interaction values |
-| **Root cause** | LightGBM represents categorical thresholds as pipe-delimited strings (`'2\|\|4\|\|5'`). The old `SingleTree` parsing code tries `float()` on these strings. |
-| **Status** | **WORKAROUND**: Our interventional mode correctly handles categorical splits via the `threshold_types` / `category_in_threshold` mechanism in the C++ backend. Users can switch to `feature_perturbation="interventional"` to avoid the crash. Root cause in path-dependent tree parsing code is NOT fixed. |
+| **Root cause** | LightGBM represents categorical thresholds as pipe-delimited strings (`'2\|\|4\|\|5'`). The old `SingleTree` parsing code tried `float()` on these strings. The pure Python `pytree.py` also lacked categorical support. |
+| **Status** | **FIXED**: `SingleTree` parsing already handles `\|\|` format correctly. C++ `tree_shap_recursive` already handles `threshold_types`. Pure Python `pytree.py` fixed by commit `e04629a2`. All code paths (path-dependent and interventional, C++ and Python) now support categorical splits. |
+| **Verified** | Path-dependent SHAP values and interaction values work for LightGBM with categorical features (0-based categories). |
 
 ---
 
@@ -107,7 +108,7 @@
 | #3 XGBoost dmatrix_props | MEDIUM | **FIXED** | `ef45a45c` |
 | #4 Categorical in interventional | HIGH | **FIXED** | `9ef0e88b`, `18983ca1` |
 | #5 LightGBM multiclass interactions | MEDIUM | **WORKAROUND** | Use interventional mode |
-| #6 LightGBM categorical crash | HIGH | **WORKAROUND** | Use interventional mode |
+| #6 LightGBM categorical crash | HIGH | **FIXED** | `e04629a2` (pytree), pre-existing (C++) |
 
 ---
 

--- a/claude_interface/BUG_TRACKER.md
+++ b/claude_interface/BUG_TRACKER.md
@@ -1,0 +1,121 @@
+# SHAP Bug Tracker — Interventional Tree SHAP Improvements
+
+> **Last updated**: 2026-02-11
+> **Scope**: Bugs found during implementation of interventional SHAP interaction values and categorical split support
+
+---
+
+## Our Commits (master branch)
+
+| Commit | Description |
+|--------|-------------|
+| `869ee4cf` | Implement interventional SHAP interaction values (Zern et al. AAAI 2023) |
+| `36e30249` | Expand brute-force test to cover 3-6 feature counts |
+| `9ef0e88b` | Add categorical split support to interventional SHAP (CPU) |
+| `18983ca1` | Add categorical split support to GPU TreeSHAP |
+| `ef45a45c` | Fix `category_in_threshold` 0-based encoding bug + XGBoost `dmatrix_props` for interaction values |
+
+---
+
+## Bug 1: Interventional interaction values return all zeros
+
+| Field | Value |
+|-------|-------|
+| **GitHub** | [#1824](https://github.com/shap/shap/issues/1824) (open since Feb 2021, 5 upvotes, 10 comments) |
+| **Severity** | CRITICAL — silent data corruption |
+| **Affects** | ALL tree models (sklearn, LightGBM, XGBoost, CatBoost) with `feature_perturbation="interventional"` |
+| **Root cause** | Interventional interaction values were **never implemented** in C++. A guard assertion was commented out during refactoring, so `shap_interaction_values()` silently returns zeros. |
+| **Status** | **FIXED** by commit `869ee4cf` |
+| **Verified** | sklearn GBR, RandomForest, LightGBM, XGBoost, CatBoost all produce correct non-zero interaction values with symmetry, row-sum additivity, and prediction additivity |
+
+---
+
+## Bug 2: `category_in_threshold` broken for category value 0
+
+| Field | Value |
+|-------|-------|
+| **GitHub** | No issue filed (discovered during our work) |
+| **Severity** | HIGH — wrong predictions and SHAP values for LightGBM models with category 0 |
+| **Affects** | LightGBM and GPBoost models where any categorical feature has value 0 |
+| **Root cause** | Two-part encoding mismatch: |
+| | **Python** (`_tree.py:1952`): `threshold += 2 ** (cat - 1)` — for cat=0 produces 0.5, truncated to 0 by `int()` cast |
+| | **C++** (`tree_shap.h:183`): `1 << (int(category) - 1)` — for category=0, `1 << -1` is undefined behavior |
+| **Impact** | Empirically confirmed: 63% relative error on predictions for samples with category 0. Affects `tree_predict()`, `tree_shap_recursive()`, `tree_shap_indep()`, `tree_shap_indep_interactions()` — all 12 call sites. |
+| **Fix** | Change both to 0-based encoding: C++ `1 << int(category)`, Python `2 ** cat`. Single function change + single Python line. |
+| **Status** | **FIXED** by commit `ef45a45c` |
+| **Verified** | Test uses 0-based categories (0-3), prediction diff dropped from 63% to 0%. All call sites fixed: CPU `category_in_threshold()`, GPU `EvaluateSplit()`, Python `SingleTree` threshold construction. |
+
+---
+
+## Bug 3: XGBoost `dmatrix_props` not propagated for interaction values
+
+| Field | Value |
+|-------|-------|
+| **GitHub** | [#3510](https://github.com/shap/shap/issues/3510), [#4091](https://github.com/shap/shap/issues/4091) (PR open) |
+| **Severity** | MEDIUM — error raised, not silent |
+| **Affects** | XGBoost models with `enable_categorical=True` using path-dependent interaction values |
+| **Root cause** | `shap_interaction_values()` line 787 creates `xgboost.DMatrix(X)` without passing `**dmatrix_props`, so XGBoost doesn't know about categorical features |
+| **Fix** | Pass `dmatrix_props` like `shap_values()` does at line 589-590 |
+| **Status** | **FIXED** by commit `ef45a45c` |
+| **Verified** | `shap_interaction_values()` now passes `_xgb_dmatrix_props` when creating `xgboost.DMatrix` |
+
+---
+
+## Bug 4: Categorical splits ignored in interventional SHAP code path
+
+| Field | Value |
+|-------|-------|
+| **GitHub** | No specific issue (pre-existing, blocked by Python guards) |
+| **Severity** | HIGH — wrong SHAP values for categorical models |
+| **Affects** | LightGBM, XGBoost, CatBoost with categorical splits using interventional mode |
+| **Root cause** | `tree_shap_indep()` and `tree_shap_indep_interactions()` always used `x > threshold` comparisons, ignoring `threshold_types`. GPU code also used numeric-only `ShapSplitCondition`. |
+| **Status** | **FIXED** by commits `9ef0e88b` (CPU) and `18983ca1` (GPU) |
+| **Verified** | LightGBM categorical test passes with SHAP value additivity, interaction symmetry, row-sum, and prediction checks |
+
+---
+
+## Bug 5: LightGBM multiclass + interaction values error (path-dependent)
+
+| Field | Value |
+|-------|-------|
+| **GitHub** | [#3574](https://github.com/shap/shap/issues/3574) (18 comments) |
+| **Severity** | MEDIUM — error raised for path-dependent mode |
+| **Affects** | LightGBM multiclass classification with `tree_path_dependent` interaction values |
+| **Root cause** | Leaf coverage check fails for multiclass LightGBM trees in `fully_defined_weighting` |
+| **Status** | **WORKAROUND**: Our interventional mode now works correctly for LightGBM multiclass interactions. Verified with Iris dataset (shape `(5, 4, 4, 3)`). |
+
+---
+
+## Bug 6: LightGBM categorical splits crash interaction values
+
+| Field | Value |
+|-------|-------|
+| **GitHub** | [#292](https://github.com/shap/shap/issues/292), [#248](https://github.com/shap/shap/issues/248), [#1644](https://github.com/shap/shap/issues/1644) |
+| **Severity** | HIGH — crash (`ValueError: could not convert string to float`) |
+| **Affects** | LightGBM with categorical features, path-dependent interaction values |
+| **Root cause** | LightGBM represents categorical thresholds as pipe-delimited strings (`'2\|\|4\|\|5'`). The old `SingleTree` parsing code tries `float()` on these strings. |
+| **Status** | **WORKAROUND**: Our interventional mode correctly handles categorical splits via the `threshold_types` / `category_in_threshold` mechanism in the C++ backend. Users can switch to `feature_perturbation="interventional"` to avoid the crash. Root cause in path-dependent tree parsing code is NOT fixed. |
+
+---
+
+## Summary
+
+| Bug | Severity | Status | Commit / Action |
+|-----|----------|--------|----------------|
+| #1 Interventional interactions zeros | CRITICAL | **FIXED** | `869ee4cf` |
+| #2 category_in_threshold cat=0 | HIGH | **FIXED** | `ef45a45c` |
+| #3 XGBoost dmatrix_props | MEDIUM | **FIXED** | `ef45a45c` |
+| #4 Categorical in interventional | HIGH | **FIXED** | `9ef0e88b`, `18983ca1` |
+| #5 LightGBM multiclass interactions | MEDIUM | **WORKAROUND** | Use interventional mode |
+| #6 LightGBM categorical crash | HIGH | **WORKAROUND** | Use interventional mode |
+
+---
+
+## GitHub Issues Our Work Closes
+
+When submitting PRs, reference these issues:
+
+- **Closes #1824** — Interventional interaction values now work (were always zeros)
+- **Fixes #3510** — XGBoost dmatrix_props propagated for interaction values
+- **Addresses #3574** — Interventional mode works for LightGBM multiclass interactions
+- **Addresses #292, #248, #1644** — Interventional mode supports LightGBM categorical splits

--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,15 @@ def run_setup(*, with_binary, with_cuda):
     ext_modules = []
     if with_binary:
         compile_args = []
+        link_args = []
         if sys.platform == "zos":
             compile_args.append("-qlonglong")
-        if sys.platform == "win32":
+        elif sys.platform == "win32":
             compile_args.append("/MD")
+            compile_args.append("/openmp")
+        else:
+            compile_args.append("-fopenmp")
+            link_args.append("-fopenmp")
 
         ext_modules.append(
             Extension(
@@ -111,6 +116,7 @@ def run_setup(*, with_binary, with_cuda):
                 sources=["shap/cext/_cext.cc"],
                 include_dirs=[np.get_include()],
                 extra_compile_args=compile_args,
+                extra_link_args=link_args,
             )
         )
     if with_cuda:

--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -44,8 +44,8 @@ struct ShapSplitCondition {
       return is_missing_branch;
     }
     if (is_categorical) {
-      // Uses same 1-based encoding as category_in_threshold() in tree_shap.h
-      int category_flag = (1 << (int(x) - 1));
+      // Uses same 0-based encoding as category_in_threshold() in tree_shap.h
+      int category_flag = (1 << int(x));
       return (category_mask & category_flag) != 0;
     }
     return x > feature_lower_bound && x <= feature_upper_bound;

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -180,7 +180,7 @@ inline transform_f get_transform(unsigned model_transform) {
 }
 
 inline bool category_in_threshold(float threshold, float category) {
-    int category_flag = (1 << (int(category) - 1));
+    int category_flag = (1 << int(category));
     return (int(threshold) & category_flag) != 0;
 }
 

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <cmath>
 #include <ctime>
+#include <vector>
 #if defined(_WIN32) || defined(WIN32)
     #include <malloc.h>
 #elif defined(__MVS__)
@@ -748,6 +749,12 @@ inline int bin_coeff(int n, int k) {
     return res;
 }
 
+// omega(a, b) = 1 / ((a+b+1) * C(a+b, a))
+// Used by interventional SHAP interaction values (Zern et al. AAAI 2023)
+inline tfloat omega_weight(int a, int b) {
+    return 1.0 / ((a + b + 1) * bin_coeff(a + b, a));
+}
+
 // note this only handles single output models, so multi-output models get explained using multiple passes
 inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
                             const unsigned num_nodes, const tfloat *x,
@@ -1107,6 +1114,365 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 }
 
 
+// Implements Corollary 1 (Eq. 14b) from Zern et al. (AAAI 2023) for a constant leaf value.
+// Updates the interaction matrix out_contribs for a leaf node with the given A and N\B feature sets.
+inline void shapley_interaction_const_leaf(
+    const tfloat value,          // leaf value (scaled by 1/|D| or cover)
+    const int *A_feats,          // array of feature indices in A
+    const int nA,                // |A|
+    const int *NB_feats,         // array of feature indices in N\B
+    const int nNB,               // |N\B|
+    const unsigned num_feats,    // M (total features)
+    tfloat *out_contribs,        // output: (num_feats+1) x (num_feats+1) interaction matrix
+    const tfloat *omega_table,   // precomputed omega table
+    const unsigned omega_stride  // stride for omega_table (max_depth+2)
+) {
+    const unsigned S = num_feats + 1; // stride for interaction matrix rows
+
+    // 1. Diagonal updates (SHAP main effects)
+    // For each j in A: phi[j,j] += value * omega(|A|-1, |N\B|)
+    if (nA >= 1) {
+        const tfloat diag_A = value * omega_table[(nA - 1) * omega_stride + nNB];
+        for (int i = 0; i < nA; ++i) {
+            out_contribs[A_feats[i] * S + A_feats[i]] += diag_A;
+        }
+    }
+
+    // For each j in N\B: phi[j,j] += -value * omega(|A|, |N\B|-1)
+    if (nNB >= 1) {
+        const tfloat diag_NB = -value * omega_table[nA * omega_stride + (nNB - 1)];
+        for (int i = 0; i < nNB; ++i) {
+            out_contribs[NB_feats[i] * S + NB_feats[i]] += diag_NB;
+        }
+    }
+
+    // 2. A x A pairs (when |A| >= 2)
+    if (nA >= 2) {
+        const tfloat phi_update = 0.5 * value * omega_table[(nA - 2) * omega_stride + nNB];
+        for (int i = 0; i < nA; ++i) {
+            for (int j = i + 1; j < nA; ++j) {
+                out_contribs[A_feats[i] * S + A_feats[j]] += phi_update;
+                out_contribs[A_feats[j] * S + A_feats[i]] += phi_update;
+                // Diagonal correction: phi[k,k] -= phi_update for each off-diag entry
+                out_contribs[A_feats[i] * S + A_feats[i]] -= phi_update;
+                out_contribs[A_feats[j] * S + A_feats[j]] -= phi_update;
+            }
+        }
+    }
+
+    // 3. A x N\B cross pairs (when |A| >= 1 and |N\B| >= 1)
+    if (nA >= 1 && nNB >= 1) {
+        const tfloat phi_update = -0.5 * value * omega_table[(nA - 1) * omega_stride + (nNB - 1)];
+        for (int i = 0; i < nA; ++i) {
+            for (int j = 0; j < nNB; ++j) {
+                out_contribs[A_feats[i] * S + NB_feats[j]] += phi_update;
+                out_contribs[NB_feats[j] * S + A_feats[i]] += phi_update;
+                // Diagonal correction
+                out_contribs[A_feats[i] * S + A_feats[i]] -= phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[j]] -= phi_update;
+            }
+        }
+    }
+
+    // 4. N\B x N\B pairs (when |N\B| >= 2)
+    if (nNB >= 2) {
+        const tfloat phi_update = 0.5 * value * omega_table[nA * omega_stride + (nNB - 2)];
+        for (int i = 0; i < nNB; ++i) {
+            for (int j = i + 1; j < nNB; ++j) {
+                out_contribs[NB_feats[i] * S + NB_feats[j]] += phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[i]] += phi_update;
+                // Diagonal correction
+                out_contribs[NB_feats[i] * S + NB_feats[i]] -= phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[j]] -= phi_update;
+            }
+        }
+    }
+}
+
+// Per-tree per-sample-pair interventional SHAP interaction values.
+// Based on tree_shap_indep() traversal but computes interaction matrix at leaves
+// using Corollary 1 (Eq. 14b) from Zern et al. (AAAI 2023).
+inline void tree_shap_indep_interactions(
+    const unsigned max_depth, const unsigned num_feats,
+    const unsigned num_nodes, const tfloat *x,
+    const bool *x_missing, const tfloat *r,
+    const bool *r_missing, tfloat *out_contribs,
+    signed short *feat_hist,
+    const tfloat *omega_table, const unsigned omega_stride,
+    int *node_stack, Node *mytree,
+    int *A_feats_buf, int *NB_feats_buf
+) {
+    int ns_ctr = 0;
+    std::fill_n(feat_hist, num_feats, 0);
+    short node = 0, cl, cr, cd, pnode;
+    long feat, pfeat = -1;
+    short next_xnode = -1, next_rnode = -1;
+    short next_node = -1, from_child = -1;
+    float thres;
+    char from_flag;
+    unsigned M = 0, N = 0;
+
+    Node curr_node = mytree[node];
+    feat = curr_node.feat;
+    thres = curr_node.thres;
+    cl = curr_node.cl;
+    cr = curr_node.cr;
+    cd = curr_node.cd;
+
+    // short circuit when this is a stump tree (with no splits)
+    if (cl < 0) {
+        out_contribs[num_feats * (num_feats + 1) + num_feats] += curr_node.value;
+        return;
+    }
+
+    if (x_missing[feat]) {
+        next_xnode = cd;
+    } else if (x[feat] > thres) {
+        next_xnode = cr;
+    } else if (x[feat] <= thres) {
+        next_xnode = cl;
+    }
+
+    if (r_missing[feat]) {
+        next_rnode = cd;
+    } else if (r[feat] > thres) {
+        next_rnode = cr;
+    } else if (r[feat] <= thres) {
+        next_rnode = cl;
+    }
+
+    if (next_xnode != next_rnode) {
+        mytree[next_xnode].from_flag = FROM_X_NOT_R;
+        mytree[next_rnode].from_flag = FROM_R_NOT_X;
+    } else {
+        mytree[next_xnode].from_flag = FROM_NEITHER;
+    }
+
+    // Check if x and r go the same way
+    if (next_xnode == next_rnode) {
+        next_node = next_xnode;
+    }
+
+    // If not, go left
+    if (next_node < 0) {
+        next_node = cl;
+        if (next_rnode == next_node) { // rpath
+            N = N+1;
+            feat_hist[feat] -= 1;
+        } else if (next_xnode == next_node) { // xpath
+            M = M+1;
+            N = N+1;
+            feat_hist[feat] += 1;
+        }
+    }
+    node_stack[ns_ctr] = node;
+    ns_ctr += 1;
+    while (true) {
+        node = next_node;
+        curr_node = mytree[node];
+        feat = curr_node.feat;
+        thres = curr_node.thres;
+        cl = curr_node.cl;
+        cr = curr_node.cr;
+        cd = curr_node.cd;
+        pnode = curr_node.pnode;
+        pfeat = curr_node.pfeat;
+        from_flag = curr_node.from_flag;
+
+        // At a leaf
+        if (cl < 0) {
+            if (N == 0) {
+                // No divergence at all: add to bias term (2D position)
+                out_contribs[num_feats * (num_feats + 1) + num_feats] += mytree[node].value;
+            } else {
+                // Build A_feats and NB_feats arrays from feat_hist
+                int nA = 0, nNB = 0;
+                for (unsigned f = 0; f < num_feats; ++f) {
+                    if (feat_hist[f] > 0) {
+                        A_feats_buf[nA++] = f;
+                    } else if (feat_hist[f] < 0) {
+                        NB_feats_buf[nNB++] = f;
+                    }
+                }
+                shapley_interaction_const_leaf(
+                    mytree[node].value, A_feats_buf, nA, NB_feats_buf, nNB,
+                    num_feats, out_contribs, omega_table, omega_stride
+                );
+            }
+
+            // Pop from node_stack
+            ns_ctr -= 1;
+            next_node = node_stack[ns_ctr];
+            from_child = node;
+            // Unwind
+            if (feat_hist[pfeat] > 0) {
+                feat_hist[pfeat] -= 1;
+            } else if (feat_hist[pfeat] < 0) {
+                feat_hist[pfeat] += 1;
+            }
+            if (feat_hist[pfeat] == 0) {
+                if (from_flag == FROM_X_NOT_R) {
+                    N = N-1;
+                    M = M-1;
+                } else if (from_flag == FROM_R_NOT_X) {
+                    N = N-1;
+                }
+            }
+            continue;
+        }
+
+        const bool x_right = x[feat] > thres;
+        const bool r_right = r[feat] > thres;
+
+        if (x_missing[feat]) {
+            next_xnode = cd;
+        } else if (x_right) {
+            next_xnode = cr;
+        } else if (!x_right) {
+            next_xnode = cl;
+        }
+
+        if (r_missing[feat]) {
+            next_rnode = cd;
+        } else if (r_right) {
+            next_rnode = cr;
+        } else if (!r_right) {
+            next_rnode = cl;
+        }
+
+        if (next_xnode >= 0) {
+          if (next_xnode != next_rnode) {
+              mytree[next_xnode].from_flag = FROM_X_NOT_R;
+              mytree[next_rnode].from_flag = FROM_R_NOT_X;
+          } else {
+              mytree[next_xnode].from_flag = FROM_NEITHER;
+          }
+        }
+
+        // Arriving at node from parent
+        if (from_child == -1) {
+            node_stack[ns_ctr] = node;
+            ns_ctr += 1;
+            next_node = -1;
+
+            // Feature is set upstream
+            if (feat_hist[feat] > 0) {
+                next_node = next_xnode;
+                feat_hist[feat] += 1;
+            } else if (feat_hist[feat] < 0) {
+                next_node = next_rnode;
+                feat_hist[feat] -= 1;
+            }
+
+            // x and r go the same way
+            if (next_node < 0) {
+                if (next_xnode == next_rnode) {
+                    next_node = next_xnode;
+                }
+            }
+
+            // Go down one path
+            if (next_node >= 0) {
+                continue;
+            }
+
+            // Go down both paths, but go left first
+            next_node = cl;
+            if (next_rnode == next_node) {
+                N = N+1;
+                feat_hist[feat] -= 1;
+            } else if (next_xnode == next_node) {
+                M = M+1;
+                N = N+1;
+                feat_hist[feat] += 1;
+            }
+            from_child = -1;
+            continue;
+        }
+
+        // Arriving at node from child
+        if (from_child != -1) {
+            next_node = -1;
+            // Check if we should unroll immediately
+            if ((next_rnode == next_xnode) || (feat_hist[feat] != 0)) {
+                next_node = pnode;
+            }
+
+            // Came from a single path, so unroll
+            if (next_node >= 0) {
+                // At the root node
+                if (node == 0) {
+                    break;
+                }
+                // Unroll (no pos_lst/neg_lst propagation needed for interactions)
+                from_child = node;
+                ns_ctr -= 1;
+
+                // Unwind
+                if (feat_hist[pfeat] > 0) {
+                    feat_hist[pfeat] -= 1;
+                } else if (feat_hist[pfeat] < 0) {
+                    feat_hist[pfeat] += 1;
+                }
+                if (feat_hist[pfeat] == 0) {
+                    if (from_flag == FROM_X_NOT_R) {
+                        N = N-1;
+                        M = M-1;
+                    } else if (from_flag == FROM_R_NOT_X) {
+                        N = N-1;
+                    }
+                }
+                continue;
+                // Go right - Arriving from the left child
+            } else if (from_child == cl) {
+                node_stack[ns_ctr] = node;
+                ns_ctr += 1;
+                next_node = cr;
+                if (next_xnode == next_node) {
+                    M = M+1;
+                    N = N+1;
+                    feat_hist[feat] += 1;
+                } else if (next_rnode == next_node) {
+                    N = N+1;
+                    feat_hist[feat] -= 1;
+                }
+                from_child = -1;
+                continue;
+                // Unroll - Arriving from the right child
+            } else if (from_child == cr) {
+                // No pos_lst/neg_lst combining needed for interactions;
+                // all contributions were written at leaf nodes.
+
+                // Check if at root
+                if (node == 0) {
+                    break;
+                }
+
+                // Pop
+                ns_ctr -= 1;
+                next_node = node_stack[ns_ctr];
+                from_child = node;
+
+                // Unwind
+                if (feat_hist[pfeat] > 0) {
+                    feat_hist[pfeat] -= 1;
+                } else if (feat_hist[pfeat] < 0) {
+                    feat_hist[pfeat] += 1;
+                }
+                if (feat_hist[pfeat] == 0) {
+                    if (from_flag == FROM_X_NOT_R) {
+                        N = N-1;
+                        M = M-1;
+                    } else if (from_flag == FROM_R_NOT_X) {
+                        N = N-1;
+                    }
+                }
+                continue;
+            }
+        }
+    }
+}
+
 inline void print_progress_bar(tfloat &last_print, tfloat start_time, unsigned i, unsigned total_count) {
     const tfloat elapsed_seconds = difftime(time(NULL), start_time);
 
@@ -1278,6 +1644,159 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
     delete[] node_stack;
     delete[] feat_hist;
     delete[] memoized_weights;
+}
+
+
+/**
+ * Runs interventional Tree SHAP interaction values on dense data.
+ * Implements Algorithm 1 from Zern et al. (AAAI 2023).
+ */
+inline void dense_independent_interactions(const TreeEnsemble& trees, const ExplanationDataset &data,
+                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
+
+    // reformat the trees for faster access
+    std::vector<Node> node_trees_vec(trees.tree_limit * trees.max_nodes);
+    Node *node_trees = node_trees_vec.data();
+    for (unsigned i = 0; i < trees.tree_limit; ++i) {
+        Node *node_tree = node_trees + i * trees.max_nodes;
+        for (unsigned j = 0; j < trees.max_nodes; ++j) {
+            const unsigned en_ind = i * trees.max_nodes + j;
+            node_tree[j].cl = trees.children_left[en_ind];
+            node_tree[j].cr = trees.children_right[en_ind];
+            node_tree[j].cd = trees.children_default[en_ind];
+            if (j == 0) {
+                node_tree[j].pnode = 0;
+            }
+            if (trees.children_left[en_ind] >= 0) {
+                node_tree[trees.children_left[en_ind]].pnode = j;
+                node_tree[trees.children_left[en_ind]].pfeat = trees.features[en_ind];
+            }
+            if (trees.children_right[en_ind] >= 0) {
+                node_tree[trees.children_right[en_ind]].pnode = j;
+                node_tree[trees.children_right[en_ind]].pfeat = trees.features[en_ind];
+            }
+
+            node_tree[j].thres = trees.thresholds[en_ind];
+            node_tree[j].feat = trees.features[en_ind];
+        }
+    }
+
+    // preallocate arrays needed by the algorithm
+    const unsigned interaction_size = (data.M + 1) * (data.M + 1);
+    std::vector<int> node_stack_vec((unsigned)trees.max_depth);
+    std::vector<signed short> feat_hist_vec(data.M);
+    std::vector<tfloat> tmp_out_contribs_vec(interaction_size);
+    std::vector<int> A_feats_buf_vec(trees.max_depth + 1);
+    std::vector<int> NB_feats_buf_vec(trees.max_depth + 1);
+
+    int *node_stack = node_stack_vec.data();
+    signed short *feat_hist = feat_hist_vec.data();
+    tfloat *tmp_out_contribs = tmp_out_contribs_vec.data();
+    int *A_feats_buf = A_feats_buf_vec.data();
+    int *NB_feats_buf = NB_feats_buf_vec.data();
+
+    // precompute omega weight table
+    const unsigned omega_stride = trees.max_depth + 2;
+    std::vector<tfloat> omega_table_vec(omega_stride * omega_stride);
+    tfloat *omega_table = omega_table_vec.data();
+    for (unsigned a = 0; a <= trees.max_depth; ++a) {
+        for (unsigned b = 0; b <= trees.max_depth; ++b) {
+            omega_table[a * omega_stride + b] = omega_weight(a, b);
+        }
+    }
+
+    // compute the explanations for each sample
+    tfloat *instance_out_contribs;
+    tfloat rescale_factor = 1.0;
+    tfloat margin_x = 0;
+    tfloat margin_r = 0;
+    const unsigned no = trees.num_outputs;
+    time_t start_time = time(NULL);
+    tfloat last_print = 0;
+    for (unsigned oind = 0; oind < no; ++oind) {
+        // set the values in the reformatted tree to the current output index
+        for (unsigned i = 0; i < trees.tree_limit; ++i) {
+            Node *node_tree = node_trees + i * trees.max_nodes;
+            for (unsigned j = 0; j < trees.max_nodes; ++j) {
+                const unsigned en_ind = i * trees.max_nodes + j;
+                node_tree[j].value = trees.values[en_ind * no + oind];
+            }
+        }
+
+        // loop over all the samples
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            const tfloat *x = data.X + i * data.M;
+            const bool *x_missing = data.X_missing + i * data.M;
+            instance_out_contribs = out_contribs + i * interaction_size * no;
+            const tfloat y_i = data.y == NULL ? 0 : data.y[i];
+
+            print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * no);
+
+            // compute the model's margin output for x
+            if (transform != NULL) {
+                margin_x = trees.base_offset[oind];
+                for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                    margin_x += tree_predict(k, trees, x, x_missing)[oind];
+                }
+            }
+
+            for (unsigned j = 0; j < data.num_R; ++j) {
+                const tfloat *r = data.R + j * data.M;
+                const bool *r_missing = data.R_missing + j * data.M;
+                std::fill_n(tmp_out_contribs, interaction_size, 0);
+
+                // compute the model's margin output for r
+                if (transform != NULL) {
+                    margin_r = trees.base_offset[oind];
+                    for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                        margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                    }
+                }
+
+                for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                    tree_shap_indep_interactions(
+                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
+                        tmp_out_contribs, feat_hist, omega_table, omega_stride,
+                        node_stack, node_trees + k * trees.max_nodes,
+                        A_feats_buf, NB_feats_buf
+                    );
+                }
+
+                // compute the rescale factor
+                if (transform != NULL) {
+                    if (margin_x == margin_r) {
+                        rescale_factor = 1.0;
+                    } else {
+                        rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
+                        rescale_factor /= margin_x - margin_r;
+                    }
+                }
+
+                // add the effect of the current reference to our running total
+                // (skip the bias entry, handle it separately)
+                const unsigned bias_2d_idx = data.M * (data.M + 1) + data.M;
+                for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                    if (jj == bias_2d_idx) continue;
+                    instance_out_contribs[jj * no + oind] +=
+                        tmp_out_contribs[jj] * rescale_factor;
+                }
+
+                // Add the base offset
+                if (transform != NULL) {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        (*transform)(trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx], 0);
+                } else {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx];
+                }
+            }
+
+            // average the results over all the references
+            for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                instance_out_contribs[jj * no + oind] /= data.num_R;
+            }
+        }
+    }
 }
 
 
@@ -1461,8 +1980,10 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
     switch (feature_dependence) {
         case FEATURE_DEPENDENCE::independent:
             if (interactions) {
-                std::cerr << "FEATURE_DEPENDENCE::independent does not support interactions!\n";
-            } else dense_independent(trees, data, out_contribs, transform);
+                dense_independent_interactions(trees, data, out_contribs, transform);
+            } else {
+                dense_independent(trees, data, out_contribs, transform);
+            }
             return;
 
         case FEATURE_DEPENDENCE::tree_path_dependent:

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -5,7 +5,6 @@ import numpy as np
 from ..utils import assert_import, record_import_error
 from ._tree import (
     TreeExplainer,
-    _xgboost_cat_unsupported,
     feature_perturbation_codes,
     output_transform_codes,
 )
@@ -70,7 +69,12 @@ class GPUTreeExplainer(TreeExplainer):
         )
 
         model = self.model
-        _xgboost_cat_unsupported(model)
+        if np.any(model.threshold_types != 0):
+            raise NotImplementedError(
+                "Categorical splits are not yet supported by GPUTreeExplainer. Use"
+                " TreeExplainer (CPU) with feature_perturbation='interventional'"
+                " or feature_perturbation='tree_path_dependent' instead."
+            )
         transform = model.get_transform()
 
         # run the core algorithm using the C extension

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -69,12 +69,6 @@ class GPUTreeExplainer(TreeExplainer):
         )
 
         model = self.model
-        if np.any(model.threshold_types != 0):
-            raise NotImplementedError(
-                "Categorical splits are not yet supported by GPUTreeExplainer. Use"
-                " TreeExplainer (CPU) with feature_perturbation='interventional'"
-                " or feature_perturbation='tree_path_dependent' instead."
-            )
         transform = model.get_transform()
 
         # run the core algorithm using the C extension

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1950,7 +1950,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** cat
+                            threshold += 2**cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -782,7 +782,6 @@ class TreeExplainer(Explainer):
         assert self.model.model_output == "raw", (
             'Only model_output = "raw" is supported for SHAP interaction values right now!'
         )
-        # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
         transform = "identity"
 
         # see if we have a default tree_limit in place.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -104,14 +104,6 @@ def _xgboost_n_iterations(tree_limit: int, num_stacked_models: int) -> int:
     return n_iterations
 
 
-def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
-    if model.model_type == "xgboost" and model.cat_feature_indices is not None:
-        raise NotImplementedError(
-            "Categorical split is not yet supported. You can still use"
-            " TreeExplainer with `feature_perturbation=tree_path_dependent`."
-        )
-
-
 class TreeExplainer(Explainer):
     """Uses Tree SHAP algorithms to explain the output of ensemble tree models.
 
@@ -658,7 +650,6 @@ class TreeExplainer(Explainer):
             X, y, tree_limit, check_additivity
         )
         transform = self.model.get_transform()
-        _xgboost_cat_unsupported(self.model)
 
         # run the core algorithm using the C extension
         assert_import("cext")

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -784,7 +784,8 @@ class TreeExplainer(Explainer):
             import xgboost
 
             if not isinstance(X, xgboost.core.DMatrix):
-                X = xgboost.DMatrix(X)
+                dmatrix_props = getattr(self.model, "_xgb_dmatrix_props", {})
+                X = xgboost.DMatrix(X, **dmatrix_props)
 
             n_iterations = _xgboost_n_iterations(tree_limit, self.model.num_stacked_models)
             phi = self.model.original_model.predict(
@@ -1949,7 +1950,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** (cat - 1)
+                            threshold += 2 ** cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1357,7 +1357,7 @@ class TreeEnsemble:
             try:
                 self.trees = [SingleTree(e, data=data, data_missing=data_missing) for e in tree_info]
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
 
             self.objective = objective_name_map.get(model.params.get("objective", "regression"), None)
             self.tree_output = tree_output_name_map.get(model.params.get("objective", "regression"), None)
@@ -1370,7 +1370,7 @@ class TreeEnsemble:
             try:
                 self.trees = [SingleTree(e, data=data, data_missing=data_missing) for e in tree_info]
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
 
             self.objective = objective_name_map.get(model.params.get("objective", "regression"), None)
             self.tree_output = tree_output_name_map.get(model.params.get("objective", "regression"), None)
@@ -1383,7 +1383,7 @@ class TreeEnsemble:
             try:
                 self.trees = [SingleTree(e, data=data, data_missing=data_missing) for e in tree_info]
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
             self.objective = objective_name_map.get(model.objective, None)
             self.tree_output = tree_output_name_map.get(model.objective, None)
             if model.objective is None:
@@ -1397,7 +1397,7 @@ class TreeEnsemble:
             try:
                 self.trees = [SingleTree(e, data=data, data_missing=data_missing) for e in tree_info]
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
             # Note: for ranker, leaving tree_output and objective as None as they
             # are not implemented in native code yet
         elif safe_isinstance(model, "lightgbm.sklearn.LGBMClassifier"):
@@ -1410,7 +1410,7 @@ class TreeEnsemble:
             try:
                 self.trees = [SingleTree(e, data=data, data_missing=data_missing) for e in tree_info]
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
             self.objective = objective_name_map.get(model.objective, None)
             self.tree_output = tree_output_name_map.get(model.objective, None)
             if model.objective is None:
@@ -1425,7 +1425,7 @@ class TreeEnsemble:
                 cb_loader = CatBoostTreeModelLoader(model)
                 self.trees = cb_loader.get_trees(data=data, data_missing=data_missing)
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
         elif safe_isinstance(model, "catboost.core.CatBoostClassifier"):
             assert_import("catboost")
             self.model_type = "catboost"
@@ -1435,7 +1435,7 @@ class TreeEnsemble:
                 cb_loader = CatBoostTreeModelLoader(model)
                 self.trees = cb_loader.get_trees(data=data, data_missing=data_missing)
             except Exception:
-                self.trees = None  # we get here because the cext can't handle categorical splits yet
+                self.trees = None  # we get here because SingleTree parsing failed
             self.tree_output = "log_odds"
             self.objective = "binary_crossentropy"
             self.cat_feature_indices = model.get_cat_feature_indices()

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -125,9 +125,9 @@ def test_xgboost_cat_unsupported() -> None:
     with pytest.raises(NotImplementedError, match="Categorical"):
         gpu_ex.shap_values(X)
 
+    # CPU TreeExplainer now supports categorical splits in interventional mode
     ex = shap.TreeExplainer(clf, X, feature_perturbation="interventional")
-    with pytest.raises(NotImplementedError, match="Categorical"):
-        ex.shap_values(X)
+    ex.shap_values(X)
 
 
 def lightgbm_base():

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -110,7 +110,7 @@ def xgboost_multiclass_classifier():
     return model, X, model.predict(X, output_margin=True)
 
 
-def test_xgboost_cat_unsupported() -> None:
+def test_xgboost_cat_supported() -> None:
     xgboost = pytest.importorskip("xgboost")
     X, y = shap.datasets.adult()
     X["Workclass"] = X["Workclass"].astype("category")
@@ -118,14 +118,10 @@ def test_xgboost_cat_unsupported() -> None:
     clf = xgboost.XGBClassifier(n_estimators=2, enable_categorical=True, device="cuda")
     clf.fit(X, y)
 
-    # Tests for both CPU and GPU in one place
-
-    # Prefer an explict error over silent invalid values.
+    # Both GPU and CPU TreeExplainer support categorical splits
     gpu_ex = shap.GPUTreeExplainer(clf, X, feature_perturbation="interventional")
-    with pytest.raises(NotImplementedError, match="Categorical"):
-        gpu_ex.shap_values(X)
+    gpu_ex.shap_values(X)
 
-    # CPU TreeExplainer now supports categorical splits in interventional mode
     ex = shap.TreeExplainer(clf, X, feature_perturbation="interventional")
     ex.shap_values(X)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2942,15 +2942,20 @@ def test_tree_explainer_random_forest_regressor():
 # --- Interventional SHAP interaction values tests ---
 
 
-def test_interventional_interaction_values_brute_force():
-    """Verify interventional interactions match brute-force Shapley computation."""
+@pytest.mark.parametrize("n_features", [3, 4, 5, 6])
+def test_interventional_interaction_values_brute_force(n_features):
+    """Verify interventional interactions match brute-force Shapley computation.
+
+    Computes exact Shapley interaction indices by definition (O(2^n) per pair)
+    and compares against our C++ implementation. Parametrized over feature counts
+    to test different set-interval configurations.
+    """
     from itertools import combinations
     from math import comb
 
     np.random.seed(42)
-    n_features = 5
     X_train = np.random.randn(200, n_features)
-    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2 % n_features]
     model = DecisionTreeRegressor(max_depth=3, random_state=42)
     model.fit(X_train, y_train)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3461,6 +3461,7 @@ def _compute_shap_with_threads(model, X, background, n_threads, **kwargs):
 def test_openmp_interventional_shap_values():
     """Multi-threaded interventional SHAP values should match single-threaded."""
     from sklearn.ensemble import RandomForestRegressor
+
     X, y = shap.datasets.california(n_points=200)
     model = RandomForestRegressor(n_estimators=20, max_depth=5, random_state=42)
     model.fit(X, y)
@@ -3472,8 +3473,7 @@ def test_openmp_interventional_shap_values():
     sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4)
 
     # Results should be identical (same accumulation order)
-    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10,
-                               err_msg="SHAP values differ between 1 and 4 threads")
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10, err_msg="SHAP values differ between 1 and 4 threads")
 
     # Verify additivity: sum of shap values + expected_value == prediction
     pred = model.predict(X_test.values)
@@ -3505,8 +3505,7 @@ def test_openmp_interventional_interaction_values():
         else:
             os.environ["OMP_NUM_THREADS"] = old_val
 
-    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10,
-                               err_msg="Interaction values differ between 1 and 4 threads")
+    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10, err_msg="Interaction values differ between 1 and 4 threads")
 
     # Verify symmetry
     for i in range(iv_4.shape[0]):
@@ -3522,17 +3521,15 @@ def test_openmp_interventional_with_transform():
     X = X[:200]
     y = y[:200]
 
-    model = xgb.XGBClassifier(n_estimators=10, max_depth=3, random_state=42,
-                               use_label_encoder=False, eval_metric="logloss")
+    model = xgb.XGBClassifier(
+        n_estimators=10, max_depth=3, random_state=42, use_label_encoder=False, eval_metric="logloss"
+    )
     model.fit(X, y)
 
     background = X[:50]
     X_test = X[50:70]
 
-    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1,
-                                             model_output="probability")
-    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4,
-                                             model_output="probability")
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1, model_output="probability")
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4, model_output="probability")
 
-    np.testing.assert_allclose(sv_1, sv_4, atol=1e-8,
-                               err_msg="SHAP values with transform differ between threads")
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-8, err_msg="SHAP values with transform differ between threads")

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2978,10 +2978,21 @@ def test_interventional_interaction_values_brute_force(n_features):
                     for S_tuple in combinations(rest, size):
                         S = set(S_tuple)
                         feats = np.arange(n_features)
-                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_S = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Si = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sj = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sij = np.mean(
+                            [
+                                model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0]
+                                for r in bg
+                            ]
+                        )
 
                         weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
                         val += weight * (v_Sij - v_Si - v_Sj + v_S)
@@ -3078,6 +3089,7 @@ def test_interventional_interaction_values_models(model_name):
         model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
     elif model_name == "RandomForestRegressor":
         from sklearn.ensemble import RandomForestRegressor
+
         model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
     else:
         raise ValueError(f"Unknown model: {model_name}")
@@ -3117,6 +3129,7 @@ def test_interventional_interaction_values_nonzero():
 def test_interventional_interaction_values_multiclass():
     """Verify interventional interactions work for multi-class models."""
     from sklearn.datasets import load_iris
+
     iris = load_iris()
     model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
     model.fit(iris.data, iris.target)
@@ -3132,9 +3145,7 @@ def test_interventional_interaction_values_multiclass():
     if isinstance(interactions, list):
         for cls_interactions in interactions:
             assert cls_interactions.shape == (5, 4, 4)
-            np.testing.assert_allclose(
-                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
-            )
+            np.testing.assert_allclose(cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4)
     else:
         assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
         if interactions.ndim == 4:
@@ -3163,7 +3174,8 @@ def test_interventional_categorical():
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
     model = lightgbm.train(
         {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
-        ds, num_boost_round=20,
+        ds,
+        num_boost_round=20,
     )
 
     X_test = X[:10]
@@ -3240,9 +3252,29 @@ def test_pytree_categorical_split():
     phi1 = np.zeros((2, 1))
     phi1[-1, :] += values[0, :]
     tree_shap_recursive(
-        children_left, children_right, children_default, features, thresholds,
-        values, node_sample_weight, np.array([1.0]), np.array([False]), phi1,
-        0, 0, fi, zf, of, pw, 1, 1, -1, 0, 0, 1, threshold_types=threshold_types,
+        children_left,
+        children_right,
+        children_default,
+        features,
+        thresholds,
+        values,
+        node_sample_weight,
+        np.array([1.0]),
+        np.array([False]),
+        phi1,
+        0,
+        0,
+        fi,
+        zf,
+        of,
+        pw,
+        1,
+        1,
+        -1,
+        0,
+        0,
+        1,
+        threshold_types=threshold_types,
     )
     assert phi1[-1, 0] + phi1[0, 0] == pytest.approx(10.0)
 
@@ -3250,9 +3282,29 @@ def test_pytree_categorical_split():
     phi2 = np.zeros((2, 1))
     phi2[-1, :] += values[0, :]
     tree_shap_recursive(
-        children_left, children_right, children_default, features, thresholds,
-        values, node_sample_weight, np.array([0.0]), np.array([False]), phi2,
-        0, 0, fi, zf, of, pw, 1, 1, -1, 0, 0, 1, threshold_types=threshold_types,
+        children_left,
+        children_right,
+        children_default,
+        features,
+        thresholds,
+        values,
+        node_sample_weight,
+        np.array([0.0]),
+        np.array([False]),
+        phi2,
+        0,
+        0,
+        fi,
+        zf,
+        of,
+        pw,
+        1,
+        1,
+        -1,
+        0,
+        0,
+        1,
+        threshold_types=threshold_types,
     )
     assert phi2[-1, 0] + phi2[0, 0] == pytest.approx(20.0)
 
@@ -3260,9 +3312,29 @@ def test_pytree_categorical_split():
     phi3 = np.zeros((2, 1))
     phi3[-1, :] += values[0, :]
     tree_shap_recursive(
-        children_left, children_right, children_default, features, thresholds,
-        values, node_sample_weight, np.array([2.0]), np.array([False]), phi3,
-        0, 0, fi, zf, of, pw, 1, 1, -1, 0, 0, 1, threshold_types=threshold_types,
+        children_left,
+        children_right,
+        children_default,
+        features,
+        thresholds,
+        values,
+        node_sample_weight,
+        np.array([2.0]),
+        np.array([False]),
+        phi3,
+        0,
+        0,
+        fi,
+        zf,
+        of,
+        pw,
+        1,
+        1,
+        -1,
+        0,
+        0,
+        1,
+        threshold_types=threshold_types,
     )
     assert phi3[-1, 0] + phi3[0, 0] == pytest.approx(10.0)
 
@@ -3270,9 +3342,29 @@ def test_pytree_categorical_split():
     phi4 = np.zeros((2, 1))
     phi4[-1, :] += values[0, :]
     tree_shap_recursive(
-        children_left, children_right, children_default, features, thresholds,
-        values, node_sample_weight, np.array([3.0]), np.array([False]), phi4,
-        0, 0, fi, zf, of, pw, 1, 1, -1, 0, 0, 1, threshold_types=threshold_types,
+        children_left,
+        children_right,
+        children_default,
+        features,
+        thresholds,
+        values,
+        node_sample_weight,
+        np.array([3.0]),
+        np.array([False]),
+        phi4,
+        0,
+        0,
+        fi,
+        zf,
+        of,
+        pw,
+        1,
+        1,
+        -1,
+        0,
+        0,
+        1,
+        threshold_types=threshold_types,
     )
     assert phi4[-1, 0] + phi4[0, 0] == pytest.approx(20.0)
 
@@ -3342,13 +3434,9 @@ def test_path_dependent_small_background():
         np.testing.assert_allclose(shap_sum, pred[:, c], atol=1e-6)
 
     # Values should converge toward full-background results
-    explainer_full = shap.TreeExplainer(
-        model, data=X, feature_perturbation="tree_path_dependent"
-    )
+    explainer_full = shap.TreeExplainer(model, data=X, feature_perturbation="tree_path_dependent")
     sv_full = explainer_full.shap_values(X[:5], check_additivity=False)
     # Not exact but reasonably close (large background → more accurate)
-    explainer_120 = shap.TreeExplainer(
-        model, data=X[:120], feature_perturbation="tree_path_dependent"
-    )
+    explainer_120 = shap.TreeExplainer(model, data=X[:120], feature_perturbation="tree_path_dependent")
     sv_120 = explainer_120.shap_values(X[:5], check_additivity=False)
     assert np.max(np.abs(sv_120 - sv_full)) < np.max(np.abs(sv - sv_full))

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2196,7 +2196,6 @@ def test_overflow_tree_path_dependent():
     exp(X)
 
 
-@pytest.mark.skip("Currently disabled due to errors, see https://github.com/uber/causalml/issues/859.")
 @pytest.mark.parametrize(
     "n_estimators",
     [

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3153,12 +3153,12 @@ def test_interventional_categorical():
 
     np.random.seed(42)
     n = 200
-    # Two categorical features (1-based to avoid pre-existing category_in_threshold
-    # issue with category 0) and one continuous feature
-    cat0 = np.random.randint(1, 5, n).astype(np.float64)
-    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    # Two categorical features (0-based, verifying category 0 works correctly)
+    # and one continuous feature
+    cat0 = np.random.randint(0, 4, n).astype(np.float64)
+    cat1 = np.random.randint(0, 3, n).astype(np.float64)
     cont = np.random.randn(n)
-    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    y = (cat0 == 1).astype(float) * 2 + cont * 0.5 + (cat1 == 2).astype(float)
     X = np.column_stack([cat0, cat1, cont])
 
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2,6 +2,7 @@
 
 import itertools
 import math
+import os
 import pickle
 import sys
 
@@ -3440,3 +3441,98 @@ def test_path_dependent_small_background():
     explainer_120 = shap.TreeExplainer(model, data=X[:120], feature_perturbation="tree_path_dependent")
     sv_120 = explainer_120.shap_values(X[:5], check_additivity=False)
     assert np.max(np.abs(sv_120 - sv_full)) < np.max(np.abs(sv - sv_full))
+
+
+def _compute_shap_with_threads(model, X, background, n_threads, **kwargs):
+    """Helper to compute SHAP values with a specific thread count."""
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    os.environ["OMP_NUM_THREADS"] = str(n_threads)
+    try:
+        explainer = shap.TreeExplainer(model, data=background, feature_perturbation="interventional", **kwargs)
+        result = explainer.shap_values(X)
+    finally:
+        if old_val is None:
+            del os.environ["OMP_NUM_THREADS"]
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+    return result, explainer.expected_value
+
+
+def test_openmp_interventional_shap_values():
+    """Multi-threaded interventional SHAP values should match single-threaded."""
+    from sklearn.ensemble import RandomForestRegressor
+    X, y = shap.datasets.california(n_points=200)
+    model = RandomForestRegressor(n_estimators=20, max_depth=5, random_state=42)
+    model.fit(X, y)
+
+    background = X[:50]
+    X_test = X[50:80]
+
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1)
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4)
+
+    # Results should be identical (same accumulation order)
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10,
+                               err_msg="SHAP values differ between 1 and 4 threads")
+
+    # Verify additivity: sum of shap values + expected_value == prediction
+    pred = model.predict(X_test.values)
+    shap_sum = ev_4 + sv_4.sum(axis=1)
+    np.testing.assert_allclose(shap_sum, pred, atol=1e-6)
+
+
+def test_openmp_interventional_interaction_values():
+    """Multi-threaded interventional interaction values should match single-threaded."""
+    X, y = shap.datasets.iris()
+    model = GradientBoostingRegressor(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X.values, y)
+
+    background = X.values[:30]
+    X_test = X.values[:10]
+
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    try:
+        os.environ["OMP_NUM_THREADS"] = "1"
+        ex1 = shap.TreeExplainer(model, data=background, feature_perturbation="interventional")
+        iv_1 = ex1.shap_interaction_values(X_test)
+
+        os.environ["OMP_NUM_THREADS"] = "4"
+        ex4 = shap.TreeExplainer(model, data=background, feature_perturbation="interventional")
+        iv_4 = ex4.shap_interaction_values(X_test)
+    finally:
+        if old_val is None:
+            os.environ.pop("OMP_NUM_THREADS", None)
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+
+    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10,
+                               err_msg="Interaction values differ between 1 and 4 threads")
+
+    # Verify symmetry
+    for i in range(iv_4.shape[0]):
+        np.testing.assert_allclose(iv_4[i], iv_4[i].T, atol=1e-10)
+
+
+def test_openmp_interventional_with_transform():
+    """Multi-threaded interventional SHAP with transform should match single-threaded."""
+    pytest.importorskip("xgboost")
+    import xgboost as xgb
+
+    X, y = shap.datasets.adult()
+    X = X[:200]
+    y = y[:200]
+
+    model = xgb.XGBClassifier(n_estimators=10, max_depth=3, random_state=42,
+                               use_label_encoder=False, eval_metric="logloss")
+    model.fit(X, y)
+
+    background = X[:50]
+    X_test = X[50:70]
+
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1,
+                                             model_output="probability")
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4,
+                                             model_output="probability")
+
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-8,
+                               err_msg="SHAP values with transform differ between threads")


### PR DESCRIPTION
## Summary

This PR implements interventional SHAP interaction values, fixes several long-standing bugs related to categorical split handling and path-dependent mode, and adds OpenMP parallelization to the interventional TreeSHAP code paths. It closes 4 open issues, addresses 3 more, and supersedes PR #4091.

### New feature: Interventional SHAP interaction values
- Implements the algorithm from [Zern et al. (AAAI 2023)](https://ojs.aaai.org/index.php/AAAI/article/view/26234) — "Interventional SHAP Values and Interaction Values for Piecewise Linear Regression Trees"
- `shap_interaction_values()` with `feature_perturbation="interventional"` previously returned **all zeros** silently (#1824). Now produces correct values.
- Verified against brute-force computation for 3–6 features, and tested on sklearn, LightGBM, XGBoost, and CatBoost models
- Satisfies symmetry, row-sum additivity, and prediction additivity properties

### Performance: OpenMP parallelization of interventional TreeSHAP
- The sample loop in `dense_independent()` and `dense_independent_interactions()` is embarrassingly parallel (each sample writes to a disjoint output region). Added OpenMP parallelization for near-linear speedup with thread count.
- Key design: extracted `from_flag` from the `Node` struct into a per-thread `char[]` array (~1 KB/thread), keeping `node_trees` fully shared and read-only — avoids deep-copying the entire tree array (~16 MB/thread).
- Per-thread workspace vectors allocated once per `#pragma omp parallel` region; `schedule(dynamic, 1)` for load balancing across samples with different tree-path lengths.
- Removed `print_progress_bar()` calls from parallel regions (requires GIL via `PySys_WriteStderr`).
- Build system: `-fopenmp` on Linux/macOS, `/openmp` on Windows.

### Bug fixes

| Bug | Severity | Issue(s) |
|-----|----------|----------|
| Interventional interaction values return all zeros | CRITICAL | Closes #1824 |
| `category_in_threshold` broken for category value 0 (UB in C++) | HIGH | — |
| XGBoost `dmatrix_props` not propagated for interaction values | MEDIUM | Fixes #3510, supersedes #4091 |
| Categorical splits ignored in interventional code path (CPU + GPU) | HIGH | — |
| Path-dependent SHAP NaN with small background datasets | MEDIUM | Addresses #3574 |
| LightGBM categorical crash in pure Python `pytree.py` | HIGH | Addresses #292, #248, #1644 |
| causalml test skipped unnecessarily (fixed upstream in v0.16.0) | LOW | — |

### Key changes

**`shap/cext/tree_shap.h`**
- New `dense_independent_interactions()` function implementing Zern et al. algorithm
- New `tree_shap_indep_interactions()` inner loop with SII weight computation
- `omega_weight()` helper for Shapley interaction index weights
- `category_in_threshold()`: fixed 0-based encoding (`1 << int(category)` instead of `1 << (int(category) - 1)`)
- Added `threshold_type` to `Node` struct; all split-routing sites handle categorical splits
- Removed `from_flag` from `Node` struct; extracted to per-thread `char *from_flags` parameter in `tree_shap_indep()` and `tree_shap_indep_interactions()`
- OpenMP parallel regions in `dense_independent()` and `dense_independent_interactions()` with per-thread workspace vectors and `schedule(dynamic, 1)`
- `#include <omp.h>` guarded by `#ifdef _OPENMP`

**`setup.py`**
- Added `-fopenmp` compile/link flags (Linux/macOS), `/openmp` (Windows)

**`shap/cext/_cext_gpu.cu`**
- GPU `EvaluateSplit()` updated with categorical split support
- `ShapSplitCondition` extended with `threshold_type` field

**`shap/explainers/_tree.py`**
- Epsilon weight fix: zero `node_sample_weight` values replaced with 1e-6 after `dense_tree_update_weights`, preventing NaN from `unwind_path()` division by zero in path-dependent mode
- `_xgb_dmatrix_props` now passed in `shap_interaction_values()` for XGBoost categorical models
- `category_in_threshold` Python-side: fixed to 0-based encoding

**`shap/explainers/pytree.py`**
- `tree_shap_recursive()` now accepts `threshold_types` and handles categorical splits

**`tests/explainers/test_tree.py`**
- 14 new tests for interventional interaction values (brute-force, symmetry, additivity, prediction, multi-model, multiclass, categorical)
- 3 new OpenMP tests: SHAP values (1 vs 4 threads), interaction values (1 vs 4 threads + symmetry), and transform/probability output (1 vs 4 threads)
- XGBoost mixed categorical + NaN test (adapted from PR #4091 by @cedricdonie)
- Interaction value additivity checks added to existing `test_xgboost_dmatrix_propagation`
- Tests for path-dependent categorical splits and small background datasets
- Re-enabled causalml test (upstream fix in v0.16.0)

## Issues closed

- **Closes #1824** — Interventional interaction values now work (were silently all zeros)
- **Fixes #3510** — XGBoost `dmatrix_props` propagated for interaction values (supersedes #4091)
- **Addresses #3574** — Path-dependent mode works with small background datasets (epsilon weight fix)
- **Addresses #292, #248, #1644** — All code paths now support LightGBM categorical splits
- **May address #3486** — Interventional TreeSHAP segfault no longer reproducible after `from_flag` refactoring

## Related issues investigated

- **#4042** (sparse data additivity failure): This is a path-dependent mode numerical overflow with extremely deep trees (depth 89+), not related to our changes. Interventional mode works correctly on the same data.
- **#3655** (CPU vs GPU SHAP differ): Related to `log_loss` transform handling at the Python level, not to categorical splits. Cannot be tested without CUDA hardware.

## Test plan

- [x] Brute-force verification of interaction values against exponential-time reference (3–6 features)
- [x] Symmetry: `phi[i,j] == phi[j,i]` for all feature pairs
- [x] Row-sum additivity: `sum(phi[i,:]) == shap_values[i]` for all features
- [x] Prediction additivity: `sum(phi) + expected_value == prediction`
- [x] Multi-model: sklearn GBR, RandomForest, LightGBM, XGBoost, CatBoost
- [x] Multiclass: sklearn GBC with 3 classes
- [x] Categorical splits: LightGBM with native categoricals (interventional + path-dependent)
- [x] XGBoost categorical + NaN: mixed category types with missing values
- [x] Small background: LightGBM multiclass with 50-sample background, values finite and convergent
- [x] OpenMP: single-threaded vs multi-threaded results match within `atol=1e-10` for SHAP values, interaction values, and probability transform
- [x] Full test suite: 136 passed, 1 skipped (16GB RAM test), 0 failures (all optional deps installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)