### PR TITLE
Add OpenMP parallelization for interventional TreeSHAP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ execute_process(
 
 target_include_directories(_cext PUBLIC ${NUMPY_INCLUDE_DIR})
 
+# OpenMP for parallelized interventional TreeSHAP
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+  target_link_libraries(_cext PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
 # Install directive for scikit-build-core
 install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 

--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,15 @@ def run_setup(*, with_binary, with_cuda):
     ext_modules = []
     if with_binary:
         compile_args = []
+        link_args = []
         if sys.platform == "zos":
             compile_args.append("-qlonglong")
-        if sys.platform == "win32":
+        elif sys.platform == "win32":
             compile_args.append("/MD")
+            compile_args.append("/openmp")
+        else:
+            compile_args.append("-fopenmp")
+            link_args.append("-fopenmp")
 
         ext_modules.append(
             Extension(
@@ -111,6 +116,7 @@ def run_setup(*, with_binary, with_cuda):
                 sources=["shap/cext/_cext.cc"],
                 include_dirs=[np.get_include()],
                 extra_compile_args=compile_args,
+                extra_link_args=link_args,
             )
         )
     if with_cuda:

--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -28,10 +28,10 @@ struct CategoryConstraint {
   __host__ __device__ static bool CategoryInMask(int categories,
                                                  float category) {
     int category_int = static_cast<int>(category);
-    if (category_int < 1) {
+    if (category_int < 0) {
       return false;
     }
-    int category_flag = 1 << (category_int - 1);
+    int category_flag = 1 << category_int;
     return (categories & category_flag) != 0;
   }
 

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -180,7 +180,7 @@ inline transform_f get_transform(unsigned model_transform) {
 }
 
 inline bool category_in_threshold(float threshold, float category) {
-    int category_flag = (1 << (int(category) - 1));
+    int category_flag = (1 << int(category));
     return (int(threshold) & category_flag) != 0;
 }
 

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <cmath>
 #include <ctime>
+#include <vector>
 #if defined(_WIN32) || defined(WIN32)
     #include <malloc.h>
 #elif defined(__MVS__)
@@ -748,6 +749,12 @@ inline int bin_coeff(int n, int k) {
     return res;
 }
 
+// omega(a, b) = 1 / ((a+b+1) * C(a+b, a))
+// Used by interventional SHAP interaction values (Zern et al. AAAI 2023)
+inline tfloat omega_weight(int a, int b) {
+    return 1.0 / ((a + b + 1) * bin_coeff(a + b, a));
+}
+
 // note this only handles single output models, so multi-output models get explained using multiple passes
 inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
                             const unsigned num_nodes, const tfloat *x,
@@ -1107,6 +1114,365 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 }
 
 
+// Implements Corollary 1 (Eq. 14b) from Zern et al. (AAAI 2023) for a constant leaf value.
+// Updates the interaction matrix out_contribs for a leaf node with the given A and N\B feature sets.
+inline void shapley_interaction_const_leaf(
+    const tfloat value,          // leaf value (scaled by 1/|D| or cover)
+    const int *A_feats,          // array of feature indices in A
+    const int nA,                // |A|
+    const int *NB_feats,         // array of feature indices in N\B
+    const int nNB,               // |N\B|
+    const unsigned num_feats,    // M (total features)
+    tfloat *out_contribs,        // output: (num_feats+1) x (num_feats+1) interaction matrix
+    const tfloat *omega_table,   // precomputed omega table
+    const unsigned omega_stride  // stride for omega_table (max_depth+2)
+) {
+    const unsigned S = num_feats + 1; // stride for interaction matrix rows
+
+    // 1. Diagonal updates (SHAP main effects)
+    // For each j in A: phi[j,j] += value * omega(|A|-1, |N\B|)
+    if (nA >= 1) {
+        const tfloat diag_A = value * omega_table[(nA - 1) * omega_stride + nNB];
+        for (int i = 0; i < nA; ++i) {
+            out_contribs[A_feats[i] * S + A_feats[i]] += diag_A;
+        }
+    }
+
+    // For each j in N\B: phi[j,j] += -value * omega(|A|, |N\B|-1)
+    if (nNB >= 1) {
+        const tfloat diag_NB = -value * omega_table[nA * omega_stride + (nNB - 1)];
+        for (int i = 0; i < nNB; ++i) {
+            out_contribs[NB_feats[i] * S + NB_feats[i]] += diag_NB;
+        }
+    }
+
+    // 2. A x A pairs (when |A| >= 2)
+    if (nA >= 2) {
+        const tfloat phi_update = 0.5 * value * omega_table[(nA - 2) * omega_stride + nNB];
+        for (int i = 0; i < nA; ++i) {
+            for (int j = i + 1; j < nA; ++j) {
+                out_contribs[A_feats[i] * S + A_feats[j]] += phi_update;
+                out_contribs[A_feats[j] * S + A_feats[i]] += phi_update;
+                // Diagonal correction: phi[k,k] -= phi_update for each off-diag entry
+                out_contribs[A_feats[i] * S + A_feats[i]] -= phi_update;
+                out_contribs[A_feats[j] * S + A_feats[j]] -= phi_update;
+            }
+        }
+    }
+
+    // 3. A x N\B cross pairs (when |A| >= 1 and |N\B| >= 1)
+    if (nA >= 1 && nNB >= 1) {
+        const tfloat phi_update = -0.5 * value * omega_table[(nA - 1) * omega_stride + (nNB - 1)];
+        for (int i = 0; i < nA; ++i) {
+            for (int j = 0; j < nNB; ++j) {
+                out_contribs[A_feats[i] * S + NB_feats[j]] += phi_update;
+                out_contribs[NB_feats[j] * S + A_feats[i]] += phi_update;
+                // Diagonal correction
+                out_contribs[A_feats[i] * S + A_feats[i]] -= phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[j]] -= phi_update;
+            }
+        }
+    }
+
+    // 4. N\B x N\B pairs (when |N\B| >= 2)
+    if (nNB >= 2) {
+        const tfloat phi_update = 0.5 * value * omega_table[nA * omega_stride + (nNB - 2)];
+        for (int i = 0; i < nNB; ++i) {
+            for (int j = i + 1; j < nNB; ++j) {
+                out_contribs[NB_feats[i] * S + NB_feats[j]] += phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[i]] += phi_update;
+                // Diagonal correction
+                out_contribs[NB_feats[i] * S + NB_feats[i]] -= phi_update;
+                out_contribs[NB_feats[j] * S + NB_feats[j]] -= phi_update;
+            }
+        }
+    }
+}
+
+// Per-tree per-sample-pair interventional SHAP interaction values.
+// Based on tree_shap_indep() traversal but computes interaction matrix at leaves
+// using Corollary 1 (Eq. 14b) from Zern et al. (AAAI 2023).
+inline void tree_shap_indep_interactions(
+    const unsigned max_depth, const unsigned num_feats,
+    const unsigned num_nodes, const tfloat *x,
+    const bool *x_missing, const tfloat *r,
+    const bool *r_missing, tfloat *out_contribs,
+    signed short *feat_hist,
+    const tfloat *omega_table, const unsigned omega_stride,
+    int *node_stack, Node *mytree,
+    int *A_feats_buf, int *NB_feats_buf
+) {
+    int ns_ctr = 0;
+    std::fill_n(feat_hist, num_feats, 0);
+    short node = 0, cl, cr, cd, pnode;
+    long feat, pfeat = -1;
+    short next_xnode = -1, next_rnode = -1;
+    short next_node = -1, from_child = -1;
+    float thres;
+    char from_flag;
+    unsigned M = 0, N = 0;
+
+    Node curr_node = mytree[node];
+    feat = curr_node.feat;
+    thres = curr_node.thres;
+    cl = curr_node.cl;
+    cr = curr_node.cr;
+    cd = curr_node.cd;
+
+    // short circuit when this is a stump tree (with no splits)
+    if (cl < 0) {
+        out_contribs[num_feats * (num_feats + 1) + num_feats] += curr_node.value;
+        return;
+    }
+
+    if (x_missing[feat]) {
+        next_xnode = cd;
+    } else if (x[feat] > thres) {
+        next_xnode = cr;
+    } else if (x[feat] <= thres) {
+        next_xnode = cl;
+    }
+
+    if (r_missing[feat]) {
+        next_rnode = cd;
+    } else if (r[feat] > thres) {
+        next_rnode = cr;
+    } else if (r[feat] <= thres) {
+        next_rnode = cl;
+    }
+
+    if (next_xnode != next_rnode) {
+        mytree[next_xnode].from_flag = FROM_X_NOT_R;
+        mytree[next_rnode].from_flag = FROM_R_NOT_X;
+    } else {
+        mytree[next_xnode].from_flag = FROM_NEITHER;
+    }
+
+    // Check if x and r go the same way
+    if (next_xnode == next_rnode) {
+        next_node = next_xnode;
+    }
+
+    // If not, go left
+    if (next_node < 0) {
+        next_node = cl;
+        if (next_rnode == next_node) { // rpath
+            N = N+1;
+            feat_hist[feat] -= 1;
+        } else if (next_xnode == next_node) { // xpath
+            M = M+1;
+            N = N+1;
+            feat_hist[feat] += 1;
+        }
+    }
+    node_stack[ns_ctr] = node;
+    ns_ctr += 1;
+    while (true) {
+        node = next_node;
+        curr_node = mytree[node];
+        feat = curr_node.feat;
+        thres = curr_node.thres;
+        cl = curr_node.cl;
+        cr = curr_node.cr;
+        cd = curr_node.cd;
+        pnode = curr_node.pnode;
+        pfeat = curr_node.pfeat;
+        from_flag = curr_node.from_flag;
+
+        // At a leaf
+        if (cl < 0) {
+            if (N == 0) {
+                // No divergence at all: add to bias term (2D position)
+                out_contribs[num_feats * (num_feats + 1) + num_feats] += mytree[node].value;
+            } else {
+                // Build A_feats and NB_feats arrays from feat_hist
+                int nA = 0, nNB = 0;
+                for (unsigned f = 0; f < num_feats; ++f) {
+                    if (feat_hist[f] > 0) {
+                        A_feats_buf[nA++] = f;
+                    } else if (feat_hist[f] < 0) {
+                        NB_feats_buf[nNB++] = f;
+                    }
+                }
+                shapley_interaction_const_leaf(
+                    mytree[node].value, A_feats_buf, nA, NB_feats_buf, nNB,
+                    num_feats, out_contribs, omega_table, omega_stride
+                );
+            }
+
+            // Pop from node_stack
+            ns_ctr -= 1;
+            next_node = node_stack[ns_ctr];
+            from_child = node;
+            // Unwind
+            if (feat_hist[pfeat] > 0) {
+                feat_hist[pfeat] -= 1;
+            } else if (feat_hist[pfeat] < 0) {
+                feat_hist[pfeat] += 1;
+            }
+            if (feat_hist[pfeat] == 0) {
+                if (from_flag == FROM_X_NOT_R) {
+                    N = N-1;
+                    M = M-1;
+                } else if (from_flag == FROM_R_NOT_X) {
+                    N = N-1;
+                }
+            }
+            continue;
+        }
+
+        const bool x_right = x[feat] > thres;
+        const bool r_right = r[feat] > thres;
+
+        if (x_missing[feat]) {
+            next_xnode = cd;
+        } else if (x_right) {
+            next_xnode = cr;
+        } else if (!x_right) {
+            next_xnode = cl;
+        }
+
+        if (r_missing[feat]) {
+            next_rnode = cd;
+        } else if (r_right) {
+            next_rnode = cr;
+        } else if (!r_right) {
+            next_rnode = cl;
+        }
+
+        if (next_xnode >= 0) {
+          if (next_xnode != next_rnode) {
+              mytree[next_xnode].from_flag = FROM_X_NOT_R;
+              mytree[next_rnode].from_flag = FROM_R_NOT_X;
+          } else {
+              mytree[next_xnode].from_flag = FROM_NEITHER;
+          }
+        }
+
+        // Arriving at node from parent
+        if (from_child == -1) {
+            node_stack[ns_ctr] = node;
+            ns_ctr += 1;
+            next_node = -1;
+
+            // Feature is set upstream
+            if (feat_hist[feat] > 0) {
+                next_node = next_xnode;
+                feat_hist[feat] += 1;
+            } else if (feat_hist[feat] < 0) {
+                next_node = next_rnode;
+                feat_hist[feat] -= 1;
+            }
+
+            // x and r go the same way
+            if (next_node < 0) {
+                if (next_xnode == next_rnode) {
+                    next_node = next_xnode;
+                }
+            }
+
+            // Go down one path
+            if (next_node >= 0) {
+                continue;
+            }
+
+            // Go down both paths, but go left first
+            next_node = cl;
+            if (next_rnode == next_node) {
+                N = N+1;
+                feat_hist[feat] -= 1;
+            } else if (next_xnode == next_node) {
+                M = M+1;
+                N = N+1;
+                feat_hist[feat] += 1;
+            }
+            from_child = -1;
+            continue;
+        }
+
+        // Arriving at node from child
+        if (from_child != -1) {
+            next_node = -1;
+            // Check if we should unroll immediately
+            if ((next_rnode == next_xnode) || (feat_hist[feat] != 0)) {
+                next_node = pnode;
+            }
+
+            // Came from a single path, so unroll
+            if (next_node >= 0) {
+                // At the root node
+                if (node == 0) {
+                    break;
+                }
+                // Unroll (no pos_lst/neg_lst propagation needed for interactions)
+                from_child = node;
+                ns_ctr -= 1;
+
+                // Unwind
+                if (feat_hist[pfeat] > 0) {
+                    feat_hist[pfeat] -= 1;
+                } else if (feat_hist[pfeat] < 0) {
+                    feat_hist[pfeat] += 1;
+                }
+                if (feat_hist[pfeat] == 0) {
+                    if (from_flag == FROM_X_NOT_R) {
+                        N = N-1;
+                        M = M-1;
+                    } else if (from_flag == FROM_R_NOT_X) {
+                        N = N-1;
+                    }
+                }
+                continue;
+                // Go right - Arriving from the left child
+            } else if (from_child == cl) {
+                node_stack[ns_ctr] = node;
+                ns_ctr += 1;
+                next_node = cr;
+                if (next_xnode == next_node) {
+                    M = M+1;
+                    N = N+1;
+                    feat_hist[feat] += 1;
+                } else if (next_rnode == next_node) {
+                    N = N+1;
+                    feat_hist[feat] -= 1;
+                }
+                from_child = -1;
+                continue;
+                // Unroll - Arriving from the right child
+            } else if (from_child == cr) {
+                // No pos_lst/neg_lst combining needed for interactions;
+                // all contributions were written at leaf nodes.
+
+                // Check if at root
+                if (node == 0) {
+                    break;
+                }
+
+                // Pop
+                ns_ctr -= 1;
+                next_node = node_stack[ns_ctr];
+                from_child = node;
+
+                // Unwind
+                if (feat_hist[pfeat] > 0) {
+                    feat_hist[pfeat] -= 1;
+                } else if (feat_hist[pfeat] < 0) {
+                    feat_hist[pfeat] += 1;
+                }
+                if (feat_hist[pfeat] == 0) {
+                    if (from_flag == FROM_X_NOT_R) {
+                        N = N-1;
+                        M = M-1;
+                    } else if (from_flag == FROM_R_NOT_X) {
+                        N = N-1;
+                    }
+                }
+                continue;
+            }
+        }
+    }
+}
+
 inline void print_progress_bar(tfloat &last_print, tfloat start_time, unsigned i, unsigned total_count) {
     const tfloat elapsed_seconds = difftime(time(NULL), start_time);
 
@@ -1278,6 +1644,159 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
     delete[] node_stack;
     delete[] feat_hist;
     delete[] memoized_weights;
+}
+
+
+/**
+ * Runs interventional Tree SHAP interaction values on dense data.
+ * Implements Algorithm 1 from Zern et al. (AAAI 2023).
+ */
+inline void dense_independent_interactions(const TreeEnsemble& trees, const ExplanationDataset &data,
+                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
+
+    // reformat the trees for faster access
+    std::vector<Node> node_trees_vec(trees.tree_limit * trees.max_nodes);
+    Node *node_trees = node_trees_vec.data();
+    for (unsigned i = 0; i < trees.tree_limit; ++i) {
+        Node *node_tree = node_trees + i * trees.max_nodes;
+        for (unsigned j = 0; j < trees.max_nodes; ++j) {
+            const unsigned en_ind = i * trees.max_nodes + j;
+            node_tree[j].cl = trees.children_left[en_ind];
+            node_tree[j].cr = trees.children_right[en_ind];
+            node_tree[j].cd = trees.children_default[en_ind];
+            if (j == 0) {
+                node_tree[j].pnode = 0;
+            }
+            if (trees.children_left[en_ind] >= 0) {
+                node_tree[trees.children_left[en_ind]].pnode = j;
+                node_tree[trees.children_left[en_ind]].pfeat = trees.features[en_ind];
+            }
+            if (trees.children_right[en_ind] >= 0) {
+                node_tree[trees.children_right[en_ind]].pnode = j;
+                node_tree[trees.children_right[en_ind]].pfeat = trees.features[en_ind];
+            }
+
+            node_tree[j].thres = trees.thresholds[en_ind];
+            node_tree[j].feat = trees.features[en_ind];
+        }
+    }
+
+    // preallocate arrays needed by the algorithm
+    const unsigned interaction_size = (data.M + 1) * (data.M + 1);
+    std::vector<int> node_stack_vec((unsigned)trees.max_depth);
+    std::vector<signed short> feat_hist_vec(data.M);
+    std::vector<tfloat> tmp_out_contribs_vec(interaction_size);
+    std::vector<int> A_feats_buf_vec(trees.max_depth + 1);
+    std::vector<int> NB_feats_buf_vec(trees.max_depth + 1);
+
+    int *node_stack = node_stack_vec.data();
+    signed short *feat_hist = feat_hist_vec.data();
+    tfloat *tmp_out_contribs = tmp_out_contribs_vec.data();
+    int *A_feats_buf = A_feats_buf_vec.data();
+    int *NB_feats_buf = NB_feats_buf_vec.data();
+
+    // precompute omega weight table
+    const unsigned omega_stride = trees.max_depth + 2;
+    std::vector<tfloat> omega_table_vec(omega_stride * omega_stride);
+    tfloat *omega_table = omega_table_vec.data();
+    for (unsigned a = 0; a <= trees.max_depth; ++a) {
+        for (unsigned b = 0; b <= trees.max_depth; ++b) {
+            omega_table[a * omega_stride + b] = omega_weight(a, b);
+        }
+    }
+
+    // compute the explanations for each sample
+    tfloat *instance_out_contribs;
+    tfloat rescale_factor = 1.0;
+    tfloat margin_x = 0;
+    tfloat margin_r = 0;
+    const unsigned no = trees.num_outputs;
+    time_t start_time = time(NULL);
+    tfloat last_print = 0;
+    for (unsigned oind = 0; oind < no; ++oind) {
+        // set the values in the reformatted tree to the current output index
+        for (unsigned i = 0; i < trees.tree_limit; ++i) {
+            Node *node_tree = node_trees + i * trees.max_nodes;
+            for (unsigned j = 0; j < trees.max_nodes; ++j) {
+                const unsigned en_ind = i * trees.max_nodes + j;
+                node_tree[j].value = trees.values[en_ind * no + oind];
+            }
+        }
+
+        // loop over all the samples
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            const tfloat *x = data.X + i * data.M;
+            const bool *x_missing = data.X_missing + i * data.M;
+            instance_out_contribs = out_contribs + i * interaction_size * no;
+            const tfloat y_i = data.y == NULL ? 0 : data.y[i];
+
+            print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * no);
+
+            // compute the model's margin output for x
+            if (transform != NULL) {
+                margin_x = trees.base_offset[oind];
+                for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                    margin_x += tree_predict(k, trees, x, x_missing)[oind];
+                }
+            }
+
+            for (unsigned j = 0; j < data.num_R; ++j) {
+                const tfloat *r = data.R + j * data.M;
+                const bool *r_missing = data.R_missing + j * data.M;
+                std::fill_n(tmp_out_contribs, interaction_size, 0);
+
+                // compute the model's margin output for r
+                if (transform != NULL) {
+                    margin_r = trees.base_offset[oind];
+                    for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                        margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                    }
+                }
+
+                for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                    tree_shap_indep_interactions(
+                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
+                        tmp_out_contribs, feat_hist, omega_table, omega_stride,
+                        node_stack, node_trees + k * trees.max_nodes,
+                        A_feats_buf, NB_feats_buf
+                    );
+                }
+
+                // compute the rescale factor
+                if (transform != NULL) {
+                    if (margin_x == margin_r) {
+                        rescale_factor = 1.0;
+                    } else {
+                        rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
+                        rescale_factor /= margin_x - margin_r;
+                    }
+                }
+
+                // add the effect of the current reference to our running total
+                // (skip the bias entry, handle it separately)
+                const unsigned bias_2d_idx = data.M * (data.M + 1) + data.M;
+                for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                    if (jj == bias_2d_idx) continue;
+                    instance_out_contribs[jj * no + oind] +=
+                        tmp_out_contribs[jj] * rescale_factor;
+                }
+
+                // Add the base offset
+                if (transform != NULL) {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        (*transform)(trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx], 0);
+                } else {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx];
+                }
+            }
+
+            // average the results over all the references
+            for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                instance_out_contribs[jj * no + oind] /= data.num_R;
+            }
+        }
+    }
 }
 
 
