### PR TITLE
Fix NumPy deprecation warning in coalition explainer

### DIFF
--- a/shap/explainers/_coalition.py
+++ b/shap/explainers/_coalition.py
@@ -289,10 +289,10 @@ class CoalitionExplainer(Explainer):
                     off_result = np.asarray(off_result).reshape(-1)
                     on_result = np.asarray(on_result).reshape(-1)
                     for i in range(num_outputs):
-                        marginal_contribution = float((on_result[i] - off_result[i]) * weight)
+                        marginal_contribution = ((on_result[i] - off_result[i]) * weight).item()
                         shap_values[feature_name_to_index[last_key], i] += marginal_contribution
                 else:
-                    marginal_contribution = float((on_result - off_result) * weight)
+                    marginal_contribution = ((on_result - off_result) * weight).item()
                     shap_values[feature_name_to_index[last_key]] += marginal_contribution
 
         # Step 5: Return results


### PR DESCRIPTION
Replace float() calls with .item() to avoid "Conversion of an array with ndim > 0 to a scalar is deprecated" warnings in both single-output and multi-output code paths.

Fixes #4290

https://claude.ai/code/session_01BvKZKAFmLXrRozVsAq9Gef

## Overview

Fixes #4290

Description of the changes proposed in this pull request:
- use `np.array.item()` for scalar arrays instead of casting them via `float`


## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
