### PR TITLE
FIX: move unreachable large-dataset warning into interventional branch

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -267,18 +267,17 @@ class TreeExplainer(Explainer):
                     FutureWarning,
                 )
                 feature_perturbation = "tree_path_dependent"
+            elif self.data.shape[0] > 1_000:
+                wmsg = (
+                    f"Passing {self.data.shape[0]} background samples may lead to slow runtimes. Consider "
+                    "using shap.sample(data, 100) to create a smaller background data set."
+                )
+                warnings.warn(wmsg)
         elif feature_perturbation != "tree_path_dependent":
             raise InvalidFeaturePerturbationError(
                 "feature_perturbation must be 'auto', 'interventional', or 'tree_path_dependent'. "
                 f"Got {feature_perturbation} instead."
             )
-
-        elif feature_perturbation == "interventional" and self.data.shape[0] > 1_000:
-            wmsg = (
-                f"Passing {self.data.shape[0]} background samples may lead to slow runtimes. Consider "
-                "using shap.sample(data, 100) to create a smaller background data set."
-            )
-            warnings.warn(wmsg)
 
         _safe_check_tree_instance_experimental(model)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -30,6 +30,21 @@ def test_unsupported_model_raises_error():
         _ = shap.TreeExplainer(CustomEstimator())
 
 
+def test_large_background_dataset_warning():
+    """A warning should be emitted when >1000 background samples are passed
+    with feature_perturbation='interventional'. Regression test for GH#4385."""
+    X, y = shap.datasets.california(n_points=1200)
+    model = DecisionTreeRegressor(max_depth=3, random_state=0)
+    model.fit(X, y)
+
+    # Use maskers.Independent with a high max_samples to bypass the default
+    # subsampling (max_samples=100), so the >1000 check is actually triggered.
+    background = shap.maskers.Independent(X, max_samples=1200)
+    with pytest.warns(UserWarning, match="may lead to slow runtimes"):
+        shap.TreeExplainer(model, background, feature_perturbation="interventional")
+
+
+
 def test_front_page_xgboost():
     xgboost = pytest.importorskip("xgboost")
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -44,7 +44,6 @@ def test_large_background_dataset_warning():
         shap.TreeExplainer(model, background, feature_perturbation="interventional")
 
 
-
 def test_front_page_xgboost():
     xgboost = pytest.importorskip("xgboost")
 


### PR DESCRIPTION
## Summary

Fixes #4385

### Problem
In `TreeExplainer.__init__`, the warning that alerts users about passing >1,000 background samples (which may lead to slow runtimes) is **unreachable dead code**. It is placed in an `elif` branch that can never execute because all possible values of `feature_perturbation` are already handled by preceding branches:

1. `"auto"` → branch 1
2. `"interventional"` → branch 2
3. anything other than `"tree_path_dependent"` → branch 3 (raises error)
4. `"interventional"` again → **unreachable** (already handled in branch 2)

### Fix
Move the >1,000 samples warning **inside** the existing `elif feature_perturbation == "interventional"` branch, as an `elif` under the `if self.data is None` check. Remove the dead 4th `elif` branch.

### Test
Added `test_large_background_dataset_warning` regression test that verifies the warning is actually emitted when >1,000 background samples are passed with `feature_perturbation="interventional"`.