@@ -1461,8 +1980,10 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
     switch (feature_dependence) {
         case FEATURE_DEPENDENCE::independent:
             if (interactions) {
-                std::cerr << "FEATURE_DEPENDENCE::independent does not support interactions!\n";
-            } else dense_independent(trees, data, out_contribs, transform);
+                dense_independent_interactions(trees, data, out_contribs, transform);
+            } else {
+                dense_independent(trees, data, out_contribs, transform);
+            }
             return;
 
         case FEATURE_DEPENDENCE::tree_path_dependent:

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -153,11 +153,26 @@ inline tfloat squared_loss_transform(const tfloat margin, const tfloat y) {
     return (margin - y) * (margin - y);
 }
 
+inline void softmax_vector(const tfloat *d, tfloat *out, unsigned num_outputs) {
+    const tfloat scale = 1.0 / (num_outputs - 1);
+    tfloat max_val = d[0] * scale;
+    for (unsigned k = 1; k < num_outputs; ++k) {
+        if (d[k] * scale > max_val) max_val = d[k] * scale;
+    }
+    tfloat sum_exp = 0;
+    for (unsigned k = 0; k < num_outputs; ++k) {
+        out[k] = exp(d[k] * scale - max_val);
+        sum_exp += out[k];
+    }
+    for (unsigned k = 0; k < num_outputs; ++k) out[k] /= sum_exp;
+}
+
 namespace MODEL_TRANSFORM {
     const unsigned identity = 0;
     const unsigned logistic = 1;
     const unsigned logistic_nlogloss = 2;
     const unsigned squared_loss = 3;
+    const unsigned softmax = 4;
 }
 
 inline transform_f get_transform(unsigned model_transform) {
@@ -1666,7 +1681,8 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
  * Implements Algorithm 1 from Zern et al. (AAAI 2023).
  */
 inline void dense_independent_interactions(const TreeEnsemble& trees, const ExplanationDataset &data,
-                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
+                       tfloat *out_contribs, tfloat transform(const tfloat, const tfloat),
+                       unsigned model_transform = MODEL_TRANSFORM::identity) {
 
     // reformat the trees for faster access
     std::vector<Node> node_trees_vec(trees.tree_limit * trees.max_nodes);
@@ -1720,6 +1736,38 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
         }
     }
 
