### PR TITLE
Fix sparse input crash in TreeExplainer 

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -13,6 +13,7 @@ import numpy.typing as npt
 import pandas as pd
 import scipy.sparse
 import scipy.special
+from scipy.sparse import issparse
 from packaging import version
 
 from .. import maskers
@@ -463,7 +464,11 @@ class TreeExplainer(Explainer):
             X = X.reshape(1, X.shape[0])
         if X.dtype != self.model.input_dtype:
             X = X.astype(self.model.input_dtype)
-        X_missing = np.isnan(X, dtype=bool)
+        if issparse(X):
+            X = X.toarray()
+            X_missing = np.isnan(X)
+        else:
+            X_missing = np.isnan(X)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 
@@ -1684,7 +1689,12 @@ class TreeEnsemble:
             X = X.reshape(1, X.shape[0])
         if X.dtype.type != self.input_dtype:
             X = X.astype(self.input_dtype)
-        X_missing = np.isnan(X, dtype=bool)
+        from scipy.sparse import issparse
+
+        if issparse(X):
+            X_missing = np.zeros(X.shape, dtype=bool)
+        else:
+            X_missing = np.isnan(X)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -13,8 +13,8 @@ import numpy.typing as npt
 import pandas as pd
 import scipy.sparse
 import scipy.special
-from scipy.sparse import issparse
 from packaging import version
+from scipy.sparse import issparse
 
 from .. import maskers
 from .._explanation import Explanation

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -466,9 +466,7 @@ class TreeExplainer(Explainer):
             X = X.astype(self.model.input_dtype)
         if issparse(X):
             X = X.toarray()
-            X_missing = np.isnan(X)
-        else:
-            X_missing = np.isnan(X)
+        X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 
@@ -1689,12 +1687,11 @@ class TreeEnsemble:
             X = X.reshape(1, X.shape[0])
         if X.dtype.type != self.input_dtype:
             X = X.astype(self.input_dtype)
-        from scipy.sparse import issparse
-
         if issparse(X):
+            X = X.toarray()
             X_missing = np.zeros(X.shape, dtype=bool)
         else:
-            X_missing = np.isnan(X)
+            X_missing = np.isnan(X, dtype=bool)
         assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
         assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
 

--- a/tests/explainers/test_tree_sparse.py
+++ b/tests/explainers/test_tree_sparse.py
@@ -1,7 +1,9 @@
-import shap
 import numpy as np
 from scipy.sparse import csr_matrix
 from sklearn.ensemble import RandomForestClassifier
+
+import shap
+
 
 def test_sparse_input_tree_explainer():
     X = csr_matrix(np.random.randint(0, 2, (10, 5)))

--- a/tests/explainers/test_tree_sparse.py
+++ b/tests/explainers/test_tree_sparse.py
@@ -1,0 +1,15 @@
+import shap
+import numpy as np
+from scipy.sparse import csr_matrix
+from sklearn.ensemble import RandomForestClassifier
+
+def test_sparse_input_tree_explainer():
+    X = csr_matrix(np.random.randint(0, 2, (10, 5)))
+    y = np.random.randint(0, 2, 10)
+
+    model = RandomForestClassifier().fit(X, y)
+    explainer = shap.TreeExplainer(model)
+
+    shap_values = explainer.shap_values(X)
+
+    assert isinstance(shap_values, np.ndarray)


### PR DESCRIPTION
Fixes #4256

## Summary
This PR fixes a crash when passing sparse matrices (e.g., CSR matrices from scikit-learn) to `TreeExplainer.shap_values`.

Previously, calling `shap_values` with sparse inputs resulted in:
- `UFuncTypeError` due to `np.isnan` being applied to unsupported types
- `AssertionError` due to strict `np.ndarray` type checks

## Root Cause
- Sparse matrices are not supported by `np.isnan`
- SHAP internally assumes dense `numpy.ndarray` inputs
- `_validate_inputs` does not handle sparse inputs before applying these operations

## Fix
- Detect sparse inputs using `scipy.sparse.issparse`
- Convert sparse matrices to dense arrays using `.toarray()` before further processing
- Ensure compatibility with existing SHAP internal expectations