### PR TITLE
Fix GPU TreeSHAP ignoring output transform

### DIFF
--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -306,41 +306,140 @@ dense_tree_independent_gpu(const TreeEnsemble &trees,
   DeviceExplanationDataset device_data(data);
   DeviceExplanationDataset::DenseDatasetWrapper X =
       device_data.GetDeviceAccessor();
-  DeviceExplanationDataset background_device_data(data, true);
-  DeviceExplanationDataset::DenseDatasetWrapper R =
-      background_device_data.GetDeviceAccessor();
 
-  thrust::device_vector<float> phis((X.NumCols() + 1) * X.NumRows() *
-                                    trees.num_outputs);
-  gpu_treeshap::GPUTreeShapInterventional(X, R, paths.begin(), paths.end(),
-                                          trees.num_outputs, phis.begin(),
-                                          phis.end());
-  // Add the base offset term to bias
-  thrust::device_vector<double> base_offset(
-      trees.base_offset, trees.base_offset + trees.num_outputs);
-  auto counting = thrust::make_counting_iterator(size_t(0));
-  auto d_phis = phis.data().get();
-  auto d_base_offset = base_offset.data().get();
+  size_t M = X.NumCols();
+  size_t num_X = X.NumRows();
   size_t num_groups = trees.num_outputs;
-  thrust::for_each(counting, counting + X.NumRows() * trees.num_outputs,
-                   [=] __device__(size_t idx) {
-                     size_t row_idx = idx / num_groups;
-                     size_t group = idx % num_groups;
-                     auto phi_idx = gpu_treeshap::IndexPhi(
-                         row_idx, num_groups, group, X.NumCols(), X.NumCols());
-                     d_phis[phi_idx] += d_base_offset[group];
-                   });
+  size_t phi_count = (M + 1) * num_X * num_groups;
+  auto counting = thrust::make_counting_iterator(size_t(0));
+  thrust::device_vector<float> phis(phi_count);
+
+  if (transform != NULL) {
+    // Exact per-reference transform rescaling, matching the CPU algorithm in
+    // dense_independent() (tree_shap.h). We call the GPU library once per
+    // reference sample to get per-reference raw SHAP values, then apply the
+    // chain-rule rescaling individually before averaging.
+    std::vector<tfloat> accum(phi_count, 0.0);
+    std::vector<float> h_phis(phi_count);
+
+    // Upload all reference data to GPU once
+    thrust::device_vector<tfloat> all_r_data(
+        data.R, data.R + data.num_R * data.M);
+    thrust::device_vector<bool> all_r_missing(
+        data.R_missing, data.R_missing + data.num_R * data.M);
+
+    // Precompute margins for all X samples
+    std::vector<std::vector<tfloat>> margins_x(num_groups);
+    for (unsigned oind = 0; oind < num_groups; ++oind) {
+      margins_x[oind].resize(num_X);
+      for (unsigned i = 0; i < num_X; ++i) {
+        const tfloat *x = data.X + i * data.M;
+        const bool *x_missing = data.X_missing + i * data.M;
+        margins_x[oind][i] = trees.base_offset[oind];
+        for (unsigned k = 0; k < trees.tree_limit; ++k) {
+          margins_x[oind][i] += tree_predict(k, trees, x, x_missing)[oind];
+        }
+      }
+    }
+
+    for (unsigned j = 0; j < data.num_R; ++j) {
+      // Create a 1-row background view into the already-uploaded R data
+      DeviceExplanationDataset::DenseDatasetWrapper R_j(
+          all_r_data.data().get() + j * data.M,
+          all_r_missing.data().get() + j * data.M, 1, data.M);
+
+      // Compute raw SHAP values for all X against this single reference
+      thrust::fill(phis.begin(), phis.end(), 0.0f);
+      gpu_treeshap::GPUTreeShapInterventional(
+          X, R_j, paths.begin(), paths.end(), trees.num_outputs, phis.begin(),
+          phis.end());
+
+      // Copy to host
+      thrust::copy(phis.begin(), phis.end(), h_phis.begin());
+
+      // Compute margin for this reference
+      const tfloat *r = data.R + j * data.M;
+      const bool *r_missing = data.R_missing + j * data.M;
+      std::vector<tfloat> margin_r(num_groups);
+      for (unsigned oind = 0; oind < num_groups; ++oind) {
+        margin_r[oind] = trees.base_offset[oind];
+        for (unsigned k = 0; k < trees.tree_limit; ++k) {
+          margin_r[oind] += tree_predict(k, trees, r, r_missing)[oind];
+        }
+      }
+
+      // Apply per-reference rescaling and accumulate
+      for (unsigned i = 0; i < num_X; ++i) {
+        const tfloat y_i = data.y == NULL ? 0 : data.y[i];
+
+        for (unsigned oind = 0; oind < num_groups; ++oind) {
+          // Chain-rule rescale factor for this (x_i, r_j) pair
+          tfloat rescale;
+          if (margins_x[oind][i] != margin_r[oind]) {
+            rescale = (transform(margins_x[oind][i], y_i) -
+                       transform(margin_r[oind], y_i)) /
+                      (margins_x[oind][i] - margin_r[oind]);
+          } else {
+            rescale = 1.0;
+          }
+
+          // Accumulate rescaled feature contributions
+          for (unsigned k = 0; k < M; ++k) {
+            auto phi_idx =
+                gpu_treeshap::IndexPhi(i, num_groups, oind, M, k);
+            accum[phi_idx] += h_phis[phi_idx] * rescale;
+          }
+
+          // Accumulate transformed bias (y=0 for bias, matching CPU)
+          auto bias_idx =
+              gpu_treeshap::IndexPhi(i, num_groups, oind, M, M);
+          accum[bias_idx] +=
+              transform(trees.base_offset[oind] + h_phis[bias_idx], 0);
+        }
+      }
+    }
+
+    // Average over references
+    for (auto &v : accum) v /= data.num_R;
+
+    // Copy result back to device for transpose
+    std::vector<float> accum_f(accum.begin(), accum.end());
+    thrust::copy(accum_f.begin(), accum_f.end(), phis.begin());
+  } else {
+    // No transform: single call with full background dataset
+    DeviceExplanationDataset background_device_data(data, true);
+    DeviceExplanationDataset::DenseDatasetWrapper R =
+        background_device_data.GetDeviceAccessor();
+    gpu_treeshap::GPUTreeShapInterventional(X, R, paths.begin(), paths.end(),
+                                            trees.num_outputs, phis.begin(),
+                                            phis.end());
+
+    // Add base offset on device
+    auto d_phis = phis.data().get();
+    thrust::device_vector<double> base_offset(
+        trees.base_offset, trees.base_offset + num_groups);
+    auto d_base_offset = base_offset.data().get();
+    thrust::for_each(counting, counting + num_X * num_groups,
+                     [=] __device__(size_t idx) {
+                       size_t row_idx = idx / num_groups;
+                       size_t group = idx % num_groups;
+                       auto phi_idx = gpu_treeshap::IndexPhi(
+                           row_idx, num_groups, group, M, M);
+                       d_phis[phi_idx] += d_base_offset[group];
+                     });
+  }
 
   // Shap uses a slightly different layout for multiclass
+  auto d_phis = phis.data().get();
   thrust::device_vector<float> transposed_phis(phis.size());
   auto d_transposed_phis = transposed_phis.data();
   thrust::for_each(
       counting, counting + phis.size(), [=] __device__(size_t idx) {
-        size_t old_shape[] = {X.NumRows(), num_groups, (X.NumCols() + 1)};
+        size_t old_shape[] = {num_X, num_groups, (M + 1)};
         size_t old_idx[array_size(old_shape)];
         gpu_treeshap::FlatIdxToTensorIdx(idx, old_shape, old_idx);
         // Define new tensor format, switch num_groups axis to end
-        size_t new_shape[] = {X.NumRows(), (X.NumCols() + 1), num_groups};
+        size_t new_shape[] = {num_X, (M + 1), num_groups};
         size_t new_idx[] = {old_idx[0], old_idx[2], old_idx[1]};
         size_t transposed_idx =
             gpu_treeshap::TensorIdxToFlatIdx(new_shape, new_idx);

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -320,11 +320,11 @@ def test_gpu_cpu_match_with_transform_gh3655():
     sv_cpu = explainer_cpu.shap_values(X_test)
     sv_gpu = explainer_gpu.shap_values(X_test)
 
-    np.testing.assert_allclose(sv_cpu, sv_gpu, atol=1e-4,
-                               err_msg="GPU vs CPU SHAP values differ with model_output='probability'")
+    np.testing.assert_allclose(
+        sv_cpu, sv_gpu, atol=1e-4, err_msg="GPU vs CPU SHAP values differ with model_output='probability'"
+    )
 
     # Verify additivity: sum(shap) + expected_value ≈ predict_proba
     proba = model.predict_proba(X_test)[:, 1]
     gpu_sum = sv_gpu.sum(axis=1) + explainer_gpu.expected_value
-    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3,
-                               err_msg="GPU SHAP values don't sum to predict_proba")
+    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3, err_msg="GPU SHAP values don't sum to predict_proba")

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -288,3 +288,43 @@ def test_lightgbm_categorical_split(use_interactions):
         else:
             shap_values = explainer.shap_values(X.iloc[:10, :])
             assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)