+    // precompute softmax values if needed
+    bool is_softmax = (model_transform == MODEL_TRANSFORM::softmax);
+    tfloat *softmax_x_all = NULL, *softmax_r_all = NULL;
+    tfloat *margin_x_all = NULL, *margin_r_all = NULL;
+
+    if (is_softmax) {
+        unsigned K = trees.num_outputs;
+        margin_x_all = new tfloat[data.num_X * K];
+        softmax_x_all = new tfloat[data.num_X * K];
+        margin_r_all = new tfloat[data.num_R * K];
+        softmax_r_all = new tfloat[data.num_R * K];
+
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            tfloat *mx = margin_x_all + i * K;
+            for (unsigned c = 0; c < K; ++c) mx[c] = trees.base_offset[c];
+            for (unsigned t = 0; t < trees.tree_limit; ++t) {
+                const tfloat *lv = tree_predict(t, trees, data.X + i * data.M, data.X_missing + i * data.M);
+                for (unsigned c = 0; c < K; ++c) mx[c] += lv[c];
+            }
+            softmax_vector(mx, softmax_x_all + i * K, K);
+        }
+        for (unsigned j = 0; j < data.num_R; ++j) {
+            tfloat *mr = margin_r_all + j * K;
+            for (unsigned c = 0; c < K; ++c) mr[c] = trees.base_offset[c];
+            for (unsigned t = 0; t < trees.tree_limit; ++t) {
+                const tfloat *lv = tree_predict(t, trees, data.R + j * data.M, data.R_missing + j * data.M);
+                for (unsigned c = 0; c < K; ++c) mr[c] += lv[c];
+            }
+            softmax_vector(mr, softmax_r_all + j * K, K);
+        }
+    }
+
     // compute the explanations for each sample
     tfloat *instance_out_contribs;
     tfloat rescale_factor = 1.0;
@@ -1748,7 +1796,7 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
             print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * no);
 
             // compute the model's margin output for x
