### PR TITLE
fix: use isinstance() instead of identity check for dict in Impute

### DIFF
--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -338,7 +338,7 @@ class Impute(Masker):  # we should inherit from Tabular once we add support for 
             The background dataset that is used for masking.
 
         """
-        if data is dict and "mean" in data:
+        if isinstance(data, dict) and "mean" in data:
             self.mean = data.get("mean", None)
             self.cov = data.get("cov", None)
             data = np.expand_dims(data["mean"], 0)

--- a/tests/maskers/test_impute.py
+++ b/tests/maskers/test_impute.py
@@ -1,0 +1,55 @@
+"""Tests for the Impute masker, specifically dict-based initialization.
+
+Regression tests for https://github.com/shap/shap/issues/4372.
+"""
+
+from collections import OrderedDict
+
+import numpy as np
+
+from shap.maskers import Impute
+
+
+def test_impute_dict_initialization():
+    """Impute correctly extracts mean/cov from a dict input.
+
+    The previous code used ``data is dict`` (identity check) instead of
+    ``isinstance(data, dict)``, so the dict branch was dead code.
+    """
+    mu = np.zeros(3)
+    cov = np.eye(3)
+    masker = Impute({"mean": mu, "cov": cov})
+
+    np.testing.assert_array_equal(masker.mean, mu)
+    np.testing.assert_array_equal(masker.cov, cov)
+    assert masker.data.shape == (1, 3)
+
+
+def test_impute_dict_subclass():
+    """isinstance(data, dict) must match dict subclasses like OrderedDict."""
+    mu = np.zeros(3)
+    cov = np.eye(3)
+    masker = Impute(OrderedDict([("mean", mu), ("cov", cov)]))
+
+    np.testing.assert_array_equal(masker.mean, mu)
+    np.testing.assert_array_equal(masker.cov, cov)
+    assert masker.data.shape == (1, 3)
+
+
+def test_impute_dict_mean_only():
+    """Dict with 'mean' but no 'cov' should set cov to None."""
+    mu = np.array([1.0, 2.0, 3.0])
+    masker = Impute({"mean": mu})
+
+    np.testing.assert_array_equal(masker.mean, mu)
+    assert masker.cov is None
+    assert masker.data.shape == (1, 3)
+
+
+def test_impute_ndarray_initialization():
+    """Impute with a plain ndarray skips the dict branch."""
+    data = np.random.randn(100, 4)
+    masker = Impute(data)
+
+    np.testing.assert_array_equal(masker.data, data)
+    assert not hasattr(masker, "mean")


### PR DESCRIPTION
Fixes #4372

**Problem**: `Impute.__init__` uses `data is dict` (identity check) instead of
`isinstance(data, dict)` to detect dict-typed input data. Since `data` is never the
`dict` class itself, the branch for extracting precomputed mean/covariance is silently
skipped for all dict inputs.

**Root cause**: `is` checks object identity, not type membership. The condition
`data is dict` is only `True` when `data` literally *is* the built-in `dict` class
object, not when `data` is a dict instance.

**Fix**: Replace `data is dict` with `isinstance(data, dict)` in
`shap/maskers/_tabular.py` line 341.

**Tests**: Added `tests/maskers/test_impute.py` with 4 regression tests:
- dict with mean + cov keys
- dict subclass (OrderedDict)
- dict with mean only (no cov)
- plain ndarray (unchanged path)

### AI Disclosure

AI tools (Claude) were used for initial investigation and test scaffolding. All code
was reviewed and verified manually.