+
+
+def test_gpu_cpu_match_with_transform_gh3655():
+    """GPU and CPU SHAP values should match when using output transforms.
+
+    Reproduces GitHub issue #3655: GPU TreeSHAP ignored the output transform
+    (model_output="probability", "log_loss", etc.), producing values that
+    differed greatly from CPU TreeExplainer.
+    """
+    xgboost = pytest.importorskip("xgboost")
+
+    X, y = shap.datasets.adult()
+    X = X.iloc[:500]
+    y = y[:500]
+
+    model = xgboost.XGBClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    background = X.iloc[:100]
+
+    # Test with model_output="probability" (logistic transform)
+    explainer_cpu = shap.TreeExplainer(
+        model, background, feature_perturbation="interventional", model_output="probability"
+    )
+    explainer_gpu = shap.GPUTreeExplainer(
+        model, background, feature_perturbation="interventional", model_output="probability"
+    )
+
+    X_test = X.iloc[100:110]
+    sv_cpu = explainer_cpu.shap_values(X_test)
+    sv_gpu = explainer_gpu.shap_values(X_test)
+
+    np.testing.assert_allclose(sv_cpu, sv_gpu, atol=1e-4,
+                               err_msg="GPU vs CPU SHAP values differ with model_output='probability'")
+
+    # Verify additivity: sum(shap) + expected_value ≈ predict_proba
+    proba = model.predict_proba(X_test)[:, 1]
+    gpu_sum = sv_gpu.sum(axis=1) + explainer_gpu.expected_value
+    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3,
+                               err_msg="GPU SHAP values don't sum to predict_proba")

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -383,3 +383,43 @@ def test_categorical_split_matches_binary_feature():
     np.testing.assert_allclose(bin_gpu, bin_cpu, atol=1e-5)
     np.testing.assert_allclose(cat_gpu, bin_gpu, atol=1e-5)
     np.testing.assert_allclose(cat_cpu, cat_gpu, atol=1e-5)
