### PR TITLE
Resolve: UserWarning: X does not have valid feature names, but LGBMRegressor was fitted with feature names

### DIFF
--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1978,7 +1978,7 @@ def test_lightgbm_interactions():
 
     model = lightgbm.LGBMClassifier(n_estimators=10, max_depth=3).fit(X, y)
     explainer = shap.TreeExplainer(model)
-    predicted = model.predict(X, raw_score=True)
+    predicted = model.predict(pd.DataFrame(X, columns=model.feature_names_in_), raw_score=True)
     explanation = explainer(X, interactions=False)
     np.testing.assert_allclose(explanation.values.sum(axis=(1)) + explanation.base_values, predicted)
 
@@ -1987,7 +1987,7 @@ def test_lightgbm_interactions():
 
     # test flat input
     explanation_flat = explainer(X[0, :], interactions=True)
-    predicted_flat = model.predict(X[[0], :], raw_score=True)
+    predicted_flat = model.predict(pd.DataFrame(X[[0], :], columns=model.feature_names_in_), raw_score=True)
 
     np.testing.assert_allclose(
         explanation_flat.values.sum((0, 1)) + explanation_flat.base_values[0], predicted_flat[0], atol=1e-4
@@ -2582,7 +2582,7 @@ def test_tree_explainer_with_lightgbm_regressor():
     assert shap_values.shape == (10, 5)
 
     # Check additivity
-    predictions = model.predict(X[:10])
+    predictions = model.predict(pd.DataFrame(X[:10], columns=model.feature_names_in_))
     assert np.abs(shap_values.sum(1) + explainer.expected_value - predictions).max() < 1e-4
 
 
@@ -2603,7 +2603,7 @@ def test_tree_explainer_with_lightgbm_classifier():
     assert shap_values.shape == (10, 4) or (isinstance(shap_values, list) and len(shap_values) == 2)
 
     # Check additivity (SHAP values are in raw score space, not probability space)
-    predictions = model.predict(X[:10], raw_score=True)
+    predictions = model.predict(pd.DataFrame(X[:10], columns=model.feature_names_in_), raw_score=True)
     if isinstance(shap_values, list):
         shap_sum = shap_values[1].sum(1) + explainer.expected_value[1]
     else:


### PR DESCRIPTION
## Overview

Resolves (part of) #3066 

Description of the changes proposed in this pull request:

`lightgbm.sklearn` internally assigns feature names to each column when none are provided with `model.fit`. When these feature names are not passed with `model.predict`, `sklearn` raises a warning. These warnings can be resolved by passing the assigned feature names. This issue is documented [here.](https://github.com/lightgbm-org/LightGBM/issues/6798)

4/8 have been resolved:

- [ ] ../../../../../opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/sklearn/utils/validation.py:2691
- [ ] ../../../../../opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/sklearn/utils/validation.py:2691
- [x] tests/explainers/test_tree.py::test_tree_explainer_with_lightgbm_regressor
- [ ] ../../../../../opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/sklearn/utils/validation.py:2691
- [ ] ../../../../../opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/sklearn/utils/validation.py:2691
- [x] tests/explainers/test_tree.py::test_lightgbm_interactions
- [x] tests/explainers/test_tree.py::test_lightgbm_interactions
- [x] tests/explainers/test_tree.py::test_tree_explainer_with_lightgbm_classifier

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
