### PR TITLE
FIX: Correct max_evals calculation in PermutationExplainer.shap_values()

### DIFF
--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -283,7 +283,7 @@ class PermutationExplainer(Explainer):
             of such matrices, one for each output.
 
         """
-        explanation = self(X, max_evals=npermutations * X.shape[1], main_effects=main_effects)
+        explanation = self(X, max_evals=npermutations * (2 * X.shape[1] + 1), main_effects=main_effects)
         return explanation.values  # type: ignore[union-attr]
 
     def __str__(self) -> str:


### PR DESCRIPTION

## Description

Closes #4433.

I was looking into how `PermutationExplainer.shap_values()` works and noticed a bug where it ends up starving the explainer of evaluation budget. It computes `max_evals` using `npermutations * X.shape[1]`. However, since every individual permutation needs an evaluation for both the forward pass and the backward pass, plus one for the baseline, the actual requirement is `2 * n_features + 1` evaluations per permutation.

Because of this under-allocation, the underlying [explain_row()](cci:1://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_permutation.py:127:4-250:9) method ends up running far fewer permutations than the user actually requested. 

## Changes:
- Updated the `max_evals` calculation in [shap_values()](cci:1://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_permutation.py:252:4-286:62) to pass `npermutations * (2 * X.shape[1] + 1)`, ensuring the explainer can execute the correct number of permutations.

All tests in `test_permutation.py` are passing locally.
