### PR TITLE
Release GIL during C++ TreeSHAP computation

### DIFF
--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -221,7 +221,9 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     );
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, R, R_missing, num_X, M, num_R);
 
+    Py_BEGIN_ALLOW_THREADS
     dense_tree_shap(trees, data, out_contribs, feature_dependence, model_output, interactions);
+    Py_END_ALLOW_THREADS
 
     // retrieve return value before python cleanup of objects
     tfloat ret_value = (double)values[0];
@@ -346,7 +348,9 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     );
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
 
+    Py_BEGIN_ALLOW_THREADS
     dense_tree_predict(out_pred, trees, data, model_output);
+    Py_END_ALLOW_THREADS
 
     // clean up the created python objects
     Py_XDECREF(children_left_array);
@@ -445,7 +449,9 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     );
     ExplanationDataset data = ExplanationDataset(X, X_missing, NULL, NULL, NULL, num_X, M, 0);
 
+    Py_BEGIN_ALLOW_THREADS
     dense_tree_update_weights(trees, data);
+    Py_END_ALLOW_THREADS
 
     // clean up the created python objects
     Py_XDECREF(children_left_array);
@@ -557,7 +563,9 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     );
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
 
+    Py_BEGIN_ALLOW_THREADS
     dense_tree_saabas(out_pred, trees, data);
+    Py_END_ALLOW_THREADS
 
     // clean up the created python objects
     Py_XDECREF(children_left_array);

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -1115,6 +1115,9 @@ inline void print_progress_bar(tfloat &last_print, tfloat start_time, unsigned i
         const double total_seconds = elapsed_seconds / fraction;
         last_print = elapsed_seconds;
 
+        // Re-acquire the GIL for Python stderr calls (may be called without GIL held)
+        PyGILState_STATE gstate = PyGILState_Ensure();
+
         PySys_WriteStderr(
             "\r%3.0f%%|%.*s%.*s| %d/%d [%02d:%02d<%02d:%02d]       ",
             fraction * 100, int(0.5 + fraction*20), "===================",
@@ -1130,6 +1133,8 @@ inline void print_progress_bar(tfloat &last_print, tfloat start_time, unsigned i
             PyObject *result = PyObject_CallMethod(pyStderr, "flush", NULL);
             Py_XDECREF(result);
         }
+
+        PyGILState_Release(gstate);
     }
 }
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2972,3 +2972,44 @@ def test_path_dependent_small_background():
     for c in range(3):
         shap_sum = explainer.expected_value[c] + sv[:, :, c].sum(axis=1)
         np.testing.assert_allclose(shap_sum, pred[:, c], atol=1e-6)
+
+
+def test_gil_released_during_shap_computation():
+    """GIL is released during C++ SHAP computation, allowing other threads to run.
+
+    Previously, the GIL was held for the entire duration of the C++ call,
+    blocking all other Python threads. Addresses #4162.
+    """
+    import threading
+    import time
+
+    np.random.seed(0)
+    X = np.random.randn(500, 10)
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    model = RandomForestClassifier(n_estimators=100, max_depth=8, random_state=0)
+    model.fit(X, y)
+
+    counter_ticks = 0
+    shap_done = threading.Event()
+
+    def counter():
+        nonlocal counter_ticks
+        while not shap_done.is_set():
+            counter_ticks += 1
+            time.sleep(0.005)
+
+    def shap_compute():
+        explainer = shap.TreeExplainer(model)
+        explainer.shap_values(X)
+        shap_done.set()
+
+    t1 = threading.Thread(target=counter)
+    t2 = threading.Thread(target=shap_compute)
+    t1.start()
+    t2.start()
+    t2.join(timeout=30)
+    t1.join(timeout=1)
+
+    # If GIL is released, counter thread runs concurrently and gets many ticks.
+    # If GIL is held, counter is starved and gets 0-1 ticks.
+    assert counter_ticks > 5, f"Counter only ticked {counter_ticks} times — GIL likely not released"


### PR DESCRIPTION
## Summary

- The C extension holds the GIL for the entire duration of TreeSHAP computation, blocking all other Python threads
- This makes SHAP unusable in threaded applications — concurrent Python work is completely starved until the SHAP call completes
- Fix: wrap all four C++ entry points in `_cext.cc` with `Py_BEGIN_ALLOW_THREADS` / `Py_END_ALLOW_THREADS`
- The progress bar in `print_progress_bar()` (`tree_shap.h`) re-acquires the GIL via `PyGILState_Ensure`/`Release` for its `PySys_WriteStderr` calls

### Changes

| File | Change |
|------|--------|
| `shap/cext/_cext.cc` | `Py_BEGIN/END_ALLOW_THREADS` around `dense_tree_shap`, `dense_tree_predict`, `dense_tree_update_weights`, `dense_tree_saabas` |
| `shap/cext/tree_shap.h` | `PyGILState_Ensure`/`Release` in `print_progress_bar()` around Python API calls |

Addresses #4162

## Test plan

- [x] `test_gil_released_during_shap_computation` — runs a counter thread alongside SHAP computation, asserts counter gets >5 ticks (would get 0-1 if GIL held)
- [x] Full test suite: 113 passed, 1 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)