### PR TITLE
Fix deprecated NumPy dtype aliases in test_kernel.py

### DIFF
--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -377,7 +377,7 @@ def test_kernel_logits_zeros_ones_probs(nsamples):
     np.testing.assert_allclose(sigm(shap_values.values.sum(1) + explainer.expected_value), pred, atol=1e-04)
 
 
-@pytest.mark.parametrize("dt", [np.bool_, np.object_])
+@pytest.mark.parametrize("dt", [bool, object])
 def test_explainer_non_number_dtype(dt):
     seed = 45479
     rng = np.random.default_rng(seed)


### PR DESCRIPTION
## Summary
- Replaced deprecated `np.bool_` and `np.object_` aliases with built-in `bool` and `object` in `tests/explainers/test_kernel.py`
- These aliases have been deprecated since NumPy 1.20 and will be removed in a future version

## Test plan
- [ ] Run `pytest tests/explainers/test_kernel.py` to verify tests still pass
- [ ] Confirm no NumPy deprecation warnings for dtype aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)