-            if (transform != NULL) {
+            if (!is_softmax && transform != NULL) {
                 margin_x = trees.base_offset[oind];
                 for (unsigned k = 0; k < trees.tree_limit; ++k) {
                     margin_x += tree_predict(k, trees, x, x_missing)[oind];
@@ -1761,7 +1809,7 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 std::fill_n(tmp_out_contribs, interaction_size, 0);
 
                 // compute the model's margin output for r
-                if (transform != NULL) {
+                if (!is_softmax && transform != NULL) {
                     margin_r = trees.base_offset[oind];
                     for (unsigned k = 0; k < trees.tree_limit; ++k) {
                         margin_r += tree_predict(k, trees, r, r_missing)[oind];
@@ -1778,7 +1826,16 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 }
 
                 // compute the rescale factor
-                if (transform != NULL) {
+                if (is_softmax) {
+                    unsigned K = trees.num_outputs;
+                    tfloat m_x = margin_x_all[i * K + oind];
+                    tfloat m_r = margin_r_all[j * K + oind];
+                    if (m_x == m_r) {
+                        rescale_factor = 1.0;
+                    } else {
+                        rescale_factor = (softmax_x_all[i * K + oind] - softmax_r_all[j * K + oind]) / (m_x - m_r);
+                    }
+                } else if (transform != NULL) {
                     if (margin_x == margin_r) {
                         rescale_factor = 1.0;
                     } else {
@@ -1797,7 +1854,10 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 }
 
                 // Add the base offset
-                if (transform != NULL) {
+                if (is_softmax) {
+                    instance_out_contribs[bias_2d_idx * no + oind] +=
+                        softmax_r_all[j * trees.num_outputs + oind];
+                } else if (transform != NULL) {
                     instance_out_contribs[bias_2d_idx * no + oind] +=
                         (*transform)(trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx], 0);
                 } else {
@@ -1811,6 +1871,13 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
                 instance_out_contribs[jj * no + oind] /= data.num_R;
             }
         }
+    }
+
+    if (is_softmax) {
+        delete[] softmax_x_all;
+        delete[] softmax_r_all;
+        delete[] margin_x_all;
+        delete[] margin_r_all;
     }
 }
 
@@ -1995,7 +2062,7 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
     switch (feature_dependence) {
         case FEATURE_DEPENDENCE::independent:
             if (interactions) {
-                dense_independent_interactions(trees, data, out_contribs, transform);
+                dense_independent_interactions(trees, data, out_contribs, transform, model_transform);
             } else {
                 dense_independent(trees, data, out_contribs, transform);
             }

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -12,6 +12,9 @@
 #include <cmath>
 #include <ctime>
 #include <vector>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 #if defined(_WIN32) || defined(WIN32)
     #include <malloc.h>
 #elif defined(__MVS__)
@@ -745,7 +748,6 @@ struct Node {
     short cl, cr, cd, pnode; // uint_16
     long feat, pfeat;
     float thres, value;
-    char from_flag;
     char threshold_type; // 0 = numeric, 1 = categorical
 };
 
@@ -777,7 +779,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
                             const bool *x_missing, const tfloat *r,
                             const bool *r_missing, tfloat *out_contribs,
                             float *pos_lst, float *neg_lst, signed short *feat_hist,
-                            float *memoized_weights, int *node_stack, Node *mytree) {
+                            float *memoized_weights, int *node_stack, Node *mytree,
+                            char *from_flags) {
 
 //     const bool DEBUG = true;
 //     ofstream myfile;
@@ -831,10 +834,10 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
     }
 
     if (next_xnode != next_rnode) {
-        mytree[next_xnode].from_flag = FROM_X_NOT_R;
-        mytree[next_rnode].from_flag = FROM_R_NOT_X;
+        from_flags[next_xnode] = FROM_X_NOT_R;
+        from_flags[next_rnode] = FROM_R_NOT_X;
     } else {
-        mytree[next_xnode].from_flag = FROM_NEITHER;
+        from_flags[next_xnode] = FROM_NEITHER;
     }
 
     // Check if x and r go the same way
@@ -866,7 +869,7 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
         cd = curr_node.cd;
         pnode = curr_node.pnode;
         pfeat = curr_node.pfeat;
-        from_flag = curr_node.from_flag;
+        from_flag = from_flags[node];
 
 
 
@@ -950,10 +953,10 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
 
         if (next_xnode >= 0) {
           if (next_xnode != next_rnode) {
-              mytree[next_xnode].from_flag = FROM_X_NOT_R;
-              mytree[next_rnode].from_flag = FROM_R_NOT_X;
+              from_flags[next_xnode] = FROM_X_NOT_R;
+              from_flags[next_rnode] = FROM_R_NOT_X;
           } else {
-              mytree[next_xnode].from_flag = FROM_NEITHER;
+              from_flags[next_xnode] = FROM_NEITHER;
           }
         }
 
@@ -1222,7 +1225,8 @@ inline void tree_shap_indep_interactions(
     signed short *feat_hist,
     const tfloat *omega_table, const unsigned omega_stride,
     int *node_stack, Node *mytree,
-    int *A_feats_buf, int *NB_feats_buf
+    int *A_feats_buf, int *NB_feats_buf,
+    char *from_flags
 ) {
     int ns_ctr = 0;
     std::fill_n(feat_hist, num_feats, 0);
@@ -1264,10 +1268,10 @@ inline void tree_shap_indep_interactions(
     }
 
     if (next_xnode != next_rnode) {
-        mytree[next_xnode].from_flag = FROM_X_NOT_R;
-        mytree[next_rnode].from_flag = FROM_R_NOT_X;
+        from_flags[next_xnode] = FROM_X_NOT_R;
+        from_flags[next_rnode] = FROM_R_NOT_X;
     } else {
-        mytree[next_xnode].from_flag = FROM_NEITHER;
+        from_flags[next_xnode] = FROM_NEITHER;
     }
 
     // Check if x and r go the same way
@@ -1299,7 +1303,7 @@ inline void tree_shap_indep_interactions(
         cd = curr_node.cd;
         pnode = curr_node.pnode;
         pfeat = curr_node.pfeat;
-        from_flag = curr_node.from_flag;
+        from_flag = from_flags[node];
 
         // At a leaf
         if (cl < 0) {
@@ -1370,10 +1374,10 @@ inline void tree_shap_indep_interactions(
 
         if (next_xnode >= 0) {
           if (next_xnode != next_rnode) {
-              mytree[next_xnode].from_flag = FROM_X_NOT_R;
-              mytree[next_rnode].from_flag = FROM_R_NOT_X;
+              from_flags[next_xnode] = FROM_X_NOT_R;
+              from_flags[next_rnode] = FROM_R_NOT_X;
           } else {
-              mytree[next_xnode].from_flag = FROM_NEITHER;
+              from_flags[next_xnode] = FROM_NEITHER;
           }
         }
 
@@ -1560,14 +1564,7 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
         }
     }
 
-    // preallocate arrays needed by the algorithm
-    float *pos_lst = new float[trees.max_nodes];
-    float *neg_lst = new float[trees.max_nodes];
-    int *node_stack = new int[(unsigned) trees.max_depth];
-    signed short *feat_hist = new signed short[data.M];
-    tfloat *tmp_out_contribs = new tfloat[(data.M + 1)];
-
-    // precompute all the weight coefficients
+    // precompute all the weight coefficients (shared read-only)
     float *memoized_weights = new float[(trees.max_depth+1) * (trees.max_depth+1)];
     for (unsigned n = 0; n <= trees.max_depth; ++n) {
         for (unsigned m = 0; m <= trees.max_depth; ++m) {
@@ -1576,14 +1573,8 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
     }
 
     // compute the explanations for each sample
-    tfloat *instance_out_contribs;
-    tfloat rescale_factor = 1.0;
-    tfloat margin_x = 0;
-    tfloat margin_r = 0;
-    time_t start_time = time(NULL);
-    tfloat last_print = 0;
     for (unsigned oind = 0; oind < trees.num_outputs; ++oind) {
-        // set the values in the reformatted tree to the current output index
+        // set the values in the reformatted tree to the current output index (serial)
         for (unsigned i = 0; i < trees.tree_limit; ++i) {
             Node *node_tree = node_trees + i * trees.max_nodes;
             for (unsigned j = 0; j < trees.max_nodes; ++j) {
@@ -1592,86 +1583,90 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
             }
         }
 
-        // loop over all the samples
-        for (unsigned i = 0; i < data.num_X; ++i) {
-            const tfloat *x = data.X + i * data.M;
-            const bool *x_missing = data.X_missing + i * data.M;
-            instance_out_contribs = out_contribs + i * (data.M + 1) * trees.num_outputs;
-            const tfloat y_i = data.y == NULL ? 0 : data.y[i];
+        // loop over all the samples (parallel)
+        #pragma omp parallel
+        {
+            // Per-thread workspace (allocated once per thread)
+            std::vector<float> t_pos_lst(trees.max_nodes);
+            std::vector<float> t_neg_lst(trees.max_nodes);
+            std::vector<int> t_node_stack((unsigned)trees.max_depth);
+            std::vector<signed short> t_feat_hist(data.M);
+            std::vector<tfloat> t_tmp_out_contribs(data.M + 1);
+            std::vector<char> t_from_flags(trees.max_nodes);
 
-            print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * trees.num_outputs);
+            #pragma omp for schedule(dynamic, 1)
+            for (unsigned i = 0; i < data.num_X; ++i) {
+                const tfloat *x = data.X + i * data.M;
+                const bool *x_missing = data.X_missing + i * data.M;
+                tfloat *instance_out_contribs = out_contribs + i * (data.M + 1) * trees.num_outputs;
+                const tfloat y_i = data.y == NULL ? 0 : data.y[i];
 
-            // compute the model's margin output for x
-            if (transform != NULL) {
-                margin_x = trees.base_offset[oind];
-                for (unsigned k = 0; k < trees.tree_limit; ++k) {
-                    margin_x += tree_predict(k, trees, x, x_missing)[oind];
-                }
-            }
-
-            for (unsigned j = 0; j < data.num_R; ++j) {
-                const tfloat *r = data.R + j * data.M;
-                const bool *r_missing = data.R_missing + j * data.M;
-                std::fill_n(tmp_out_contribs, (data.M + 1), 0);
-
-                // compute the model's margin output for r
+                // compute the model's margin output for x
+                tfloat margin_x = 0;
                 if (transform != NULL) {
-                    margin_r = trees.base_offset[oind];
+                    margin_x = trees.base_offset[oind];
                     for (unsigned k = 0; k < trees.tree_limit; ++k) {
-                        margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                        margin_x += tree_predict(k, trees, x, x_missing)[oind];
                     }
                 }
 
-                for (unsigned k = 0; k < trees.tree_limit; ++k) {
-                    tree_shap_indep(
-                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
-                        tmp_out_contribs, pos_lst, neg_lst, feat_hist, memoized_weights,
-                        node_stack, node_trees + k * trees.max_nodes
-                    );
-                }
+                for (unsigned j = 0; j < data.num_R; ++j) {
+                    const tfloat *r = data.R + j * data.M;
+                    const bool *r_missing = data.R_missing + j * data.M;
+                    std::fill_n(t_tmp_out_contribs.data(), (data.M + 1), 0);
 
-                // compute the rescale factor
-                if (transform != NULL) {
-                    if (margin_x == margin_r) {
-                        rescale_factor = 1.0;
+                    // compute the model's margin output for r
+                    tfloat margin_r = 0;
+                    if (transform != NULL) {
+                        margin_r = trees.base_offset[oind];
+                        for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                            margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                        }
+                    }
+
+                    for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                        tree_shap_indep(
+                            trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
+                            t_tmp_out_contribs.data(), t_pos_lst.data(), t_neg_lst.data(),
+                            t_feat_hist.data(), memoized_weights,
+                            t_node_stack.data(), node_trees + k * trees.max_nodes,
+                            t_from_flags.data()
+                        );
+                    }
+
+                    // compute the rescale factor
+                    tfloat rescale_factor = 1.0;
+                    if (transform != NULL) {
+                        if (margin_x == margin_r) {
+                            rescale_factor = 1.0;
+                        } else {
+                            rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
+                            rescale_factor /= margin_x - margin_r;
+                        }
+                    }
+
+                    // add the effect of the current reference to our running total
+                    for (unsigned k = 0; k < data.M; ++k) {
+                        instance_out_contribs[k * trees.num_outputs + oind] += t_tmp_out_contribs[k] * rescale_factor;
+                    }
+
+                    // Add the base offset
+                    if (transform != NULL) {
+                        instance_out_contribs[data.M * trees.num_outputs + oind] += (*transform)(trees.base_offset[oind] + t_tmp_out_contribs[data.M], 0);
                     } else {
-                        rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
-                        rescale_factor /= margin_x - margin_r;
+                        instance_out_contribs[data.M * trees.num_outputs + oind] += trees.base_offset[oind] + t_tmp_out_contribs[data.M];
                     }
                 }
 
-                // add the effect of the current reference to our running total
-                // this is where we can do per reference scaling for non-linear transformations
-                for (unsigned k = 0; k < data.M; ++k) {
-                    instance_out_contribs[k * trees.num_outputs + oind] += tmp_out_contribs[k] * rescale_factor;
-                }
-
-                // Add the base offset
-                if (transform != NULL) {
-                    instance_out_contribs[data.M * trees.num_outputs + oind] += (*transform)(trees.base_offset[oind] + tmp_out_contribs[data.M], 0);
-                } else {
-                    instance_out_contribs[data.M * trees.num_outputs + oind] += trees.base_offset[oind] + tmp_out_contribs[data.M];
+                // average the results over all the references.
+                for (unsigned j = 0; j < (data.M + 1); ++j) {
+                    instance_out_contribs[j * trees.num_outputs + oind] /= data.num_R;
                 }
             }
-
-            // average the results over all the references.
-            for (unsigned j = 0; j < (data.M + 1); ++j) {
-                instance_out_contribs[j * trees.num_outputs + oind] /= data.num_R;
-            }
-
-            // apply the base offset to the bias term
-            // for (unsigned j = 0; j < trees.num_outputs; ++j) {
-            //     instance_out_contribs[data.M * trees.num_outputs + j] += (*transform)(trees.base_offset[j], 0);
-            // }
-        }
+        } // end omp parallel
     }
 
-    delete[] tmp_out_contribs;
     delete[] node_trees;
-    delete[] pos_lst;
-    delete[] neg_lst;
-    delete[] node_stack;
-    delete[] feat_hist;
     delete[] memoized_weights;
 }
 
@@ -1712,21 +1707,9 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
         }
     }
 
-    // preallocate arrays needed by the algorithm
     const unsigned interaction_size = (data.M + 1) * (data.M + 1);
-    std::vector<int> node_stack_vec((unsigned)trees.max_depth);
-    std::vector<signed short> feat_hist_vec(data.M);
-    std::vector<tfloat> tmp_out_contribs_vec(interaction_size);
-    std::vector<int> A_feats_buf_vec(trees.max_depth + 1);
-    std::vector<int> NB_feats_buf_vec(trees.max_depth + 1);
 
-    int *node_stack = node_stack_vec.data();
-    signed short *feat_hist = feat_hist_vec.data();
-    tfloat *tmp_out_contribs = tmp_out_contribs_vec.data();
-    int *A_feats_buf = A_feats_buf_vec.data();
-    int *NB_feats_buf = NB_feats_buf_vec.data();
-
-    // precompute omega weight table
+    // precompute omega weight table (shared read-only)
     const unsigned omega_stride = trees.max_depth + 2;
     std::vector<tfloat> omega_table_vec(omega_stride * omega_stride);
     tfloat *omega_table = omega_table_vec.data();
@@ -1769,15 +1752,9 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
     }
 
     // compute the explanations for each sample
-    tfloat *instance_out_contribs;
-    tfloat rescale_factor = 1.0;
-    tfloat margin_x = 0;
-    tfloat margin_r = 0;
     const unsigned no = trees.num_outputs;
-    time_t start_time = time(NULL);
-    tfloat last_print = 0;
     for (unsigned oind = 0; oind < no; ++oind) {
-        // set the values in the reformatted tree to the current output index
+        // set the values in the reformatted tree to the current output index (serial)
         for (unsigned i = 0; i < trees.tree_limit; ++i) {
             Node *node_tree = node_trees + i * trees.max_nodes;
             for (unsigned j = 0; j < trees.max_nodes; ++j) {
@@ -1786,91 +1763,106 @@ inline void dense_independent_interactions(const TreeEnsemble& trees, const Expl
             }
         }
 
-        // loop over all the samples
-        for (unsigned i = 0; i < data.num_X; ++i) {
-            const tfloat *x = data.X + i * data.M;
-            const bool *x_missing = data.X_missing + i * data.M;
-            instance_out_contribs = out_contribs + i * interaction_size * no;
-            const tfloat y_i = data.y == NULL ? 0 : data.y[i];
+        // loop over all the samples (parallel)
+        #pragma omp parallel
+        {
+            // Per-thread workspace (allocated once per thread)
+            std::vector<int> t_node_stack((unsigned)trees.max_depth);
+            std::vector<signed short> t_feat_hist(data.M);
+            std::vector<tfloat> t_tmp_out_contribs(interaction_size);
+            std::vector<int> t_A_feats_buf(trees.max_depth + 1);
+            std::vector<int> t_NB_feats_buf(trees.max_depth + 1);
+            std::vector<char> t_from_flags(trees.max_nodes);
 
-            print_progress_bar(last_print, start_time, oind * data.num_X + i, data.num_X * no);
+            #pragma omp for schedule(dynamic, 1)
+            for (unsigned i = 0; i < data.num_X; ++i) {
+                const tfloat *x = data.X + i * data.M;
+                const bool *x_missing = data.X_missing + i * data.M;
+                tfloat *instance_out_contribs = out_contribs + i * interaction_size * no;
+                const tfloat y_i = data.y == NULL ? 0 : data.y[i];
 
-            // compute the model's margin output for x
-            if (!is_softmax && transform != NULL) {
-                margin_x = trees.base_offset[oind];
-                for (unsigned k = 0; k < trees.tree_limit; ++k) {
-                    margin_x += tree_predict(k, trees, x, x_missing)[oind];
-                }
-            }
-
-            for (unsigned j = 0; j < data.num_R; ++j) {
-                const tfloat *r = data.R + j * data.M;
-                const bool *r_missing = data.R_missing + j * data.M;
-                std::fill_n(tmp_out_contribs, interaction_size, 0);
-
-                // compute the model's margin output for r
+                // compute the model's margin output for x
+                tfloat margin_x = 0;
                 if (!is_softmax && transform != NULL) {
-                    margin_r = trees.base_offset[oind];
+                    margin_x = trees.base_offset[oind];
                     for (unsigned k = 0; k < trees.tree_limit; ++k) {
-                        margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                        margin_x += tree_predict(k, trees, x, x_missing)[oind];
                     }
                 }
 
-                for (unsigned k = 0; k < trees.tree_limit; ++k) {
-                    tree_shap_indep_interactions(
-                        trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
-                        tmp_out_contribs, feat_hist, omega_table, omega_stride,
-                        node_stack, node_trees + k * trees.max_nodes,
-                        A_feats_buf, NB_feats_buf
-                    );
-                }
+                for (unsigned j = 0; j < data.num_R; ++j) {
+                    const tfloat *r = data.R + j * data.M;
+                    const bool *r_missing = data.R_missing + j * data.M;
+                    std::fill_n(t_tmp_out_contribs.data(), interaction_size, 0);
 
-                // compute the rescale factor
-                if (is_softmax) {
-                    unsigned K = trees.num_outputs;
-                    tfloat m_x = margin_x_all[i * K + oind];
-                    tfloat m_r = margin_r_all[j * K + oind];
-                    if (m_x == m_r) {
-                        rescale_factor = 1.0;
+                    // compute the model's margin output for r
+                    tfloat margin_r = 0;
+                    if (!is_softmax && transform != NULL) {
+                        margin_r = trees.base_offset[oind];
+                        for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                            margin_r += tree_predict(k, trees, r, r_missing)[oind];
+                        }
+                    }
+
+                    for (unsigned k = 0; k < trees.tree_limit; ++k) {
+                        tree_shap_indep_interactions(
+                            trees.max_depth, data.M, trees.max_nodes, x, x_missing, r, r_missing,
+                            t_tmp_out_contribs.data(), t_feat_hist.data(), omega_table, omega_stride,
+                            t_node_stack.data(), node_trees + k * trees.max_nodes,
+                            t_A_feats_buf.data(), t_NB_feats_buf.data(),
+                            t_from_flags.data()
+                        );
+                    }
+
+                    // compute the rescale factor
+                    tfloat rescale_factor = 1.0;
+                    if (is_softmax) {
+                        unsigned K = trees.num_outputs;
+                        tfloat m_x = margin_x_all[i * K + oind];
+                        tfloat m_r = margin_r_all[j * K + oind];
+                        if (m_x == m_r) {
+                            rescale_factor = 1.0;
+                        } else {
+                            rescale_factor = (softmax_x_all[i * K + oind] - softmax_r_all[j * K + oind]) / (m_x - m_r);
+                        }
+                    } else if (transform != NULL) {
+                        if (margin_x == margin_r) {
+                            rescale_factor = 1.0;
+                        } else {
+                            rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
+                            rescale_factor /= margin_x - margin_r;
+                        }
+                    }
+
+                    // add the effect of the current reference to our running total
+                    const unsigned bias_2d_idx = data.M * (data.M + 1) + data.M;
+                    for (unsigned jj = 0; jj < interaction_size; ++jj) {
+                        if (jj == bias_2d_idx) continue;
+                        instance_out_contribs[jj * no + oind] +=
+                            t_tmp_out_contribs[jj] * rescale_factor;
+                    }
+
+                    // Add the base offset
+                    if (is_softmax) {
+                        instance_out_contribs[bias_2d_idx * no + oind] +=
+                            softmax_r_all[j * trees.num_outputs + oind];
+                    } else if (transform != NULL) {
+                        instance_out_contribs[bias_2d_idx * no + oind] +=
+                            (*transform)(trees.base_offset[oind] + t_tmp_out_contribs[bias_2d_idx], 0);
                     } else {
-                        rescale_factor = (softmax_x_all[i * K + oind] - softmax_r_all[j * K + oind]) / (m_x - m_r);
-                    }
-                } else if (transform != NULL) {
-                    if (margin_x == margin_r) {
-                        rescale_factor = 1.0;
-                    } else {
-                        rescale_factor = (*transform)(margin_x, y_i) - (*transform)(margin_r, y_i);
-                        rescale_factor /= margin_x - margin_r;
+                        instance_out_contribs[bias_2d_idx * no + oind] +=
+                            trees.base_offset[oind] + t_tmp_out_contribs[bias_2d_idx];
                     }
                 }
 
-                // add the effect of the current reference to our running total
-                // (skip the bias entry, handle it separately)
+                // average the results over all the references
                 const unsigned bias_2d_idx = data.M * (data.M + 1) + data.M;
                 for (unsigned jj = 0; jj < interaction_size; ++jj) {
                     if (jj == bias_2d_idx) continue;
-                    instance_out_contribs[jj * no + oind] +=
-                        tmp_out_contribs[jj] * rescale_factor;
-                }
-
-                // Add the base offset
-                if (is_softmax) {
-                    instance_out_contribs[bias_2d_idx * no + oind] +=
-                        softmax_r_all[j * trees.num_outputs + oind];
-                } else if (transform != NULL) {
-                    instance_out_contribs[bias_2d_idx * no + oind] +=
-                        (*transform)(trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx], 0);
-                } else {
-                    instance_out_contribs[bias_2d_idx * no + oind] +=
-                        trees.base_offset[oind] + tmp_out_contribs[bias_2d_idx];
+                    instance_out_contribs[jj * no + oind] /= data.num_R;
                 }
             }
-
-            // average the results over all the references
-            for (unsigned jj = 0; jj < interaction_size; ++jj) {
-                instance_out_contribs[jj * no + oind] /= data.num_R;
-            }
-        }
+        } // end omp parallel
     }
 
     if (is_softmax) {

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -5,7 +5,6 @@ import numpy as np
 from ..utils import assert_import, record_import_error
 from ._tree import (
     TreeExplainer,
-    _xgboost_cat_unsupported,
     feature_perturbation_codes,
     output_transform_codes,
 )
@@ -70,7 +69,12 @@ class GPUTreeExplainer(TreeExplainer):
         )
 
         model = self.model
-        _xgboost_cat_unsupported(model)
+        if np.any(model.threshold_types != 0):
+            raise NotImplementedError(
+                "Categorical splits are not yet supported by GPUTreeExplainer. Use"
+                " TreeExplainer (CPU) with feature_perturbation='interventional'"
+                " or feature_perturbation='tree_path_dependent' instead."
+            )
         transform = model.get_transform()
 
         # run the core algorithm using the C extension

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1950,7 +1950,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** cat
+                            threshold += 2**cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -782,7 +782,6 @@ class TreeExplainer(Explainer):
         assert self.model.model_output == "raw", (
             'Only model_output = "raw" is supported for SHAP interaction values right now!'
         )
-        # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
         transform = "identity"
 
         # see if we have a default tree_limit in place.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -104,14 +104,6 @@ def _xgboost_n_iterations(tree_limit: int, num_stacked_models: int) -> int:
     return n_iterations
 
 
-def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
-    if model.model_type == "xgboost" and model.cat_feature_indices is not None:
-        raise NotImplementedError(
-            "Categorical split is not yet supported. You can still use"
-            " TreeExplainer with `feature_perturbation=tree_path_dependent`."
-        )
-
-
 class TreeExplainer(Explainer):
     """Uses Tree SHAP algorithms to explain the output of ensemble tree models.
 
@@ -658,7 +650,6 @@ class TreeExplainer(Explainer):
             X, y, tree_limit, check_additivity
         )
         transform = self.model.get_transform()
-        _xgboost_cat_unsupported(self.model)
 
         # run the core algorithm using the C extension
         assert_import("cext")

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -784,7 +784,8 @@ class TreeExplainer(Explainer):
             import xgboost
 
             if not isinstance(X, xgboost.core.DMatrix):
-                X = xgboost.DMatrix(X)
+                dmatrix_props = getattr(self.model, "_xgb_dmatrix_props", {})
+                X = xgboost.DMatrix(X, **dmatrix_props)
 
             n_iterations = _xgboost_n_iterations(tree_limit, self.model.num_stacked_models)
             phi = self.model.original_model.predict(
@@ -1949,7 +1950,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** (cat - 1)
+                            threshold += 2 ** cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1981,7 +1981,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** cat
+                            threshold += 2**cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -811,7 +811,8 @@ class TreeExplainer(Explainer):
             import xgboost
 
             if not isinstance(X, xgboost.core.DMatrix):
-                X = xgboost.DMatrix(X)
+                dmatrix_props = getattr(self.model, "_xgb_dmatrix_props", {})
+                X = xgboost.DMatrix(X, **dmatrix_props)
 
             n_iterations = _xgboost_n_iterations(tree_limit, self.model.num_stacked_models)
             phi = self.model.original_model.predict(
@@ -1980,7 +1981,7 @@ class SingleTree:
                         threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
                         for cat in categories:
-                            threshold += 2 ** (cat - 1)
+                            threshold += 2 ** cat
                         self.thresholds[vsplit_idx] = threshold
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -801,7 +801,6 @@ class TreeExplainer(Explainer):
         assert self.model.model_output == "raw", (
             'Only model_output = "raw" is supported for SHAP interaction values right now!'
         )
-        # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
         transform = "identity"
 
         # see if we have a default tree_limit in place.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -797,10 +797,13 @@ class TreeExplainer(Explainer):
                 Return type for models with multiple outputs changed from list to np.ndarray.
 
         """
-        assert self.model.model_output == "raw", (
-            'Only model_output = "raw" is supported for SHAP interaction values right now!'
-        )
-        transform = "identity"
+        if self.feature_perturbation == "interventional":
+            transform = self.model.get_transform()
+        else:
+            assert self.model.model_output == "raw", (
+                'Only model_output = "raw" is supported for SHAP interaction values with tree_path_dependent!'
+            )
+            transform = "identity"
 
         # see if we have a default tree_limit in place.
         if tree_limit is None:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -677,7 +677,6 @@ class TreeExplainer(Explainer):
             X, y, tree_limit, check_additivity
         )
         transform = self.model.get_transform()
-        _xgboost_cat_unsupported(self.model)
 
         # run the core algorithm using the C extension
         assert_import("cext")

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -125,9 +125,9 @@ def test_xgboost_cat_unsupported() -> None:
     with pytest.raises(NotImplementedError, match="Categorical"):
         gpu_ex.shap_values(X)
 
+    # CPU TreeExplainer now supports categorical splits in interventional mode
     ex = shap.TreeExplainer(clf, X, feature_perturbation="interventional")
-    with pytest.raises(NotImplementedError, match="Categorical"):
-        ex.shap_values(X)
+    ex.shap_values(X)
 
 
 def lightgbm_base():

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -126,9 +126,9 @@ def test_xgboost_cat_unsupported() -> None:
     with pytest.raises(NotImplementedError, match="Categorical"):
         gpu_ex.shap_values(X)
 
+    # CPU TreeExplainer now supports categorical splits in interventional mode
     ex = shap.TreeExplainer(clf, X, feature_perturbation="interventional")
-    with pytest.raises(NotImplementedError, match="Categorical"):
-        ex.shap_values(X)
+    ex.shap_values(X)
 
 
 def lightgbm_base():

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1338,6 +1338,36 @@ class TestExplainerXGBoost:
         shap_values = explainer.shap_values(X_nan)
         # check that SHAP values sum to model output
         assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X_nan)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+
+    @pytest.mark.parametrize("Clf", classifiers)
+    def test_xgboost_mixed_category_and_nan(self, Clf):
+        """Test that xgboost explanations can handle categorical data with missing values.
+
+        Adapted from PR #4091 by @cedricdonie.
+        """
+        X, y = shap.datasets.adult(n_points=100)
+        # convert to category type (int/string for XGBoost 2.x+ compatibility)
+        X["Education-Num"] = X["Education-Num"].astype(int).astype("category")
+        X["Workclass"] = X["Workclass"].astype("category")
+        X["Country"] = X["Country"].astype("category")
+        # add a few missing values
+        X.loc[X.sample(frac=0.3, random_state=42).index, "Country"] = np.nan
+
+        clf = Clf(random_state=42, enable_categorical=True)
+        clf.fit(X, y)
+        margin = clf.predict(X, output_margin=True)
+        explainer = shap.TreeExplainer(clf)
+        shap_values = explainer.shap_values(X)
+        # check that SHAP values sum to model output
+        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
 
     @pytest.mark.parametrize("Reg", regressors)
     def test_xgboost_direct(self, Reg):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2196,7 +2196,6 @@ def test_overflow_tree_path_dependent():
     exp(X)
 
 
-@pytest.mark.skip("Currently disabled due to errors, see https://github.com/uber/causalml/issues/859.")
 @pytest.mark.parametrize(
     "n_estimators",
     [

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3183,6 +3183,53 @@ def test_interventional_interaction_values_multiclass():
                 )
 
 
+def test_interventional_categorical():
+    """Verify interventional SHAP values and interactions work with categorical splits."""
+    lightgbm = pytest.importorskip("lightgbm")
+
+    np.random.seed(42)
+    n = 200
+    # Two categorical features (1-based to avoid pre-existing category_in_threshold
+    # issue with category 0) and one continuous feature
+    cat0 = np.random.randint(1, 5, n).astype(np.float64)
+    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    cont = np.random.randn(n)
+    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    X = np.column_stack([cat0, cat1, cont])
+
+    ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
+    model = lightgbm.train(
+        {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
+        ds, num_boost_round=20,
+    )
+
+    X_test = X[:10]
+    bg = X[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+
+    # --- SHAP values ---
+    sv = explainer.shap_values(X_test)
+    preds = model.predict(X_test)
+    # Prediction additivity: sum of SHAP values + expected value ≈ prediction
+    np.testing.assert_allclose(sv.sum(axis=1) + explainer.expected_value, preds, atol=1e-4)
+
+    # --- Interaction values ---
+    interactions = explainer.shap_interaction_values(X_test)
+    n_feats = X_test.shape[1]
+
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-6)
+
+    # Row-sum additivity: interactions[i, j, :].sum() == sv[i, j]
+    row_sums = interactions.sum(axis=2)
+    np.testing.assert_allclose(row_sums[:, :n_feats], sv, atol=1e-4)
+
+    # Prediction additivity
+    total = interactions.sum(axis=(1, 2))
+    np.testing.assert_allclose(total + explainer.expected_value, preds, atol=1e-4)
+
+
 def test_interventional_vs_path_dependent_uncorrelated():
     """On uncorrelated data, both modes should approximately agree."""
     np.random.seed(42)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2,6 +2,7 @@
 
 import itertools
 import math
+import os
 import pickle
 import sys
 
@@ -3278,3 +3279,130 @@ def test_interventional_vs_path_dependent_uncorrelated():
 
     # Loose tolerance since finite-sample effects and slight correlation in random data
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
+
+def test_path_dependent_categorical():
+    """Verify path-dependent mode works with LightGBM categorical features."""
+    lightgbm = pytest.importorskip("lightgbm")
+
+    np.random.seed(42)
+    n = 200
+    cat0 = np.random.randint(0, 4, n).astype(np.float64)
+    cat1 = np.random.randint(0, 3, n).astype(np.float64)
+    cont = np.random.randn(n)
+    y = (cat0 == 1).astype(float) * 2 + cont * 0.5 + (cat1 == 2).astype(float)
+    X = np.column_stack([cat0, cat1, cont])
+
+    ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
+    model = lightgbm.train({"verbose": -1, "num_leaves": 8}, ds, num_boost_round=10)
+
+    # Path-dependent SHAP values (no background data, uses LightGBM native)
+    explainer = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    sv = explainer.shap_values(X[:5])
+    assert sv.shape == (5, 3)
+    assert np.count_nonzero(sv) > 0
+
+    # Path-dependent interaction values (uses C++ tree_shap_recursive)
+    iv = explainer.shap_interaction_values(X[:5])
+    assert iv.shape == (5, 3, 3)
+    # Symmetry
+    np.testing.assert_allclose(iv, np.swapaxes(iv, 1, 2))
+    # Row-sum equals SHAP values
+    np.testing.assert_allclose(iv.sum(axis=2), sv, atol=1e-10)
+
+    assert np.max(np.abs(sv_120 - sv_full)) < np.max(np.abs(sv - sv_full))
+
+
+def _compute_shap_with_threads(model, X, background, n_threads, **kwargs):
+    """Helper to compute SHAP values with a specific thread count."""
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    os.environ["OMP_NUM_THREADS"] = str(n_threads)
+    try:
+        explainer = shap.TreeExplainer(model, data=background, feature_perturbation="interventional", **kwargs)
+        result = explainer.shap_values(X)
+    finally:
+        if old_val is None:
+            del os.environ["OMP_NUM_THREADS"]
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+    return result, explainer.expected_value
+
+
+def test_openmp_interventional_shap_values():
+    """Multi-threaded interventional SHAP values should match single-threaded."""
+    from sklearn.ensemble import RandomForestRegressor
+    X, y = shap.datasets.california(n_points=200)
+    model = RandomForestRegressor(n_estimators=20, max_depth=5, random_state=42)
+    model.fit(X, y)
+
+    background = X[:50]
+    X_test = X[50:80]
+
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1)
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4)
+
+    # Results should be identical (same accumulation order)
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10,
+                               err_msg="SHAP values differ between 1 and 4 threads")
+
+    # Verify additivity: sum of shap values + expected_value == prediction
+    pred = model.predict(X_test.values)
+    shap_sum = ev_4 + sv_4.sum(axis=1)
+    np.testing.assert_allclose(shap_sum, pred, atol=1e-6)
+
+
+def test_openmp_interventional_interaction_values():
+    """Multi-threaded interventional interaction values should match single-threaded."""
+    X, y = shap.datasets.iris()
+    model = GradientBoostingRegressor(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X.values, y)
+
+    background = X.values[:30]
+    X_test = X.values[:10]
+
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    try:
+        os.environ["OMP_NUM_THREADS"] = "1"
+        ex1 = shap.TreeExplainer(model, data=background, feature_perturbation="interventional")
+        iv_1 = ex1.shap_interaction_values(X_test)
+
+        os.environ["OMP_NUM_THREADS"] = "4"
+        ex4 = shap.TreeExplainer(model, data=background, feature_perturbation="interventional")
+        iv_4 = ex4.shap_interaction_values(X_test)
+    finally:
+        if old_val is None:
+            os.environ.pop("OMP_NUM_THREADS", None)
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+
+    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10,
+                               err_msg="Interaction values differ between 1 and 4 threads")
+
+    # Verify symmetry
+    for i in range(iv_4.shape[0]):
+        np.testing.assert_allclose(iv_4[i], iv_4[i].T, atol=1e-10)
+
+
+def test_openmp_interventional_with_transform():
+    """Multi-threaded interventional SHAP with transform should match single-threaded."""
+    pytest.importorskip("xgboost")
+    import xgboost as xgb
+
+    X, y = shap.datasets.adult()
+    X = X[:200]
+    y = y[:200]
+
+    model = xgb.XGBClassifier(n_estimators=10, max_depth=3, random_state=42,
+                               use_label_encoder=False, eval_metric="logloss")
+    model.fit(X, y)
+
+    background = X[:50]
+    X_test = X[50:70]
+
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1,
+                                             model_output="probability")
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4,
+                                             model_output="probability")
+
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-8,
+                               err_msg="SHAP values with transform differ between threads")
+

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2978,15 +2978,20 @@ def test_path_dependent_small_background():
 # --- Interventional SHAP interaction values tests ---
 
 
