### PR TITLE
FIX: Correct random state restoration using get_state/set_state

### DIFF
--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -104,7 +104,7 @@ class ExplanationError:
 
         # it is important that we choose the same permutations for the different explanations we are comparing
         # so as to avoid needless noise
-        old_seed = np.random.seed()
+        old_state = np.random.get_state()
         np.random.seed(self.seed)
 
         pbar = None
@@ -186,6 +186,6 @@ class ExplanationError:
         svals = np.array(svals)
 
         # reset the random seed so we don't mess up the caller
-        np.random.seed(old_seed)
+        np.random.set_state(old_state)
 
         return BenchmarkResult("explanation error", name, value=np.sqrt(np.sum(total_values) / len(total_values)))

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -421,19 +421,19 @@ def to_array(*args):
 
 def const_rand(size, seed=23980):
     """Generate a random array with a fixed seed."""
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(seed)
     out = np.random.rand(size)
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
     return out
 
 
 def const_shuffle(arr, seed=23980):
     """Shuffle an array in-place with a fixed seed."""
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(seed)
     np.random.shuffle(arr)
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
 
 def strip_list(attrs):

--- a/shap/benchmark/metrics.py
+++ b/shap/benchmark/metrics.py
@@ -24,7 +24,7 @@ def runtime(X, y, model_generator, method_name):
     transform = "negate_log"
     sort_order = 2
     """
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(3293)
 
     # average the method scores over several train/test splits
@@ -48,7 +48,7 @@ def runtime(X, y, model_generator, method_name):
         # we always normalize the explain time as though we were explaining 1000 samples
         # even if to reduce the runtime of the benchmark we do less (like just 100)
         method_reps.append(build_time + explain_time * 1000.0 / X_test.shape[0])
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return None, np.mean(method_reps)
 
@@ -502,7 +502,7 @@ def __score_method(
     except NameError:
         raise ImportError("The 'dill' package could not be loaded and is needed for the benchmark!")
 
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(3293)
 
     # average the method scores over several train/test splits
@@ -547,7 +547,7 @@ def __score_method(
         else:
             method_reps.append(score(None))
 
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
     return np.array(method_reps).mean(0)
 
 

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -528,7 +528,7 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
 
     """
     # set a constant seed
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -564,7 +564,7 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
     y = f(X) + np.random.randn(N) * 1e-2
 
     # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 
