### PR TITLE
Implement interventional SHAP interaction values and fix categorical split handling

### DIFF
--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -109,6 +109,31 @@ static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
     return ret;
 }
 
+static bool has_categorical_splits(PyArrayObject *threshold_types_array, int tree_limit)
+{
+    const int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    const npy_intp ndim = PyArray_NDIM(threshold_types_array);
+    if (ndim >= 2) {
+        const npy_intp num_trees = PyArray_DIM(threshold_types_array, 0);
+        const npy_intp max_nodes = PyArray_DIM(threshold_types_array, 1);
+        npy_intp effective_tree_limit = tree_limit < 0 ? num_trees : static_cast<npy_intp>(tree_limit);
+        if (effective_tree_limit > num_trees) effective_tree_limit = num_trees;
+        for (npy_intp i = 0; i < effective_tree_limit * max_nodes; ++i) {
+            if (threshold_types[i] == 1) {
+                return true;
+            }
+        }
+    } else {
+        const npy_intp num_threshold_types = PyArray_SIZE(threshold_types_array);
+        for (npy_intp i = 0; i < num_threshold_types; ++i) {
+            if (threshold_types[i] == 1) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 
 static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 {
@@ -118,6 +143,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     PyObject *node_sample_weights_obj;
     int max_depth;
@@ -135,8 +161,8 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
+        args, "OOOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &node_sample_weights_obj,
         &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
         &out_contribs_obj, &feature_dependence, &model_output, &interactions
     )) return NULL;
@@ -148,6 +174,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *node_sample_weights_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -164,14 +191,15 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
-        values_array == NULL || node_sample_weights_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_contribs_array == NULL) {
+        cat_bitsets_array == NULL || values_array == NULL || node_sample_weights_array == NULL || X_array == NULL ||
+        X_missing_array == NULL || out_contribs_array == NULL || base_offset_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
         Py_XDECREF((PyObject*)children_right_array);
         Py_XDECREF((PyObject*)children_default_array);
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         Py_XDECREF((PyObject*)node_sample_weights_array);
         Py_XDECREF((PyObject*)X_array);
@@ -180,6 +208,31 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
         if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
         if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
         //PyArray_ResolveWritebackIfCopy(out_contribs_array);
+        Py_XDECREF((PyObject*)out_contribs_array);
+        Py_XDECREF((PyObject*)base_offset_array);
+        return NULL;
+    }
+
+    if (feature_dependence == FEATURE_DEPENDENCE::global_path_dependent &&
+        has_categorical_splits(threshold_types_array, tree_limit)) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "feature_perturbation='global_path_dependent' does not support categorical splits."
+        );
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)node_sample_weights_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+        if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
+        if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
         Py_XDECREF((PyObject*)out_contribs_array);
         Py_XDECREF((PyObject*)base_offset_array);
         return NULL;
@@ -199,6 +252,8 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
+    size_t num_cat_bitsets = static_cast<size_t>(PyArray_SIZE(cat_bitsets_array));
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weights_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -215,7 +270,8 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     // these are just a wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types,
+        cat_bitsets, num_cat_bitsets, values,
         node_sample_weights, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );
@@ -233,6 +289,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     Py_XDECREF((PyObject*)node_sample_weights_array);
     Py_XDECREF((PyObject*)X_array);
@@ -258,6 +315,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     int max_depth;
     int tree_limit;
@@ -270,8 +328,8 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+        args, "OOOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
         &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
     )) return NULL;
 
@@ -282,6 +340,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -293,7 +352,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
-        values_array == NULL || X_array == NULL ||
+        cat_bitsets_array == NULL || values_array == NULL || base_offset_array == NULL || X_array == NULL ||
         X_missing_array == NULL || out_pred_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
         Py_XDECREF((PyObject*)children_right_array);
@@ -301,6 +360,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         Py_XDECREF((PyObject*)base_offset_array);
         Py_XDECREF((PyObject*)X_array);
@@ -319,6 +379,19 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     const unsigned num_offsets = PyArray_DIM(base_offset_array, 0);
     if (num_offsets != num_outputs) {
         std::cerr << "The passed base_offset array does that have the same number of outputs as the values array: " << num_offsets << " vs. " << num_outputs << std::endl;
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)base_offset_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+        Py_XDECREF((PyObject*)out_pred_array);
         return NULL;
     }
 
@@ -329,6 +402,8 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
+    size_t num_cat_bitsets = static_cast<size_t>(PyArray_SIZE(cat_bitsets_array));
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -340,7 +415,8 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types,
+        cat_bitsets, num_cat_bitsets, values,
         NULL, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );
@@ -355,6 +431,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     Py_XDECREF((PyObject*)base_offset_array);
     Py_XDECREF((PyObject*)X_array);
@@ -377,6 +454,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     int tree_limit;
     PyObject *node_sample_weight_obj;
@@ -385,8 +463,8 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
+        args, "OOOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
     )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
@@ -396,6 +474,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -404,7 +483,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
-        values_array == NULL || node_sample_weight_array == NULL || X_array == NULL ||
+        cat_bitsets_array == NULL || values_array == NULL || node_sample_weight_array == NULL || X_array == NULL ||
         X_missing_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
         Py_XDECREF((PyObject*)children_right_array);
@@ -412,6 +491,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         //PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
         Py_XDECREF((PyObject*)node_sample_weight_array);
@@ -432,6 +512,8 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
+    size_t num_cat_bitsets = static_cast<size_t>(PyArray_SIZE(cat_bitsets_array));
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *node_sample_weight = (tfloat*)PyArray_DATA(node_sample_weight_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -440,7 +522,8 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types,
+        cat_bitsets, num_cat_bitsets, values,
         node_sample_weight, 0, tree_limit, 0, max_nodes, 0
     );
     ExplanationDataset data = ExplanationDataset(X, X_missing, NULL, NULL, NULL, num_X, M, 0);
@@ -454,6 +537,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
     Py_XDECREF((PyObject*)node_sample_weight_array);
@@ -474,6 +558,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     int max_depth;
     int tree_limit;
@@ -487,8 +572,8 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+        args, "OOOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
         &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
     )) return NULL;
 
@@ -499,6 +584,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -510,7 +596,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL ||
-        values_array == NULL || X_array == NULL ||
+        threshold_types_array == NULL || cat_bitsets_array == NULL || values_array == NULL || base_offset_array == NULL || X_array == NULL ||
         X_missing_array == NULL || out_pred_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
         Py_XDECREF((PyObject*)children_right_array);
@@ -518,6 +604,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         Py_XDECREF((PyObject*)base_offset_array);
         Py_XDECREF((PyObject*)X_array);
@@ -540,6 +627,8 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
+    size_t num_cat_bitsets = static_cast<size_t>(PyArray_SIZE(cat_bitsets_array));
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -551,7 +640,8 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types,
+        cat_bitsets, num_cat_bitsets, values,
         NULL, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );
@@ -566,6 +656,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     Py_XDECREF((PyObject*)base_offset_array);
     Py_XDECREF((PyObject*)X_array);

