### PR TITLE
docs: clarify expected_value math formula in TreeExplainer #4414

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -550,12 +550,12 @@ class TreeExplainer(Explainer):
             * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
             * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
 
-            .. note:: 
-               The ``explainer_model_output`` is NOT necessarily what ``model.predict()`` 
-               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default 
-               ``model_output="raw"``, the explainer returns log-odds (margins). 
+            .. note::
+               The ``explainer_model_output`` is NOT necessarily what ``model.predict()``
+               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default
+               ``model_output="raw"``, the explainer returns log-odds (margins).
                To compare this mathematically against ``predict_proba()`` probabilities,
-               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
+               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied
                to the sum.
 
             The shape of the returned array depends on the number of model outputs:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -904,6 +904,16 @@ class TreeExplainer(Explainer):
                     f" was {sum_val[ind]:f}, while the model output was {model_output[ind]:f}. If this"
                     " difference is acceptable you can set check_additivity=False to disable this check."
                 )
+                # Diagnostic for common binary classification link function confusion (GH #4414)
+                try:
+                    if np.allclose(scipy.special.expit(sum_val), model_output, atol=1e-2, rtol=1e-2):
+                        err_msg += (
+                            "\n\nHINT: The SHAP values sum to the model's raw output (margins), "
+                            "but it looks like you are comparing them to probabilities. "
+                            "Apply a logistic transform (scipy.special.expit) to the sum to match."
+                        )
+                except Exception:
+                    pass
                 raise ExplainerError(err_msg)
 
         if isinstance(phi, list):

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -543,15 +543,14 @@ class TreeExplainer(Explainer):
         np.array
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
-            For each output, the SHAP values (summed across all features) plus the
-            expected value equals the model's output in the space of the ``model_output``
-            argument for that sample:
+            For each output, the sum of the SHAP values plus the ``expected_value``
+            equals the model's output (in the specified output space):
 
-            * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
-            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
+            * Single output: ``shap_values[i, :].sum() + expected_value = f(x)[i]``
+            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = f(x)[i, j]``
 
             .. note::
-               The ``explainer_model_output`` is NOT necessarily what ``model.predict()``
+               The ``f(x)`` value is NOT necessarily what ``model.predict()``
                or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default
                ``model_output="raw"``, the explainer returns log-odds (margins).
                To compare this mathematically against ``predict_proba()`` probabilities,

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -544,10 +544,19 @@ class TreeExplainer(Explainer):
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
             For each output, the SHAP values (summed across all features) plus the
-            expected value equals the model's output for that sample:
+            expected value equals the model's output in the space of the ``model_output``
+            argument for that sample:
 
-            * Single output: ``shap_values[i, :].sum() + expected_value = model_output[i]``
-            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = model_output[i, j]``
+            * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
+            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
+
+            .. note:: 
+               The ``explainer_model_output`` is NOT necessarily what ``model.predict()`` 
+               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default 
+               ``model_output="raw"``, the explainer returns log-odds (margins). 
+               To compare this mathematically against ``predict_proba()`` probabilities,
+               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
+               to the sum.
 
             The shape of the returned array depends on the number of model outputs:
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -558,6 +558,9 @@ class TreeExplainer(Explainer):
                a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied
                to the sum.
 
+               Furthermore, the additivity formula requires SHAP values and model
+               predictions to be computed on the same samples in the same order.
+
             The shape of the returned array depends on the number of model outputs:
 
             * one output: array of shape ``(#num_samples, *X.shape[1:])``.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -904,14 +904,7 @@ class TreeExplainer(Explainer):
                     f" was {sum_val[ind]:f}, while the model output was {model_output[ind]:f}. If this"
                     " difference is acceptable you can set check_additivity=False to disable this check."
                 )
-                # Diagnostic for common binary classification link function confusion (GH #4414)
-                if sum_val.shape == model_output.shape:
-                    if np.allclose(scipy.special.expit(sum_val), model_output, atol=1e-2, rtol=1e-2):
-                        err_msg += (
-                            "\n\nHINT: The SHAP values sum to the model's raw output (margins), "
-                            "but it looks like you are comparing them to probabilities. "
-                            "Apply a logistic transform (scipy.special.expit) to the sum to match."
-                        )
+
                 raise ExplainerError(err_msg)
 
         if isinstance(phi, list):

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -905,15 +905,13 @@ class TreeExplainer(Explainer):
                     " difference is acceptable you can set check_additivity=False to disable this check."
                 )
                 # Diagnostic for common binary classification link function confusion (GH #4414)
-                try:
+                if sum_val.shape == model_output.shape:
                     if np.allclose(scipy.special.expit(sum_val), model_output, atol=1e-2, rtol=1e-2):
                         err_msg += (
                             "\n\nHINT: The SHAP values sum to the model's raw output (margins), "
                             "but it looks like you are comparing them to probabilities. "
                             "Apply a logistic transform (scipy.special.expit) to the sum to match."
                         )
-                except Exception:
-                    pass
                 raise ExplainerError(err_msg)
 
         if isinstance(phi, list):


### PR DESCRIPTION
### What does this PR do?
This PR clarifies the documentation for `TreeExplainer.shap_values`, specifically the relationship between summed SHAP values and the model output.

### What problem does it solve?
As discussed in #4414, the current documentation can be confusing regarding how `expected_value + sum(shap_values)` relates to model predictions.

For models like XGBoost and LightGBM (with `model_output="raw"`), SHAP values are computed in the raw margin (log-odds) space, while users often compare them with probability outputs from `predict()` or `predict_proba()`.

This PR improves clarity by:
- Clarifying that the formula applies to the explainer's model output (raw margin)
- Adding a note explaining that users may need to apply a transformation (e.g., logistic function) to compare with probabilities

Fixes #4414

### Checklist
- [x] I have read the CONTRIBUTING.md
- [x] I have updated the documentation accordingly
- [x] Tests not required (documentation-only change)
