### PR TITLE
ENH: log info when background dataset is sub-sampled in Tabular masker (#3461)

### DIFF
--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -54,6 +54,11 @@ class Tabular(Masker):
             data = np.expand_dims(data["mean"], 0)
 
         if hasattr(data, "shape") and data.shape[0] > max_samples:
+            log.info(
+                f"Background dataset has {data.shape[0]} samples, which exceeds max_samples={max_samples}. "
+                f"Subsampling to {max_samples} samples. SHAP values may differ from those computed with the "
+                "full background dataset. Pass a pre-sampled dataset or increase max_samples to silence this."
+            )
             data = utils.sample(data, max_samples)
 
         self.data = data

--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -154,6 +154,19 @@ def test_independent_masker_with_sampling():
     assert masker.data.shape[1] == 5
 
 
+def test_independent_masker_logs_on_subsampling(caplog):
+    """Tabular masker should emit an info log when the background dataset is sub-sampled — GH #3461."""
+    import logging
+
+    large_data = np.random.randn(150, 5)
+    with caplog.at_level(logging.INFO, logger="shap"):
+        shap.maskers.Independent(large_data, max_samples=50)
+
+    assert any("Subsampling" in record.message for record in caplog.records), (
+        "Expected an info log warning about background dataset sub-sampling"
+    )
+
+
 def test_independent_masker_with_no_clustering():
     """Test Independent masker without clustering."""
     data = np.random.randn(10, 3)


### PR DESCRIPTION
## Summary

Closes #3461

When a background dataset exceeds `max_samples`, the `Tabular` masker
silently sub-samples it. This causes SHAP values to differ from those
computed with the full dataset, with no indication to the user that
approximation has occurred.

**Fix:** emit a `logging.info()` message at the point of sub-sampling,
reporting the original size, the `max_samples` limit, and how to
silence the warning.

## Changes

- `shap/maskers/_tabular.py`: add `log.info()` before sub-sampling call
- `tests/maskers/test_tabular.py`: add `caplog`-based test asserting
  the message is emitted when data exceeds `max_samples`

## Test plan

- [x] `pytest tests/maskers/test_tabular.py` — all existing + new tests pass