-def test_interventional_interaction_values_brute_force():
-    """Verify interventional interactions match brute-force Shapley computation."""
+@pytest.mark.parametrize("n_features", [3, 4, 5, 6])
+def test_interventional_interaction_values_brute_force(n_features):
+    """Verify interventional interactions match brute-force Shapley computation.
+
+    Computes exact Shapley interaction indices by definition (O(2^n) per pair)
+    and compares against our C++ implementation. Parametrized over feature counts
+    to test different set-interval configurations.
+    """
     from itertools import combinations
     from math import comb
 
     np.random.seed(42)
-    n_features = 5
     X_train = np.random.randn(200, n_features)
-    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2 % n_features]
     model = DecisionTreeRegressor(max_depth=3, random_state=42)
     model.fit(X_train, y_train)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3405,4 +3405,3 @@ def test_openmp_interventional_with_transform():
 
     np.testing.assert_allclose(sv_1, sv_4, atol=1e-8,
                                err_msg="SHAP values with transform differ between threads")
-

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2939,6 +2939,7 @@ def test_tree_explainer_random_forest_regressor():
         assert np.abs(shap_sum - predictions).max() < 1e-4
 
 
+<<<<<<< HEAD
 def test_path_dependent_small_background():
     """Path-dependent SHAP with small background that has uncovered leaves.
 
@@ -2972,3 +2973,227 @@ def test_path_dependent_small_background():
     for c in range(3):
         shap_sum = explainer.expected_value[c] + sv[:, :, c].sum(axis=1)
         np.testing.assert_allclose(shap_sum, pred[:, c], atol=1e-6)
+
+
+# --- Interventional SHAP interaction values tests ---
+
+
+def test_interventional_interaction_values_brute_force():
+    """Verify interventional interactions match brute-force Shapley computation."""
+    from itertools import combinations
+    from math import comb
+
+    np.random.seed(42)
+    n_features = 5
+    X_train = np.random.randn(200, n_features)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(2, n_features)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    N = list(range(n_features))
+    for idx in range(len(X_test)):
+        x = X_test[idx]
+        phi_bf = np.zeros((n_features, n_features))
+
+        for i in range(n_features):
+            for j in range(i + 1, n_features):
+                rest = [f for f in N if f != i and f != j]
+                val = 0.0
+                for size in range(len(rest) + 1):
+                    for S_tuple in combinations(rest, size):
+                        S = set(S_tuple)
+                        feats = np.arange(n_features)
+                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+
+                        weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
+                        val += weight * (v_Sij - v_Si - v_Sj + v_S)
+                # SHAP library convention: off-diagonal stores half
+                phi_bf[i, j] = val / 2
+                phi_bf[j, i] = val / 2
+
+        # Diagonal = SHAP value - sum of off-diagonal
+        for i in range(n_features):
+            phi_bf[i, i] = sv[idx, i] - phi_bf[i, :].sum() + phi_bf[i, i]
+
+        np.testing.assert_allclose(interactions[idx], phi_bf, atol=1e-4)
+
+
+def test_interventional_interaction_values_symmetry():
+    """Verify phi[i,j] == phi[j,i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-10)
+
+
+def test_interventional_interaction_values_additivity():
+    """Verify sum_j phi[i,j] == shap_value[i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+
+
+def test_interventional_interaction_values_prediction():
+    """Verify interactions sum to prediction - expected_value."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    preds = model.predict(X_test)
+    total = interactions.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, preds, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "GradientBoostingRegressor",
+        "RandomForestRegressor",
+        "lightgbm",
+        "xgboost",
+        "catboost",
+    ],
+)
+def test_interventional_interaction_values_models(model_name):
+    """Verify interventional interactions work for multiple tree model types."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    if model_name == "lightgbm":
+        lightgbm = pytest.importorskip("lightgbm")
+        model = lightgbm.LGBMRegressor(n_estimators=20, max_depth=3, verbose=-1, random_state=42)
+    elif model_name == "xgboost":
+        xgboost = pytest.importorskip("xgboost")
+        model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "catboost":
+        catboost = pytest.importorskip("catboost")
+        model = catboost.CatBoostRegressor(n_estimators=20, max_depth=3, random_seed=42, verbose=0)
+    elif model_name == "GradientBoostingRegressor":
+        model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "RandomForestRegressor":
+        from sklearn.ensemble import RandomForestRegressor
+        model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
+    else:
+        raise ValueError(f"Unknown model: {model_name}")
+
+    model.fit(X_train, y_train)
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Shape check
+    assert interactions.shape == (3, 6, 6)
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-4)
+    # Row-sum additivity
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+    # Non-zero
+    assert np.abs(interactions).max() > 0
+
+
+def test_interventional_interaction_values_nonzero():
+    """Verify interventional interactions are NOT all zeros (Issue #1824)."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    assert np.abs(interactions).max() > 0.01, "Interactions are all zeros (Issue #1824 not fixed)"
+
+
+def test_interventional_interaction_values_multiclass():
+    """Verify interventional interactions work for multi-class models."""
+    from sklearn.datasets import load_iris
+    iris = load_iris()
+    model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(iris.data, iris.target)
+
+    X_test = iris.data[:5]
+    bg = iris.data[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+
+    # Multi-class: should be 4D array (n_samples, n_features, n_features, n_classes)
+    # or a list of 3D arrays
+    if isinstance(interactions, list):
+        for cls_interactions in interactions:
+            assert cls_interactions.shape == (5, 4, 4)
+            np.testing.assert_allclose(
+                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
+            )
+    else:
+        assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
+        if interactions.ndim == 4:
+            for c in range(interactions.shape[3]):
+                np.testing.assert_allclose(
+                    interactions[:, :, :, c],
+                    np.swapaxes(interactions[:, :, :, c], 1, 2),
+                    atol=1e-4,
+                )
+
+
+def test_interventional_vs_path_dependent_uncorrelated():
+    """On uncorrelated data, both modes should approximately agree."""
+    np.random.seed(42)
+    X = np.random.randn(500, 5)
+    y = X[:, 0] * X[:, 1] + X[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    X_test = X[:5]
+    bg = X[:100]
+
+    explainer_iv = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions_iv = explainer_iv.shap_interaction_values(X_test)
+
+    explainer_pd = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    interactions_pd = explainer_pd.shap_interaction_values(X_test)
+
+    # Loose tolerance since finite-sample effects and slight correlation in random data
+    np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3189,12 +3189,12 @@ def test_interventional_categorical():
 
     np.random.seed(42)
     n = 200
-    # Two categorical features (1-based to avoid pre-existing category_in_threshold
-    # issue with category 0) and one continuous feature
-    cat0 = np.random.randint(1, 5, n).astype(np.float64)
-    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    # Two categorical features (0-based, verifying category 0 works correctly)
+    # and one continuous feature
+    cat0 = np.random.randint(0, 4, n).astype(np.float64)
+    cat1 = np.random.randint(0, 3, n).astype(np.float64)
     cont = np.random.randn(n)
-    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    y = (cat0 == 1).astype(float) * 2 + cont * 0.5 + (cat1 == 2).astype(float)
     X = np.column_stack([cat0, cat1, cont])
 
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3225,6 +3225,53 @@ def test_interventional_interaction_values_multiclass():
                 )
 
 
+def test_interventional_categorical():
+    """Verify interventional SHAP values and interactions work with categorical splits."""
+    lightgbm = pytest.importorskip("lightgbm")
+
+    np.random.seed(42)
+    n = 200
+    # Two categorical features (1-based to avoid pre-existing category_in_threshold
+    # issue with category 0) and one continuous feature
+    cat0 = np.random.randint(1, 5, n).astype(np.float64)
+    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    cont = np.random.randn(n)
+    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    X = np.column_stack([cat0, cat1, cont])
+
+    ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
+    model = lightgbm.train(
+        {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
+        ds, num_boost_round=20,
+    )
+
+    X_test = X[:10]
+    bg = X[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+
+    # --- SHAP values ---
+    sv = explainer.shap_values(X_test)
+    preds = model.predict(X_test)
+    # Prediction additivity: sum of SHAP values + expected value ≈ prediction
+    np.testing.assert_allclose(sv.sum(axis=1) + explainer.expected_value, preds, atol=1e-4)
+
+    # --- Interaction values ---
+    interactions = explainer.shap_interaction_values(X_test)
+    n_feats = X_test.shape[1]
+
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-6)
+
+    # Row-sum additivity: interactions[i, j, :].sum() == sv[i, j]
+    row_sums = interactions.sum(axis=2)
+    np.testing.assert_allclose(row_sums[:, :n_feats], sv, atol=1e-4)
+
+    # Prediction additivity
+    total = interactions.sum(axis=(1, 2))
+    np.testing.assert_allclose(total + explainer.expected_value, preds, atol=1e-4)
+
+
 def test_interventional_vs_path_dependent_uncorrelated():
     """On uncorrelated data, both modes should approximately agree."""
     np.random.seed(42)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1350,9 +1350,11 @@ class TestExplainerXGBoost:
         # check that SHAP values sum to model output
         np.testing.assert_allclose(margin, explainer.expected_value + shap_values.sum(axis=1), atol=1e-4, rtol=1e-4)
         # check that interaction values sum to SHAP values and model output
+        # XGBoost computes interactions in float32 (HostDeviceVector<float>),
+        # so summing features accumulates ~1e-6 rounding error
         interaction_values = explainer.shap_interaction_values(X_nan)
-        assert np.allclose(shap_values, interaction_values.sum(axis=2))
-        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+        np.testing.assert_allclose(shap_values, interaction_values.sum(axis=2), atol=1e-5)
+        np.testing.assert_allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)), atol=1e-5)
 
     @pytest.mark.parametrize("Clf", classifiers)
     def test_xgboost_mixed_category_and_nan(self, Clf):
