### PR TITLE
Fix: The structure of inputs doesn't match the expected structure

### DIFF
--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -148,7 +148,7 @@ def test_tf_keras_activations(activation):
     model.fit(x, y, epochs=30, shuffle=False, verbose=0)
 
     # explain
-    e = shap.DeepExplainer((model.inputs[0], model.layers[-1].output), x)
+    e = shap.DeepExplainer((model.inputs, model.layers[-1].output), x)
     shap_values = e.shap_values(x)
     preds = model.predict(x)
 


### PR DESCRIPTION
## Overview

Closes #3972 and supports #3066

Description of the changes proposed in this pull request:

First argument (`model`) of `shap.DeepExplainer` is expected to be either a `tf.keras.Model` or `(input : [tf.Operation], output : tf.Operation)`. [from the class docstring]

Inside function `test_tf_keras_activations`, only the first element of the list was passed instead of the list. Due to how `deep_tf.py` works, this caused the warning. 

Updated the argument to pass a list and resolved the warning.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
