### PR TITLE
ENH: Overhaul text plot styling and API (#3806)

### DIFF
--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 
+from .. import Explanation
 from . import colors
 
 try:
@@ -19,24 +20,26 @@ except ImportError:
 # TODO: we should support text output explanations (from models that output text not numbers), this would require the force
 # the force plot and the coloring to update based on mouseovers (or clicks to make it fixed) of the output text
 def text(
-    shap_values,
-    num_starting_labels=0,
-    grouping_threshold=0.01,
-    separator="",
-    xmin=None,
-    xmax=None,
-    cmax=None,
-    display=True,
+    shap_values: Explanation,
+    num_starting_labels: int = 0,
+    grouping_threshold: float = 0.01,
+    separator: str = "",
+    xmin: float | None = None,
+    xmax: float | None = None,
+    cmax: float | None = None,
+    display: bool = True,
 ):
     """Plots an explanation of a string of text using coloring and interactive labels.
 
     The output is interactive HTML and you can click on any token to toggle the display of the
     SHAP value assigned to that token.
+    Unlike Matplotlib-based plots, this function renders HTML and therefore does not
+    accept an ``ax`` argument.
 
     Parameters
     ----------
-    shap_values : [numpy.array]
-        List of arrays of SHAP values. Each array has the shap values for a string (#input_tokens x output_tokens).
+    shap_values : shap.Explanation
+        A :class:`.Explanation` object containing SHAP values for text tokens.
 
     num_starting_labels : int
         Number of tokens (sorted in descending order by corresponding SHAP values)
@@ -67,11 +70,19 @@ def text(
     display: bool
         Whether to display or return html to further manipulate or embed. Default: ``True``
 
+    Returns
+    -------
+    html: str or None
+        Returns the generated HTML string if ``display=False``. Otherwise returns ``None`` after display.
+
     Examples
     --------
     See `text plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/text.html>`_.
 
     """
+    if not isinstance(shap_values, Explanation):
+        emsg = "The text plot requires an `Explanation` object as the `shap_values` argument."
+        raise TypeError(emsg)
 
     def values_min_max(values, base_values):
         """Used to pick our axis limits."""
@@ -140,7 +151,11 @@ def text(
         for i in range(shap_values.shape[-1]):
             values, clustering = unpack_shap_explanation_contents(shap_values[:, i])
             tokens, values, group_sizes = process_shap_values(
-                shap_values[:, i].data, values, grouping_threshold, separator, clustering
+                shap_values[:, i].data,
+                values,
+                grouping_threshold,
+                separator,
+                clustering,
             )
 
             # if i == 0:
@@ -252,7 +267,11 @@ def text(
             for j in range(shap_values.shape[0]):
                 values, clustering = unpack_shap_explanation_contents(shap_values[j, :, i])
                 tokens, values, group_sizes = process_shap_values(
-                    shap_values[j, :, i].data, values, grouping_threshold, separator, clustering
+                    shap_values[j, :, i].data,
+                    values,
+                    grouping_threshold,
+                    separator,
+                    clustering,
                 )
 
                 xmin_i, xmax_i, cmax_i = values_min_max(values, shap_values[j, :, i].base_values)
@@ -375,7 +394,14 @@ def text(
         return out
 
 
-def process_shap_values(tokens, values, grouping_threshold, separator, clustering=None, return_meta_data=False):
+def process_shap_values(
+    tokens,
+    values,
+    grouping_threshold,
+    separator,
+    clustering=None,
+    return_meta_data=False,
+):
     # See if we got hierarchical input data. If we did then we need to reprocess the
     # shap_values and tokens to get the groups we want to display
     M = len(tokens)
@@ -490,7 +516,13 @@ def process_shap_values(tokens, values, grouping_threshold, separator, clusterin
         collapsed_node_ids = np.arange(M)
 
     if return_meta_data:
-        return tokens, values, group_sizes, token_id_to_node_id_mapping, collapsed_node_ids
+        return (
+            tokens,
+            values,
+            group_sizes,
+            token_id_to_node_id_mapping,
+            collapsed_node_ids,
+        )
     else:
         return tokens, values, group_sizes
 
@@ -543,7 +575,10 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax, output_nam
         s += draw_tick_mark(pos)
     s += draw_tick_mark(base_values, label="base value", backing=True)
     s += draw_tick_mark(
-        fx, bold=True, label=f'f<tspan baseline-shift="sub" font-size="8px">{output_name}</tspan>(inputs)', backing=True
+        fx,
+        bold=True,
+        label=f'f<tspan baseline-shift="sub" font-size="8px">{output_name}</tspan>(inputs)',
+        backing=True,
     )
 
     ### Positive value marks ###
@@ -746,7 +781,14 @@ def svg_force_plot(values, base_values, fx, tokens, uuid, xmin, xmax, output_nam
     return s
 
 
-def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, grouping_threshold=1, separator=""):
+def text_old(
+    shap_values,
+    tokens,
+    partition_tree=None,
+    num_starting_labels=0,
+    grouping_threshold=1,
+    separator="",
+):
     """Plots an explanation of a string of text using coloring and interactive labels.
 
     The output is interactive HTML and you can click on any token to toggle the display of the
@@ -780,7 +822,11 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
             ri = partition_tree[i, 1]
             groups.append(groups[li] + groups[ri])
             lower_values[M + i] = lower_values[li] + lower_values[ri] + shap_values[M + i]
-            max_values[i + M] = max(abs(shap_values[M + i]) / len(groups[M + i]), max_values[li], max_values[ri])
+            max_values[i + M] = max(
+                abs(shap_values[M + i]) / len(groups[M + i]),
+                max_values[li],
+                max_values[ri],
+            )
 
         # compute the upper_values
         upper_values = np.zeros(len(shap_values))
@@ -1066,9 +1112,13 @@ def heatmap(shap_values):
         max_val = 0
 
         for index, output_token in enumerate(shap_values.output_names):
-            tokens, values, group_sizes, token_id_to_node_id_mapping, collapsed_node_ids = process_shap_values(
-                shap_values.data, unpacked_values[:, index], 1, "", clustering, True
-            )
+            (
+                tokens,
+                values,
+                group_sizes,
+                token_id_to_node_id_mapping,
+                collapsed_node_ids,
+            ) = process_shap_values(shap_values.data, unpacked_values[:, index], 1, "", clustering, True)
             processed_value = {
                 "tokens": tokens,
                 "values": values,
@@ -1206,7 +1256,9 @@ def heatmap(shap_values):
             input_text_html += f'<div id="{uuid}_input_node_{input_index}_content" style="display:inline;">'
             for child_index, child_content in token_list_subtree[input_index][TREE_NODE_KEY_CHILDREN].items():
                 input_text_html = populate_input_tree(
-                    child_index, token_list_subtree[input_index][TREE_NODE_KEY_CHILDREN], input_text_html
+                    child_index,
+                    token_list_subtree[input_index][TREE_NODE_KEY_CHILDREN],
+                    input_text_html,
                 )
             input_text_html += "</div>"
         else:

--- a/tests/plots/test_text.py
+++ b/tests/plots/test_text.py
@@ -1,6 +1,51 @@
 import numpy as np
+import pytest
 
 import shap
+
+
+def test_text_plot_input_is_explanation():
+    with pytest.raises(
+        TypeError,
+        match="text plot requires an `Explanation` object",
+    ):
+        shap.plots.text(np.array([[1.0, -1.0]]))
+
+
+def test_text_plot_returns_html_when_display_false():
+    explanation = shap.Explanation(
+        values=np.array([0.25, -0.1]),
+        base_values=0.0,
+        data=np.array(["hello ", "world"]),
+    )
+    html = shap.plots.text(explanation, display=False)
+
+    assert isinstance(html, str)
+    assert "<div" in html
+
+
+def test_text_plot_multirow_returns_html_when_display_false():
+    explanation = shap.Explanation(
+        values=np.array([[0.25, -0.1], [0.3, -0.2]]),
+        base_values=np.array([0.0, 0.0]),
+        data=np.array([["hello ", "world"], ["goodbye ", "world"]], dtype=object),
+    )
+    html = shap.plots.text(explanation, display=False)
+
+    assert isinstance(html, str)
+    assert "<div" in html
+
+
+def test_text_plot_display_requires_ipython(monkeypatch):
+    explanation = shap.Explanation(
+        values=np.array([0.25, -0.1]),
+        base_values=0.0,
+        data=np.array(["hello ", "world"]),
+    )
+    monkeypatch.setattr(shap.plots._text, "have_ipython", False)
+
+    with pytest.raises(ImportError, match="IPython is required for this function"):
+        shap.plots.text(explanation, display=True)
 
 
 def test_single_text_to_text():


### PR DESCRIPTION
## Overview
Closes #3806
This PR addresses #3806 as part of the broader visualisation overhaul (#3411). from my understanding to fix the issue i   modernize the `shap/plots/_text.py` file by refactoring the internal logic to fully support the explanation object, moving away from legacy `shap_values` patterns,  ensuring it aligns with the project's new standards for consistency and return values.
i also added explicit type checking for the `shap_values` argument. It now raises a clear TypeError when an ndarray is passed instead of an Explanation object, preventing confusing AttributeError: ... has no attribute 'output_names' downstream. here is a screenshot to show the changes :
Before:
<img width="1221" height="381" alt="Screenshot 2026-04-05 at 00 44 22" src="https://github.com/user-attachments/assets/4094ea30-0b9b-4c09-84d8-938569ad4006" />
After:
<img width="1203" height="387" alt="Screenshot 2026-04-05 at 01 47 32" src="https://github.com/user-attachments/assets/b476af5c-b605-4188-9120-8f6a9910f60c" />

### Checklist

- [x ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x ] Unit tests added (if fixing a bug or adding a new feature)

### AI Usage :
i used an AI assistant (cursor) to help with:
-  restructuring the `shap_values` type-checking logic to raise a descriptive `TypeError`.
- drafting the descriptive `TypeError` message for improved input validation.
- Structuring the PR description to align with the SHAP visualisation overhaul standards.
All AI-generated suggestions were manually reviewed by me, tested and verified locally.