### PR TITLE
TEST: increase test coverage for shap/explainers/other/_treegain.py

### DIFF
--- a/tests/explainers/other/test_treegain.py
+++ b/tests/explainers/other/test_treegain.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+from shap.explainers.other import TreeGain
+
+
+def test_treegain_xgbregressor():
+    pytest.importorskip("xgboost")
+    import xgboost
+
+    # Train a simple model
+    X = np.random.randn(10, 3)
+    y = np.random.randn(10)
+    model = xgboost.XGBRegressor(n_estimators=10)
+    model.fit(X, y)
+
+    # Check that TreeGain can explain it
+    explainer = TreeGain(model)
+    attributions = explainer.attributions(X)
+
+    assert isinstance(attributions, np.ndarray)
+    assert attributions.shape == (10, 3)
+    # attributions should be tiled feature_importances_
+    np.testing.assert_allclose(attributions[0], model.feature_importances_)
+    np.testing.assert_allclose(attributions[-1], model.feature_importances_)
+
+
+def test_treegain_unsupported_model():
+    class UnsupportedModel:
+        pass
+
+    model = UnsupportedModel()
+    with pytest.raises(NotImplementedError, match="The passed model is not yet supported by TreeGainExplainer"):
+        TreeGain(model)
+
+
+def test_treegain_missing_feature_importances():
+    pytest.importorskip("xgboost")
+    import xgboost
+
+    # Unfitted model lacks feature_importances_
+    model = xgboost.XGBRegressor()
+
+    with pytest.raises(AssertionError, match="The passed model does not have a feature_importances_ attribute"):
+        TreeGain(model)


### PR DESCRIPTION
## Overview

Addresses #3690 <!-- Using "Addresses" instead of "Closes" because #3690 is a meta-issue tracking multiple files -->

Description of the changes proposed in this pull request:
This PR increases the test coverage for `shap/explainers/other/_treegain.py` up to 100%, completing a Good First Issue for the ESoC 2026 warm-up task.

Specifically, it adds `tests/explainers/other/test_treegain.py` covering:
- `test_treegain_xgbregressor`: Validates that `TreeGain` attributions successfully extract and tile `feature_importances_` from a fitted tree model.
- `test_treegain_unsupported_model`: Validates that a `NotImplementedError` is properly raised for non-supported model types.
- `test_treegain_missing_feature_importances`: Validates that an `AssertionError` is properly raised for unfitted trees missing the `feature_importances_` attribute.

### AI Usage Disclosure
*As per the SHAP AI Usage Policy:*
- **What the AI did:** I used an AI pair-programming assistant to help me explore the repository structure for `_treegain.py` and generate the `pytest` boilerplate for the three test functions.
- **What I did:** I initiated the coverage strategy, validated the implementation of the tests, manually ran the test suite and coverage reports directly on my machine, and verified that these tests correctly assert the expected behaviors. I take full responsibility for and understand every line of code submitted in this PR.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
