### PR TITLE
ENH: add cross-links between API Reference and API Examples pages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,8 @@ Explanation
 
 explainers
 ----------
+*See also:* :ref:`Explainer API Examples <explainers_examples>`.
+
 .. autosummary::
     :toctree: generated/
 
@@ -49,6 +51,8 @@ explainers
 
 plots
 -----
+*See also:* :ref:`Plot API Examples <plots_examples>`.
+
 .. autosummary::
     :toctree: generated/
 
@@ -74,6 +78,8 @@ plots
 
 maskers
 -------
+*See also:* :ref:`Masker API Examples <maskers_examples>`.
+
 .. autosummary::
     :toctree: generated/
 

--- a/docs/api_examples.rst
+++ b/docs/api_examples.rst
@@ -20,7 +20,7 @@ are `available on GitHub <https://github.com/shap/shap/tree/master/notebooks/api
 
 explainers
 ==========
-.. Examples for members of :ref:`shap.explainers <explainers_api>`.
+*See also:* :ref:`Explainer API Reference <explainers_api>`.
 
 .. toctree::
     :glob:
@@ -33,7 +33,7 @@ explainers
 
 maskers
 =======
-.. Examples for members of :ref:`shap.maskers <maskers_api>`.
+*See also:* :ref:`Masker API Reference <maskers_api>`.
 
 .. toctree::
     :glob:
@@ -62,7 +62,7 @@ Work in progress.
 
 plots
 =====
-.. Examples for members of :ref:`shap.plots <plots_api>`.
+*See also:* :ref:`Plot API Reference <plots_api>`.
 
 .. toctree::
     :glob:

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -29,6 +29,10 @@ class ExactExplainer(Explainer):
     explainer minimizes the number of function evaluations needed by ordering the masking sets to
     minimize sequential differences. This is done using gray codes for standard Shapley values
     and a greedy sorting method for hclustering structured maskers.
+
+    Examples
+    --------
+    See `Exact explainer examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/explainers/Exact.html>`_
     """
 
     model: Model

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -22,7 +22,7 @@ class GPUTreeExplainer(TreeExplainer):
 
     Examples
     --------
-    See `GPUTree explainer examples <https://shap.readthedocs.io/en/latest/api_examples/explainers/GPUTreeExplainer.html>`_
+    See `GPUTree explainer examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/explainers/GPUTree.html>`_
 
     """
 

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -24,6 +24,10 @@ class PermutationExplainer(Explainer):
     model evaluations and the ability to efficiently avoid evaluating the model when the background values
     for a feature are the same as the current input value. We can also account for hierarchical data
     structures with partition trees, something not currently implemented for KernalExplainer or SamplingExplainer.
+
+    Examples
+    --------
+    See `Permutation explainer examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/explainers/Permutation.html>`_
     """
 
     def __init__(


### PR DESCRIPTION
## Overview

Closes #3171

When navigating the SHAP documentation, there's no easy way to jump between the API Reference and the corresponding API Examples pages. Users have to manually explore the sidebar, which is inconvenient especially since clicking a category heading changes the page completely.

This adds "See also" links so users can quickly jump between related pages.

- **`docs/api.rst`**: Added *See also* links under explainers, plots, and maskers sections pointing to their API Examples counterparts.
- **`docs/api_examples.rst`**: Converted hidden RST comments into visible *See also* links pointing back to the API Reference sections.
- **`shap/explainers/_exact.py`**: Added `Examples` section with a link to the Exact explainer notebook.
- **`shap/explainers/_permutation.py`**: Added `Examples` section with a link to the Permutation explainer notebook.
- **`shap/explainers/_gpu_tree.py`**: Fixed a broken URL in the existing `Examples` section (old link was returning 404).

The pattern follows the scikit-learn style suggested in the issue discussion, and is consistent with the `Examples` sections already present in other explainer and plot docstrings.

## Checklist

- [x] All pre-commit checks(https://pre-commit.com/install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)

No unit tests needed. This is a documentation-only change (docstrings + RST files).
