### PR TITLE
DOCS: Fix Python installation version from 3.11 to 3.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ green `<> Code` button on your projects home page.
 Create a new isolated environment for the project, e.g. with conda:
 
 ```bash
-conda create -n shap python=3.11
+conda create -n shap python=3.12
 conda activate shap
 ```
 


### PR DESCRIPTION
Updated Python version in conda environment setup docs

``` pip install --editable '.[test,plots,docs]'```
Build will fail if using 3.11.
Because its a trivial fix, didn't open Issue


## Checklist

- [✓ ] All [pre-commit checks](https://pre-commit.com/#install) pass.

