### PR TITLE
Improve DimensionError message in force_plot for mismatched input shapes

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -179,7 +179,16 @@ def force(
                     " You might be using an old format shap_values array with the base value "
                     "as the last column. In this case, just pass the array without the last column."
                 )
-            raise DimensionError(emsg)
+            raise DimensionError(
+                f"{emsg}\n\n"
+                f"Details:\n"
+                f"- Number of features provided: {len(features)}\n"
+                f"- Number of SHAP values: {shap_values.shape[1]}\n\n"
+                f"Possible fixes:\n"
+                f"- Ensure features match the same sample used to compute SHAP values\n"
+                f"- For multi-class models, select the correct class index (e.g., shap_values[i])\n"
+                f"- Ensure you are passing a single sample (not the full dataset)\n"
+            )
 
         instance = Instance(np.zeros((1, len(feature_names))), features)
         e = AdditiveExplanation(


### PR DESCRIPTION
## Overview

Closes #4127

Improves the error handling when feature and SHAP value dimensions do not match in `force_plot`.

---

## Description of the changes proposed in this pull request

* Enhanced the `DimensionError` message in `shap/plots/_force.py`
* Added detailed information about:

  * Number of features provided
  * Number of SHAP values
* Included helpful suggestions to resolve common issues such as:

  * Mismatched input shapes
  * Incorrect class selection in multi-class models
  * Passing full dataset instead of a single sample

This change improves the developer experience by making debugging easier without altering existing functionality.

---

## Checklist

* [x] All pre-commit checks pass (locally tested)
* [ ] Unit tests added (not required for this change)
