### PR TITLE
update LightGBM links

### DIFF
--- a/docs/notebooks/plots/decision_plot.html
+++ b/docs/notebooks/plots/decision_plot.html
@@ -13226,7 +13226,7 @@ $( document ).ready(function(){
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h2 id="Load-the-dataset-and-train-the-model">Load the dataset and train the model<a class="anchor-link" href="#Load-the-dataset-and-train-the-model">&#182;</a></h2><p>For most of the examples, we empoy a <a href="https://github.com/microsoft/LightGBM">LightGBM</a> model trained on the <a href="https://archive.ics.uci.edu/ml/datasets/adult">UCI Adult Income</a> data set. The objective: predict whether an individual makes over $50K per year.</p>
+<h2 id="Load-the-dataset-and-train-the-model">Load the dataset and train the model<a class="anchor-link" href="#Load-the-dataset-and-train-the-model">&#182;</a></h2><p>For most of the examples, we empoy a <a href="https://github.com/lightgbm-org/LightGBM">LightGBM</a> model trained on the <a href="https://archive.ics.uci.edu/ml/datasets/adult">UCI Adult Income</a> data set. The objective: predict whether an individual makes over $50K per year.</p>
 
 </div>
 </div>

--- a/notebooks/api_examples/plots/decision_plot.ipynb
+++ b/notebooks/api_examples/plots/decision_plot.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "source": [
     "### Load the dataset and train the model\n",
-    "For most of the examples, we empoy a [LightGBM](https://github.com/microsoft/LightGBM) model trained on the [UCI Adult Income](https://archive.ics.uci.edu/ml/datasets/adult) data set. The objective: predict whether an individual makes over $50K per year."
+    "For most of the examples, we empoy a [LightGBM](https://github.com/lightgbm-org/LightGBM) model trained on the [UCI Adult Income](https://archive.ics.uci.edu/ml/datasets/adult) data set. The objective: predict whether an individual makes over $50K per year."
    ]
   },
   {

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -681,7 +681,7 @@ def rank() -> tuple[ssp.csr_matrix, np.ndarray, ssp.csr_matrix, np.ndarray, np.n
 
     Notes
     -----
-    Data Source: LightGBM repository https://github.com/microsoft/LightGBM/tree/master/examples/lambdarank
+    Data Source: LightGBM repository https://github.com/lightgbm-org/LightGBM/tree/master/examples/lambdarank
 
     Examples
     --------
@@ -690,7 +690,7 @@ def rank() -> tuple[ssp.csr_matrix, np.ndarray, ssp.csr_matrix, np.ndarray, np.n
         x_train, y_train, x_test, y_test, q_train, q_test = shap.datasets.rank()
 
     """
-    rank_data_url = "https://raw.githubusercontent.com/Microsoft/LightGBM/master/examples/lambdarank/"
+    rank_data_url = "https://raw.githubusercontent.com/lightgbm-org/LightGBM/master/examples/lambdarank/"
     x_train, y_train = sklearn.datasets.load_svmlight_file(cache(rank_data_url + "rank.train"))
     x_test, y_test = sklearn.datasets.load_svmlight_file(cache(rank_data_url + "rank.test"))
     q_train = np.loadtxt(cache(rank_data_url + "rank.train.query"))

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1988,7 +1988,7 @@ class SingleTree:
                     # We should be technically be assigning the number of samples used to
                     # train the model as the weight here, but unfortunately this info is
                     # currently unavailable in `tree`, so we set to 0 first.
-                    # cf. https://github.com/microsoft/LightGBM/issues/5962
+                    # cf. https://github.com/lightgbm-org/LightGBM/issues/5962
                     self.node_sample_weight[vleaf_idx] = vertex.get("leaf_count", 0)
             self.values = np.asarray(self.values)
             self.values = np.multiply(self.values, scaling)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -908,7 +908,7 @@ class TestSingleTree:
             "shrinkage": 1,
             "tree_structure": {
                 "leaf_value": 0,
-                # "leaf_count": 123,  # FIXME(upstream): microsoft/LightGBM#5962
+                # "leaf_count": 123,  # FIXME(upstream): lightgbm-org/LightGBM#5962
             },
         }
         stree = SingleTree(sample_tree)


### PR DESCRIPTION
## Overview

LightGBM has moved out of `Microsoft/` to its own organization: https://github.com/lightgbm-org/LightGBM/issues/7187

This updates links in this project to reflect that.

Thanks for helping people use LightGBM!

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
