### PR TITLE
Fix missing array to scalar conversion in MAPLE

### DIFF
--- a/shap/explainers/other/_maple.py
+++ b/shap/explainers/other/_maple.py
@@ -244,7 +244,7 @@ class MAPLE:
                 # Local linear model
                 lr_model = Ridge(alpha=regularization)
                 lr_model.fit(X_train_p, MR_train, weights)
-                lr_predictions[i] = lr_model.predict(X_val_p[i].reshape(1, -1))
+                lr_predictions[i] = lr_model.predict(X_val_p[i].reshape(1, -1))[0]
 
             rmse_curr = np.sqrt(mean_squared_error(lr_predictions, MR_val))
 

--- a/tests/explainers/other/test_maple.py
+++ b/tests/explainers/other/test_maple.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from shap.explainers.other._maple import MAPLE
+
+
+def test_maple_small():
+    """Test a small MAPLE model."""
+    rs = np.random.RandomState(0)
+    X_train = rs.randn(10, 4)
+    y_train = X_train[:, 0] * 2 + rs.randn(10) * 0.1
+    X_val = rs.randn(5, 4)
+    y_val = X_val[:, 0] * 2 + rs.randn(5) * 0.1
+
+    maple = MAPLE(X_train, y_train, X_val, y_val)
+
+    preds = maple.predict(X_val)
+    assert preds.shape == (5,)


### PR DESCRIPTION
## Overview

Closes #4280 

Description of the changes proposed in this pull request:
- Add explicit array to scalar conversion via `[0]`
- Did not use `.item` as the result in this case is identical and the existing style in the file uses `[0]`
- Added a small test invoking the MAPLE class with a prediction. The outcome locally is as expected
```terminal
                  │  py-310 (numpy 2.2.6)            │  py-313 (numpy 2.4.2)
──────────────────┼──────────────────────────────────┼──────────────────────────────────
 master (unfixed) │  PASS (20 DeprecationWarnings)   │  FAIL (ValueError)
──────────────────┼──────────────────────────────────┼──────────────────────────────────
 fix branch       │  PASS                            │  PASS
```

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
