### PR TITLE
Fix spelling error in docs: perterbation to perturbation

### DIFF
--- a/notebooks/tabular_examples/neural_networks/Census income classification with Keras.ipynb
+++ b/notebooks/tabular_examples/neural_networks/Census income classification with Keras.ipynb
@@ -261,7 +261,7 @@
    "source": [
     "### Explain a single prediction\n",
     "\n",
-    "Here we use a selection of 50 samples from the dataset to represent \"typical\" feature values, and then use 500 perterbation samples to estimate the SHAP values for a given prediction. Note that this requires 500 * 50 evaluations of the model."
+    "Here we use a selection of 50 samples from the dataset to represent \"typical\" feature values, and then use 500 perturbation samples to estimate the SHAP values for a given prediction. Note that this requires 500 * 50 evaluations of the model."
    ]
   },
   {


### PR DESCRIPTION
## Overview

Fix minor typo in documentation: "perterbation" → "perturbation"  
in the Census income classification Keras example notebook.
