### PR TITLE
Add OpenMP parallelization for path-dependent TreeSHAP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,15 @@ def run_setup(*, with_binary, with_cuda):
     ext_modules = []
     if with_binary:
         compile_args = []
+        link_args = []
         if sys.platform == "zos":
             compile_args.append("-qlonglong")
         if sys.platform == "win32":
             compile_args.append("/MD")
+            compile_args.append("/openmp")
+        else:
+            compile_args.append("-fopenmp")
+            link_args.append("-fopenmp")
 
         ext_modules.append(
             Extension(
@@ -111,6 +116,7 @@ def run_setup(*, with_binary, with_cuda):
                 sources=["shap/cext/_cext.cc"],
                 include_dirs=[np.get_include()],
                 extra_compile_args=compile_args,
+                extra_link_args=link_args,
             )
         )
     if with_cuda:

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -11,6 +11,9 @@
 #include <stdio.h>
 #include <cmath>
 #include <ctime>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 #if defined(_WIN32) || defined(WIN32)
     #include <malloc.h>
 #elif defined(__MVS__)
@@ -1286,25 +1289,29 @@ inline void dense_independent(const TreeEnsemble& trees, const ExplanationDatase
  */
 inline void dense_tree_path_dependent(const TreeEnsemble& trees, const ExplanationDataset &data,
                                tfloat *out_contribs, tfloat transform(const tfloat, const tfloat)) {
-    tfloat *instance_out_contribs;
-    TreeEnsemble tree;
-    ExplanationDataset instance;
 
     // build explanation for each sample
-    for (unsigned i = 0; i < data.num_X; ++i) {
-        instance_out_contribs = out_contribs + static_cast<unsigned long long>(i) * (data.M + 1) * trees.num_outputs;
-        data.get_x_instance(instance, i);
+    #pragma omp parallel
+    {
+        TreeEnsemble tree;
+        ExplanationDataset instance;
 
-        // aggregate the effect of explaining each tree
-        // (this works because of the linearity property of Shapley values)
-        for (unsigned j = 0; j < trees.tree_limit; ++j) {
-            trees.get_tree(tree, j);
-            tree_shap(tree, instance, instance_out_contribs, 0, 0);
-        }
+        #pragma omp for schedule(dynamic, 1)
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            tfloat *instance_out_contribs = out_contribs + static_cast<unsigned long long>(i) * (data.M + 1) * trees.num_outputs;
+            data.get_x_instance(instance, i);
 
-        // apply the base offset to the bias term
-        for (unsigned j = 0; j < trees.num_outputs; ++j) {
-            instance_out_contribs[data.M * trees.num_outputs + j] += trees.base_offset[j];
+            // aggregate the effect of explaining each tree
+            // (this works because of the linearity property of Shapley values)
+            for (unsigned j = 0; j < trees.tree_limit; ++j) {
+                trees.get_tree(tree, j);
+                tree_shap(tree, instance, instance_out_contribs, 0, 0);
+            }
+
+            // apply the base offset to the bias term
+            for (unsigned j = 0; j < trees.num_outputs; ++j) {
+                instance_out_contribs[data.M * trees.num_outputs + j] += trees.base_offset[j];
+            }
         }
     }
 }
@@ -1348,62 +1355,67 @@ inline void dense_tree_interactions_path_dependent(const TreeEnsemble& trees, co
     }
 
     // build an interaction explanation for each sample
-    tfloat *instance_out_contribs;
-    TreeEnsemble tree;
-    ExplanationDataset instance;
     const unsigned contrib_row_size = (data.M + 1) * trees.num_outputs;
-    tfloat *diag_contribs = new tfloat[contrib_row_size];
-    tfloat *on_contribs = new tfloat[contrib_row_size];
-    tfloat *off_contribs = new tfloat[contrib_row_size];
-    for (unsigned i = 0; i < data.num_X; ++i) {
-        instance_out_contribs = out_contribs + i * (data.M + 1) * contrib_row_size;
-        data.get_x_instance(instance, i);
 
-        // aggregate the effect of explaining each tree
-        // (this works because of the linearity property of Shapley values)
-        std::fill(diag_contribs, diag_contribs + contrib_row_size, 0);
-        for (unsigned j = 0; j < trees.tree_limit; ++j) {
-            trees.get_tree(tree, j);
-            tree_shap(tree, instance, diag_contribs, 0, 0);
+    #pragma omp parallel
+    {
+        TreeEnsemble tree;
+        ExplanationDataset instance;
+        tfloat *diag_contribs = new tfloat[contrib_row_size];
+        tfloat *on_contribs = new tfloat[contrib_row_size];
+        tfloat *off_contribs = new tfloat[contrib_row_size];
 
-            const int *unique_features_row = unique_features + j * amount_of_unique_features;
-            for (unsigned k = 0; k < amount_of_unique_features; ++k) {
-                const int ind = unique_features_row[k];
-                if (ind < 0) break; // < 0 means we have seen all the features for this tree
+        #pragma omp for schedule(dynamic, 1)
+        for (unsigned i = 0; i < data.num_X; ++i) {
+            tfloat *instance_out_contribs = out_contribs + static_cast<unsigned long long>(i) * (data.M + 1) * contrib_row_size;
+            data.get_x_instance(instance, i);
 
-                // compute the shap value with this feature held on and off
-                std::fill(on_contribs, on_contribs + contrib_row_size, 0);
-                std::fill(off_contribs, off_contribs + contrib_row_size, 0);
-                tree_shap(tree, instance, on_contribs, 1, ind);
-                tree_shap(tree, instance, off_contribs, -1, ind);
+            // aggregate the effect of explaining each tree
+            // (this works because of the linearity property of Shapley values)
+            std::fill(diag_contribs, diag_contribs + contrib_row_size, 0);
+            for (unsigned j = 0; j < trees.tree_limit; ++j) {
+                trees.get_tree(tree, j);
+                tree_shap(tree, instance, diag_contribs, 0, 0);
 
-                // save the difference between on and off as the interaction value
-                for (unsigned l = 0; l < contrib_row_size; ++l) {
-                    const tfloat val = (on_contribs[l] - off_contribs[l]) / 2;
-                    instance_out_contribs[ind * contrib_row_size + l] += val;
-                    diag_contribs[l] -= val;
+                const int *unique_features_row = unique_features + j * amount_of_unique_features;
+                for (unsigned k = 0; k < amount_of_unique_features; ++k) {
+                    const int ind = unique_features_row[k];
+                    if (ind < 0) break; // < 0 means we have seen all the features for this tree
+
+                    // compute the shap value with this feature held on and off
+                    std::fill(on_contribs, on_contribs + contrib_row_size, 0);
+                    std::fill(off_contribs, off_contribs + contrib_row_size, 0);
+                    tree_shap(tree, instance, on_contribs, 1, ind);
+                    tree_shap(tree, instance, off_contribs, -1, ind);
+
+                    // save the difference between on and off as the interaction value
+                    for (unsigned l = 0; l < contrib_row_size; ++l) {
+                        const tfloat val = (on_contribs[l] - off_contribs[l]) / 2;
+                        instance_out_contribs[ind * contrib_row_size + l] += val;
+                        diag_contribs[l] -= val;
+                    }
                 }
             }
-        }
 
-        // set the diagonal
-        for (unsigned j = 0; j < data.M + 1; ++j) {
-            const unsigned offset = j * contrib_row_size + j * trees.num_outputs;
-            for (unsigned k = 0; k < trees.num_outputs; ++k) {
-                instance_out_contribs[offset + k] = diag_contribs[j * trees.num_outputs + k];
+            // set the diagonal
+            for (unsigned j = 0; j < data.M + 1; ++j) {
+                const unsigned offset = j * contrib_row_size + j * trees.num_outputs;
+                for (unsigned k = 0; k < trees.num_outputs; ++k) {
+                    instance_out_contribs[offset + k] = diag_contribs[j * trees.num_outputs + k];
+                }
+            }
+
+            // apply the base offset to the bias term
+            const unsigned last_ind = (data.M * (data.M + 1) + data.M) * trees.num_outputs;
+            for (unsigned j = 0; j < trees.num_outputs; ++j) {
+                instance_out_contribs[last_ind + j] += trees.base_offset[j];
             }
         }
 
-        // apply the base offset to the bias term
-        const unsigned last_ind = (data.M * (data.M + 1) + data.M) * trees.num_outputs;
-        for (unsigned j = 0; j < trees.num_outputs; ++j) {
-            instance_out_contribs[last_ind + j] += trees.base_offset[j];
-        }
-    }
-
-    delete[] diag_contribs;
-    delete[] on_contribs;
-    delete[] off_contribs;
+        delete[] diag_contribs;
+        delete[] on_contribs;
+        delete[] off_contribs;
+    } // end omp parallel
     delete[] unique_features;
 }
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3001,9 +3001,11 @@ def test_openmp_path_dependent():
         else:
             os.environ["OMP_NUM_THREADS"] = old_val
 
-    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10,
-                               err_msg="Path-dependent SHAP values differ between 1 and 4 threads")
-    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10,
-                               err_msg="Path-dependent interaction values differ between 1 and 4 threads")
+    np.testing.assert_allclose(
+        sv_1, sv_4, atol=1e-10, err_msg="Path-dependent SHAP values differ between 1 and 4 threads"
+    )
+    np.testing.assert_allclose(
+        iv_1, iv_4, atol=1e-10, err_msg="Path-dependent interaction values differ between 1 and 4 threads"
+    )
     # Verify symmetry
     np.testing.assert_allclose(iv_4, np.swapaxes(iv_4, 1, 2), atol=1e-10)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2972,3 +2972,38 @@ def test_path_dependent_small_background():
     for c in range(3):
         shap_sum = explainer.expected_value[c] + sv[:, :, c].sum(axis=1)
         np.testing.assert_allclose(shap_sum, pred[:, c], atol=1e-6)
+
+
+def test_openmp_path_dependent():
+    """Multi-threaded path-dependent SHAP values should match single-threaded."""
+    import os
+
+    np.random.seed(42)
+    X = np.random.randn(200, 8)
+    y = X[:, 0] * X[:, 1] + X[:, 2]
+    model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=42)
+    model.fit(X, y)
+
+    old_val = os.environ.get("OMP_NUM_THREADS")
+    try:
+        os.environ["OMP_NUM_THREADS"] = "1"
+        ex1 = shap.TreeExplainer(model)
+        sv_1 = ex1.shap_values(X[:50])
+        iv_1 = ex1.shap_interaction_values(X[:20])
+
+        os.environ["OMP_NUM_THREADS"] = "4"
+        ex4 = shap.TreeExplainer(model)
+        sv_4 = ex4.shap_values(X[:50])
+        iv_4 = ex4.shap_interaction_values(X[:20])
+    finally:
+        if old_val is None:
+            os.environ.pop("OMP_NUM_THREADS", None)
+        else:
+            os.environ["OMP_NUM_THREADS"] = old_val
+
+    np.testing.assert_allclose(sv_1, sv_4, atol=1e-10,
+                               err_msg="Path-dependent SHAP values differ between 1 and 4 threads")
+    np.testing.assert_allclose(iv_1, iv_4, atol=1e-10,
+                               err_msg="Path-dependent interaction values differ between 1 and 4 threads")
+    # Verify symmetry
+    np.testing.assert_allclose(iv_4, np.swapaxes(iv_4, 1, 2), atol=1e-10)


### PR DESCRIPTION
## Summary

- The path-dependent sample loops in `dense_tree_path_dependent()` and `dense_tree_interactions_path_dependent()` run sequentially, using only one CPU core
- Both loops are embarrassingly parallel — each sample writes to a disjoint output region
- Add `#pragma omp parallel for` with per-thread workspace allocations (`TreeEnsemble`, `ExplanationDataset`, and for interactions: `diag_contribs`, `on_contribs`, `off_contribs`) and `schedule(dynamic, 1)` for load balancing
- Also adds `-fopenmp` compile/link flags to `setup.py` and guarded `#include <omp.h>`

### Changes

| File | Change |
|------|--------|
| `shap/cext/tree_shap.h` | OpenMP parallel regions in `dense_tree_path_dependent()` and `dense_tree_interactions_path_dependent()`, `#include <omp.h>` |
| `setup.py` | `-fopenmp` compile/link flags (Linux/macOS), `/openmp` (Windows) |

## Test plan

- [x] `test_openmp_path_dependent` — 1-thread vs 4-thread SHAP values and interaction values match within `atol=1e-10`, interaction symmetry verified
- [x] Full test suite: 113 passed, 1 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)