### PR TITLE
FIX: correct NaN branch routing in GPU TreeSHAP

### DIFF
--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -76,19 +76,20 @@ void RecurseTree(
 
   // Add left split to the path
   unsigned left_child = tree.children_left[pos];
+  bool is_left_default = tree.children_default[pos] == left_child;
   double left_zero_fraction =
       tree.node_sample_weights[left_child] / tree.node_sample_weights[pos];
   // Encode the range of feature values that flow down this path
   tmp_path->emplace_back(0, tree.features[pos], 0,
-                         ShapSplitCondition{-inf, tree.thresholds[pos], false},
+                         ShapSplitCondition{-inf, tree.thresholds[pos], is_left_default},
                          left_zero_fraction, 0.0f);
 
   RecurseTree(left_child, tree, tmp_path, paths, path_idx, num_outputs);
 
-  // Add left split to the path
+  // Add right split to the path
   tmp_path->back() = gpu_treeshap::PathElement<ShapSplitCondition>(
       0, tree.features[pos], 0,
-      ShapSplitCondition{tree.thresholds[pos], inf, false},
+      ShapSplitCondition{tree.thresholds[pos], inf, !is_left_default},
       1.0 - left_zero_fraction, 0.0f);
 
   RecurseTree(tree.children_right[pos], tree, tmp_path, paths, path_idx,

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -242,6 +242,33 @@ def test_gpu_tree_explainer_shap(task, feature_perturbation):
 
 
 @pytest.mark.parametrize("task", tasks, ids=idfn)
+@pytest.mark.parametrize("feature_perturbation", ["interventional", "tree_path_dependent"])
+def test_gpu_tree_explainer_shap_nan(task, feature_perturbation):
+    """Test that GPU TreeSHAP handles NaN inputs correctly by comparing to CPU."""
+    model, X, _ = task
+    gpu_ex = shap.GPUTreeExplainer(model, X, feature_perturbation=feature_perturbation)
+    ex = shap.TreeExplainer(model, X, feature_perturbation=feature_perturbation)
+
+    # Mask a random subset of input values with NaN
+    rng = np.random.RandomState(42)
+    X_nan = X.copy()
+    nan_col = rng.choice(X_nan.shape[1], 1, replace=False)
+    nan_row = rng.choice(X_nan.shape[0], max(1, int(0.1 * X_nan.shape[0])), replace=False)
+    X_nan[nan_row, nan_col] = np.nan
+
+    host_shap_nan = ex.shap_values(X_nan, check_additivity=True)
+    gpu_shap_nan = gpu_ex.shap_values(X_nan, check_additivity=True)
+
+    # Normalize shape for multiclass
+    if np.array(gpu_shap_nan).ndim == 3:
+        gpu_shap_nan = np.moveaxis(np.array(gpu_shap_nan), [0, 1, 2], [2, 0, 1])
+    else:
+        gpu_shap_nan = np.array(gpu_shap_nan, copy=False)
+
+    assert np.allclose(host_shap_nan, gpu_shap_nan, 1e-3, 1e-3), "SHAP values don't match when input has NaNs!"
+
+
+@pytest.mark.parametrize("task", tasks, ids=idfn)
 @pytest.mark.parametrize("feature_perturbation", ["tree_path_dependent"])
 def test_gpu_tree_explainer_shap_interactions(task, feature_perturbation):
     model, X, margin = task


### PR DESCRIPTION
## Overview
Closes #3936 (partially — addresses the NaN handling bug)

Related to #4182 (GPUTreeExplainer tracker)

## Problem

I was looking into the GPU TreeSHAP issues tracked in #4182 and noticed that `RecurseTree()` in `_cext_gpu.cu` hardcodes `is_missing_branch = false` for both left and right child splits. This means `EvaluateSplit()` always returns `false` for NaN inputs:

## fix 
use children_default[pos] to figure out which child is the default for missing values, then pass that into ShapSplitCondition


## Tests
Added test_gpu_tree_explainer_shap_nan which:
* Takes each model fixture
* Runs both CPU and GPU TreeExplainer on the NaN'd data
* Checks that the SHAP values match within tolerance