### PR TITLE
TYP: add type hints for explainers.tf_utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ module = [
   # "shap.explainers._coalition",      # NOW TYPE CHECKED - type hints added
   "shap.explainers.other._random",
   "shap.explainers.pytree",
-  "shap.explainers.tf_utils",
+  # "shap.explainers.tf_utils",        # NOW TYPE CHECKED - type hints added
   # "shap.maskers._composite",  # NOW TYPE CHECKED - type hints added
   # "shap.maskers._fixed",      # NOW TYPE CHECKED - type hints added
   "shap.maskers._image",

--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from types import ModuleType
 
 tf: ModuleType | None = None
+
+
+class TFModel(Protocol):
+    """Structural type for TensorFlow Keras models used by the TF-based explainers.
+
+    Captures the attributes accessed in this module so callers can pass any
+    Keras-style model without importing TensorFlow at type-check time.
+    """
+
+    inputs: Any
+    outputs: Any
+    layers: list[Any]
 
 
 def _import_tf() -> None:
@@ -54,7 +66,7 @@ def _get_graph(explainer: Any) -> Any:
         return graph
 
 
-def _get_model_inputs(model: Any) -> Any:
+def _get_model_inputs(model: TFModel | tuple[Any, Any]) -> Any:
     """Common utility to determine the model inputs.
 
     Parameters
@@ -64,6 +76,8 @@ def _get_model_inputs(model: Any) -> Any:
 
     """
     _import_tf()
+    if isinstance(model, tuple):
+        return model[0]
     if (
         str(type(model)).endswith("keras.engine.sequential.Sequential'>")
         or str(type(model)).endswith("keras.models.Sequential'>")
@@ -71,14 +85,12 @@ def _get_model_inputs(model: Any) -> Any:
         or isinstance(model, tf.keras.Model)  # type: ignore[union-attr]
     ):
         return model.inputs
-    if str(type(model)).endswith("tuple'>"):
-        return model[0]
 
     emsg = f"{type(model)} is not currently a supported model type!"
     raise ValueError(emsg)
 
 
-def _get_model_output(model: Any) -> Any:
+def _get_model_output(model: TFModel | tuple[Any, Any]) -> Any:
     """Common utility to determine the model output.
 
     Parameters
@@ -88,6 +100,8 @@ def _get_model_output(model: Any) -> Any:
 
     """
     _import_tf()
+    if isinstance(model, tuple):
+        return model[1]
     if (
         str(type(model)).endswith("keras.engine.sequential.Sequential'>")
         or str(type(model)).endswith("keras.models.Sequential'>")
@@ -100,8 +114,6 @@ def _get_model_output(model: Any) -> Any:
             return model.outputs[0]
         else:
             return model.layers[-1].output
-    if str(type(model)).endswith("tuple'>"):
-        return model[1]
 
     emsg = f"{type(model)} is not currently a supported model type!"
     raise ValueError(emsg)

--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -1,26 +1,27 @@
+from __future__ import annotations
+
 import warnings
+from typing import TYPE_CHECKING, Any
 
-tf = None
+if TYPE_CHECKING:
+    from types import ModuleType
+
+tf: ModuleType | None = None
 
 
-def _import_tf():
+def _import_tf() -> None:
     """Tries to import tensorflow."""
-    global tf
+    global tf  # noqa: PLW0603
     if tf is None:
-        import tensorflow as tf
+        import tensorflow as tf  # type: ignore[no-redef]  # noqa: PLW0603
 
 
-def _get_session(session):
+def _get_session(session: Any | None) -> Any:
     """Common utility to get the session for the tensorflow-based explainer.
 
     Parameters
     ----------
-    explainer : Explainer
-
-        One of the tensorflow-based explainers.
-
     session : tf.compat.v1.Session
-
         An optional existing session.
 
     """
@@ -28,24 +29,23 @@ def _get_session(session):
     # if we are not given a session find a default session
     if session is None:
         try:
-            session = tf.compat.v1.keras.backend.get_session()
+            session = tf.compat.v1.keras.backend.get_session()  # type: ignore[union-attr]
         except Exception:
-            session = tf.keras.backend.get_session()
-    return tf.get_default_session() if session is None else session
+            session = tf.keras.backend.get_session()  # type: ignore[union-attr]
+    return tf.get_default_session() if session is None else session  # type: ignore[union-attr]
 
 
-def _get_graph(explainer):
+def _get_graph(explainer: Any) -> Any:
     """Common utility to get the graph for the tensorflow-based explainer.
 
     Parameters
     ----------
     explainer : Explainer
-
         One of the tensorflow-based explainers.
 
     """
     _import_tf()
-    if not tf.executing_eagerly():
+    if not tf.executing_eagerly():  # type: ignore[union-attr]
         return explainer.session.graph
     else:
         from tensorflow.python.keras import backend
@@ -54,13 +54,12 @@ def _get_graph(explainer):
         return graph
 
 
-def _get_model_inputs(model):
+def _get_model_inputs(model: Any) -> Any:
     """Common utility to determine the model inputs.
 
     Parameters
     ----------
     model : Tensorflow Keras model or tuple
-
         The tensorflow model or tuple.
 
     """
@@ -69,7 +68,7 @@ def _get_model_inputs(model):
         str(type(model)).endswith("keras.engine.sequential.Sequential'>")
         or str(type(model)).endswith("keras.models.Sequential'>")
         or str(type(model)).endswith("keras.engine.training.Model'>")
-        or isinstance(model, tf.keras.Model)
+        or isinstance(model, tf.keras.Model)  # type: ignore[union-attr]
     ):
         return model.inputs
     if str(type(model)).endswith("tuple'>"):
@@ -79,13 +78,12 @@ def _get_model_inputs(model):
     raise ValueError(emsg)
 
 
-def _get_model_output(model):
+def _get_model_output(model: Any) -> Any:
     """Common utility to determine the model output.
 
     Parameters
     ----------
     model : Tensorflow Keras model or tuple
-
         The tensorflow model or tuple.
 
     """
@@ -94,7 +92,7 @@ def _get_model_output(model):
         str(type(model)).endswith("keras.engine.sequential.Sequential'>")
         or str(type(model)).endswith("keras.models.Sequential'>")
         or str(type(model)).endswith("keras.engine.training.Model'>")
-        or isinstance(model, tf.keras.Model)
+        or isinstance(model, tf.keras.Model)  # type: ignore[union-attr]
     ):
         if len(model.layers[-1]._inbound_nodes) == 0:
             if len(model.outputs) > 1:


### PR DESCRIPTION
Part of #3730

**What:** Add type annotations to `shap/explainers/tf_utils.py` and enable
`check_untyped_defs` for this module.

**Changes:**
- Add return and parameter type hints to `_import_tf`, `_get_session`,
  `_get_graph`, `_get_model_inputs`, `_get_model_output`
- Type the module-level lazy `tf` global as `ModuleType | None`
- Add `type: ignore[union-attr]` comments where the optional `tf` module
  is accessed after the `_import_tf()` guard (mypy can't infer the narrowing
  across the global assignment)
- Remove `shap.explainers.tf_utils` from the mypy exclusion list in
  `pyproject.toml`

**Verification:** `mypy --check-untyped-defs` passes with zero errors on this
module. `ruff check` passes. Runtime imports verified. No TF-specific tests
affected (TF is an optional dependency).

### AI Disclosure

AI tools (Claude) were used for initial investigation and annotation scaffolding.
All code was reviewed and verified manually.