### PR TITLE
fix: record 'sample' in Explanation.op_history instead of '__getitem__'

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -622,7 +622,12 @@ class Explanation(metaclass=MetaExplanation):
         length = self.shape[0]
         assert length is not None
         inds = rng.choice(length, size=min(max_samples, length), replace=replace)
-        return self[list(inds)]
+        prev_shape = self.shape
+        new_self = self[list(inds)]
+        # Replace the __getitem__ entry with "sample" so op_history
+        # reflects the high-level operation the user actually called.
+        new_self.op_history[-1] = OpHistoryItem(name="sample", args=(max_samples,), prev_shape=prev_shape)
+        return new_self
 
     def hclust(self, metric: str = "sqeuclidean", axis: Literal[0, 1] = 0) -> npt.NDArray[np.int64]:
         """Computes an optimal leaf ordering sort order using hclustering.

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -136,7 +136,7 @@ def test_populating_op_history():
     exp += 2
     expected_op_names = [
         "abs",
-        "__getitem__",
+        "sample",
         "flip",
         "__getitem__",
         "mean",


### PR DESCRIPTION
## Summary

Closes #4374

`Explanation.sample()` delegates to `self[list(inds)]`, which records `"__getitem__"` in `op_history`. This misrepresents the actual operation the user called — the history should say `"sample"`, not `"__getitem__"`.

**Root cause:** The fix belongs in `_explanation.py`, not in the test. The test expectations were correct for the *previous* behavior. The issue is that `sample()` never recorded its own name in `op_history`.

**Fix:** After `sample()` performs the slice via `__getitem__`, replace the last `op_history` entry with a `"sample"` entry that captures the correct operation name and the pre-slice shape. This follows the same pattern used by `_numpy_func` methods (`abs`, `flip`, `mean`, etc.) which each record their own name.

## Test plan
- [x] `test_populating_op_history` updated to expect `"sample"` and passes
- [x] All 14 tests in `test_explanation.py` pass
- [x] No existing tests broken

Ref: #4374

**Note:** Tests were scaffolded with AI assistance and reviewed/validated locally.