@@ -1374,11 +1376,12 @@ class TestExplainerXGBoost:
         explainer = shap.TreeExplainer(clf)
         shap_values = explainer.shap_values(X)
         # check that SHAP values sum to model output
-        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # XGBoost computes SHAP in float32, atol=1e-5 for accumulation noise
+        np.testing.assert_allclose(margin, explainer.expected_value + shap_values.sum(axis=1), atol=1e-5)
         # check that interaction values sum to SHAP values and model output
         interaction_values = explainer.shap_interaction_values(X)
-        assert np.allclose(shap_values, interaction_values.sum(axis=2))
-        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+        np.testing.assert_allclose(shap_values, interaction_values.sum(axis=2), atol=1e-5)
+        np.testing.assert_allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)), atol=1e-5)
 
     @pytest.mark.parametrize("Reg", regressors)
     def test_xgboost_direct(self, Reg):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3087,10 +3087,21 @@ def test_interventional_interaction_values_brute_force(n_features):
                     for S_tuple in combinations(rest, size):
                         S = set(S_tuple)
                         feats = np.arange(n_features)
-                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
-                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_S = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Si = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sj = np.mean(
+                            [model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg]
+                        )
+                        v_Sij = np.mean(
+                            [
+                                model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0]
+                                for r in bg
+                            ]
+                        )
 
                         weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
                         val += weight * (v_Sij - v_Si - v_Sj + v_S)
