### PR TITLE
Fix cluster ordering not reversed due to missing np.flipud assignment

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -541,7 +541,7 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
 
         # make sure that we put the higher predictions first...just for consistency
         if sum(arr[clustOrder[0]].effects) < sum(arr[clustOrder[-1]].effects):
-            np.flipud(clustOrder)  # reverse
+            clustOrder = np.flipud(clustOrder)  # reverse
 
         # build the json data
         clustOrder = np.argsort(clustOrder)  # inverse permutation


### PR DESCRIPTION
## Overview

Closes #4370
Description of the changes proposed in this pull request:

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