--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -28,10 +28,10 @@ struct CategoryConstraint {
   __host__ __device__ static bool CategoryInMask(int categories,
                                                  float category) {
     int category_int = static_cast<int>(category);
-    if (category_int < 1) {
+    if (category_int < 0) {
       return false;
     }
-    int category_flag = 1 << (category_int - 1);
+    int category_flag = 1 << category_int;
     return (categories & category_flag) != 0;
   }
 

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -180,7 +180,7 @@ inline transform_f get_transform(unsigned model_transform) {
 }
 
 inline bool category_in_threshold(float threshold, float category) {
-    int category_flag = (1 << (int(category) - 1));
+    int category_flag = (1 << int(category));
     return (int(threshold) & category_flag) != 0;
 }
 

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <cmath>
 #include <ctime>
+#include <vector>
 #if defined(_WIN32) || defined(WIN32)
     #include <malloc.h>
 #elif defined(__MVS__)
@@ -748,6 +749,12 @@ inline int bin_coeff(int n, int k) {
     return res;
 }
 
+// omega(a, b) = 1 / ((a+b+1) * C(a+b, a))
+// Used by interventional SHAP interaction values (Zern et al. AAAI 2023)
+inline tfloat omega_weight(int a, int b) {
+    return 1.0 / ((a + b + 1) * bin_coeff(a + b, a));
+}
+
 // note this only handles single output models, so multi-output models get explained using multiple passes
 inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
                             const unsigned num_nodes, const tfloat *x,
@@ -1107,6 +1114,365 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 }
 
 
+// Implements Corollary 1 (Eq. 14b) from Zern et al. (AAAI 2023) for a constant leaf value.
+// Updates the interaction matrix out_contribs for a leaf node with the given A and N\B feature sets.
+inline void shapley_interaction_const_leaf(
+    const tfloat value,          // leaf value (scaled by 1/|D| or cover)
+    const int *A_feats,          // array of feature indices in A
+    const int nA,                // |A|
+    const int *NB_feats,         // array of feature indices in N\B
+    const int nNB,               // |N\B|
+    const unsigned num_feats,    // M (total features)
+    tfloat *out_contribs,        // output: (num_feats+1) x (num_feats+1) interaction matrix
+    const tfloat *omega_table,   // precomputed omega table
+    const unsigned omega_stride  // stride for omega_table (max_depth+2)
+) {
+    const unsigned S = num_feats + 1; // stride for interaction matrix rows
+
+    // 1. Diagonal updates (SHAP main effects)
+    // For each j in A: phi[j,j] += value * omega(|A|-1, |N\B|)
+    if (nA >= 1) {
+        const tfloat diag_A = value * omega_table[(nA - 1) * omega_stride + nNB];
+        for (int i = 0; i < nA; ++i) {
+            out_contribs[A_feats[i] * S + A_feats[i]] += diag_A;
+        }
+    }
+
+    // For each j in N\B: phi[j,j] += -value * omega(|A|, |N\B|-1)
+    if (nNB >= 1) {
+        const tfloat diag_NB = -value * omega_table[nA * omega_stride + (nNB - 1)];
+        for (int i = 0; i < nNB; ++i) {
+            out_contribs[NB_feats[i] * S + NB_feats[i]] += diag_NB;
+        }
+    }
+
+    // 2. A x A pairs (when |A| >= 2)
+    if (nA >= 2) {
+        const tfloat phi_update = 0.5 * value * omega_table[(nA - 2) * omega_stride + nNB];
+        for (int i = 0; i < nA; ++i) {
+            for (int j = i + 1; j < nA; ++j) {
+                out_contribs[A_feats[i] * S + A_feats[j]] += phi_update;
+                out_contribs[A_feats[j] * S + A_feats[i]] += phi_update;
+                // Diagonal correction: phi[k,k] -= phi_update for each off-diag entry
+                out_contribs[A_feats[i] * S + A_feats[i]] -= phi_update;
+                out_contribs[A_feats[j] * S + A_feats[j]] -= phi_update;
+            }
+        }
+    }
+
+    // 3. A x N\B cross pairs (when |A| >= 1 and |N\B| >= 1)
+    if (nA >= 1 && nNB >= 1) {
+        const tfloat phi_update = -0.5 * value * omega_table[(nA - 1) * omega_stride + (nNB - 1)];
+        for (int i = 0; i < nA; ++i) {
+            for (int j = 0; j < nNB; ++j) {
+                out_contribs[A_feats[i] * S + NB_feats[j]] += phi_update;
+                out_contribs[NB_feats[j] * S + A_feats[i]] += phi_update;
+                // Diagonal correction
+                out_contribs[A_feats[i] * S + A_feats[i]] -= phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[j]] -= phi_update;
+            }
+        }
+    }
+
+    // 4. N\B x N\B pairs (when |N\B| >= 2)
+    if (nNB >= 2) {
+        const tfloat phi_update = 0.5 * value * omega_table[nA * omega_stride + (nNB - 2)];
+        for (int i = 0; i < nNB; ++i) {
+            for (int j = i + 1; j < nNB; ++j) {
+                out_contribs[NB_feats[i] * S + NB_feats[j]] += phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[i]] += phi_update;
+                // Diagonal correction
+                out_contribs[NB_feats[i] * S + NB_feats[i]] -= phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[j]] -= phi_update;
+            }
+        }
+    }
+}
+
+// Per-tree per-sample-pair interventional SHAP interaction values.
+// Based on tree_shap_indep() traversal but computes interaction matrix at leaves
+// using Corollary 1 (Eq. 14b) from Zern et al. (AAAI 2023).
+inline void tree_shap_indep_interactions(
+    const unsigned max_depth, const unsigned num_feats,
+    const unsigned num_nodes, const tfloat *x,
+    const bool *x_missing, const tfloat *r,
+    const bool *r_missing, tfloat *out_contribs,
+    signed short *feat_hist,
+    const tfloat *omega_table, const unsigned omega_stride,
+    int *node_stack, Node *mytree,
+    int *A_feats_buf, int *NB_feats_buf
+) {
+    int ns_ctr = 0;
+    std::fill_n(feat_hist, num_feats, 0);
+    short node = 0, cl, cr, cd, pnode;
+    long feat, pfeat = -1;
+    short next_xnode = -1, next_rnode = -1;
+    short next_node = -1, from_child = -1;
+    float thres;
+    char from_flag;
+    unsigned M = 0, N = 0;
+
+    Node curr_node = mytree[node];
+    feat = curr_node.feat;
+    thres = curr_node.thres;
+    cl = curr_node.cl;
+    cr = curr_node.cr;
+    cd = curr_node.cd;
+
+    // short circuit when this is a stump tree (with no splits)
+    if (cl < 0) {
+        out_contribs[num_feats * (num_feats + 1) + num_feats] += curr_node.value;
+        return;
+    }
+
+    if (x_missing[feat]) {
+        next_xnode = cd;
+    } else if (x[feat] > thres) {
+        next_xnode = cr;
+    } else if (x[feat] <= thres) {
+        next_xnode = cl;
+    }
+
+    if (r_missing[feat]) {
+        next_rnode = cd;
+    } else if (r[feat] > thres) {
+        next_rnode = cr;
+    } else if (r[feat] <= thres) {
+        next_rnode = cl;
+    }
+
+    if (next_xnode != next_rnode) {
+        mytree[next_xnode].from_flag = FROM_X_NOT_R;
+        mytree[next_rnode].from_flag = FROM_R_NOT_X;
+    } else {
+        mytree[next_xnode].from_flag = FROM_NEITHER;
+    }
+
+    // Check if x and r go the same way
+    if (next_xnode == next_rnode) {
+        next_node = next_xnode;
+    }
+
+    // If not, go left
+    if (next_node < 0) {
+        next_node = cl;
+        if (next_rnode == next_node) { // rpath
+            N = N+1;
+            feat_hist[feat] -= 1;
+        } else if (next_xnode == next_node) { // xpath
+            M = M+1;
+            N = N+1;
+            feat_hist[feat] += 1;
+        }
+    }
+    node_stack[ns_ctr] = node;
+    ns_ctr += 1;
+    while (true) {
+        node = next_node;
+        curr_node = mytree[node];
+        feat = curr_node.feat;
+        thres = curr_node.thres;
+        cl = curr_node.cl;
+        cr = curr_node.cr;
+        cd = curr_node.cd;
+        pnode = curr_node.pnode;
+        pfeat = curr_node.pfeat;
+        from_flag = curr_node.from_flag;
+
+        // At a leaf
+        if (cl < 0) {
+            if (N == 0) {
+                // No divergence at all: add to bias term (2D position)
+                out_contribs[num_feats * (num_feats + 1) + num_feats] += mytree[node].value;
+            } else {
+                // Build A_feats and NB_feats arrays from feat_hist
+                int nA = 0, nNB = 0;
+                for (unsigned f = 0; f < num_feats; ++f) {
+                    if (feat_hist[f] > 0) {
+                        A_feats_buf[nA++] = f;
+                    } else if (feat_hist[f] < 0) {
+                        NB_feats_buf[nNB++] = f;
+                    }
+                }
+                shapley_interaction_const_leaf(
+                    mytree[node].value, A_feats_buf, nA, NB_feats_buf, nNB,
+                    num_feats, out_contribs, omega_table, omega_stride
+                );
+            }
+
+            // Pop from node_stack
+            ns_ctr -= 1;
+            next_node = node_stack[ns_ctr];
+            from_child = node;
+            // Unwind
+            if (feat_hist[pfeat] > 0) {
+                feat_hist[pfeat] -= 1;
+            } else if (feat_hist[pfeat] < 0) {
+                feat_hist[pfeat] += 1;
+            }
+            if (feat_hist[pfeat] == 0) {
+                if (from_flag == FROM_X_NOT_R) {
+                    N = N-1;
+                    M = M-1;
+                } else if (from_flag == FROM_R_NOT_X) {
+                    N = N-1;
+                }
+            }
+            continue;
+        }
+
+        const bool x_right = x[feat] > thres;
+        const bool r_right = r[feat] > thres;
+
+        if (x_missing[feat]) {
+            next_xnode = cd;
+        } else if (x_right) {
+            next_xnode = cr;
+        } else if (!x_right) {
+            next_xnode = cl;
+        }
+
+        if (r_missing[feat]) {
+            next_rnode = cd;
+        } else if (r_right) {
+            next_rnode = cr;
+        } else if (!r_right) {
+            next_rnode = cl;
+        }
+
+        if (next_xnode >= 0) {
+          if (next_xnode != next_rnode) {
+              mytree[next_xnode].from_flag = FROM_X_NOT_R;
+              mytree[next_rnode].from_flag = FROM_R_NOT_X;
+          } else {
+              mytree[next_xnode].from_flag = FROM_NEITHER;
+          }
+        }
+
+        // Arriving at node from parent
+        if (from_child == -1) {
+            node_stack[ns_ctr] = node;
+            ns_ctr += 1;
+            next_node = -1;
+
+            // Feature is set upstream
+            if (feat_hist[feat] > 0) {
+                next_node = next_xnode;
+                feat_hist[feat] += 1;
+            } else if (feat_hist[feat] < 0) {
+                next_node = next_rnode;
+                feat_hist[feat] -= 1;
+            }
+
+            // x and r go the same way
+            if (next_node < 0) {
+                if (next_xnode == next_rnode) {
+                    next_node = next_xnode;
+                }
+            }
+
+            // Go down one path
+            if (next_node >= 0) {
+                continue;
+            }
+
+            // Go down both paths, but go left first
+            next_node = cl;
+            if (next_rnode == next_node) {
+                N = N+1;
+                feat_hist[feat] -= 1;
+            } else if (next_xnode == next_node) {
+                M = M+1;
+                N = N+1;
+                feat_hist[feat] += 1;
+            }
+            from_child = -1;
+            continue;
+        }
+
+        // Arriving at node from child
+        if (from_child != -1) {
+            next_node = -1;
+            // Check if we should unroll immediately
+            if ((next_rnode == next_xnode) || (feat_hist[feat] != 0)) {
+                next_node = pnode;
+            }
+
+            // Came from a single path, so unroll
+            if (next_node >= 0) {
+                // At the root node
+                if (node == 0) {
+                    break;
+                }
+                // Unroll (no pos_lst/neg_lst propagation needed for interactions)
+                from_child = node;
+                ns_ctr -= 1;
+
+                // Unwind
+                if (feat_hist[pfeat] > 0) {
+                    feat_hist[pfeat] -= 1;
+                } else if (feat_hist[pfeat] < 0) {
+                    feat_hist[pfeat] += 1;
+                }
+                if (feat_hist[pfeat] == 0) {
+                    if (from_flag == FROM_X_NOT_R) {
+                        N = N-1;
+                        M = M-1;
+                    } else if (from_flag == FROM_R_NOT_X) {
+                        N = N-1;
+                    }
+                }
+                continue;
+                // Go right - Arriving from the left child
+            } else if (from_child == cl) {
+                node_stack[ns_ctr] = node;
+                ns_ctr += 1;
+                next_node = cr;
+                if (next_xnode == next_node) {
+                    M = M+1;
+                    N = N+1;
+                    feat_hist[feat] += 1;
+                } else if (next_rnode == next_node) {
+                    N = N+1;
+                    feat_hist[feat] -= 1;
+                }
+                from_child = -1;
+                continue;
+                // Unroll - Arriving from the right child
+            } else if (from_child == cr) {
+                // No pos_lst/neg_lst combining needed for interactions;
+                // all contributions were written at leaf nodes.
+
+                // Check if at root
+                if (node == 0) {
+                    break;
+                }
+
+                // Pop
+                ns_ctr -= 1;
+                next_node = node_stack[ns_ctr];
+                from_child = node;
+
+                // Unwind
+                if (feat_hist[pfeat] > 0) {
+                    feat_hist[pfeat] -= 1;
+                } else if (feat_hist[pfeat] < 0) {
+                    feat_hist[pfeat] += 1;
+                }
+                if (feat_hist[pfeat] == 0) {
+                    if (from_flag == FROM_X_NOT_R) {
+                        N = N-1;
+                        M = M-1;
+                    } else if (from_flag == FROM_R_NOT_X) {
+                        N = N-1;
+                    }
+                }
+                continue;
+            }
+        }
+    }
+}
+
 inline void print_progress_bar(tfloat &last_print, tfloat start_time, unsigned i, unsigned total_count) {
     const tfloat elapsed_seconds = difftime(time(NULL), start_time);
 
@@ -1278,6 +1644,159 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
     delete[] node_stack;
     delete[] feat_hist;
     delete[] memoized_weights;
+}
+
+
+/**
+ * Runs interventional Tree SHAP interaction values on dense data.
+ * Implements Algorithm 1 from Zern et al. (AAAI 2023).
+ */
+inline void dense_independent_interactions(const TreeEnsemble& trees, const ExplanationDataset &data,
+                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
+
+    // reformat the trees for faster access
+    std::vector<Node> node_trees_vec(trees.tree_limit * trees.max_nodes);
+    Node *node_trees = node_trees_vec.data();
+    for (unsigned i = 0; i < trees.tree_limit; ++i) {
+        Node *node_tree = node_trees + i * trees.max_nodes;
+        for (unsigned j = 0; j < trees.max_nodes; ++j) {
+            const unsigned en_ind = i * trees.max_nodes + j;
+            node_tree[j].cl = trees.children_left[en_ind];
+            node_tree[j].cr = trees.children_right[en_ind];
+            node_tree[j].cd = trees.children_default[en_ind];
+            if (j == 0) {
+                node_tree[j].pnode = 0;
+            }
+            if (trees.children_left[en_ind] >= 0) {
+                node_tree[trees.children_left[en_ind]].pnode = j;
+                node_tree[trees.children_left[en_ind]].pfeat = trees.features[en_ind];
+            }
+            if (trees.children_right[en_ind] >= 0) {
+                node_tree[trees.children_right[en_ind]].pnode = j;
+                node_tree[trees.children_right[en_ind]].pfeat = trees.features[en_ind];
+            }
+
+            node_tree[j].thres = trees.thresholds[en_ind];
+            node_tree[j].feat = trees.features[en_ind];
+        }
+    }
+
+    // preallocate arrays needed by the algorithm
+    const unsigned interaction_size = (data.M + 1) * (data.M + 1);
+    std::vector<int> node_stack_vec((unsigned)trees.max_depth);
+    std::vector<signed short> feat_hist_vec(data.M);
+    std::vector<tfloat> tmp_out_contribs_vec(interaction_size);
+    std::vector<int> A_feats_buf_vec(trees.max_depth + 1);
+    std::vector<int> NB_feats_buf_vec(trees.max_depth + 1);
+
+    int *node_stack = node_stack_vec.data();
+    signed short *feat_hist = feat_hist_vec.data();
+    tfloat *tmp_out_contribs = tmp_out_contribs_vec.data();
+    int *A_feats_buf = A_feats_buf_vec.data();
+    int *NB_feats_buf = NB_feats_buf_vec.data();
+
+    // precompute omega weight table
+    const unsigned omega_stride = trees.max_depth + 2;
+    std::vector<tfloat> omega_table_vec(omega_stride * omega_stride);
+    tfloat *omega_table = omega_table_vec.data();
+    for (unsigned a = 0; a <= trees.max_depth; ++a) {
+        for (unsigned b = 0; b <= trees.max_depth; ++b) {
+            omega_table[a * omega_stride + b] = omega_weight(a, b);
+        }
+    }
+
+    // compute the explanations for each sample
+    tfloat *instance_out_contribs;
+    tfloat rescale_factor = 1.0;
+    tfloat margin_x = 0;
+    tfloat margin_r = 0;
+    const unsigned no = trees.num_outputs;
+    time_t start_time = time(NULL);
+    tfloat last_print = 0;
+    for (unsigned oind = 0; oind < no; ++oind) {
+        // set the values in the reformatted tree to the current output index
+        for (unsigned i = 0; i < trees.tree_limit; ++i) {
+            Node *node_tree = node_trees + i * trees.max_nodes;
+            for (unsigned j = 0; j < trees.max_nodes; ++j) {
+                const unsigned en_ind = i * trees.max_nodes + j;
+                node_tree[j].value = trees.values[en_ind * no + oind];
+            }
+        }
+
+        // loop over all the samples
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            const tfloat *x = data.X + i * data.M;
+            const bool *x_missing = data.X_missing + i * data.M;
+            instance_out_contribs = out_contribs + i * interaction_size * no;
+            const tfloat y_i = data.y == NULL ? 0 : data.y[i];
+
+            print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * no);
+
+            // compute the model's margin output for x
+            if (transform != NULL) {
+                margin_x = trees.base_offset[oind];
+                for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                    margin_x += tree_predict(k, trees, x, x_missing)[oind];
+                }
+            }
+
+            for (unsigned j = 0; j < data.num_R; ++j) {
+                const tfloat *r = data.R + j * data.M;
+                const bool *r_missing = data.R_missing + j * data.M;
+                std::fill_n(tmp_out_contribs, interaction_size, 0);
+
+                // compute the model's margin output for r
+                if (transform != NULL) {
+                    margin_r = trees.base_offset[oind];
+                    for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                        margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                    }
+                }
+
+                for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                    tree_shap_indep_interactions(
+                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
+                        tmp_out_contribs, feat_hist, omega_table, omega_stride,
+                        node_stack, node_trees + k * trees.max_nodes,
+                        A_feats_buf, NB_feats_buf
+                    );
+                }
+
+                // compute the rescale factor
+                if (transform != NULL) {
+                    if (margin_x == margin_r) {
+                        rescale_factor = 1.0;
+                    } else {
+                        rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
+                        rescale_factor /= margin_x - margin_r;
+                    }
+                }
+
+                // add the effect of the current reference to our running total
+                // (skip the bias entry, handle it separately)
+                const unsigned bias_2d_idx = data.M * (data.M + 1) + data.M;
+                for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                    if (jj == bias_2d_idx) continue;
+                    instance_out_contribs[jj * no + oind] +=
+                        tmp_out_contribs[jj] * rescale_factor;
+                }
+
+                // Add the base offset
+                if (transform != NULL) {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        (*transform)(trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx], 0);
+                } else {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx];
+                }
+            }
+
+            // average the results over all the references
+            for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                instance_out_contribs[jj * no + oind] /= data.num_R;
+            }
+        }
+    }
 }
 
 
@@ -1461,8 +1980,10 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
     switch (feature_dependence) {
         case FEATURE_DEPENDENCE::independent:
             if (interactions) {
-                std::cerr << "FEATURE_DEPENDENCE::independent does not support interactions!\n";
-            } else dense_independent(trees, data, out_contribs, transform);
+                dense_independent_interactions(trees, data, out_contribs, transform);
+            } else {
+                dense_independent(trees, data, out_contribs, transform);
+            }
             return;
 
         case FEATURE_DEPENDENCE::tree_path_dependent:

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -153,11 +153,26 @@ inline tfloat squared_loss_transform(const tfloat margin, const tfloat y) {
     return (margin - y) * (margin - y);
 }
 
