### PR TITLE
Increasing test coverage of shap/plots/colors/_colors.py

### DIFF
--- a/tests/plots/test_colors.py
+++ b/tests/plots/test_colors.py
@@ -15,6 +15,11 @@ def test_colors():
     assert_allclose(colors.red_rgb, np.array([1.0, 0.0, 0.31796406]))
 
 
+def test_red_blue_special_values():
+    assert_allclose(colors.red_blue(np.nan), np.array([0.51615537, 0.51615111, 0.5161729, 1.0]))
+    assert_allclose(colors.red_blue(2.0), np.array([0.51615537, 0.51615111, 0.5161729, 1.0]))
+    assert_allclose(colors.red_blue(-1.0), np.array([0.51615537, 0.51615111, 0.5161729, 1.0]))
+
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize(
     "cmap",

--- a/tests/plots/test_colors.py
+++ b/tests/plots/test_colors.py
@@ -20,6 +20,7 @@ def test_red_blue_special_values():
     assert_allclose(colors.red_blue(2.0), np.array([0.51615537, 0.51615111, 0.5161729, 1.0]))
     assert_allclose(colors.red_blue(-1.0), np.array([0.51615537, 0.51615111, 0.5161729, 1.0]))
 
+
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize(
     "cmap",


### PR DESCRIPTION
## Overview

Part of #3690   

- Added tests to validate handling of special values (NaN, under-range, and over-range) for the red_blue colormap.
- Ensures correct application of `set_bad`, `set_under`, and `set_over` configurations.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
