### PR TITLE
ENH: add logging.info when background data is sub-sampled (closes #3461)

### DIFF
--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -54,7 +54,7 @@ class Tabular(Masker):
             data = np.expand_dims(data["mean"], 0)
 
         if hasattr(data, "shape") and data.shape[0] > max_samples:
-            log.info(
+            log.warning(
                 "Background dataset has %d samples but max_samples=%d. "
                 "Subsampling to %d samples for SHAP value computation. "
                 "To use all samples, set max_samples=%d when initializing the masker.",

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -54,6 +54,15 @@ class Tabular(Masker):
             data = np.expand_dims(data["mean"], 0)
 
         if hasattr(data, "shape") and data.shape[0] > max_samples:
+            log.info(
+                "Background dataset has %d samples but max_samples=%d. "
+                "Subsampling to %d samples for SHAP value computation. "
+                "To use all samples, set max_samples=%d when initializing the masker.",
+                data.shape[0],
+                max_samples,
+                max_samples,
+                data.shape[0],
+            )
             data = utils.sample(data, max_samples)
 
         self.data = data

--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -1,5 +1,6 @@
 """This file contains tests for the Tabular maskers."""
 
+import logging
 import tempfile
 
 import numpy as np
@@ -241,3 +242,15 @@ def test_independent_masker_with_small_data():
     # Should keep all data
     assert masker.data.shape[0] == 5
     assert masker.data.shape[1] == 3
+
+
+def test_subsampling_warning_when_data_exceeds_max_samples(caplog):
+    """Test that a warning is logged when background data is subsampled."""
+    data = np.random.randn(200, 5)
+
+    with caplog.at_level(logging.WARNING, logger="shap"):
+        shap.maskers.Independent(data, max_samples=50)
+
+    assert len(caplog.records) == 1
+    assert "200" in caplog.records[0].message
+    assert "max_samples=50" in caplog.records[0].message


### PR DESCRIPTION
Closes #3461

Adds a logging.info() message when the background dataset 
is larger than max_samples and sub-sampling occurs. This 
improves transparency by informing users that their SHAP 
values are computed on a subset of the provided background 
data, and suggests how to avoid sub-sampling if desired.

Note: logging infrastructure (import logging, log = 
logging.getLogger("shap")) was already present in the file.