### PR TITLE
Add unit test for DimensionError in force_plot with mismatched inputs

### DIFF
--- a/tests/plots/test_force_plot.py
+++ b/tests/plots/test_force_plot.py
@@ -1,0 +1,13 @@
+import pytest
+import numpy as np
+import shap
+from shap.utils._exceptions import DimensionError
+
+
+def test_force_plot_dimension_mismatch():
+    base_value = 0.5
+    shap_values = np.array([1, 2, 3])
+    features = np.array([1, 2])  # mismatch
+
+    with pytest.raises(DimensionError):
+        shap.force_plot(base_value, shap_values, features, matplotlib=True)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,0 +1,41 @@
+import pytest
+
+try:
+    import tensorflow as tf
+    from shap.utils._keras import clone_keras_layers, split_keras_model
+    TF_AVAILABLE = True
+except ImportError:
+    TF_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
+
+
+def create_simple_model():
+    return tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(8, activation="relu"),
+        tf.keras.layers.Dense(2)
+    ])
+
+
+def test_clone_keras_layers_basic():
+    model = create_simple_model()
+    new_model = clone_keras_layers(model, 0, len(model.layers) - 1)
+
+    assert new_model is not None
+    assert isinstance(new_model, tf.keras.Model)
+
+
+def test_split_keras_model_basic():
+    model = create_simple_model()
+    model1, model2 = split_keras_model(model, 1)
+
+    assert isinstance(model1, tf.keras.Model)
+    assert isinstance(model2, tf.keras.Model)
+
+
+def test_split_keras_model_invalid_layer():
+    model = create_simple_model()
+
+    with pytest.raises(Exception):
+        split_keras_model(model, 100)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -2,7 +2,9 @@ import pytest
 
 try:
     import tensorflow as tf
+
     from shap.utils._keras import clone_keras_layers, split_keras_model
+
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
@@ -11,11 +13,9 @@ pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not install
 
 
 def create_simple_model():
-    return tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(8, activation="relu"),
-        tf.keras.layers.Dense(2)
-    ])
+    return tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(8, activation="relu"), tf.keras.layers.Dense(2)]
+    )
 
 
 def test_clone_keras_layers_basic():


### PR DESCRIPTION
## Overview

Related to #4127

This PR adds a unit test to reproduce the DimensionError raised when the number of features does not match the number of SHAP values in force_plot.

## Changes

* Added test for mismatched feature and SHAP value lengths in force_plot

## Checklist

* [x] All pre-commit checks pass.
* [x] Unit tests added
