### PR TITLE
Resolve: DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)

### DIFF
--- a/shap/explainers/_deep/deep_utils.py
+++ b/shap/explainers/_deep/deep_utils.py
@@ -11,12 +11,12 @@ def _check_additivity(explainer, model_output_values, output_phis):
     for t in range(len(explainer.expected_value)):
         if not explainer.multi_input:
             diffs = (
-                model_output_values[:, t]
-                - explainer.expected_value[t]
+                model_output_values[:, t].numpy()
+                - np.asarray(explainer.expected_value[t])
                 - output_phis[t].sum(axis=tuple(range(1, output_phis[t].ndim)))
             )
         else:
-            diffs = model_output_values[:, t] - explainer.expected_value[t]
+            diffs = model_output_values[:, t].numpy() - np.asarray(explainer.expected_value[t])
 
             for i in range(len(output_phis[t])):
                 diffs -= output_phis[t][i].sum(axis=tuple(range(1, output_phis[t][i].ndim)))


### PR DESCRIPTION
## Overview

Resolves (part of) #3066 

```python
DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)
```

Description of the changes proposed in this pull request:

This warning is raised when `explainer.expected_value[t]` and `output_phis[t].sum(axis=tuple(range(1, output_phis[t].ndim)))` are subtracted from`model_output_values[:, t]`. 

The warning is raised when a `numpy-ndarray` is subtracted from a `torch.Tensor` as illustrated in the toy example below (probably due to the implicit type conversion).

<img width="1029" height="268" alt="Screenshot 2026-04-10 at 7 32 45 PM" src="https://github.com/user-attachments/assets/76cf1386-123a-4e15-ac68-5d25ceb4e431" />


`model_output_values[:, t]` is either a `torch.Tensor` or a `tensorflow.python.framework.ops.EagerTensor`, depending on the framework being used. Both tensors support the `.numpy()` method, so in the updated code it is called to convert them to `numpy-ndarray`.

`output_phis[t].sum(axis=tuple(range(1, output_phis[t].ndim)))` is `numpy-ndarray`.

`explainer.expected_value[t]` is either a `tensor` or `numpy-ndarray`, or `np.float32`. Using `np.asarray` is the best method to convert to `numpy-ndarray` as it doesn't raise a warning when a numpy array or tensor is passed to it. Other ways to convert `explainer.expected_value[t]` to `numpy-ndarray` are to use `np.array` (which raises the DeprecationWarning) or do `explainer.expected_value[t].numpy() if hasattr(explainer.expected_value[t], 'numpy') else explainer.expected_value[t]` (less clean).

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