@@ -3187,6 +3198,7 @@ def test_interventional_interaction_values_models(model_name):
         model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
     elif model_name == "RandomForestRegressor":
         from sklearn.ensemble import RandomForestRegressor
+
         model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
     else:
         raise ValueError(f"Unknown model: {model_name}")
@@ -3226,6 +3238,7 @@ def test_interventional_interaction_values_nonzero():
 def test_interventional_interaction_values_multiclass():
     """Verify interventional interactions work for multi-class models."""
     from sklearn.datasets import load_iris
+
     iris = load_iris()
     model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
     model.fit(iris.data, iris.target)
@@ -3241,9 +3254,7 @@ def test_interventional_interaction_values_multiclass():
     if isinstance(interactions, list):
         for cls_interactions in interactions:
             assert cls_interactions.shape == (5, 4, 4)
-            np.testing.assert_allclose(
-                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
-            )
+            np.testing.assert_allclose(cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4)
     else:
         assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
         if interactions.ndim == 4:
@@ -3272,7 +3283,8 @@ def test_interventional_categorical():
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)
     model = lightgbm.train(
         {"objective": "regression", "verbose": -1, "n_estimators": 20, "max_depth": 4},
-        ds, num_boost_round=20,
+        ds,
+        num_boost_round=20,
     )
 
     X_test = X[:10]
