### PR TITLE
Re-enable causalml tests 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,7 @@ test = [
   # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
   # See GH #3707, #3768, 3922
   "numpy>=2.0",
-  "numba==0.63.0", # needed since causalml fails when importing causalml.datasets when built with numba==0.63.1, see https://github.com/uber/causalml/issues/859
-  # "scikit-learn<=1.6.1",  # needed since causalml doesn't support scikit-learn 1.7.0 and above as of 2025-06-11
-  "causalml",
+  "causalml>=0.15.5",
   "selenium",  # needed to test the javascript based plots
 ]
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2196,7 +2196,6 @@ def test_overflow_tree_path_dependent():
     exp(X)
 
 
-@pytest.mark.skip("Currently disabled due to errors, see https://github.com/uber/causalml/issues/859.")
 @pytest.mark.parametrize(
     "n_estimators",
     [


### PR DESCRIPTION
Fixes #4237

The upstream Cython import bug  that was breaking our tests has been fixed in causalml 0.15.5.

This PR:
Unskips the causalml test
Pins causalml >= 0.15.5
Removes the numba == 0.63.0 workaround since it's no longer needed
Removes the stale scikit-learn version comment