### PR TITLE
FIX: Raise ValueError for unsupported method in embedding ()

### DIFF
--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -52,8 +52,8 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
     elif hasattr(method, "shape") and method.shape[1] == 2:
         embedding_values = method
     else:
-        print("Unsupported embedding method:", method)
-        return
+        emsg = f"Unsupported embedding method: {method}. Expected 'pca' or a numpy array of shape (# samples x 2)."
+        raise ValueError(emsg)
 
     plt.scatter(embedding_values[:, 0], embedding_values[:, 1], c=cvals, cmap=colors.red_blue, alpha=alpha, linewidth=0)
     plt.axis("off")

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -53,6 +53,7 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
         embedding_values = method
     else:
         print("Unsupported embedding method:", method)
+        return
 
     plt.scatter(embedding_values[:, 0], embedding_values[:, 1], c=cvals, cmap=colors.red_blue, alpha=alpha, linewidth=0)
     plt.axis("off")


### PR DESCRIPTION
## Overview

Fixes #4394 

When passing an unsupported `method` argument to `shap.plots.embedding()`, the function prints an error message but then immediately crashes with an `UnboundLocalError` because `embedding_values` is never assigned in the `else` branch.

Added `return` after the print statement in `shap/plots/_embedding.py` so the function exits after printing the error.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (test added in PR #4389)
