### PR TITLE
fix: replace identity type checks with isinstance in Explainer and Impute

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -114,9 +114,9 @@ class Explainer(Serializable):
                 self.masker = maskers.Text(masker, mask_token="...", collapse_mask_token=True)
             else:
                 self.masker = maskers.Text(masker)
-        elif (masker is list or masker is tuple) and masker[0] is not str:
+        elif isinstance(masker, (list, tuple)) and not isinstance(masker[0], str):
             self.masker = maskers.Composite(*masker)
-        elif (masker is dict) and ("mean" in masker):
+        elif isinstance(masker, dict) and ("mean" in masker):
             self.masker = maskers.Independent(masker)
         elif masker is None and isinstance(self.model, models.TransformersPipeline):
             return self.__init__(  # type: ignore[misc]

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -114,7 +114,12 @@ class Explainer(Serializable):
                 self.masker = maskers.Text(masker, mask_token="...", collapse_mask_token=True)
             else:
                 self.masker = maskers.Text(masker)
-        elif isinstance(masker, (list, tuple)) and not isinstance(masker[0], str):
+        elif (
+            isinstance(masker, (list, tuple))
+            and len(masker) > 0
+            and not isinstance(masker[0], str)
+            and all(isinstance(m, maskers.Masker) for m in masker)
+        ):
             self.masker = maskers.Composite(*masker)
         elif isinstance(masker, dict) and ("mean" in masker):
             self.masker = maskers.Independent(masker)

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -338,7 +338,7 @@ class Impute(Masker):  # we should inherit from Tabular once we add support for 
             The background dataset that is used for masking.
 
         """
-        if data is dict and "mean" in data:
+        if isinstance(data, dict) and "mean" in data:
             self.mean = data.get("mean", None)
             self.cov = data.get("cov", None)
             data = np.expand_dims(data["mean"], 0)

--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -241,3 +241,53 @@ def test_independent_masker_with_small_data():
     # Should keep all data
     assert masker.data.shape[0] == 5
     assert masker.data.shape[1] == 3
+
+
+def test_impute_masker_with_dict_mean_cov():
+    """Test that Impute masker correctly handles dict input with mean and cov.
+
+    Regression test for the bug where ``data is dict`` (identity check against
+    the type object) was used instead of ``isinstance(data, dict)``, making the
+    dict branch unreachable.
+    """
+    mean = np.array([1.0, 2.0, 3.0])
+    cov = np.eye(3)
+    masker = shap.maskers.Impute({"mean": mean, "cov": cov})
+
+    assert np.allclose(masker.mean, mean)
+    assert np.allclose(masker.cov, cov)
+    # data should be reshaped from the mean vector
+    assert masker.data.shape == (1, 3)
+
+
+def test_explainer_creates_independent_from_dict_masker():
+    """Test that Explainer.__init__ routes a dict masker to Independent.
+
+    Regression test for ``masker is dict`` identity check.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    X = np.random.RandomState(0).randn(20, 3)
+    y = X @ [1, 2, 3]
+    model = LinearRegression().fit(X, y)
+
+    mean = X.mean(axis=0)
+    cov = np.cov(X.T)
+    explainer = shap.Explainer(model.predict, masker={"mean": mean, "cov": cov})
+
+    assert isinstance(explainer.masker, shap.maskers.Independent)
+
+
+def test_explainer_creates_composite_from_list_masker():
+    """Test that Explainer.__init__ routes a list of maskers to Composite.
+
+    Regression test for ``masker is list`` identity check.
+    """
+    X = np.random.RandomState(0).randn(20, 3)
+    masker1 = shap.maskers.Independent(X[:, :2])
+    masker2 = shap.maskers.Independent(X[:, 2:])
+
+    # Should not raise; the list branch should create a Composite masker
+    explainer = shap.Explainer(lambda x: x.sum(axis=1), masker=[masker1, masker2])
+
+    assert isinstance(explainer.masker, shap.maskers.Composite)


### PR DESCRIPTION
## Summary

Closes #4372

Three type checks use `is` (identity) instead of `isinstance`, making their branches unreachable dead code:

| Location | Bug | Effect |
|---|---|---|
| `_explainer.py:117` | `masker is list or masker is tuple` | Composite masker path never executes |
| `_explainer.py:117` | `masker[0] is not str` | Same line, same pattern |
| `_explainer.py:119` | `masker is dict` | Dict-to-Independent masker path never executes |
| `_tabular.py:341` | `data is dict` | Impute dict initialization never executes |

`x is dict` compares an instance to the `dict` type object, which is always `False`. The correct pattern is `isinstance(x, dict)`.

## Changes
- Replace all four identity checks with `isinstance()` in `_explainer.py` and `_tabular.py`
- Add regression tests for each fixed code path (Impute dict init, Explainer dict masker, Explainer list masker)

## Test plan
- [x] Three new regression tests pass
- [x] All existing masker tests pass
- [x] Bug confirmed: `{'mean': ...} is dict` → `False`, `isinstance({'mean': ...}, dict)` → `True`

**Note:** This is a more complete fix than #4373, which addresses lines 119 and 341 but misses the `masker is list or masker is tuple` bug on line 117 and includes no tests.

**Note:** Tests were scaffolded with AI assistance and reviewed/validated locally.