+
+
+def test_gpu_cpu_match_with_transform_gh3655():
+    """GPU and CPU SHAP values should match when using output transforms.
+
+    Reproduces GitHub issue #3655: GPU TreeSHAP ignored the output transform
+    (model_output="probability", "log_loss", etc.), producing values that
+    differed greatly from CPU TreeExplainer.
+    """
+    xgboost = pytest.importorskip("xgboost")
+
+    X, y = shap.datasets.adult()
+    X = X.iloc[:500]
+    y = y[:500]
+
+    model = xgboost.XGBClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    background = X.iloc[:100]
+
+    # Test with model_output="probability" (logistic transform)
+    explainer_cpu = shap.TreeExplainer(
+        model, background, feature_perturbation="interventional", model_output="probability"
+    )
+    explainer_gpu = shap.GPUTreeExplainer(
+        model, background, feature_perturbation="interventional", model_output="probability"
+    )
+
+    X_test = X.iloc[100:110]
+    sv_cpu = explainer_cpu.shap_values(X_test)
+    sv_gpu = explainer_gpu.shap_values(X_test)
+
+    np.testing.assert_allclose(sv_cpu, sv_gpu, atol=1e-4,
+                               err_msg="GPU vs CPU SHAP values differ with model_output='probability'")
+
+    # Verify additivity: sum(shap) + expected_value ≈ predict_proba
+    proba = model.predict_proba(X_test)[:, 1]
+    gpu_sum = sv_gpu.sum(axis=1) + explainer_gpu.expected_value
+    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3,
+                               err_msg="GPU SHAP values don't sum to predict_proba")

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -385,12 +385,13 @@ def test_categorical_split_matches_binary_feature():
     np.testing.assert_allclose(cat_cpu, cat_gpu, atol=1e-5)
 
 
-def test_gpu_cpu_match_with_transform_gh3655():
+@pytest.mark.parametrize("model_output", ["log_loss", "probability"])
+def test_gpu_cpu_match_with_transform_gh3655(model_output):
     """GPU and CPU SHAP values should match when using output transforms.
 
     Reproduces GitHub issue #3655: GPU TreeSHAP ignored the output transform
-    (model_output="probability", "log_loss", etc.), producing values that
-    differed greatly from CPU TreeExplainer.
+    (model_output="log_loss", "probability"), producing values that differed
+    greatly from CPU TreeExplainer. The original report uses log_loss.
     """
     xgboost = pytest.importorskip("xgboost")
 
@@ -402,24 +403,23 @@ def test_gpu_cpu_match_with_transform_gh3655():
     model.fit(X, y)
 
     background = X.iloc[:100]
+    X_test = X.iloc[100:110]
+    y_test = y[100:110]
 
