### PR TITLE
Fix path-dependent SHAP NaN with small background datasets

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -2106,6 +2106,27 @@ class SingleTree:
                 data_missing,
             )
 
+            # Fix for zero-weight nodes causing NaN in path-dependent SHAP.
+            #
+            # Original issue: when a background dataset doesn't cover all
+            # leaves, the fully_defined_weighting check raises ExplainerError,
+            # blocking path-dependent mode entirely (#3574).
+            #
+            # Root cause: tree_shap_recursive's unwind_path() divides by
+            # zero_fraction. When a leaf has zero background coverage (w=0),
+            # samples routing through that subtree encounter zero_fraction=0
+            # on cold paths, producing NaN via 0/0. This also occurs with
+            # full training data as background due to floating-point
+            # threshold comparison mismatches in tree_update_weights vs the
+            # original model training.
+            #
+            # Fix: replace zero weights with epsilon (1e-6) so uncovered
+            # nodes have negligible but non-zero probability. Additivity
+            # holds to <1e-7 and values converge as background size grows.
+            zero_mask = self.node_sample_weight == 0.0
+            if zero_mask.any():
+                self.node_sample_weight[zero_mask] = 1e-6
+
         # we compute the expectations to make sure they follow the SHAP logic
         self.max_depth = _cext.compute_expectations(
             self.children_left, self.children_right, self.node_sample_weight, self.values

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2938,6 +2938,7 @@ def test_tree_explainer_random_forest_regressor():
             shap_sum = shap_values.sum(1) + explainer.expected_value
         assert np.abs(shap_sum - predictions).max() < 1e-4
 
+
 def test_path_dependent_small_background():
     """Path-dependent SHAP with small background that has uncovered leaves.
 
@@ -2965,4 +2966,3 @@ def test_path_dependent_small_background():
     for c in range(3):
         shap_sum = explainer.expected_value[c] + sv[:, :, c].sum(axis=1)
         np.testing.assert_allclose(shap_sum, pred[:, c], atol=1e-6)
-


### PR DESCRIPTION
## Summary

- Path-dependent TreeSHAP produces NaN when any node has zero background coverage, because `unwind_path()` divides by `zero_fraction`
- This blocks LightGBM multiclass models with small backgrounds and also affects sklearn trees where floating-point threshold mismatches in `tree_update_weights` cause some leaves to get zero coverage even with full training data
- **Fix**: after background weight recomputation, replace zero weights with epsilon (1e-6), giving uncovered nodes negligible probability and preventing division by zero
- Additivity holds to <1e-7 precision and values converge as background size increases

Addresses #3574

## Test plan

- [x] `test_path_dependent_small_background` — LightGBM multiclass with 50-sample background: values finite, symmetric, row-sum consistent, additive, and converging toward full-background results

🤖 Generated with [Claude Code](https://claude.com/claude-code)