### PR TITLE
MAINT: replace deprecated `return_all_scores` with `top_k=None` (#3974)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ import transformers
 import shap
 
 # load a transformers pipeline model
-model = transformers.pipeline('sentiment-analysis', return_all_scores=True)
+model = transformers.pipeline('sentiment-analysis', top_k=None)
 
 # explain the model on two sample inputs
 explainer = shap.Explainer(model)

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -259,7 +259,7 @@ def test_tf_deep_imbdb_transformers():
 
     # data from datasets imdb dataset
     short_data = ["I lov", "Worth", "its a", "STAR ", "First", "I had", "Isaac", "It ac", "Techn", "Hones"]
-    classifier = transformers.pipeline("sentiment-analysis", return_all_scores=True)
+    classifier = transformers.pipeline("sentiment-analysis", top_k=None)
     pmodel = models.TransformersPipeline(classifier, rescale_to_logits=True)
     explainer3 = shap.Explainer(pmodel, classifier.tokenizer)
     shap_values3 = explainer3(short_data[:10])


### PR DESCRIPTION
## Overview

Closes #3974

Fixes the CI deprecation warning for `return_all_scores` in HuggingFace transformers (sub-issue of #3066).

The `return_all_scores` parameter in `transformers.pipeline()` has been deprecated. The warning states:

> `return_all_scores` is now deprecated, use `top_k=None` instead of `return_all_scores=True` or `top_k=1` instead of `return_all_scores=False`.

This PR replaces `return_all_scores=True` with `top_k=None` in:

| File | Change |
|------|--------|
| `tests/explainers/test_deep.py` | Updated `test_tf_deep_imbdb_transformers` to use `top_k=None` |
| `README.md` | Updated the NLP example to use `top_k=None` |

> **Note:** The same deprecated parameter also exists in two Jupyter notebooks under `notebooks/text_examples/sentiment_analysis/`, but those are tracked separately under #3036 (one notebook per PR), so they are intentionally not included here.

The behavior of `top_k=None` is functionally identical to `return_all_scores=True` — both return scores for all output classes.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