-    # Test with model_output="probability" (logistic transform)
     explainer_cpu = shap.TreeExplainer(
-        model, background, feature_perturbation="interventional", model_output="probability"
+        model, background, feature_perturbation="interventional", model_output=model_output
     )
     explainer_gpu = shap.GPUTreeExplainer(
-        model, background, feature_perturbation="interventional", model_output="probability"
+        model, background, feature_perturbation="interventional", model_output=model_output
     )
 
-    X_test = X.iloc[100:110]
-    sv_cpu = explainer_cpu.shap_values(X_test)
-    sv_gpu = explainer_gpu.shap_values(X_test)
+    if model_output == "log_loss":
+        sv_cpu = explainer_cpu.shap_values(X_test, y_test)
+        sv_gpu = explainer_gpu.shap_values(X_test, y_test)
+    else:
+        sv_cpu = explainer_cpu.shap_values(X_test)
+        sv_gpu = explainer_gpu.shap_values(X_test)
 
     np.testing.assert_allclose(
-        sv_cpu, sv_gpu, atol=1e-4, err_msg="GPU vs CPU SHAP values differ with model_output='probability'"
+        sv_cpu, sv_gpu, atol=1e-4, err_msg=f"GPU vs CPU SHAP values differ with model_output='{model_output}'"
     )
-
-    # Verify additivity: sum(shap) + expected_value ≈ predict_proba
-    proba = model.predict_proba(X_test)[:, 1]
-    gpu_sum = sv_gpu.sum(axis=1) + explainer_gpu.expected_value
-    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3, err_msg="GPU SHAP values don't sum to predict_proba")

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -415,11 +415,11 @@ def test_gpu_cpu_match_with_transform_gh3655():
     sv_cpu = explainer_cpu.shap_values(X_test)
     sv_gpu = explainer_gpu.shap_values(X_test)
 
-    np.testing.assert_allclose(sv_cpu, sv_gpu, atol=1e-4,
-                               err_msg="GPU vs CPU SHAP values differ with model_output='probability'")
+    np.testing.assert_allclose(
+        sv_cpu, sv_gpu, atol=1e-4, err_msg="GPU vs CPU SHAP values differ with model_output='probability'"
+    )
 
     # Verify additivity: sum(shap) + expected_value ≈ predict_proba
     proba = model.predict_proba(X_test)[:, 1]
     gpu_sum = sv_gpu.sum(axis=1) + explainer_gpu.expected_value
-    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3,
-                               err_msg="GPU SHAP values don't sum to predict_proba")
+    np.testing.assert_allclose(gpu_sum, proba, atol=1e-3, err_msg="GPU SHAP values don't sum to predict_proba")


### PR DESCRIPTION
## Summary

- GPU interventional TreeSHAP received the `transform` function pointer but never applied it, causing GPU SHAP values to differ from CPU when using `model_output="probability"` (or any non-identity transform like `"logloss"`)
- Implements exact per-reference chain-rule rescaling matching the CPU algorithm in `dense_independent()` (`tree_shap.h`)
- For each reference sample, calls `GPUTreeShapInterventional` individually to get per-reference raw SHAP values, applies the chain-rule rescale factor `(T(margin_x) - T(margin_r)) / (margin_x - margin_r)`, and accumulates before averaging — no approximation
- The no-transform path (`model_output="raw"`) is completely unchanged

## Root cause

In `_cext_gpu.cu`, `dense_tree_independent_gpu()` receives a `transform` function pointer from `dense_tree_shap_gpu()` but the original code unconditionally ignored it — it only added `base_offset` to the bias term and transposed the output. The CPU code in `dense_independent()` applies per-reference chain-rule rescaling when a transform is present.

## Design

The GPU library (`GPUTreeShapInterventional`) returns SHAP values averaged across all reference samples. To get exact per-reference values for the chain-rule rescaling, we call the library once per reference with a single-row background dataset:

1. Extract tree paths and upload X to GPU once
2. Upload all R data to GPU once, create per-reference `DenseDatasetWrapper` views
3. For each reference `r_j`: compute raw SHAP values via GPU, copy to host, apply `rescale = (T(margin_x, y) - T(margin_r_j, y)) / (margin_x - margin_r_j)`, accumulate
4. Average over references, transpose on device

This matches the CPU algorithm exactly — same rescale factors, same bias handling (`y=0` for bias term).

Fixes #3655

## Test plan

- [ ] Verify GPU SHAP values with `model_output="probability"` match CPU values (requires CUDA hardware — requesting @madakkmi to verify)
- [ ] Verify `model_output="raw"` path unchanged (no-transform path is identical)
- [ ] Verify additivity: `sum(shap_values) + expected_value ≈ model.predict_proba()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)