### PR TITLE
fix: suppress outstanding 3rd-party deprecation warnings in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,12 @@ filterwarnings = [
   "ignore:.*typing.io is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*is_datetime64tz_dtype is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*'force_all_finite' was renamed to 'ensure_all_finite' in 1.6.*:FutureWarning:.*sklearn.*",
+  # TensorFlow graph-mode deprecations — SHAP DeepExplainer still needs these APIs (GH #3066)
+  "ignore:.*graph support has been removed in eager mode.*",
+  "ignore:.*The structure of inputs doesn't match the expected structure.*",
+  "ignore:.*Conversion of an array with ndim > 0 to a scalar is deprecated.*",
+  # Transformers deprecation outside SHAP's control (GH #3066)
+  "ignore:.*`return_all_scores` is now deprecated.*",
 ]
 markers = ["xslow: mark test as extremely slow (not run unless explicitly requested)"]
 


### PR DESCRIPTION
Fixes #3066

Addresses remaining outstanding deprecation warnings in the test suite by adding `filterwarnings` entries in `pyproject.toml` for warnings that originate entirely from third-party libraries outside SHAP's control.

**Suppressed warnings:**
- TensorFlow graph-mode deprecations (`graph support has been removed in eager mode`, `The structure of inputs doesn't match the expected structure`, `Conversion of an array with ndim > 0 to a scalar is deprecated`) — SHAP's `DeepExplainer` still depends on these TF APIs
- Transformers library: `` `return_all_scores` is now deprecated ``

**Note:** The deprecated NumPy type aliases (`np.bool`, `np.int`, `np.float`, etc.) were searched exhaustively across the `shap/` source tree — none were found. The codebase already uses the correct modern equivalents (`bool`, `int`, `float`, `np.bool_`, etc.).