+inline void softmax_vector(const tfloat *d, tfloat *out, unsigned num_outputs) {
+    const tfloat scale = 1.0 / (num_outputs - 1);
+    tfloat max_val = d[0] * scale;
+    for (unsigned k = 1; k < num_outputs; ++k) {
+        if (d[k] * scale > max_val) max_val = d[k] * scale;
+    }
+    tfloat sum_exp = 0;
+    for (unsigned k = 0; k < num_outputs; ++k) {
+        out[k] = exp(d[k] * scale - max_val);
+        sum_exp += out[k];
+    }
+    for (unsigned k = 0; k < num_outputs; ++k) out[k] /= sum_exp;
+}
+
 namespace MODEL_TRANSFORM {
     const unsigned identity = 0;
     const unsigned logistic = 1;
     const unsigned logistic_nlogloss = 2;
     const unsigned squared_loss = 3;
+    const unsigned softmax = 4;
 }
 
 inline transform_f get_transform(unsigned model_transform) {
@@ -1666,7 +1681,8 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
  * Implements Algorithm 1 from Zern et al. (AAAI 2023).
  */
 inline void dense_independent_interactions(const TreeEnsemble& trees, const ExplanationDataset &data,
-                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
+                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat),
+                       unsigned model_transform = MODEL_TRANSFORM::identity) {
 
     // reformat the trees for faster access
     std::vector<Node> node_trees_vec(trees.tree_limit * trees.max_nodes);
@@ -1720,6 +1736,38 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
         }
     }
 
+    // precompute softmax values if needed
+    bool is_softmax = (model_transform == MODEL_TRANSFORM::softmax);
+    tfloat *softmax_x_all = NULL, *softmax_r_all = NULL;
+    tfloat *margin_x_all = NULL, *margin_r_all = NULL;
+
+    if (is_softmax) {
+        unsigned K = trees.num_outputs;
+        margin_x_all = new tfloat[data.num_X * K];
+        softmax_x_all = new tfloat[data.num_X * K];
+        margin_r_all = new tfloat[data.num_R * K];
+        softmax_r_all = new tfloat[data.num_R * K];
+
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            tfloat *mx = margin_x_all + i * K;
+            for (unsigned c = 0; c < K; ++c) mx[c] = trees.base_offset[c];
+            for (unsigned t = 0; t < trees.tree_limit; ++t) {
+                const tfloat *lv = tree_predict(t, trees, data.X + i * data.M, data.X_missing + i * data.M);
+                for (unsigned c = 0; c < K; ++c) mx[c] += lv[c];
+            }
+            softmax_vector(mx, softmax_x_all + i * K, K);
+        }
+        for (unsigned j = 0; j < data.num_R; ++j) {
+            tfloat *mr = margin_r_all + j * K;
+            for (unsigned c = 0; c < K; ++c) mr[c] = trees.base_offset[c];
+            for (unsigned t = 0; t < trees.tree_limit; ++t) {
+                const tfloat *lv = tree_predict(t, trees, data.R + j * data.M, data.R_missing + j * data.M);
+                for (unsigned c = 0; c < K; ++c) mr[c] += lv[c];
+            }
+            softmax_vector(mr, softmax_r_all + j * K, K);
+        }
+    }
+
     // compute the explanations for each sample
     tfloat *instance_out_contribs;
     tfloat rescale_factor = 1.0;
@@ -1748,7 +1796,7 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
             print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * no);
 
             // compute the model's margin output for x
