### PR TITLE
DOCS: Clarify sample alignment requirement for shap_values additivity…

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -549,6 +549,12 @@ class TreeExplainer(Explainer):
 
             * Single output: ``shap_values[i, :].sum() + expected_value = model_output[i]``
             * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = model_output[i, j]``
+            .. note::
+                This property holds only when ``shap_values`` and ``model_output``
+                are computed on the **same samples in the same order**. A common
+                mistake is computing SHAP values on a subset of samples while
+                comparing against predictions from a different batch, which will
+                cause assertion failures even though the formula itself is correct.
 
             The shape of the returned array depends on the number of model outputs:
 


### PR DESCRIPTION
## What does this PR do?
It adds a note to the `TreeExplainer.shap_values` docstring clarifying that 
the additivity formula requires SHAP values and model predictions to be 
computed on the same samples in the same order.

## What problem does it solve?
In issue #4414, users encounter assertion failures when computing 
SHAP values on a subset of samples and comparing against predictions from 
a different batch. The formula itself is correct - the root cause is 
sample index misalignment.

## Investigation
I reproduced the RandomForest case from #4414 with a controlled dummy 
dataset, testing both `feature_perturbation='tree_path_dependent'` and 
`feature_perturbation='interventional'`. All assertions passed in both 
modes when the same samples were used for both SHAP and predictions, 
confirming the root cause is sample misalignment and not a bug in SHAP.

## Related
- Partially addresses #4414 (output space confusion addressed separately in #4418)
- Related to #4418

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] Branch is up to date with master
- [x] Pre-commit hooks pass
- [x] Documentation builds cleanly
- [x] No new tests required (documentation-only change)