@@ -3323,7 +3335,6 @@ def test_interventional_vs_path_dependent_uncorrelated():
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
 
 
-
 def test_interventional_interaction_values_with_transform():
     """Interventional interaction values with logistic transform (probability output).
 
@@ -3341,8 +3352,7 @@ def test_interventional_interaction_values_with_transform():
     bg = X[:50]
     X_test = X[50:55]
 
-    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional",
-                                   model_output="probability")
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional", model_output="probability")
     iv = explainer.shap_interaction_values(X_test)
     sv = explainer.shap_values(X_test)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3015,3 +3015,227 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+
+# --- Interventional SHAP interaction values tests ---
+
+
+def test_interventional_interaction_values_brute_force():
+    """Verify interventional interactions match brute-force Shapley computation."""
+    from itertools import combinations
+    from math import comb
+
+    np.random.seed(42)
+    n_features = 5
+    X_train = np.random.randn(200, n_features)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(2, n_features)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    N = list(range(n_features))
+    for idx in range(len(X_test)):
+        x = X_test[idx]
+        phi_bf = np.zeros((n_features, n_features))
+
+        for i in range(n_features):
+            for j in range(i + 1, n_features):
+                rest = [f for f in N if f != i and f != j]
+                val = 0.0
+                for size in range(len(rest) + 1):
+                    for S_tuple in combinations(rest, size):
+                        S = set(S_tuple)
+                        feats = np.arange(n_features)
+                        v_S = np.mean([model.predict(np.where(np.isin(feats, list(S)), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Si = np.mean([model.predict(np.where(np.isin(feats, list(S | {i})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sj = np.mean([model.predict(np.where(np.isin(feats, list(S | {j})), x, r).reshape(1, -1))[0] for r in bg])
+                        v_Sij = np.mean([model.predict(np.where(np.isin(feats, list(S | {i, j})), x, r).reshape(1, -1))[0] for r in bg])
+
+                        weight = 1.0 / ((n_features - 1) * comb(n_features - 2, len(S)))
+                        val += weight * (v_Sij - v_Si - v_Sj + v_S)
+                # SHAP library convention: off-diagonal stores half
+                phi_bf[i, j] = val / 2
+                phi_bf[j, i] = val / 2
+
+        # Diagonal = SHAP value - sum of off-diagonal
+        for i in range(n_features):
+            phi_bf[i, i] = sv[idx, i] - phi_bf[i, :].sum() + phi_bf[i, i]
+
+        np.testing.assert_allclose(interactions[idx], phi_bf, atol=1e-4)
+
+
+def test_interventional_interaction_values_symmetry():
+    """Verify phi[i,j] == phi[j,i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-10)
+
+
+def test_interventional_interaction_values_additivity():
+    """Verify sum_j phi[i,j] == shap_value[i]."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+
+
+def test_interventional_interaction_values_prediction():
+    """Verify interactions sum to prediction - expected_value."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 8)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2] ** 2
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(5, 8)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    preds = model.predict(X_test)
+    total = interactions.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, preds, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "GradientBoostingRegressor",
+        "RandomForestRegressor",
+        "lightgbm",
+        "xgboost",
+        "catboost",
+    ],
+)
+def test_interventional_interaction_values_models(model_name):
+    """Verify interventional interactions work for multiple tree model types."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    if model_name == "lightgbm":
+        lightgbm = pytest.importorskip("lightgbm")
+        model = lightgbm.LGBMRegressor(n_estimators=20, max_depth=3, verbose=-1, random_state=42)
+    elif model_name == "xgboost":
+        xgboost = pytest.importorskip("xgboost")
+        model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "catboost":
+        catboost = pytest.importorskip("catboost")
+        model = catboost.CatBoostRegressor(n_estimators=20, max_depth=3, random_seed=42, verbose=0)
+    elif model_name == "GradientBoostingRegressor":
+        model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    elif model_name == "RandomForestRegressor":
+        from sklearn.ensemble import RandomForestRegressor
+        model = RandomForestRegressor(n_estimators=20, max_depth=3, random_state=42)
+    else:
+        raise ValueError(f"Unknown model: {model_name}")
+
+    model.fit(X_train, y_train)
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Shape check
+    assert interactions.shape == (3, 6, 6)
+    # Symmetry
+    np.testing.assert_allclose(interactions, np.swapaxes(interactions, 1, 2), atol=1e-4)
+    # Row-sum additivity
+    np.testing.assert_allclose(interactions.sum(axis=2), sv, atol=1e-4)
+    # Non-zero
+    assert np.abs(interactions).max() > 0
+
+
+def test_interventional_interaction_values_nonzero():
+    """Verify interventional interactions are NOT all zeros (Issue #1824)."""
+    np.random.seed(42)
+    X_train = np.random.randn(200, 6)
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X_train, y_train)
+
+    X_test = np.random.randn(3, 6)
+    bg = X_train[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+    assert np.abs(interactions).max() > 0.01, "Interactions are all zeros (Issue #1824 not fixed)"
+
+
+def test_interventional_interaction_values_multiclass():
+    """Verify interventional interactions work for multi-class models."""
+    from sklearn.datasets import load_iris
+    iris = load_iris()
+    model = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(iris.data, iris.target)
+
+    X_test = iris.data[:5]
+    bg = iris.data[:50]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions = explainer.shap_interaction_values(X_test)
+
+    # Multi-class: should be 4D array (n_samples, n_features, n_features, n_classes)
+    # or a list of 3D arrays
+    if isinstance(interactions, list):
+        for cls_interactions in interactions:
+            assert cls_interactions.shape == (5, 4, 4)
+            np.testing.assert_allclose(
+                cls_interactions, np.swapaxes(cls_interactions, 1, 2), atol=1e-4
+            )
+    else:
+        assert interactions.shape == (5, 4, 4, 3) or interactions.shape == (5, 4, 4)
+        if interactions.ndim == 4:
+            for c in range(interactions.shape[3]):
+                np.testing.assert_allclose(
+                    interactions[:, :, :, c],
+                    np.swapaxes(interactions[:, :, :, c], 1, 2),
+                    atol=1e-4,
+                )
+
+
+def test_interventional_vs_path_dependent_uncorrelated():
+    """On uncorrelated data, both modes should approximately agree."""
+    np.random.seed(42)
+    X = np.random.randn(500, 5)
+    y = X[:, 0] * X[:, 1] + X[:, 2]
+    model = DecisionTreeRegressor(max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    X_test = X[:5]
+    bg = X[:100]
+
+    explainer_iv = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    interactions_iv = explainer_iv.shap_interaction_values(X_test)
+
+    explainer_pd = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    interactions_pd = explainer_pd.shap_interaction_values(X_test)
+
+    # Loose tolerance since finite-sample effects and slight correlation in random data
+    np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3020,15 +3020,20 @@ def test_nullable_pandas_dtype():
 # --- Interventional SHAP interaction values tests ---
 
 
-def test_interventional_interaction_values_brute_force():
-    """Verify interventional interactions match brute-force Shapley computation."""
+@pytest.mark.parametrize("n_features", [3, 4, 5, 6])
+def test_interventional_interaction_values_brute_force(n_features):
+    """Verify interventional interactions match brute-force Shapley computation.
+
+    Computes exact Shapley interaction indices by definition (O(2^n) per pair)
+    and compares against our C++ implementation. Parametrized over feature counts
+    to test different set-interval configurations.
+    """
     from itertools import combinations
     from math import comb
 
     np.random.seed(42)
-    n_features = 5
     X_train = np.random.randn(200, n_features)
-    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2]
+    y_train = X_train[:, 0] * X_train[:, 1] + X_train[:, 2 % n_features]
     model = DecisionTreeRegressor(max_depth=3, random_state=42)
     model.fit(X_train, y_train)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2,6 +2,7 @@
 
 import itertools
 import math
+import os
 import pickle
 import sys
 
@@ -3369,3 +3370,95 @@ def test_interventional_interaction_values_with_transform():
 
     # Symmetry
     np.testing.assert_allclose(iv, np.swapaxes(iv, 1, 2), atol=1e-10)
+
+
+def _compute_shap_with_threads(model, X, background, n_threads, **kwargs):
+    """Helper to compute SHAP values with a specific thread count."""
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    os.environ["OMP_NUM_THREADS"] = str(n_threads)
+    try:
+        explainer = shap.TreeExplainer(model, data=background, feature_perturbation="interventional", **kwargs)
+        result = explainer.shap_values(X)
+    finally:
+        if old_val is None:
+            del os.environ["OMP_NUM_THREADS"]
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+    return result, explainer.expected_value
+
+
+def test_openmp_interventional_shap_values():
+    """Multi-threaded interventional SHAP values should match single-threaded."""
+    from sklearn.ensemble import RandomForestRegressor
+
+    X, y = shap.datasets.california(n_points=200)
+    model = RandomForestRegressor(n_estimators=20, max_depth=5, random_state=42)
+    model.fit(X, y)
+
+    background = X[:50]
+    X_test = X[50:80]
+
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1)
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4)
+
+    # Results should be identical (same accumulation order)
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10, err_msg="SHAP values differ between 1 and 4 threads")
+
+    # Verify additivity: sum of shap values + expected_value == prediction
+    pred = model.predict(X_test.values)
+    shap_sum = ev_4 + sv_4.sum(axis=1)
+    np.testing.assert_allclose(shap_sum, pred, atol=1e-6)
+
+
+def test_openmp_interventional_interaction_values():
+    """Multi-threaded interventional interaction values should match single-threaded."""
+    X, y = shap.datasets.iris()
+    model = GradientBoostingRegressor(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X.values, y)
+
+    background = X.values[:30]
+    X_test = X.values[:10]
+
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    try:
+        os.environ["OMP_NUM_THREADS"] = "1"
+        ex1 = shap.TreeExplainer(model, data=background, feature_perturbation="interventional")
+        iv_1 = ex1.shap_interaction_values(X_test)
+
+        os.environ["OMP_NUM_THREADS"] = "4"
+        ex4 = shap.TreeExplainer(model, data=background, feature_perturbation="interventional")
+        iv_4 = ex4.shap_interaction_values(X_test)
+    finally:
+        if old_val is None:
+            os.environ.pop("OMP_NUM_THREADS", None)
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+
+    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10, err_msg="Interaction values differ between 1 and 4 threads")
+
+    # Verify symmetry
+    for i in range(iv_4.shape[0]):
+        np.testing.assert_allclose(iv_4[i], iv_4[i].T, atol=1e-10)
+
+
+def test_openmp_interventional_with_transform():
+    """Multi-threaded interventional SHAP with transform should match single-threaded."""
+    pytest.importorskip("xgboost")
+    import xgboost as xgb
+
+    X, y = shap.datasets.adult()
+    X = X[:200]
+    y = y[:200]
+
+    model = xgb.XGBClassifier(
+        n_estimators=10, max_depth=3, random_state=42, use_label_encoder=False, eval_metric="logloss"
+    )
+    model.fit(X, y)
+
+    background = X[:50]
+    X_test = X[50:70]
+
+    sv_1, ev_1 = _compute_shap_with_threads(model, X_test, background, n_threads=1, model_output="probability")
+    sv_4, ev_4 = _compute_shap_with_threads(model, X_test, background, n_threads=4, model_output="probability")
+
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-8, err_msg="SHAP values with transform differ between threads")

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3231,12 +3231,12 @@ def test_interventional_categorical():
 
     np.random.seed(42)
     n = 200
-    # Two categorical features (1-based to avoid pre-existing category_in_threshold
-    # issue with category 0) and one continuous feature
-    cat0 = np.random.randint(1, 5, n).astype(np.float64)
-    cat1 = np.random.randint(1, 4, n).astype(np.float64)
+    # Two categorical features (0-based, verifying category 0 works correctly)
+    # and one continuous feature
+    cat0 = np.random.randint(0, 4, n).astype(np.float64)
+    cat1 = np.random.randint(0, 3, n).astype(np.float64)
     cont = np.random.randn(n)
-    y = (cat0 == 2).astype(float) * 2 + cont * 0.5 + (cat1 == 3).astype(float)
+    y = (cat0 == 1).astype(float) * 2 + cont * 0.5 + (cat1 == 2).astype(float)
     X = np.column_stack([cat0, cat1, cont])
 
     ds = lightgbm.Dataset(X, label=y, categorical_feature=[0, 1], free_raw_data=False)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1349,6 +1349,36 @@ class TestExplainerXGBoost:
         shap_values = explainer.shap_values(X_nan)
         # check that SHAP values sum to model output
         np.testing.assert_allclose(margin, explainer.expected_value + shap_values.sum(axis=1), atol=1e-4, rtol=1e-4)
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X_nan)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
+
+    @pytest.mark.parametrize("Clf", classifiers)
+    def test_xgboost_mixed_category_and_nan(self, Clf):
+        """Test that xgboost explanations can handle categorical data with missing values.
+
+        Adapted from PR #4091 by @cedricdonie.
+        """
+        X, y = shap.datasets.adult(n_points=100)
+        # convert to category type (int/string for XGBoost 2.x+ compatibility)
+        X["Education-Num"] = X["Education-Num"].astype(int).astype("category")
+        X["Workclass"] = X["Workclass"].astype("category")
+        X["Country"] = X["Country"].astype("category")
+        # add a few missing values
+        X.loc[X.sample(frac=0.3, random_state=42).index, "Country"] = np.nan
+
+        clf = Clf(random_state=42, enable_categorical=True)
+        clf.fit(X, y)
+        margin = clf.predict(X, output_margin=True)
+        explainer = shap.TreeExplainer(clf)
+        shap_values = explainer.shap_values(X)
+        # check that SHAP values sum to model output
+        assert np.allclose(margin, explainer.expected_value + shap_values.sum(axis=1))
+        # check that interaction values sum to SHAP values and model output
+        interaction_values = explainer.shap_interaction_values(X)
+        assert np.allclose(shap_values, interaction_values.sum(axis=2))
+        assert np.allclose(margin, explainer.expected_value + interaction_values.sum(axis=(1, 2)))
 
     @pytest.mark.parametrize("Reg", regressors)
     def test_xgboost_direct(self, Reg):

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3321,3 +3321,38 @@ def test_interventional_vs_path_dependent_uncorrelated():
 
     # Loose tolerance since finite-sample effects and slight correlation in random data
     np.testing.assert_allclose(interactions_iv, interactions_pd, atol=0.15, rtol=0.3)
+
+
+
+def test_interventional_interaction_values_with_transform():
+    """Interventional interaction values with logistic transform (probability output).
+
+    Verifies that interaction values in probability space satisfy:
+    1. Row-sum additivity: sum_j(phi[i,j]) == shap_value[i]
+    2. Prediction additivity: sum(phi) + expected_value == predict_proba
+    3. Symmetry: phi[i,j] == phi[j,i]
+    """
+    np.random.seed(42)
+    X = np.random.randn(200, 5)
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    model = GradientBoostingClassifier(n_estimators=10, max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    bg = X[:50]
+    X_test = X[50:55]
+
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional",
+                                   model_output="probability")
+    iv = explainer.shap_interaction_values(X_test)
+    sv = explainer.shap_values(X_test)
+
+    # Row-sum: interaction values sum to SHAP values per feature
+    np.testing.assert_allclose(iv.sum(axis=2), sv, atol=1e-4)
+
+    # Prediction additivity
+    pred = model.predict_proba(X_test)[:, 1]
+    total = iv.sum(axis=(1, 2)) + explainer.expected_value
+    np.testing.assert_allclose(total, pred, atol=1e-4)
+
+    # Symmetry
+    np.testing.assert_allclose(iv, np.swapaxes(iv, 1, 2), atol=1e-10)


### PR DESCRIPTION
## Summary

- Parallelizes the sample loop in `dense_independent()` and `dense_independent_interactions()` with OpenMP for near-linear speedup
- Extracted `from_flag` from the `Node` struct into a per-thread `char[]` array (~1 KB/thread), keeping `node_trees` fully shared and read-only — avoids deep-copying the entire tree array (~16 MB/thread)
- Per-thread workspace vectors allocated once per `#pragma omp parallel` region; `schedule(dynamic, 1)` for load balancing
- Removed `print_progress_bar()` calls from parallel regions (requires GIL via `PySys_WriteStderr`)
- Build: `-fopenmp` on Linux/macOS, `/openmp` on Windows

**Depends on #4274** — this modifies `dense_independent_interactions()` and the `Node` struct introduced there.

## Test plan

- [x] `test_openmp_interventional_shap_values` — 1-thread vs 4-thread results match within `atol=1e-10`
- [x] `test_openmp_interventional_interaction_values` — 1-thread vs 4-thread match + symmetry check
- [x] `test_openmp_interventional_with_transform` — probability transform output matches across threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)