### PR TITLE
Fix NameError when with_binary=False and with_cuda=True by initializing compile_args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,9 @@ def compile_cuda_module(host_args):
 
 def run_setup(*, with_binary, with_cuda):
     ext_modules = []
+    compile_args = []   # initialize here so it always exists
+
     if with_binary:
-        compile_args = []
         if sys.platform == "zos":
             compile_args.append("-qlonglong")
         if sys.platform == "win32":
@@ -113,6 +114,7 @@ def run_setup(*, with_binary, with_cuda):
                 extra_compile_args=compile_args,
             )
         )
+
     if with_cuda:
         try:
             cuda_home, _ = get_cuda_path()
@@ -137,7 +139,6 @@ def run_setup(*, with_binary, with_cuda):
             )
         except Exception as e:
             raise Exception("Error building cuda module: " + repr(e)) from e
-
     ext_modules.append(
         Extension("_kernel_lib", sources=["shap/explainers/_kernel_lib.pyx"], include_dirs=[np.get_include()])
     )

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ def compile_cuda_module(host_args):
 
 def run_setup(*, with_binary, with_cuda):
     ext_modules = []
-    compile_args = []   # initialize here so it always exists
+    compile_args = []  # initialize here so it always exists
 
     if with_binary:
         if sys.platform == "zos":


### PR DESCRIPTION
…ng compile_args

## Overview
Fixes a bug in setup.py where `compile_args` was only initialized inside the
`if with_binary:` block but later used inside the `if with_cuda:` block.

When `with_binary=False` and `with_cuda=True`, this caused:
NameError: name 'compile_args' is not defined.

This PR initializes `compile_args` at the beginning of the function so it is
always defined regardless of configuration.

Closes #4321 
## Overview
Fixes a bug in setup.py where `compile_args` was only initialized inside the
`if with_binary:` block but later used inside the `if with_cuda:` block.

When `with_binary=False` and `with_cuda=True`, this caused:
NameError: name 'compile_args' is not defined.

This PR initializes `compile_args` at the beginning of the function so it is
always defined regardless of configuration.



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
