### PR TITLE
FIX: Use isinstance() instead of 'is' for type checks

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -116,7 +116,7 @@ class Explainer(Serializable):
                 self.masker = maskers.Text(masker)
         elif (masker is list or masker is tuple) and masker[0] is not str:
             self.masker = maskers.Composite(*masker)
-        elif (masker is dict) and ("mean" in masker):
+        elif isinstance(masker, dict) and ("mean" in masker):
             self.masker = maskers.Independent(masker)
         elif masker is None and isinstance(self.model, models.TransformersPipeline):
             return self.__init__(  # type: ignore[misc]

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -338,7 +338,7 @@ class Impute(Masker):  # we should inherit from Tabular once we add support for 
             The background dataset that is used for masking.
 
         """
-        if data is dict and "mean" in data:
+        if isinstance(data, dict) and "mean" in data:
             self.mean = data.get("mean", None)
             self.cov = data.get("cov", None)
             data = np.expand_dims(data["mean"], 0)


### PR DESCRIPTION
## Overview

Closes #4372  

Description of the changes proposed in this pull request:
The expressions 'data is dict' and 'masker is dict' compare an instance
 to the dict type object, which always returns False. This caused the
 dict-based initialization paths to be unreachable.
 
 Fixed in:
 - shap/maskers/_tabular.py: Impute.__init__
 - shap/explainers/_explainer.py: Explainer.__init__

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