@@ -599,7 +599,7 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
 
     """
     # set a constant seed
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -618,7 +618,7 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
     y = f(X) + np.random.randn(N) * 1e-2
 
     # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -102,7 +102,6 @@ def test_explainer_with_tokenizer_auto_wraps_text_masker_and_explains_text():
     """Exercise Explainer text masker auto-wrapping with real tokenizer inputs."""
     transformers = pytest.importorskip("transformers")
     tokenizer = transformers.AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-BertModel")
-
     # Keep the model simple but text-shaped: one numeric score per string.
     def model(texts):
         texts = np.asarray(texts, dtype=object)

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -1,6 +1,5 @@
 """Tests for Explainer class."""
 
-import numpy as np
 import pytest
 import sklearn
 
@@ -96,26 +95,3 @@ def test_explainer_xgboost():
     # check the properties of Explanation object
     assert explanation.values.shape == (*X.shape,)  # type: ignore[union-attr]
     assert explanation.base_values.shape == (len(X),)  # type: ignore[union-attr]
-
-
-def test_explainer_with_tokenizer_auto_wraps_text_masker_and_explains_text():
-    """Exercise Explainer text masker auto-wrapping with real tokenizer inputs."""
-    transformers = pytest.importorskip("transformers")
-    tokenizer = transformers.AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-BertModel")
-    # Keep the model simple but text-shaped: one numeric score per string.
-    def model(texts):
-        texts = np.asarray(texts, dtype=object)
-        return np.array([float(len(str(text).split())) for text in texts])
-
-    explainer = shap.Explainer(model, tokenizer, seed=1)
-
-    assert isinstance(explainer, shap.PartitionExplainer)
-    assert shap.utils.safe_isinstance(explainer.masker, "shap.maskers.Text")
-
-    inputs = ["This game was unexpectedly good", "The gameplay looked too real"]
-    shap_values = explainer(inputs, max_evals=64, silent=True)
-
-    assert len(shap_values.values) == len(inputs)  # type: ignore[arg-type]
-    assert len(shap_values.data) == len(inputs)  # type: ignore[arg-type]
-    for values, data in zip(shap_values.values, shap_values.data):  # type: ignore[arg-type]
-        assert len(values) == len(data)

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -102,6 +102,7 @@ def test_explainer_with_tokenizer_auto_wraps_text_masker_and_explains_text():
     """Exercise Explainer text masker auto-wrapping with real tokenizer inputs."""
     transformers = pytest.importorskip("transformers")
     tokenizer = transformers.AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-BertModel")
+
     # Keep the model simple but text-shaped: one numeric score per string.
     def model(texts):
         texts = np.asarray(texts, dtype=object)

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -1,5 +1,6 @@
 """Tests for Explainer class."""
 
+import numpy as np
 import pytest
 import sklearn
 
@@ -95,3 +96,26 @@ def test_explainer_xgboost():
     # check the properties of Explanation object
     assert explanation.values.shape == (*X.shape,)  # type: ignore[union-attr]
     assert explanation.base_values.shape == (len(X),)  # type: ignore[union-attr]
+
+
+def test_explainer_with_tokenizer_auto_wraps_text_masker_and_explains_text():
+    """Exercise Explainer text masker auto-wrapping with real tokenizer inputs."""
+    transformers = pytest.importorskip("transformers")
+    tokenizer = transformers.AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-BertModel")
+    # Keep the model simple but text-shaped: one numeric score per string.
+    def model(texts):
+        texts = np.asarray(texts, dtype=object)
+        return np.array([float(len(str(text).split())) for text in texts])
+
+    explainer = shap.Explainer(model, tokenizer, seed=1)
+
+    assert isinstance(explainer, shap.PartitionExplainer)
+    assert shap.utils.safe_isinstance(explainer.masker, "shap.maskers.Text")
+
+    inputs = ["This game was unexpectedly good", "The gameplay looked too real"]
+    shap_values = explainer(inputs, max_evals=64, silent=True)
+
+    assert len(shap_values.values) == len(inputs)  # type: ignore[arg-type]
+    assert len(shap_values.data) == len(inputs)  # type: ignore[arg-type]
+    for values, data in zip(shap_values.values, shap_values.data):  # type: ignore[arg-type]
+        assert len(values) == len(data)

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -76,12 +76,11 @@ def test_partition_tree_with_nan():
     assert isinstance(result, np.ndarray)
     assert result.shape == (2, 4)
 
+
 def test_hclust_accepts_dataframe():
-    #checks for whether hclust accepts dataframe
+    # checks for whether hclust accepts dataframe
     pytest.importorskip("xgboost")
-    X = pd.DataFrame(
-        np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
-    )
+    X = pd.DataFrame(np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100))))
     y = np.where(X.iloc[:, 0] > 5, 1, 0)
     result = hclust(X, y, random_state=0)
     assert isinstance(result, np.ndarray)
@@ -89,24 +88,25 @@ def test_hclust_accepts_dataframe():
 
 
 def test_xgboost_distances_r2_constant_feature_warns():
-    #Constant features should trigger a warning.
+    # Constant features should trigger a warning.
     pytest.importorskip("xgboost")
     from shap.utils._clustering import xgboost_distances_r2
-    
+
     X = np.column_stack((np.ones(20), np.arange(1, 21)))
     y = np.arange(1, 21, dtype=float)
-    
+
     with pytest.warns(UserWarning, match="No/low signal found from feature"):
         xgboost_distances_r2(X, y, random_state=0)
+
 
 def test_hclust_ordering():
     # Covers lines 129-131: internal leaf ordering logic.
     from shap.utils._clustering import hclust_ordering
-    
+
     # Pass 10 samples with 3 features
-    X = np.random.randn(10, 3) 
+    X = np.random.randn(10, 3)
     order = hclust_ordering(X)
-    
+
     # It should return a valid permutation array of the 10 row indices
     assert isinstance(order, np.ndarray)
     assert len(order) == 10
@@ -117,7 +117,7 @@ def test_hclust_warns_when_y_given_with_non_xgboost_metric():
     # Covers line 298: fallback warning when users misuse y.
     X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
     y = np.where(X[:, 0] > 5, 1, 0)
-    
+
     # 'cosine' ignores y, so it should explicitly warn the user
     with pytest.warns(UserWarning, match="Ignoring the y argument"):
         hclust(X, y=y, metric="cosine", random_state=0)

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -1,7 +1,8 @@
 import numpy as np
+import pandas as pd
 import pytest
 
-from shap.utils import hclust
+from shap.utils import hclust, partition_tree
 from shap.utils._exceptions import DimensionError
 
 
@@ -40,3 +41,37 @@ def test_hclust_errors_on_unknown_linkages():
     X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
     with pytest.raises(ValueError, match=r"Unknown linkage type:"):
         hclust(X, linkage="random-string", random_state=0)  # type: ignore
+
+
+def test_hclust_with_nan_values():
+    # NaN values in X should be imputed (filled with column mean) and not crash
+    X = np.array(
+        [
+            [1.0, 100.0],
+            [np.nan, 200.0],
+            [3.0, 300.0],
+            [4.0, np.nan],
+            [5.0, 500.0],
+            [6.0, 600.0],
+            [7.0, 700.0],
+            [8.0, 800.0],
+            [9.0, 900.0],
+        ]
+    )
+    result = hclust(X, random_state=0)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (1, 4)
+
+
+def test_partition_tree_with_nan():
+    # partition_tree should handle NaN via fillna(mean)
+    X = pd.DataFrame(
+        {
+            "a": [1.0, np.nan, 3.0, 4.0, 5.0],
+            "b": [10.0, 20.0, np.nan, 40.0, 50.0],
+            "c": [100.0, 200.0, 300.0, 400.0, 500.0],
+        }
+    )
+    result = partition_tree(X)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (2, 4)

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -75,3 +75,49 @@ def test_partition_tree_with_nan():
     result = partition_tree(X)
     assert isinstance(result, np.ndarray)
     assert result.shape == (2, 4)
+
+def test_hclust_accepts_dataframe():
+    #checks for whether hclust accepts dataframe
+    pytest.importorskip("xgboost")
+    X = pd.DataFrame(
+        np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
+    )
+    y = np.where(X.iloc[:, 0] > 5, 1, 0)
+    result = hclust(X, y, random_state=0)
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (1, 4)
+
+
+def test_xgboost_distances_r2_constant_feature_warns():
+    #Constant features should trigger a warning.
+    pytest.importorskip("xgboost")
+    from shap.utils._clustering import xgboost_distances_r2
+    
+    X = np.column_stack((np.ones(20), np.arange(1, 21)))
+    y = np.arange(1, 21, dtype=float)
+    
+    with pytest.warns(UserWarning, match="No/low signal found from feature"):
+        xgboost_distances_r2(X, y, random_state=0)
+
+def test_hclust_ordering():
+    # Covers lines 129-131: internal leaf ordering logic.
+    from shap.utils._clustering import hclust_ordering
+    
+    # Pass 10 samples with 3 features
+    X = np.random.randn(10, 3) 
+    order = hclust_ordering(X)
+    
+    # It should return a valid permutation array of the 10 row indices
+    assert isinstance(order, np.ndarray)
+    assert len(order) == 10
+    assert sorted(order) == list(range(10))
+
+
+def test_hclust_warns_when_y_given_with_non_xgboost_metric():
+    # Covers line 298: fallback warning when users misuse y.
+    X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
+    y = np.where(X[:, 0] > 5, 1, 0)
+    
+    # 'cosine' ignores y, so it should explicitly warn the user
+    with pytest.warns(UserWarning, match="Ignoring the y argument"):
+        hclust(X, y=y, metric="cosine", random_state=0)


### PR DESCRIPTION
## Overview

Closes #4403 

Fixes incorrect random state restoration in 4 files where `np.random.seed()` is called without arguments (returning `None`) instead of properly using `np.random.get_state()` and `np.random.set_state()`.

### Problem
Functions attempt to save the random state with `old_seed = np.random.seed()`, which returns `None`. Later calling `np.random.seed(old_seed)` doesn't restore the previous state, breaking reproducibility.

### Solution
Replace all occurrences with the correct NumPy API:
```python
# Before (buggy)
old_seed = np.random.seed()  # Returns None!
np.random.seed(123)
# ... code ...
np.random.seed(old_seed)  # Doesn't restore anything

# After (correct)
old_state = np.random.get_state()
np.random.seed(123)
# ... code ...
np.random.set_state(old_state)  # Properly restores state
```

## Changes

**Files Modified (7 locations across 4 files):**

1. **shap/benchmark/_explanation_error.py**
   - Lines 107, 189: Fixed random state save/restore

2. **shap/benchmark/measures.py**
   - Lines 424, 427: Fixed `const_rand()` function
   - Lines 433, 436: Fixed `const_shuffle()` function

3. **shap/benchmark/metrics.py**
   - Lines 27, 51: Fixed `runtime()` function
   - Lines 505, 550: Fixed benchmark function

4. **shap/datasets.py**
   - Lines 531, 567: Fixed `corrgroups60()` function
   - Lines 602, 621: Fixed `independentlinear60()` function

### Impact
- **Correctness**: Random state properly isolated within functions
- **Reproducibility**: Caller's random state preserved across function calls
- **No Breaking Changes**: Backward compatible, only corrects buggy behavior

## Verification

Demonstrates the fix works correctly:
```python
import numpy as np
from shap.datasets import corrgroups60

# Set known seed and generate values
np.random.seed(42)
val1 = np.random.rand()

# Call function that temporarily changes seed internally
data, target = corrgroups60(n_points=100)

# Random state should continue correctly
val2 = np.random.rand()

# Verify: should match as if corrgroups60() never changed the state
np.random.seed(42)
expected1 = np.random.rand()
expected2 = np.random.rand()
print(f"Before: {val1} == {expected1}: {val1 == expected1}")  # True
print(f"After: {val2} == {expected2}: {val2 == expected2}")    # True (with fix)
```

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