-            if (transform != NULL) {
+            if (!is_softmax && transform != NULL) {
                 margin_x = trees.base_offset[oind];
                 for (unsigned k = 0; k < trees.tree_limit; ++k) {
                     margin_x += tree_predict(k, trees, x, x_missing)[oind];
@@ -1761,7 +1809,7 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 std::fill_n(tmp_out_contribs, interaction_size, 0);
 
                 // compute the model's margin output for r
-                if (transform != NULL) {
+                if (!is_softmax && transform != NULL) {
                     margin_r = trees.base_offset[oind];
                     for (unsigned k = 0; k < trees.tree_limit; ++k) {
                         margin_r += tree_predict(k, trees, r, r_missing)[oind];
@@ -1778,7 +1826,16 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 }
 
                 // compute the rescale factor
-                if (transform != NULL) {
+                if (is_softmax) {
+                    unsigned K = trees.num_outputs;
+                    tfloat m_x = margin_x_all[i * K + oind];
+                    tfloat m_r = margin_r_all[j * K + oind];
+                    if (m_x == m_r) {
+                        rescale_factor = 1.0;
+                    } else {
+                        rescale_factor = (softmax_x_all[i * K + oind] - softmax_r_all[j * K + oind]) / (m_x - m_r);
+                    }
+                } else if (transform != NULL) {
                     if (margin_x == margin_r) {
                         rescale_factor = 1.0;
                     } else {
@@ -1797,7 +1854,10 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 }
 
                 // Add the base offset
-                if (transform != NULL) {
+                if (is_softmax) {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        softmax_r_all[j * trees.num_outputs + oind];
+                } else if (transform != NULL) {
                     instance_out_contribs[bias_2d_idx * no + oind] +=
                         (*transform)(trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx], 0);
                 } else {
@@ -1811,6 +1871,13 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 instance_out_contribs[jj * no + oind] /= data.num_R;
             }
         }
+    }
+
+    if (is_softmax) {
+        delete[] softmax_x_all;
+        delete[] softmax_r_all;
+        delete[] margin_x_all;
+        delete[] margin_r_all;
     }
 }
 
@@ -1995,7 +2062,7 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
     switch (feature_dependence) {
         case FEATURE_DEPENDENCE::independent:
             if (interactions) {
-                dense_independent_interactions(trees, data, out_contribs, transform);
+                dense_independent_interactions(trees, data, out_contribs, transform, model_transform);
             } else {
                 dense_independent(trees, data, out_contribs, transform);
             }

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -37,6 +37,8 @@ struct TreeEnsemble {
     int *features;
     tfloat *thresholds;
     int* threshold_types;
+    unsigned int *cat_bitsets;
+    size_t num_cat_bitsets;
     tfloat *values;
     tfloat *node_sample_weights;
     unsigned max_depth;
@@ -45,14 +47,30 @@ struct TreeEnsemble {
     unsigned max_nodes;
     unsigned num_outputs;
 
-    TreeEnsemble() {}
+    TreeEnsemble() :
+        children_left(NULL), children_right(NULL), children_default(NULL), features(NULL),
+        thresholds(NULL), threshold_types(NULL), cat_bitsets(NULL), num_cat_bitsets(0),
+        values(NULL), node_sample_weights(NULL), max_depth(0), tree_limit(0), base_offset(NULL),
+        max_nodes(0), num_outputs(0) {}
     TreeEnsemble(int *children_left, int *children_right, int *children_default, int *features,
                  tfloat *thresholds, int *threshold_types, tfloat *values, tfloat *node_sample_weights,
                  unsigned max_depth, unsigned tree_limit, tfloat *base_offset,
                  unsigned max_nodes, unsigned num_outputs) :
         children_left(children_left), children_right(children_right),
         children_default(children_default), features(features), thresholds(thresholds),
-        threshold_types(threshold_types), values(values), node_sample_weights(node_sample_weights),
+        threshold_types(threshold_types), cat_bitsets(NULL), num_cat_bitsets(0),
+        values(values), node_sample_weights(node_sample_weights),
+        max_depth(max_depth), tree_limit(tree_limit),
+        base_offset(base_offset), max_nodes(max_nodes), num_outputs(num_outputs) {}
+    TreeEnsemble(int *children_left, int *children_right, int *children_default, int *features,
+                 tfloat *thresholds, int *threshold_types, unsigned int *cat_bitsets,
+                 size_t num_cat_bitsets, tfloat *values, tfloat *node_sample_weights,
+                 unsigned max_depth, unsigned tree_limit, tfloat *base_offset,
+                 unsigned max_nodes, unsigned num_outputs) :
+        children_left(children_left), children_right(children_right),
+        children_default(children_default), features(features), thresholds(thresholds),
+        threshold_types(threshold_types), cat_bitsets(cat_bitsets), num_cat_bitsets(num_cat_bitsets),
+        values(values), node_sample_weights(node_sample_weights),
         max_depth(max_depth), tree_limit(tree_limit),
         base_offset(base_offset), max_nodes(max_nodes), num_outputs(num_outputs) {}
 
@@ -65,6 +83,8 @@ struct TreeEnsemble {
         tree.features = features + d;
         tree.thresholds = thresholds + d;
         tree.threshold_types = threshold_types + d;
+        tree.cat_bitsets = cat_bitsets;
+        tree.num_cat_bitsets = num_cat_bitsets;
         tree.values = values + d * num_outputs;
         tree.node_sample_weights = node_sample_weights + d;
         tree.max_depth = max_depth;
@@ -88,6 +108,8 @@ struct TreeEnsemble {
         features = new int[tree_limit * max_nodes];
         thresholds = new tfloat[tree_limit * max_nodes];
         threshold_types = new int[tree_limit * max_nodes];
+        cat_bitsets = NULL;
+        num_cat_bitsets = 0;
         values = new tfloat[tree_limit * max_nodes * num_outputs];
         node_sample_weights = new tfloat[tree_limit * max_nodes];
     }
@@ -194,9 +216,43 @@ inline transform_f get_transform(unsigned model_transform) {
     return transform;
 }
 
-inline bool category_in_threshold(float threshold, float category) {
-    int category_flag = (1 << int(category));
-    return (int(threshold) & category_flag) != 0;
+inline bool is_valid_unsigned_integral_tfloat(tfloat value) {
+    return std::isfinite(value) && value >= 0 &&
+           std::floor(value) == value;
+}
+
+inline bool category_in_threshold(const unsigned int *cat_bitsets, size_t num_cat_bitsets,
+                                  tfloat threshold, tfloat category) {
+    if (cat_bitsets == NULL || num_cat_bitsets == 0 ||
+        !is_valid_unsigned_integral_tfloat(threshold) ||
+        threshold >= static_cast<tfloat>(num_cat_bitsets) ||
+        !is_valid_unsigned_integral_tfloat(category)) {
+        return false;
+    }
+
+    const size_t offset = static_cast<size_t>(threshold);
+    const size_t n_words = static_cast<size_t>(cat_bitsets[offset]);
+    if (n_words > num_cat_bitsets - offset - 1) {
+        return false;
+    }
+
+    if (category / 32 >= static_cast<tfloat>(n_words)) {
+        return false;
+    }
+
+    const size_t category_ind = static_cast<size_t>(category);
+    const size_t word_ind = category_ind / 32;
+    const unsigned bit_ind = category_ind % 32;
+    return (cat_bitsets[offset + 1 + word_ind] & (1u << bit_ind)) != 0;
+}
+
+inline bool has_categorical_split(const TreeEnsemble &trees) {
+    for (unsigned i = 0; i < trees.tree_limit * trees.max_nodes; ++i) {
+        if (trees.children_left[i] >= 0 && trees.threshold_types[i] == 1) {
+            return true;
+        }
+    }
+    return false;
 }
 
 inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat *x, const bool *x_missing) {
@@ -216,7 +272,7 @@ inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat 
             node = trees.children_default[pos];
         } else if (trees.threshold_types[pos] == 0 && x[feature] <= trees.thresholds[pos]) {
             node = trees.children_left[pos];
-        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.thresholds[pos], x[feature])) {
+        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.cat_bitsets, trees.num_cat_bitsets, trees.thresholds[pos], x[feature])) {
             node = trees.children_left[pos];
         } else {
             node = trees.children_right[pos];
@@ -280,7 +336,7 @@ inline void tree_update_weights(unsigned i, TreeEnsemble &trees, const tfloat *x
             node = trees.children_default[pos];
         } else if (trees.threshold_types[pos] == 0 && x[feature] <= trees.thresholds[pos]) {
             node = trees.children_left[pos];
-        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.thresholds[pos], x[feature])) {
+        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.cat_bitsets, trees.num_cat_bitsets, trees.thresholds[pos], x[feature])) {
             node = trees.children_left[pos];
         }
          else {
@@ -317,7 +373,9 @@ inline void tree_saabas(tfloat *out, const TreeEnsemble &tree, const Explanation
         const unsigned feature = tree.features[curr_node];
         if (data.X_missing[feature]) {
             next_node = tree.children_default[curr_node];
-        } else if (data.X[feature] <= tree.thresholds[curr_node]) {
+        } else if (tree.threshold_types[curr_node] == 0 && data.X[feature] <= tree.thresholds[curr_node]) {
+            next_node = tree.children_left[curr_node];
+        } else if (tree.threshold_types[curr_node] == 1 && category_in_threshold(tree.cat_bitsets, tree.num_cat_bitsets, tree.thresholds[curr_node], data.X[feature])) {
             next_node = tree.children_left[curr_node];
         } else {
             next_node = tree.children_right[curr_node];
@@ -427,7 +485,9 @@ inline tfloat unwound_path_sum(const PathElement *unique_path, unsigned unique_d
 inline void tree_shap_recursive(const unsigned num_outputs, const int *children_left,
                                 const int *children_right,
                                 const int *children_default, const int *features,
-                                const tfloat *thresholds, const int *threshold_types, const tfloat *values,
+                                const tfloat *thresholds, const int *threshold_types,
+                                const unsigned int *cat_bitsets, size_t num_cat_bitsets,
+                                const tfloat *values,
                                 const tfloat *node_sample_weight,
                                 const tfloat *x, const bool *x_missing, tfloat *phi,
                                 unsigned node_index, unsigned unique_depth,
@@ -471,7 +531,7 @@ inline void tree_shap_recursive(const unsigned num_outputs, const int *children_
             hot_index = children_default[node_index];
         } else if (type == 0 && x[split_index] <= thresholds[node_index]) {
             hot_index = children_left[node_index];
-        } else if (type == 1 && category_in_threshold(thresholds[node_index], x[split_index])) {
+        } else if (type == 1 && category_in_threshold(cat_bitsets, num_cat_bitsets, thresholds[node_index], x[split_index])) {
             hot_index = children_left[node_index];
         }
         else {
@@ -511,14 +571,16 @@ inline void tree_shap_recursive(const unsigned num_outputs, const int *children_
         }
 
         tree_shap_recursive(
-            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types, values,
+            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types,
+            cat_bitsets, num_cat_bitsets, values,
             node_sample_weight, x, x_missing, phi, hot_index, unique_depth + 1, unique_path,
             hot_zero_fraction * incoming_zero_fraction, incoming_one_fraction,
             split_index, condition, condition_feature, hot_condition_fraction
         );
 
         tree_shap_recursive(
-            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types, values,
+            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types,
+            cat_bitsets, num_cat_bitsets, values,
             node_sample_weight, x, x_missing, phi, cold_index, unique_depth + 1, unique_path,
             cold_zero_fraction * incoming_zero_fraction, 0,
             split_index, condition, condition_feature, cold_condition_fraction
@@ -571,7 +633,8 @@ inline void tree_shap(const TreeEnsemble& tree, const ExplanationDataset &data,
 
     tree_shap_recursive(
         tree.num_outputs, tree.children_left, tree.children_right, tree.children_default,
-        tree.features, tree.thresholds, tree.threshold_types, tree.values, tree.node_sample_weights, data.X,
+        tree.features, tree.thresholds, tree.threshold_types, tree.cat_bitsets, tree.num_cat_bitsets,
+        tree.values, tree.node_sample_weights, data.X,
         data.X_missing, out_contribs, 0, 0, unique_path_data, 1, 1, -1, condition,
         condition_feature, 1
     );
@@ -608,6 +671,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
         out_tree.children_default[pos] = -1;
         out_tree.features[pos] = -1;
         out_tree.thresholds[pos] = 0;
+        out_tree.threshold_types[pos] = 0;
         out_tree.node_sample_weights[pos] = num_background_data_inds;
 
         return pos;
@@ -699,6 +763,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
 
         out_tree.features[pos] = trees.features[row_offset + i];
         out_tree.thresholds[pos] = trees.thresholds[row_offset + i];
+        out_tree.threshold_types[pos] = trees.threshold_types[row_offset + i];
         out_tree.node_sample_weights[pos] = num_background_data_inds;
 
         // build the right subtree
@@ -744,7 +809,8 @@ inline void build_merged_tree(TreeEnsemble &out_tree, const ExplanationDataset &
 struct Node {
     short cl, cr, cd, pnode; // uint_16
     long feat, pfeat;
-    float thres, value;
+    tfloat thres;
+    float value;
     char from_flag;
     char threshold_type; // 0 = numeric, 1 = categorical
 };
@@ -777,7 +843,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
                             const bool *x_missing, const tfloat *r,
                             const bool *r_missing, tfloat *out_contribs,
                             float *pos_lst, float *neg_lst, signed short *feat_hist,
-                            float *memoized_weights, int *node_stack, Node *mytree) {
+                            float *memoized_weights, int *node_stack, Node *mytree,
+                            const unsigned int *cat_bitsets, size_t num_cat_bitsets) {
 
 //     const bool DEBUG = true;
 //     ofstream myfile;
@@ -791,7 +858,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
     long feat, pfeat = -1;
     short next_xnode = -1, next_rnode = -1;
     short next_node = -1, from_child = -1;
-    float thres, pos_x = 0, neg_x = 0, pos_r = 0, neg_r = 0;
+    tfloat thres;
+    float pos_x = 0, neg_x = 0, pos_r = 0, neg_r = 0;
     char from_flag;
     unsigned M = 0, N = 0;
 
@@ -816,7 +884,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 
     if (x_missing[feat]) {
         next_xnode = cd;
-    } else if (curr_node.threshold_type == 1 ? category_in_threshold(thres, x[feat]) : x[feat] <= thres) {
+    } else if (curr_node.threshold_type == 1 ? category_in_threshold(cat_bitsets, num_cat_bitsets, thres, x[feat]) : x[feat] <= thres) {
         next_xnode = cl;
     } else {
         next_xnode = cr;
@@ -824,7 +892,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 
     if (r_missing[feat]) {
         next_rnode = cd;
-    } else if (curr_node.threshold_type == 1 ? category_in_threshold(thres, r[feat]) : r[feat] <= thres) {
+    } else if (curr_node.threshold_type == 1 ? category_in_threshold(cat_bitsets, num_cat_bitsets, thres, r[feat]) : r[feat] <= thres) {
         next_rnode = cl;
     } else {
         next_rnode = cr;
@@ -925,8 +993,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 
         bool x_right, r_right;
         if (curr_node.threshold_type == 1) {
-            x_right = !category_in_threshold(thres, x[feat]);
-            r_right = !category_in_threshold(thres, r[feat]);
+            x_right = !category_in_threshold(cat_bitsets, num_cat_bitsets, thres, x[feat]);
+            r_right = !category_in_threshold(cat_bitsets, num_cat_bitsets, thres, r[feat]);
         } else {
             x_right = x[feat] > thres;
             r_right = r[feat] > thres;
@@ -1222,7 +1290,8 @@ inline void tree_shap_indep_interactions(
     signed short *feat_hist,
     const tfloat *omega_table, const unsigned omega_stride,
     int *node_stack, Node *mytree,
-    int *A_feats_buf, int *NB_feats_buf
+    int *A_feats_buf, int *NB_feats_buf,
+    const unsigned int *cat_bitsets, size_t num_cat_bitsets
 ) {
     int ns_ctr = 0;
     std::fill_n(feat_hist, num_feats, 0);
@@ -1230,7 +1299,7 @@ inline void tree_shap_indep_interactions(
     long feat, pfeat = -1;
     short next_xnode = -1, next_rnode = -1;
     short next_node = -1, from_child = -1;
-    float thres;
+    tfloat thres;
     char from_flag;
     unsigned M = 0, N = 0;
 
@@ -1249,7 +1318,7 @@ inline void tree_shap_indep_interactions(
 
     if (x_missing[feat]) {
         next_xnode = cd;
-    } else if (curr_node.threshold_type == 1 ? category_in_threshold(thres, x[feat]) : x[feat] <= thres) {
+    } else if (curr_node.threshold_type == 1 ? category_in_threshold(cat_bitsets, num_cat_bitsets, thres, x[feat]) : x[feat] <= thres) {
         next_xnode = cl;
     } else {
         next_xnode = cr;
@@ -1257,7 +1326,7 @@ inline void tree_shap_indep_interactions(
 
     if (r_missing[feat]) {
         next_rnode = cd;
-    } else if (curr_node.threshold_type == 1 ? category_in_threshold(thres, r[feat]) : r[feat] <= thres) {
+    } else if (curr_node.threshold_type == 1 ? category_in_threshold(cat_bitsets, num_cat_bitsets, thres, r[feat]) : r[feat] <= thres) {
         next_rnode = cl;
     } else {
         next_rnode = cr;
@@ -1345,8 +1414,8 @@ inline void tree_shap_indep_interactions(
 
         bool x_right, r_right;
         if (curr_node.threshold_type == 1) {
-            x_right = !category_in_threshold(thres, x[feat]);
-            r_right = !category_in_threshold(thres, r[feat]);
+            x_right = !category_in_threshold(cat_bitsets, num_cat_bitsets, thres, x[feat]);
+            r_right = !category_in_threshold(cat_bitsets, num_cat_bitsets, thres, r[feat]);
         } else {
             x_right = x[feat] > thres;
             r_right = r[feat] > thres;
@@ -1626,7 +1695,8 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
                     tree_shap_indep(
                         trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
                         tmp_out_contribs, pos_lst, neg_lst, feat_hist, memoized_weights,
-                        node_stack, node_trees + k * trees.max_nodes
+                        node_stack, node_trees + k * trees.max_nodes,
+                        trees.cat_bitsets, trees.num_cat_bitsets
                     );
                 }
 
@@ -1821,7 +1891,8 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                         trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
                         tmp_out_contribs, feat_hist, omega_table, omega_stride,
                         node_stack, node_trees + k * trees.max_nodes,
-                        A_feats_buf, NB_feats_buf
+                        A_feats_buf, NB_feats_buf,
+                        trees.cat_bitsets, trees.num_cat_bitsets
                     );
                 }
 
@@ -2017,6 +2088,11 @@ inline void dense_tree_interactions_path_dependent(const TreeEnsemble& trees, co
  */
 inline void dense_global_path_dependent(const TreeEnsemble& trees, const ExplanationDataset &data,
                                  tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
+
+    if (has_categorical_split(trees)) {
+        std::cerr << "FEATURE_DEPENDENCE::global_path_dependent does not support categorical splits!\n";
+        return;
+    }
 
     // allocate space for our new merged tree (we save enough room to totally split all samples if need be)
     TreeEnsemble merged_tree;

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -5,7 +5,6 @@ import numpy as np
 from ..utils import assert_import, record_import_error
 from ._tree import (
     TreeExplainer,
-    _xgboost_cat_unsupported,
     feature_perturbation_codes,
     output_transform_codes,
 )
@@ -70,7 +69,12 @@ class GPUTreeExplainer(TreeExplainer):
         )
 
         model = self.model
-        _xgboost_cat_unsupported(model)
+        if np.any(model.threshold_types != 0):
+            raise NotImplementedError(
+                "Categorical splits are not yet supported by GPUTreeExplainer. Use"
+                " TreeExplainer (CPU) with feature_perturbation='interventional'"
+                " or feature_perturbation='tree_path_dependent' instead."
+            )
         transform = model.get_transform()
 
         # run the core algorithm using the C extension

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1950,7 +1950,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** cat
+                            threshold += 2**cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -782,7 +782,6 @@ class TreeExplainer(Explainer):
         assert self.model.model_output == "raw", (
             'Only model_output = "raw" is supported for SHAP interaction values right now!'
         )
-        # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
         transform = "identity"
 
         # see if we have a default tree_limit in place.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -104,14 +104,6 @@ def _xgboost_n_iterations(tree_limit: int, num_stacked_models: int) -> int:
     return n_iterations
 
 
-def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
-    if model.model_type == "xgboost" and model.cat_feature_indices is not None:
-        raise NotImplementedError(
-            "Categorical split is not yet supported. You can still use"
-            " TreeExplainer with `feature_perturbation=tree_path_dependent`."
-        )
-
-
 class TreeExplainer(Explainer):
     """Uses Tree SHAP algorithms to explain the output of ensemble tree models.
 
@@ -658,7 +650,6 @@ class TreeExplainer(Explainer):
             X, y, tree_limit, check_additivity
         )
         transform = self.model.get_transform()
-        _xgboost_cat_unsupported(self.model)
 
         # run the core algorithm using the C extension
         assert_import("cext")

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -784,7 +784,8 @@ class TreeExplainer(Explainer):
             import xgboost
 
             if not isinstance(X, xgboost.core.DMatrix):
-                X = xgboost.DMatrix(X)
+                dmatrix_props = getattr(self.model, "_xgb_dmatrix_props", {})
+                X = xgboost.DMatrix(X, **dmatrix_props)
 
             n_iterations = _xgboost_n_iterations(tree_limit, self.model.num_stacked_models)
             phi = self.model.original_model.predict(
@@ -1949,7 +1950,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** (cat - 1)
+                            threshold += 2 ** cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -770,10 +770,13 @@ class TreeExplainer(Explainer):
                 Return type for models with multiple outputs changed from list to np.ndarray.
 
         """
-        assert self.model.model_output == "raw", (
-            'Only model_output = "raw" is supported for SHAP interaction values right now!'
-        )
-        transform = "identity"
+        if self.feature_perturbation == "interventional":
+            transform = self.model.get_transform()
+        else:
+            assert self.model.model_output == "raw", (
+                'Only model_output = "raw" is supported for SHAP interaction values with tree_path_dependent!'
+            )
+            transform = "identity"
 
         # see if we have a default tree_limit in place.
         if tree_limit is None:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1981,7 +1981,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** cat
+                            threshold += 2**cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -811,7 +811,8 @@ class TreeExplainer(Explainer):
             import xgboost
 
             if not isinstance(X, xgboost.core.DMatrix):
-                X = xgboost.DMatrix(X)
+                dmatrix_props = getattr(self.model, "_xgb_dmatrix_props", {})
+                X = xgboost.DMatrix(X, **dmatrix_props)
 
             n_iterations = _xgboost_n_iterations(tree_limit, self.model.num_stacked_models)
             phi = self.model.original_model.predict(
@@ -1980,7 +1981,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** (cat - 1)
+                            threshold += 2 ** cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -801,7 +801,6 @@ class TreeExplainer(Explainer):
         assert self.model.model_output == "raw", (
             'Only model_output = "raw" is supported for SHAP interaction values right now!'
         )
-        # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
         transform = "identity"
 
         # see if we have a default tree_limit in place.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -114,6 +114,89 @@ def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
         )
 
 
+def _empty_cat_bitsets() -> npt.NDArray[np.uint32]:
+    return np.empty(0, dtype=np.uint32)
+
+
+def _check_cat_bitset_offset_representable(offset: int, dtype: npt.DTypeLike, context: str) -> None:
+    threshold_value = np.asarray(offset, dtype=dtype).item()
+    if not np.isfinite(threshold_value) or int(threshold_value) != offset:
+        raise ValueError(
+            f"Categorical bitset offset {offset} for {context} cannot be represented exactly "
+            f"in threshold dtype {np.dtype(dtype)}."
+        )
+
+
+def _cat_bitset_offset_from_threshold(
+    threshold: float,
+    cat_bitsets_size: int,
+    context: str,
+) -> int:
+    if not np.isfinite(threshold):
+        raise ValueError(f"Categorical bitset offset for {context} must be finite, got {threshold}.")
+    offset = int(threshold)
+    if offset != threshold or offset < 0:
+        raise ValueError(f"Categorical bitset offset for {context} must be a non-negative integer, got {threshold}.")
+    if offset >= cat_bitsets_size:
+        raise ValueError(
+            f"Categorical bitset offset {offset} for {context} is outside cat_bitsets buffer "
+            f"of length {cat_bitsets_size}."
+        )
+    return offset
+
+
+def _validate_cat_bitset_block(cat_bitsets: npt.NDArray[np.uint32], offset: int, context: str) -> None:
+    n_words = int(cat_bitsets[offset])
+    if n_words <= 0:
+        raise ValueError(f"Categorical bitset block for {context} must contain at least one word.")
+    end = offset + 1 + n_words
+    if end > cat_bitsets.size:
+        raise ValueError(
+            f"Categorical bitset block for {context} extends past cat_bitsets buffer "
+            f"(offset {offset}, n_words {n_words}, length {cat_bitsets.size})."
+        )
+
+
+def _validate_cat_bitsets(
+    threshold_types: npt.NDArray[np.int32],
+    thresholds: npt.NDArray[Any],
+    cat_bitsets: npt.NDArray[np.uint32],
+    context: str,
+) -> None:
+    if threshold_types.shape != thresholds.shape:
+        raise ValueError(
+            f"{context} threshold_types shape {threshold_types.shape} does not match thresholds shape {thresholds.shape}."
+        )
+    cat_nodes = np.flatnonzero(threshold_types == 1)
+    if cat_nodes.size == 0:
+        return
+    if cat_bitsets.size == 0:
+        raise ValueError(
+            f"{context} has categorical threshold_types but no cat_bitsets buffer. "
+            "Categorical thresholds must be offsets into a uint32 cat_bitsets buffer."
+        )
+    for node_idx in cat_nodes:
+        offset = _cat_bitset_offset_from_threshold(float(thresholds[node_idx]), cat_bitsets.size, context)
+        _check_cat_bitset_offset_representable(offset, thresholds.dtype, context)
+        _validate_cat_bitset_block(cat_bitsets, offset, context)
+
+
+def _build_cat_bitset_block(categories: list[int], context: str) -> npt.NDArray[np.uint32]:
+    if not categories:
+        raise ValueError(f"Categorical split for {context} must contain at least one category.")
+    for category in categories:
+        if category < 0:
+            raise ValueError(f"Categorical split for {context} has negative category {category}.")
+    n_words = max(categories) // 32 + 1
+    block = np.zeros(n_words + 1, dtype=np.uint32)
+    block[0] = n_words
+    for category in categories:
+        word = category // 32
+        bit = category % 32
+        block[1 + word] |= np.uint32(1 << bit)
+    return block
+
+
 class TreeExplainer(Explainer):
     """Uses Tree SHAP algorithms to explain the output of ensemble tree models.
 
@@ -690,6 +773,7 @@ class TreeExplainer(Explainer):
                 self.model.features,
                 self.model.thresholds,
                 self.model.threshold_types,
+                self.model.cat_bitsets,
                 self.model.values,
                 self.model.node_sample_weight,
                 self.model.max_depth,
@@ -713,6 +797,7 @@ class TreeExplainer(Explainer):
                 self.model.features,
                 self.model.thresholds,
                 self.model.threshold_types,
+                self.model.cat_bitsets,
                 self.model.values,
                 self.model.max_depth,
                 tree_limit,
@@ -861,6 +946,7 @@ class TreeExplainer(Explainer):
             self.model.features,
             self.model.thresholds,
             self.model.threshold_types,
+            self.model.cat_bitsets,
             self.model.values,
             self.model.node_sample_weight,
             self.model.max_depth,
@@ -967,6 +1053,7 @@ class TreeEnsemble:
     features: npt.NDArray[np.int32]
     thresholds: npt.NDArray[Any]
     threshold_types: npt.NDArray[np.int32]
+    cat_bitsets: npt.NDArray[np.uint32]
     values: npt.NDArray[Any]
     node_sample_weight: npt.NDArray[Any]
     num_nodes: npt.NDArray[np.int32]
@@ -999,6 +1086,7 @@ class TreeEnsemble:
         self.tree_limit = None  # used for limiting the number of trees we use by default (like from early stopping)
         self.num_stacked_models = 1  # If this is greater than 1 it means we have multiple stacked models with the same number of trees in each model (XGBoost multi-output style)
         self.cat_feature_indices = None  # If this is set it tells us which features are treated categorically
+        self.cat_bitsets = _empty_cat_bitsets()
         self._xgb_enable_categorical = False
 
         # we use names like keras
@@ -1556,14 +1644,39 @@ class TreeEnsemble:
             self.threshold_types = np.zeros((num_trees, max_nodes), dtype=np.int32)
             self.values = np.zeros((num_trees, max_nodes, self.num_outputs), dtype=self.internal_dtype)
             self.node_sample_weight = np.zeros((num_trees, max_nodes), dtype=self.internal_dtype)
+            cat_bitsets: list[npt.NDArray[np.uint32]] = []
+            cat_bitset_offset = 0
 
             for i in range(num_trees):
-                self.children_left[i, : len(self.trees[i].children_left)] = self.trees[i].children_left
-                self.children_right[i, : len(self.trees[i].children_right)] = self.trees[i].children_right
-                self.children_default[i, : len(self.trees[i].children_default)] = self.trees[i].children_default
-                self.features[i, : len(self.trees[i].features)] = self.trees[i].features
-                self.thresholds[i, : len(self.trees[i].thresholds)] = self.trees[i].thresholds
-                self.threshold_types[i, : len(self.trees[i].threshold_types)] = self.trees[i].threshold_types
+                tree = self.trees[i]
+                self.children_left[i, : len(tree.children_left)] = tree.children_left
+                self.children_right[i, : len(tree.children_right)] = tree.children_right
+                self.children_default[i, : len(tree.children_default)] = tree.children_default
+                self.features[i, : len(tree.features)] = tree.features
+                self.threshold_types[i, : len(tree.threshold_types)] = tree.threshold_types
+
+                tree_thresholds = tree.thresholds.astype(self.internal_dtype, copy=True)
+                cat_nodes = np.flatnonzero(tree.threshold_types == 1)
+                if cat_nodes.size > 0:
+                    if tree.cat_bitsets.size == 0:
+                        raise ValueError(
+                            f"Tree {i} has categorical threshold_types but no cat_bitsets buffer. "
+                            "Categorical thresholds must be offsets into a uint32 cat_bitsets buffer."
+                        )
+                    for node_idx in cat_nodes:
+                        local_offset = _cat_bitset_offset_from_threshold(
+                            float(tree.thresholds[node_idx]), tree.cat_bitsets.size, f"tree {i}, node {node_idx}"
+                        )
+                        _validate_cat_bitset_block(tree.cat_bitsets, local_offset, f"tree {i}, node {node_idx}")
+                        global_offset = cat_bitset_offset + local_offset
+                        _check_cat_bitset_offset_representable(
+                            global_offset, self.internal_dtype, f"tree {i}, node {node_idx}"
+                        )
+                        tree_thresholds[node_idx] = global_offset
+                self.thresholds[i, : len(tree_thresholds)] = tree_thresholds
+                if tree.cat_bitsets.size > 0:
+                    cat_bitsets.append(tree.cat_bitsets)
+                    cat_bitset_offset += tree.cat_bitsets.size
 
                 # XGBoost supports boosting forest, which is not compatible with the
                 # current assumption here that the number of stacked models represents
@@ -1575,15 +1688,16 @@ class TreeEnsemble:
 
                 if n_stacks > 1:
                     stack_pos = i % n_stacks
-                    self.values[i, : len(self.trees[i].values[:, 0]), stack_pos] = self.trees[i].values[:, 0]
+                    self.values[i, : len(tree.values[:, 0]), stack_pos] = tree.values[:, 0]
                 else:
-                    self.values[i, : len(self.trees[i].values)] = self.trees[i].values
-                self.node_sample_weight[i, : len(self.trees[i].node_sample_weight)] = self.trees[i].node_sample_weight
+                    self.values[i, : len(tree.values)] = tree.values
+                self.node_sample_weight[i, : len(tree.node_sample_weight)] = tree.node_sample_weight
 
                 # ensure that the passed background dataset lands in every leaf
-                if np.min(self.trees[i].node_sample_weight) <= 0:
+                if np.min(tree.node_sample_weight) <= 0:
                     self.fully_defined_weighting = False
 
+            self.cat_bitsets = np.concatenate(cat_bitsets) if cat_bitsets else _empty_cat_bitsets()
             self.num_nodes = np.array([len(t.values) for t in self.trees], dtype=np.int32)
             self.max_depth = np.max([t.max_depth for t in self.trees])
 
@@ -1737,6 +1851,7 @@ class TreeEnsemble:
             self.features,
             self.thresholds,
             self.threshold_types,
+            self.cat_bitsets,
             self.values,
             self.max_depth,
             tree_limit,
@@ -1813,6 +1928,7 @@ class SingleTree:
     features: npt.NDArray[np.int32]
     thresholds: npt.NDArray[np.float64]
     threshold_types: npt.NDArray[np.int32]
+    cat_bitsets: npt.NDArray[np.uint32]
     values: npt.NDArray[Any]
     node_sample_weight: npt.NDArray[np.float64]
     max_depth: int
@@ -1826,6 +1942,7 @@ class SingleTree:
         data_missing: npt.NDArray[np.bool_] | None = None,
     ) -> None:
         assert_import("cext")
+        self.cat_bitsets = _empty_cat_bitsets()
 
         if safe_isinstance(
             tree,
@@ -1854,8 +1971,12 @@ class SingleTree:
             self.children_right = tree["children_right"].astype(np.int32)
             self.children_default = tree["children_default"].astype(np.int32)
             self.features = tree["features"].astype(np.int32)
-            self.thresholds = tree["thresholds"]
-            self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.thresholds = np.asarray(tree["thresholds"])
+            self.threshold_types = np.asarray(
+                tree.get("threshold_types", tree.get("threshold_type", np.zeros_like(self.thresholds))),
+                dtype=np.int32,
+            )
+            self.cat_bitsets = np.asarray(tree.get("cat_bitsets", _empty_cat_bitsets()), dtype=np.uint32)
             self.values = tree["values"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
@@ -1865,8 +1986,12 @@ class SingleTree:
             self.children_right = tree["children_right"].astype(np.int32)
             self.children_default = tree["children_default"].astype(np.int32)
             self.features = tree["feature"].astype(np.int32)
-            self.thresholds = tree["threshold"]
-            self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.thresholds = np.asarray(tree["threshold"])
+            self.threshold_types = np.asarray(
+                tree.get("threshold_types", tree.get("threshold_type", np.zeros_like(self.thresholds))),
+                dtype=np.int32,
+            )
+            self.cat_bitsets = np.asarray(tree.get("cat_bitsets", _empty_cat_bitsets()), dtype=np.uint32)
             self.values = tree["value"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
@@ -1948,6 +2073,8 @@ class SingleTree:
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
             self.values = [-2 for _ in range(num_nodes)]  # type: ignore[assignment]
             self.node_sample_weight = np.empty(num_nodes, dtype=np.float64)
+            cat_bitsets: list[npt.NDArray[np.uint32]] = []
+            cat_bitset_offset = 0
 
             # BFS traversal through the tree structure
             visited, queue = [], [start]
@@ -1981,12 +2108,15 @@ class SingleTree:
                         self.thresholds[vsplit_idx] = vertex["threshold"]
                         self.threshold_types[vsplit_idx] = 0
                     elif isinstance(vertex["threshold"], str):
-                        threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
-                        for cat in categories:
-                            threshold += 2**cat
-                        self.thresholds[vsplit_idx] = threshold
+                        block = _build_cat_bitset_block(categories, f"LightGBM node {vsplit_idx}")
+                        _check_cat_bitset_offset_representable(
+                            cat_bitset_offset, self.thresholds.dtype, f"LightGBM node {vsplit_idx}"
+                        )
+                        self.thresholds[vsplit_idx] = cat_bitset_offset
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
+                        cat_bitsets.append(block)
+                        cat_bitset_offset += block.size
                     else:
                         raise TypeError(f"Threshold type {type(vertex['threshold'])} not supported")
                     self.values[vsplit_idx] = [vertex["internal_value"]]
@@ -2017,6 +2147,7 @@ class SingleTree:
                     self.node_sample_weight[vleaf_idx] = vertex.get("leaf_count", 0)
             self.values = np.asarray(self.values)
             self.values = np.multiply(self.values, scaling)
+            self.cat_bitsets = np.concatenate(cat_bitsets) if cat_bitsets else _empty_cat_bitsets()
 
         elif isinstance(tree, dict) and "nodeid" in tree:
             """ Directly create tree given the JSON dump (with stats) of a XGBoost model.
@@ -2114,6 +2245,8 @@ class SingleTree:
         else:
             raise TypeError("Unknown input to SingleTree constructor: " + str(tree))
 
+        _validate_cat_bitsets(self.threshold_types, self.thresholds, self.cat_bitsets, "SingleTree")
+
         # Re-compute the number of samples that pass through each node if we are given data
         if data is not None and data_missing is not None:
             self.node_sample_weight.fill(0.0)
@@ -2124,6 +2257,7 @@ class SingleTree:
                 self.features,
                 self.thresholds,
                 self.threshold_types,
+                self.cat_bitsets,
                 self.values,
                 1,
                 self.node_sample_weight,

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -797,10 +797,13 @@ class TreeExplainer(Explainer):
                 Return type for models with multiple outputs changed from list to np.ndarray.
 
         """
-        assert self.model.model_output == "raw", (
-            'Only model_output = "raw" is supported for SHAP interaction values right now!'
-        )
-        transform = "identity"
+        if self.feature_perturbation == "interventional":
+            transform = self.model.get_transform()
+        else:
+            assert self.model.model_output == "raw", (
+                'Only model_output = "raw" is supported for SHAP interaction values with tree_path_dependent!'
+            )
+            transform = "identity"
 
         # see if we have a default tree_limit in place.
         if tree_limit is None:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -677,7 +677,6 @@ class TreeExplainer(Explainer):
             X, y, tree_limit, check_additivity
         )
         transform = self.model.get_transform()
-        _xgboost_cat_unsupported(self.model)
 
         # run the core algorithm using the C extension
         assert_import("cext")

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -125,9 +125,9 @@ def test_xgboost_cat_unsupported() -> None:
     with pytest.raises(NotImplementedError, match="Categorical"):
         gpu_ex.shap_values(X)
 
+    # CPU TreeExplainer now supports categorical splits in interventional mode
     ex = shap.TreeExplainer(clf, X, feature_perturbation="interventional")
-    with pytest.raises(NotImplementedError, match="Categorical"):
-        ex.shap_values(X)
+    ex.shap_values(X)
 
 
 def lightgbm_base():

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -126,9 +126,9 @@ def test_xgboost_cat_unsupported() -> None:
     with pytest.raises(NotImplementedError, match="Categorical"):
         gpu_ex.shap_values(X)
 
+    # CPU TreeExplainer now supports categorical splits in interventional mode
     ex = shap.TreeExplainer(clf, X, feature_perturbation="interventional")
-    with pytest.raises(NotImplementedError, match="Categorical"):
-        ex.shap_values(X)
+    ex.shap_values(X)
 
 
 def lightgbm_base():

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1338,6 +1338,36 @@ class TestExplainerXGBoost:
         shap_values = explainer.shap_values(X_nan)
         # check that SHAP values sum to model output
         assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X_nan)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+
+    @pytest.mark.parametrize("Clf", classifiers)
+    def test_xgboost_mixed_category_and_nan(self, Clf):
+        """Test that xgboost explanations can handle categorical data with missing values.
+
+        Adapted from PR #4091 by @cedricdonie.
+        """
+        X, y = shap.datasets.adult(n_points=100)
+        # convert to category type (int/string for XGBoost 2.x+ compatibility)
+        X["Education-Num"] = X["Education-Num"].astype(int).astype("category")
+        X["Workclass"] = X["Workclass"].astype("category")
+        X["Country"] = X["Country"].astype("category")
+        # add a few missing values
+        X.loc[X.sample(frac=0.3, random_state=42).index, "Country"] = np.nan
+
+        clf = Clf(random_state=42, enable_categorical=True)
+        clf.fit(X, y)
+        margin = clf.predict(X, output_margin=True)
+        explainer = shap.TreeExplainer(clf)
+        shap_values = explainer.shap_values(X)
+        # check that SHAP values sum to model output
+        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
 
     @pytest.mark.parametrize("Reg", regressors)
     def test_xgboost_direct(self, Reg):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2196,7 +2196,6 @@ def test_overflow_tree_path_dependent():
     exp(X)
 
 
-@pytest.mark.skip("Currently disabled due to errors, see https://github.com/uber/causalml/issues/859.")
 @pytest.mark.parametrize(
     "n_estimators",
     [

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2968,7 +2968,6 @@ def test_tree_explainer_random_forest_regressor():
         assert np.abs(shap_sum - predictions).max() < 1e-4
 
 
-<<<<<<< HEAD
 def test_path_dependent_small_background():
     """Path-dependent SHAP with small background that has uncovered leaves.
 
@@ -3278,3 +3277,38 @@ def test_interventional_vs_path_dependent_uncorrelated():
 
     # Loose tolerance since finite-sample effects and slight correlation in random data
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
+
+
+
+def test_interventional_interaction_values_with_transform():
+    """Interventional interaction values with logistic transform (probability output).
+
+    Verifies that interaction values in probability space satisfy:
+    1. Row-sum additivity: sum_j(phi[i,j]) == shap_value[i]
+    2. Prediction additivity: sum(phi) + expected_value == predict_proba
+    3. Symmetry: phi[i,j] == phi[j,i]
+    """
+    np.random.seed(42)
+    X = np.random.randn(200, 5)
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    model = GradientBoostingClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    bg = X[:50]
+    X_test = X[50:55]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional",
+                                   model_output="probability")
+    iv = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Row-sum: interaction values sum to SHAP values per feature
+    np.testing.assert_allclose(iv.sum(axis=2), sv, atol=1e-4)
+
+    # Prediction additivity
+    pred = model.predict_proba(X_test)[:, 1]
+    total = iv.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, pred, atol=1e-4)
+
+    # Symmetry
+    np.testing.assert_allclose(iv, np.swapaxes(iv, 1, 2), atol=1e-10)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3183,6 +3183,53 @@ def test_interventional_interaction_values_multiclass():
                 )
 
 
+def test_interventional_categorical():
+    """Verify interventional SHAP values and interactions work with categorical splits."""
+    lightgbm = pytest.importorskip("lightgbm")
+
+    np.random.seed(42)
+    n = 200
+    # Two categorical features (1-based to avoid pre-existing category_in_threshold
+    # issue with category 0) and one continuous feature
+    cat0 = np.random.randint(1, 5, n).astype(np.float64)
+    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    cont = np.random.randn(n)
+    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    X = np.column_stack([cat0, cat1, cont])
+
+    ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
+    model = lightgbm.train(
+        {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
+        ds, num_boost_round=20,
+    )
+
+    X_test = X[:10]
+    bg = X[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+
+    # --- SHAP values ---
+    sv = explainer.shap_values(X_test)
+    preds = model.predict(X_test)
+    # Prediction additivity: sum of SHAP values + expected value ≈ prediction
+    np.testing.assert_allclose(sv.sum(axis=1) + explainer.expected_value, preds, atol=1e-4)
+
+    # --- Interaction values ---
+    interactions = explainer.shap_interaction_values(X_test)
+    n_feats = X_test.shape[1]
+
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-6)
+
+    # Row-sum additivity: interactions[i, j, :].sum() == sv[i, j]
+    row_sums = interactions.sum(axis=2)
+    np.testing.assert_allclose(row_sums[:, :n_feats], sv, atol=1e-4)
+
+    # Prediction additivity
+    total = interactions.sum(axis=(1, 2))
+    np.testing.assert_allclose(total + explainer.expected_value, preds, atol=1e-4)
+
+
 def test_interventional_vs_path_dependent_uncorrelated():
     """On uncorrelated data, both modes should approximately agree."""
     np.random.seed(42)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2978,15 +2978,20 @@ def test_path_dependent_small_background():
 # --- Interventional SHAP interaction values tests ---
 
 
-def test_interventional_interaction_values_brute_force():
-    """Verify interventional interactions match brute-force Shapley computation."""
+@pytest.mark.parametrize("n_features", [3, 4, 5, 6])
+def test_interventional_interaction_values_brute_force(n_features):
+    """Verify interventional interactions match brute-force Shapley computation.
+
+    Computes exact Shapley interaction indices by definition (O(2^n) per pair)
+    and compares against our C++ implementation. Parametrized over feature counts
+    to test different set-interval configurations.
+    """
     from itertools import combinations
     from math import comb
 
     np.random.seed(42)
-    n_features = 5
     X_train = np.random.randn(200, n_features)
-    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2 % n_features]
     model = DecisionTreeRegressor(max_depth=3, random_state=42)
     model.fit(X_train, y_train)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3043,10 +3043,21 @@ def test_interventional_interaction_values_brute_force(n_features):
                     for S_tuple in combinations(rest, size):
                         S = set(S_tuple)
                         feats = np.arange(n_features)
-                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_S = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Si = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sj = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sij = np.mean(
+                            [
+                                model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0]
+                                for r in bg
+                            ]
+                        )
 
                         weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
                         val += weight * (v_Sij - v_Si - v_Sj + v_S)
@@ -3143,6 +3154,7 @@ def test_interventional_interaction_values_models(model_name):
         model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
     elif model_name == "RandomForestRegressor":
         from sklearn.ensemble import RandomForestRegressor
+
         model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
     else:
         raise ValueError(f"Unknown model: {model_name}")
@@ -3182,6 +3194,7 @@ def test_interventional_interaction_values_nonzero():
 def test_interventional_interaction_values_multiclass():
     """Verify interventional interactions work for multi-class models."""
     from sklearn.datasets import load_iris
+
     iris = load_iris()
     model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
     model.fit(iris.data, iris.target)
@@ -3197,9 +3210,7 @@ def test_interventional_interaction_values_multiclass():
     if isinstance(interactions, list):
         for cls_interactions in interactions:
             assert cls_interactions.shape == (5, 4, 4)
-            np.testing.assert_allclose(
-                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
-            )
+            np.testing.assert_allclose(cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4)
     else:
         assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
         if interactions.ndim == 4:
@@ -3228,7 +3239,8 @@ def test_interventional_categorical():
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
     model = lightgbm.train(
         {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
-        ds, num_boost_round=20,
+        ds,
+        num_boost_round=20,
     )
 
     X_test = X[:10]
@@ -3279,7 +3291,6 @@ def test_interventional_vs_path_dependent_uncorrelated():
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
 
 
-
 def test_interventional_interaction_values_with_transform():
     """Interventional interaction values with logistic transform (probability output).
 
@@ -3297,8 +3308,7 @@ def test_interventional_interaction_values_with_transform():
     bg = X[:50]
     X_test = X[50:55]
 
-    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional",
-                                   model_output="probability")
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional", model_output="probability")
     iv = explainer.shap_interaction_values(X_test)
     sv = explainer.shap_values(X_test)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2939,6 +2939,7 @@ def test_tree_explainer_random_forest_regressor():
         assert np.abs(shap_sum - predictions).max() < 1e-4
 
 
+<<<<<<< HEAD
 def test_path_dependent_small_background():
     """Path-dependent SHAP with small background that has uncovered leaves.
 
@@ -2972,3 +2973,227 @@ def test_path_dependent_small_background():
     for c in range(3):
         shap_sum = explainer.expected_value[c] + sv[:, :, c].sum(axis=1)
         np.testing.assert_allclose(shap_sum, pred[:, c], atol=1e-6)
+
+
+# --- Interventional SHAP interaction values tests ---
+
+
+def test_interventional_interaction_values_brute_force():
+    """Verify interventional interactions match brute-force Shapley computation."""
+    from itertools import combinations
+    from math import comb
+
+    np.random.seed(42)
+    n_features = 5
+    X_train = np.random.randn(200, n_features)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(2, n_features)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    N = list(range(n_features))
+    for idx in range(len(X_test)):
+        x = X_test[idx]
+        phi_bf = np.zeros((n_features, n_features))
+
+        for i in range(n_features):
+            for j in range(i + 1, n_features):
+                rest = [f for f in N if f != i and f != j]
+                val = 0.0
+                for size in range(len(rest) + 1):
+                    for S_tuple in combinations(rest, size):
+                        S = set(S_tuple)
+                        feats = np.arange(n_features)
+                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+
+                        weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
+                        val += weight * (v_Sij - v_Si - v_Sj + v_S)
+                # SHAP library convention: off-diagonal stores half
+                phi_bf[i, j] = val / 2
+                phi_bf[j, i] = val / 2
+
+        # Diagonal = SHAP value - sum of off-diagonal
+        for i in range(n_features):
+            phi_bf[i, i] = sv[idx, i] - phi_bf[i, :].sum() + phi_bf[i, i]
+
+        np.testing.assert_allclose(interactions[idx], phi_bf, atol=1e-4)
+
+
+def test_interventional_interaction_values_symmetry():
+    """Verify phi[i,j] == phi[j,i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-10)
+
+
+def test_interventional_interaction_values_additivity():
+    """Verify sum_j phi[i,j] == shap_value[i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+
+
+def test_interventional_interaction_values_prediction():
+    """Verify interactions sum to prediction - expected_value."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    preds = model.predict(X_test)
+    total = interactions.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, preds, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "GradientBoostingRegressor",
+        "RandomForestRegressor",
+        "lightgbm",
+        "xgboost",
+        "catboost",
+    ],
+)
+def test_interventional_interaction_values_models(model_name):
+    """Verify interventional interactions work for multiple tree model types."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    if model_name == "lightgbm":
+        lightgbm = pytest.importorskip("lightgbm")
+        model = lightgbm.LGBMRegressor(n_estimators=20, max_depth=3, verbose=-1, random_state=42)
+    elif model_name == "xgboost":
+        xgboost = pytest.importorskip("xgboost")
+        model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "catboost":
+        catboost = pytest.importorskip("catboost")
+        model = catboost.CatBoostRegressor(n_estimators=20, max_depth=3, random_seed=42, verbose=0)
+    elif model_name == "GradientBoostingRegressor":
+        model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "RandomForestRegressor":
+        from sklearn.ensemble import RandomForestRegressor
+        model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
+    else:
+        raise ValueError(f"Unknown model: {model_name}")
+
+    model.fit(X_train, y_train)
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Shape check
+    assert interactions.shape == (3, 6, 6)
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-4)
+    # Row-sum additivity
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+    # Non-zero
+    assert np.abs(interactions).max() > 0
+
+
+def test_interventional_interaction_values_nonzero():
+    """Verify interventional interactions are NOT all zeros (Issue #1824)."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    assert np.abs(interactions).max() > 0.01, "Interactions are all zeros (Issue #1824 not fixed)"
+
+
+def test_interventional_interaction_values_multiclass():
+    """Verify interventional interactions work for multi-class models."""
+    from sklearn.datasets import load_iris
+    iris = load_iris()
+    model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(iris.data, iris.target)
+
+    X_test = iris.data[:5]
+    bg = iris.data[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+
+    # Multi-class: should be 4D array (n_samples, n_features, n_features, n_classes)
+    # or a list of 3D arrays
+    if isinstance(interactions, list):
+        for cls_interactions in interactions:
+            assert cls_interactions.shape == (5, 4, 4)
+            np.testing.assert_allclose(
+                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
+            )
+    else:
+        assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
+        if interactions.ndim == 4:
+            for c in range(interactions.shape[3]):
+                np.testing.assert_allclose(
+                    interactions[:, :, :, c],
+                    np.swapaxes(interactions[:, :, :, c], 1, 2),
+                    atol=1e-4,
+                )
+
+
+def test_interventional_vs_path_dependent_uncorrelated():
+    """On uncorrelated data, both modes should approximately agree."""
+    np.random.seed(42)
+    X = np.random.randn(500, 5)
+    y = X[:, 0] * X[:, 1] + X[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    X_test = X[:5]
+    bg = X[:100]
+
+    explainer_iv = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions_iv = explainer_iv.shap_interaction_values(X_test)
+
+    explainer_pd = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    interactions_pd = explainer_pd.shap_interaction_values(X_test)
+
+    # Loose tolerance since finite-sample effects and slight correlation in random data
+    np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3189,12 +3189,12 @@ def test_interventional_categorical():
 
     np.random.seed(42)
     n = 200
-    # Two categorical features (1-based to avoid pre-existing category_in_threshold
-    # issue with category 0) and one continuous feature
-    cat0 = np.random.randint(1, 5, n).astype(np.float64)
-    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    # Two categorical features (0-based, verifying category 0 works correctly)
+    # and one continuous feature
+    cat0 = np.random.randint(0, 4, n).astype(np.float64)
+    cat1 = np.random.randint(0, 3, n).astype(np.float64)
     cont = np.random.randn(n)
-    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    y = (cat0 == 1).astype(float) * 2 + cont * 0.5 + (cat1 == 2).astype(float)
     X = np.column_stack([cat0, cat1, cont])
 
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3225,6 +3225,53 @@ def test_interventional_interaction_values_multiclass():
                 )
 
 
+def test_interventional_categorical():
+    """Verify interventional SHAP values and interactions work with categorical splits."""
+    lightgbm = pytest.importorskip("lightgbm")
+
+    np.random.seed(42)
+    n = 200
+    # Two categorical features (1-based to avoid pre-existing category_in_threshold
+    # issue with category 0) and one continuous feature
+    cat0 = np.random.randint(1, 5, n).astype(np.float64)
+    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    cont = np.random.randn(n)
+    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    X = np.column_stack([cat0, cat1, cont])
+
+    ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
+    model = lightgbm.train(
+        {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
+        ds, num_boost_round=20,
+    )
+
+    X_test = X[:10]
+    bg = X[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+
+    # --- SHAP values ---
+    sv = explainer.shap_values(X_test)
+    preds = model.predict(X_test)
+    # Prediction additivity: sum of SHAP values + expected value ≈ prediction
+    np.testing.assert_allclose(sv.sum(axis=1) + explainer.expected_value, preds, atol=1e-4)
+
+    # --- Interaction values ---
+    interactions = explainer.shap_interaction_values(X_test)
+    n_feats = X_test.shape[1]
+
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-6)
+
+    # Row-sum additivity: interactions[i, j, :].sum() == sv[i, j]
+    row_sums = interactions.sum(axis=2)
+    np.testing.assert_allclose(row_sums[:, :n_feats], sv, atol=1e-4)
+
+    # Prediction additivity
+    total = interactions.sum(axis=(1, 2))
+    np.testing.assert_allclose(total + explainer.expected_value, preds, atol=1e-4)
+
+
 def test_interventional_vs_path_dependent_uncorrelated():
     """On uncorrelated data, both modes should approximately agree."""
     np.random.seed(42)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1350,9 +1350,11 @@ class TestExplainerXGBoost:
         # check that SHAP values sum to model output
         np.testing.assert_allclose(margin, explainer.expected_value + shap_values.sum(axis=1), atol=1e-4, rtol=1e-4)
         # check that interaction values sum to SHAP values and model output
+        # XGBoost computes interactions in float32 (HostDeviceVector<float>),
+        # so summing features accumulates ~1e-6 rounding error
         interaction_values = explainer.shap_interaction_values(X_nan)
-        assert np.allclose(shap_values, interaction_values.sum(axis=2))
-        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+        np.testing.assert_allclose(shap_values, interaction_values.sum(axis=2), atol=1e-5)
+        np.testing.assert_allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)), atol=1e-5)
 
     @pytest.mark.parametrize("Clf", classifiers)
     def test_xgboost_mixed_category_and_nan(self, Clf):
@@ -1374,11 +1376,12 @@ class TestExplainerXGBoost:
         explainer = shap.TreeExplainer(clf)
         shap_values = explainer.shap_values(X)
         # check that SHAP values sum to model output
-        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # XGBoost computes SHAP in float32, atol=1e-5 for accumulation noise
+        np.testing.assert_allclose(margin, explainer.expected_value + shap_values.sum(axis=1), atol=1e-5)
         # check that interaction values sum to SHAP values and model output
         interaction_values = explainer.shap_interaction_values(X)
-        assert np.allclose(shap_values, interaction_values.sum(axis=2))
-        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+        np.testing.assert_allclose(shap_values, interaction_values.sum(axis=2), atol=1e-5)
+        np.testing.assert_allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)), atol=1e-5)
 
     @pytest.mark.parametrize("Reg", regressors)
     def test_xgboost_direct(self, Reg):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3087,10 +3087,21 @@ def test_interventional_interaction_values_brute_force(n_features):
                     for S_tuple in combinations(rest, size):
                         S = set(S_tuple)
                         feats = np.arange(n_features)
-                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_S = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Si = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sj = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sij = np.mean(
+                            [
+                                model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0]
+                                for r in bg
+                            ]
+                        )
 
                         weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
                         val += weight * (v_Sij - v_Si - v_Sj + v_S)
@@ -3187,6 +3198,7 @@ def test_interventional_interaction_values_models(model_name):
         model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
     elif model_name == "RandomForestRegressor":
         from sklearn.ensemble import RandomForestRegressor
+
         model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
     else:
         raise ValueError(f"Unknown model: {model_name}")
@@ -3226,6 +3238,7 @@ def test_interventional_interaction_values_nonzero():
 def test_interventional_interaction_values_multiclass():
     """Verify interventional interactions work for multi-class models."""
     from sklearn.datasets import load_iris
+
     iris = load_iris()
     model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
     model.fit(iris.data, iris.target)
@@ -3241,9 +3254,7 @@ def test_interventional_interaction_values_multiclass():
     if isinstance(interactions, list):
         for cls_interactions in interactions:
             assert cls_interactions.shape == (5, 4, 4)
-            np.testing.assert_allclose(
-                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
-            )
+            np.testing.assert_allclose(cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4)
     else:
         assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
         if interactions.ndim == 4:
@@ -3272,7 +3283,8 @@ def test_interventional_categorical():
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
     model = lightgbm.train(
         {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
-        ds, num_boost_round=20,
+        ds,
+        num_boost_round=20,
     )
 
     X_test = X[:10]
@@ -3323,7 +3335,6 @@ def test_interventional_vs_path_dependent_uncorrelated():
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
 
 
-
 def test_interventional_interaction_values_with_transform():
     """Interventional interaction values with logistic transform (probability output).
 
@@ -3341,8 +3352,7 @@ def test_interventional_interaction_values_with_transform():
     bg = X[:50]
     X_test = X[50:55]
 
-    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional",
-                                   model_output="probability")
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional", model_output="probability")
     iv = explainer.shap_interaction_values(X_test)
     sv = explainer.shap_values(X_test)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3015,3 +3015,227 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+
+# --- Interventional SHAP interaction values tests ---
+
+
+def test_interventional_interaction_values_brute_force():
+    """Verify interventional interactions match brute-force Shapley computation."""
+    from itertools import combinations
+    from math import comb
+
+    np.random.seed(42)
+    n_features = 5
+    X_train = np.random.randn(200, n_features)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(2, n_features)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    N = list(range(n_features))
+    for idx in range(len(X_test)):
+        x = X_test[idx]
+        phi_bf = np.zeros((n_features, n_features))
+
+        for i in range(n_features):
+            for j in range(i + 1, n_features):
+                rest = [f for f in N if f != i and f != j]
+                val = 0.0
+                for size in range(len(rest) + 1):
+                    for S_tuple in combinations(rest, size):
+                        S = set(S_tuple)
+                        feats = np.arange(n_features)
+                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+
+                        weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
+                        val += weight * (v_Sij - v_Si - v_Sj + v_S)
+                # SHAP library convention: off-diagonal stores half
+                phi_bf[i, j] = val / 2
+                phi_bf[j, i] = val / 2
+
+        # Diagonal = SHAP value - sum of off-diagonal
+        for i in range(n_features):
+            phi_bf[i, i] = sv[idx, i] - phi_bf[i, :].sum() + phi_bf[i, i]
+
+        np.testing.assert_allclose(interactions[idx], phi_bf, atol=1e-4)
+
+
+def test_interventional_interaction_values_symmetry():
+    """Verify phi[i,j] == phi[j,i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-10)
+
+
+def test_interventional_interaction_values_additivity():
+    """Verify sum_j phi[i,j] == shap_value[i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+
+
+def test_interventional_interaction_values_prediction():
+    """Verify interactions sum to prediction - expected_value."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    preds = model.predict(X_test)
+    total = interactions.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, preds, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "GradientBoostingRegressor",
+        "RandomForestRegressor",
+        "lightgbm",
+        "xgboost",
+        "catboost",
+    ],
+)
+def test_interventional_interaction_values_models(model_name):
+    """Verify interventional interactions work for multiple tree model types."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    if model_name == "lightgbm":
+        lightgbm = pytest.importorskip("lightgbm")
+        model = lightgbm.LGBMRegressor(n_estimators=20, max_depth=3, verbose=-1, random_state=42)
+    elif model_name == "xgboost":
+        xgboost = pytest.importorskip("xgboost")
+        model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "catboost":
+        catboost = pytest.importorskip("catboost")
+        model = catboost.CatBoostRegressor(n_estimators=20, max_depth=3, random_seed=42, verbose=0)
+    elif model_name == "GradientBoostingRegressor":
+        model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "RandomForestRegressor":
+        from sklearn.ensemble import RandomForestRegressor
+        model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
+    else:
+        raise ValueError(f"Unknown model: {model_name}")
+
+    model.fit(X_train, y_train)
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Shape check
+    assert interactions.shape == (3, 6, 6)
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-4)
+    # Row-sum additivity
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+    # Non-zero
+    assert np.abs(interactions).max() > 0
+
+
+def test_interventional_interaction_values_nonzero():
+    """Verify interventional interactions are NOT all zeros (Issue #1824)."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    assert np.abs(interactions).max() > 0.01, "Interactions are all zeros (Issue #1824 not fixed)"
+
+
+def test_interventional_interaction_values_multiclass():
+    """Verify interventional interactions work for multi-class models."""
+    from sklearn.datasets import load_iris
+    iris = load_iris()
+    model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(iris.data, iris.target)
+
+    X_test = iris.data[:5]
+    bg = iris.data[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+
+    # Multi-class: should be 4D array (n_samples, n_features, n_features, n_classes)
+    # or a list of 3D arrays
+    if isinstance(interactions, list):
+        for cls_interactions in interactions:
+            assert cls_interactions.shape == (5, 4, 4)
+            np.testing.assert_allclose(
+                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
+            )
+    else:
+        assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
+        if interactions.ndim == 4:
+            for c in range(interactions.shape[3]):
+                np.testing.assert_allclose(
+                    interactions[:, :, :, c],
+                    np.swapaxes(interactions[:, :, :, c], 1, 2),
+                    atol=1e-4,
+                )
+
+
+def test_interventional_vs_path_dependent_uncorrelated():
+    """On uncorrelated data, both modes should approximately agree."""
+    np.random.seed(42)
+    X = np.random.randn(500, 5)
+    y = X[:, 0] * X[:, 1] + X[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    X_test = X[:5]
+    bg = X[:100]
+
+    explainer_iv = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions_iv = explainer_iv.shap_interaction_values(X_test)
+
+    explainer_pd = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    interactions_pd = explainer_pd.shap_interaction_values(X_test)
+
+    # Loose tolerance since finite-sample effects and slight correlation in random data
+    np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3020,15 +3020,20 @@ def test_nullable_pandas_dtype():
 # --- Interventional SHAP interaction values tests ---
 
 
-def test_interventional_interaction_values_brute_force():
-    """Verify interventional interactions match brute-force Shapley computation."""
+@pytest.mark.parametrize("n_features", [3, 4, 5, 6])
+def test_interventional_interaction_values_brute_force(n_features):
+    """Verify interventional interactions match brute-force Shapley computation.
+
+    Computes exact Shapley interaction indices by definition (O(2^n) per pair)
+    and compares against our C++ implementation. Parametrized over feature counts
+    to test different set-interval configurations.
+    """
     from itertools import combinations
     from math import comb
 
     np.random.seed(42)
-    n_features = 5
     X_train = np.random.randn(200, n_features)
-    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2 % n_features]
     model = DecisionTreeRegressor(max_depth=3, random_state=42)
     model.fit(X_train, y_train)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3231,12 +3231,12 @@ def test_interventional_categorical():
 
     np.random.seed(42)
     n = 200
-    # Two categorical features (1-based to avoid pre-existing category_in_threshold
-    # issue with category 0) and one continuous feature
-    cat0 = np.random.randint(1, 5, n).astype(np.float64)
-    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    # Two categorical features (0-based, verifying category 0 works correctly)
+    # and one continuous feature
+    cat0 = np.random.randint(0, 4, n).astype(np.float64)
+    cat1 = np.random.randint(0, 3, n).astype(np.float64)
     cont = np.random.randn(n)
-    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    y = (cat0 == 1).astype(float) * 2 + cont * 0.5 + (cat1 == 2).astype(float)
     X = np.column_stack([cat0, cat1, cont])
 
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1349,6 +1349,36 @@ class TestExplainerXGBoost:
         shap_values = explainer.shap_values(X_nan)
         # check that SHAP values sum to model output
         np.testing.assert_allclose(margin, explainer.expected_value + shap_values.sum(axis=1), atol=1e-4, rtol=1e-4)
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X_nan)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+
+    @pytest.mark.parametrize("Clf", classifiers)
+    def test_xgboost_mixed_category_and_nan(self, Clf):
+        """Test that xgboost explanations can handle categorical data with missing values.
+
+        Adapted from PR #4091 by @cedricdonie.
+        """
+        X, y = shap.datasets.adult(n_points=100)
+        # convert to category type (int/string for XGBoost 2.x+ compatibility)
+        X["Education-Num"] = X["Education-Num"].astype(int).astype("category")
+        X["Workclass"] = X["Workclass"].astype("category")
+        X["Country"] = X["Country"].astype("category")
+        # add a few missing values
+        X.loc[X.sample(frac=0.3, random_state=42).index, "Country"] = np.nan
+
+        clf = Clf(random_state=42, enable_categorical=True)
+        clf.fit(X, y)
+        margin = clf.predict(X, output_margin=True)
+        explainer = shap.TreeExplainer(clf)
+        shap_values = explainer.shap_values(X)
+        # check that SHAP values sum to model output
+        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
 
     @pytest.mark.parametrize("Reg", regressors)
     def test_xgboost_direct(self, Reg):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3321,3 +3321,38 @@ def test_interventional_vs_path_dependent_uncorrelated():
 
     # Loose tolerance since finite-sample effects and slight correlation in random data
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
+
+
+
+def test_interventional_interaction_values_with_transform():
+    """Interventional interaction values with logistic transform (probability output).
+
+    Verifies that interaction values in probability space satisfy:
+    1. Row-sum additivity: sum_j(phi[i,j]) == shap_value[i]
+    2. Prediction additivity: sum(phi) + expected_value == predict_proba
+    3. Symmetry: phi[i,j] == phi[j,i]
+    """
+    np.random.seed(42)
+    X = np.random.randn(200, 5)
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    model = GradientBoostingClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    bg = X[:50]
+    X_test = X[50:55]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional",
+                                   model_output="probability")
+    iv = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Row-sum: interaction values sum to SHAP values per feature
+    np.testing.assert_allclose(iv.sum(axis=2), sv, atol=1e-4)
+
+    # Prediction additivity
+    pred = model.predict_proba(X_test)[:, 1]
+    total = iv.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, pred, atol=1e-4)
+
+    # Symmetry
+    np.testing.assert_allclose(iv, np.swapaxes(iv, 1, 2), atol=1e-10)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3317,6 +3317,184 @@ def test_interventional_categorical():
     np.testing.assert_allclose(total + explainer.expected_value, preds, atol=1e-4)
 
 
+def _wide_categorical_lightgbm_model():
+    lightgbm = pytest.importorskip("lightgbm")
+
+    categories = np.tile(np.arange(50, dtype=np.float64), 10)
+    cont = np.linspace(-1.0, 1.0, categories.size)
+    X = np.column_stack([categories, cont])
+    y = np.where(np.isin(categories, [0, 31, 32, 47]), 10.0, -1.0) + 0.1 * cont
+
+    required = np.array(
+        [
+            [0, -0.75],
+            [31, -0.25],
+            [32, 0.25],
+            [47, 0.75],
+        ],
+        dtype=np.float64,
+    )
+    required_y = np.where(np.isin(required[:, 0], [0, 31, 32, 47]), 10.0, -1.0) + 0.1 * required[:, 1]
+    X = np.vstack([required, X])
+    y = np.concatenate([required_y, y])
+
+    dataset = lightgbm.Dataset(X, label=y, categorical_feature=[0], free_raw_data=False)
+    model = lightgbm.train(
+        {
+            "objective": "regression",
+            "verbose": -1,
+            "learning_rate": 0.5,
+            "num_leaves": 8,
+            "max_depth": 3,
+            "min_data_in_leaf": 1,
+            "min_data_in_bin": 1,
+            "max_cat_to_onehot": 1,
+            "cat_smooth": 0,
+            "cat_l2": 0,
+            "seed": 0,
+            "feature_fraction_seed": 0,
+            "bagging_seed": 0,
+            "data_random_seed": 0,
+            "num_threads": 1,
+        },
+        dataset,
+        num_boost_round=6,
+    )
+    return model, X, required
+
+
+def _cat_bitset_contains(cat_bitsets, offset, category):
+    word_index = category // 32
+    bit_index = category % 32
+    n_words = int(cat_bitsets[offset])
+    return word_index < n_words and (int(cat_bitsets[offset + 1 + word_index]) & (1 << bit_index)) != 0
+
+
+def test_interventional_categorical_uint32_bitsets():
+    """Verify interventional TreeSHAP handles LightGBM categorical splits past category 31."""
+    model, X, X_test = _wide_categorical_lightgbm_model()
+    bg = X[:80]
+    required_categories = {0, 31, 32, 47}
+    assert required_categories.issubset(set(X_test[:, 0].astype(int)))
+    assert required_categories.issubset(set(bg[:, 0].astype(int)))
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+
+    cat_nodes = np.argwhere(explainer.model.threshold_types == 1)
+    assert cat_nodes.shape[0] > 1
+    assert explainer.model.cat_bitsets.dtype == np.uint32
+    global_offsets = explainer.model.thresholds[explainer.model.threshold_types == 1].astype(int)
+    np.testing.assert_allclose(global_offsets, explainer.model.thresholds[explainer.model.threshold_types == 1])
+    assert np.all(global_offsets >= 0)
+    assert np.all(global_offsets < explainer.model.cat_bitsets.size)
+    assert any(int(explainer.model.cat_bitsets[offset]) >= 2 for offset in global_offsets)
+    assert any(_cat_bitset_contains(explainer.model.cat_bitsets, offset, 0) for offset in global_offsets)
+    assert any(_cat_bitset_contains(explainer.model.cat_bitsets, offset, 31) for offset in global_offsets)
+    assert any(_cat_bitset_contains(explainer.model.cat_bitsets, offset, 32) for offset in global_offsets)
+    assert any(_cat_bitset_contains(explainer.model.cat_bitsets, offset, 47) for offset in global_offsets)
+
+    cat_bitset_offset = 0
+    shifted_later_tree = False
+    for tree_idx, tree in enumerate(explainer.model.trees):
+        local_cat_nodes = np.flatnonzero(tree.threshold_types == 1)
+        if local_cat_nodes.size:
+            local_offsets = tree.thresholds[local_cat_nodes].astype(int)
+            dense_offsets = explainer.model.thresholds[tree_idx, local_cat_nodes].astype(int)
+            np.testing.assert_array_equal(dense_offsets, local_offsets + cat_bitset_offset)
+            shifted_later_tree |= cat_bitset_offset > 0 and np.any(local_offsets == 0)
+        cat_bitset_offset += tree.cat_bitsets.size
+    assert cat_bitset_offset == explainer.model.cat_bitsets.size
+    assert shifted_later_tree
+
+    sv = explainer.shap_values(X_test)
+    preds = model.predict(X_test)
+    np.testing.assert_allclose(sv.sum(axis=1) + explainer.expected_value, preds, atol=1e-4)
+
+    interactions = explainer.shap_interaction_values(X_test)
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-6)
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+    np.testing.assert_allclose(interactions.sum(axis=(1, 2)) + explainer.expected_value, preds, atol=1e-4)
+
+
+def test_lightgbm_categorical_uint32_bitsets_saabas():
+    """Approximate Tree SHAP must route categorical bitset offsets correctly."""
+    model, X, X_test = _wide_categorical_lightgbm_model()
+    explainer = shap.TreeExplainer(model, X[:80], feature_perturbation="interventional")
+
+    shap_values = explainer.shap_values(X_test, approximate=True)
+    preds = model.predict(X_test)
+
+    np.testing.assert_allclose(shap_values.sum(axis=1) + explainer.expected_value, preds, atol=1e-4)
+
+
+def _categorical_tree_dict(cat_bitsets=None):
+    tree = {
+        "children_left": np.array([1, -1, -1], dtype=np.int32),
+        "children_right": np.array([2, -1, -1], dtype=np.int32),
+        "children_default": np.array([1, -1, -1], dtype=np.int32),
+        "features": np.array([0, -1, -1], dtype=np.int32),
+        "thresholds": np.array([0.0, -1.0, -1.0], dtype=np.float64),
+        "threshold_types": np.array([1, -1, -1], dtype=np.int32),
+        "values": np.array([[0.0], [1.0], [-1.0]], dtype=np.float64),
+        "node_sample_weight": np.array([2.0, 1.0, 1.0], dtype=np.float64),
+    }
+    if cat_bitsets is not None:
+        tree["cat_bitsets"] = cat_bitsets
+    return tree
+
+
+def test_categorical_tree_requires_cat_bitsets():
+    """Categorical nodes must not fall back to legacy packed threshold masks."""
+    from shap.explainers._tree import TreeEnsemble
+
+    message = "categorical threshold_types but no cat_bitsets buffer"
+    with pytest.raises(ValueError, match=message):
+        SingleTree(_categorical_tree_dict())
+
+    tree = SingleTree(_categorical_tree_dict(np.array([2, 1, 1], dtype=np.uint32)))
+    tree.cat_bitsets = np.empty(0, dtype=np.uint32)
+    with pytest.raises(ValueError, match=message):
+        TreeEnsemble([tree])
+
+
+def test_categorical_global_path_dependent_rejected():
+    """The global path dependent C extension path must reject categorical offsets."""
+    from shap import _cext
+    from shap.explainers import _tree
+    from shap.explainers._tree import TreeEnsemble
+
+    tree = SingleTree(_categorical_tree_dict(np.array([2, 1, 1], dtype=np.uint32)))
+    ensemble = TreeEnsemble([tree])
+    X = np.array([[0.0], [32.0], [7.0]], dtype=np.float64)
+    X_missing = np.zeros_like(X, dtype=bool)
+    phi = np.zeros((X.shape[0], X.shape[1] + 1, 1), dtype=np.float64)
+
+    with pytest.raises(ValueError, match="global_path_dependent.*categorical splits"):
+        _cext.dense_tree_shap(
+            ensemble.children_left,
+            ensemble.children_right,
+            ensemble.children_default,
+            ensemble.features,
+            ensemble.thresholds,
+            ensemble.threshold_types,
+            ensemble.cat_bitsets,
+            ensemble.values,
+            ensemble.node_sample_weight,
+            ensemble.max_depth,
+            X,
+            X_missing,
+            None,
+            X,
+            X_missing,
+            -1,
+            ensemble.base_offset,
+            phi,
+            _tree.feature_perturbation_codes["global_path_dependent"],
+            _tree.output_transform_codes["identity"],
+            False,
+        )
+
+
 def test_interventional_vs_path_dependent_uncorrelated():
     """On uncorrelated data, both modes should approximately agree."""
     np.random.seed(42)


### PR DESCRIPTION
## Summary

Implements interventional SHAP interaction values for tree models, fixes categorical split handling across CPU paths, and corrects the GPU categorical encoding for CPU/GPU parity.

### New feature: Interventional SHAP interaction values

Implements the algorithm from [Zern et al. (AAAI 2023)](https://ojs.aaai.org/index.php/AAAI/article/view/26234). Previously, `shap_interaction_values()` with `feature_perturbation="interventional"` returned all zeros silently (#1824). Now produces correct interaction values verified against brute-force Shapley computation for 3 through 6 features and tested across sklearn, LightGBM, XGBoost, and CatBoost.

### Categorical splits: uint32 bitset representation

Replaces the packed integer mask categorical representation (`1 << cat` stored in a float threshold) with a uint32 bitset buffer design. The bitset approach removes the ~31 category limit, provides explicit bounds checking for malformed inputs, and aligns with how LightGBM stores categorical splits internally.

The bitset design is adopted from PR #5079 by @stevenellis-od, which solves the same representation problem for the path-dependent code path. We apply it coherently across all CPU entry points that handle categorical thresholds: interventional SHAP values and interactions, exact path-dependent Tree SHAP, prediction, background weight updates, and approximate (Saabas) explanations. Global path-dependent mode explicitly rejects categorical splits rather than silently misrouting offset values as numeric thresholds.

Legacy packed-mask custom trees are not migrated. Categorical nodes must provide a proper `cat_bitsets` buffer or they raise a clear error.

### Bug fixes

- **`category_in_threshold` 0-based encoding**: was `1 << (cat-1)` (undefined behavior for category 0), now uses 0-based bitset lookup. GPU `CategoryInMask` in `_cext_gpu.cu` updated to match for CPU/GPU parity.
- **XGBoost `dmatrix_props` not propagated** for interaction values (#3510).
- **`tree_saabas()` ignored `threshold_types`**: categorical nodes were routed as numeric thresholds. Now bitset-aware.
- **`build_merged_tree_recursive()` dropped `threshold_types`**: merged trees lost categorical type info. Now preserved.

### Key changes

| File | Change |
|------|--------|
| `shap/cext/tree_shap.h` | `TreeEnsemble` gains `cat_bitsets`/`num_cat_bitsets`. New 4-arg `category_in_threshold()` with bounds checking. `tree_shap_indep()`, `tree_shap_indep_interactions()`, `tree_shap_recursive()`, `tree_predict()`, `tree_update_weights()`, `tree_saabas()` all updated. `dense_independent_interactions()` and `omega_weight()` added. `Node.thres` widened to `tfloat`. `global_path_dependent` rejects categorical splits. |
| `shap/cext/_cext.cc` | All 4 C extension entry points (`dense_tree_shap`, `dense_tree_predict`, `dense_tree_update_weights`, `dense_tree_saabas`) accept `cat_bitsets` parameter. Global-path categorical rejection at Python/C boundary. |
| `shap/cext/_cext_gpu.cu` | `CategoryInMask` encoding fixed to 0-based for CPU/GPU parity. |
| `shap/explainers/_tree.py` | `TreeEnsemble` and `SingleTree` gain `cat_bitsets` field. LightGBM parser builds bitset blocks. Dense ensemble assembly concatenates per-tree bitsets with offset shifting. Validation helpers reject malformed categorical inputs. |
| `tests/explainers/test_tree.py` | Interaction brute-force tests (3-6 features), symmetry, additivity, multi-model, multiclass, >31 category bitset tests with boundary coverage (0/31/32/47), per-tree offset shifting verification, Saabas bitset routing, legacy mask rejection, global-path rejection. |

## Issues

- Closes #1824 — Interventional interaction values now work
- Fixes #3510 — XGBoost `dmatrix_props` propagated for interaction values

## Test plan

- [x] Brute-force verification of interaction values (3-6 features)
- [x] Symmetry, row-sum additivity, prediction additivity
- [x] Multi-model: sklearn GBR, RandomForest, LightGBM, XGBoost, CatBoost
- [x] Multiclass: sklearn GBC with 3 classes
- [x] Categorical >31 categories with boundary coverage (0, 31, 32, 47)
- [x] Per-tree bitset offset shifting verified across multi-tree ensembles
- [x] Saabas/approximate with categorical bitsets
- [x] Legacy packed-mask rejection
- [x] Global-path-dependent categorical rejection
- [x] XGBoost float32 interaction tolerance (verified against xgboost 3.2.0 and 3.3.0)
- [x] Transform support (probability output) for interaction values

Investigated, designed and implemented by J.H.S. Schlepers
Coding support and research help using LLM (Claude Opus 4.6, Anthropic)
