### PR TITLE
DOC: Fix spelling errors in source code docstrings and comments

### DIFF
--- a/shap/benchmark/experiments.py
+++ b/shap/benchmark/experiments.py
@@ -268,7 +268,7 @@ def __thread_worker(q, host):
     hostname, python_binary = host.split(":")
     while True:
         # make sure we are not sending too many ssh connections to the host
-        # (if we send too many connections ssh thottling will lock us out)
+        # (if we send too many connections ssh throttling will lock us out)
         while True:
             all_clear = False
 

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -16,7 +16,7 @@ def remove_retrain(
     If you want to know how important a set of features is you can ask how the model would be
     different if those features had never existed. To determine this we can mask those features
     across the entire training and test datasets, then retrain the model. If we apply compare the
-    output of this retrained model to the original model we can see the effect produced by knowning
+    output of this retrained model to the original model we can see the effect produced by knowing
     the features we masked. Since for individualized explanation methods each test sample has a
     different set of most important features we need to retrain the model for every test sample
     to get the change in model performance when a specified fraction of the most important features
@@ -216,7 +216,7 @@ def keep_retrain(
     different if only those features had existed. To determine this we can mask the other features
     across the entire training and test datasets, then retrain the model. If we apply compare the
     output of this retrained model to the original model we can see the effect produced by only
-    knowning the important features. Since for individualized explanation methods each test sample
+    knowing the important features. Since for individualized explanation methods each test sample
     has a different set of most important features we need to retrain the model for every test sample
     to get the change in model performance when a specified fraction of the most important features
     are retained.

--- a/shap/explainers/_coalition.py
+++ b/shap/explainers/_coalition.py
@@ -247,7 +247,7 @@ class CoalitionExplainer(Explainer):
         )  # generate permutations of neighbours consistent with partition tree, and related weights
         self.masks, self.keys = _create_masks(
             self.root, self.masker.feature_names
-        )  # turn the premutations into valid masks for inference
+        )  # turn the permutations into valid masks for inference
         self.masks_dict = dict(zip(self.keys, self.masks))
         self.mask_permutations = _create_combined_masks(
             self.combinations_list, self.masks_dict

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1595,7 +1595,7 @@ class TreeEnsemble:
 
     @property
     def num_outputs(self) -> int:
-        # Currrently, XGBoost models derive the num_outputs attribute from the input
+        # Currently, XGBoost models derive the num_outputs attribute from the input
         # models, which is set during model load.
         if self.model_type == "xgboost":
             assert hasattr(self, "_xgboost_n_outputs")

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -133,7 +133,7 @@ class Image(Masker):
         )
 
     def build_partition_tree(self):
-        """This partitions an image into a herarchical clustering based on axis-aligned splits."""
+        """This partitions an image into a hierarchical clustering based on axis-aligned splits."""
         xmin = 0
         xmax = self.input_shape[0]
         ymin = 0
@@ -173,7 +173,7 @@ class Image(Masker):
 
 @njit
 def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q):
-    """This partitions an image into a herarchical clustering based on axis-aligned splits."""
+    """This partitions an image into a hierarchical clustering based on axis-aligned splits."""
     # heapq.heappush(q, (0, xmin, xmax, ymin, ymax, zmin, zmax, -1, False))
 
     # q.put((0, xmin, xmax, ymin, ymax, zmin, zmax, -1, False))

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -234,7 +234,7 @@ def scatter(
     if x_jitter == "auto":
         x_jitter = _suggest_x_jitter(features[:, ind])
 
-    # guess what other feature as the stongest interaction with the plotted feature
+    # guess what other feature as the strongest interaction with the plotted feature
     if interaction_index == "auto":
         interaction_index = approximate_interactions(ind, shap_values_arr, features)[0]
     interaction_index = convert_name(interaction_index, shap_values_arr, feature_names)
@@ -566,7 +566,7 @@ def dependence_legacy(
     interaction_index : "auto", None, int, or string
         The index of the feature used to color the plot. The name of a feature can also be passed
         as a string. If "auto" then shap.common.approximate_interactions is used to pick what
-        seems to be the strongest interaction (note that to find to true stongest interaction you
+        seems to be the strongest interaction (note that to find to true strongest interaction you
         need to compute the SHAP interaction values).
 
     x_jitter : float (0 - 1)
@@ -628,7 +628,7 @@ def dependence_legacy(
 
     ind = convert_name(ind, shap_values, feature_names)
 
-    # guess what other feature as the stongest interaction with the plotted feature
+    # guess what other feature as the strongest interaction with the plotted feature
     if not hasattr(ind, "__len__"):
         if interaction_index == "auto":
             interaction_index = approximate_interactions(ind, shap_values, features)[0]

--- a/shap/plots/_style.py
+++ b/shap/plots/_style.py
@@ -99,7 +99,7 @@ def set_style(_style: StyleConfig | None = None, /, **options: Unpack[StyleOptio
     Pass keyword arguments to set individual options, or pass a StyleConfig dataclass to replace all options.
     """
     if _style is not None:
-        # Unpack the dataclass; any keyword arguments take precendence.
+        # Unpack the dataclass; any keyword arguments take precedence.
         options = _style.asdict() | options
     global _STYLE
     _STYLE = _apply_options(_STYLE, options)


### PR DESCRIPTION
Closes #4443

Replaces 11 instances of technical spelling errors (such as `thottling`, `premutations`, and `herarchical`) natively inside the core components of the repository using `codespell`. Because these are purely text block replacements inside docstrings and comments, this presents zero risk to execution logic.
