### PR TITLE
TEST: improve coverage for shap/maskers/_tabular.py with focused behaviour tests

### DIFF
--- a/tests/maskers/test_tabular.py
+++ b/tests/maskers/test_tabular.py
@@ -1,10 +1,16 @@
 """This file contains tests for the Tabular maskers."""
 
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pandas as pd
+import pytest
 
 import shap
+from shap.maskers._tabular import Tabular
+from shap.utils import MaskedModel
+from shap.utils._exceptions import InvalidClusteringError
 
 
 def test_serialization_independent_masker_dataframe():
@@ -241,3 +247,91 @@ def test_independent_masker_with_small_data():
     # Should keep all data
     assert masker.data.shape[0] == 5
     assert masker.data.shape[1] == 3
+
+
+@pytest.mark.parametrize("bad_clustering", [1.0, [0, 1], {"metric": "correlation"}])
+def test_tabular_rejects_non_string_non_ndarray_clustering(bad_clustering):
+    """Invalid clustering types raise InvalidClusteringError (targets _tabular.py:78)."""
+    data = np.array([[0.0, 1.0], [2.0, 3.0]])
+    with pytest.raises(InvalidClusteringError):
+        Tabular(data, clustering=bad_clustering)
+
+
+def test_tabular_rejects_clustering_and_partition_together():
+    """Passing both clustering and partition raises ValueError (targets _tabular.py:71)."""
+    data = np.array([[0.0, 1.0], [2.0, 3.0]])
+    partition = np.array([[0, 1]], dtype=np.int64)
+    with pytest.raises(ValueError, match="both 'clustering' and 'partition'"):
+        Tabular(data, clustering="correlation", partition=partition)
+
+
+def test_tabular_partition_only_sets_partition_and_clears_clustering():
+    """Explicit partition without clustering stores partition and clears clustering (targets _tabular.py:83-84)."""
+    data = np.array([[0.0, 1.0], [2.0, 3.0]])
+    partition = np.array([[0, 1]], dtype=np.int64)
+    masker = Tabular(data, partition=partition)
+    assert masker.partition is partition
+    assert masker.clustering is None
+
+
+def test_independent_dataframe_boolean_mask_returns_dataframe():
+    """Boolean masking with DataFrame-initialized masker returns a DataFrame (targets _tabular.py:138)."""
+    df = pd.DataFrame({"a": [0.0, 1.0], "b": [2.0, 3.0]})
+    masker = shap.maskers.Independent(df)
+    x = np.array([10.0, 20.0])
+    mask = np.array([True, False])
+    out = masker(mask, x)
+    assert isinstance(out, pd.DataFrame)
+    assert list(out.columns) == ["a", "b"]
+    # True keeps x; False uses background — first background row has b == 2.0
+    expected = x * mask + df.iloc[0].values * ~mask
+    assert np.allclose(out.iloc[0].values, expected)
+
+
+def test_independent_dict_init_save_stores_mean_cov_tuple():
+    """Tabular.save persists dict-initialized data as (mean, cov) (targets _tabular.py:178)."""
+    mean = np.array([1.0, 2.0])
+    cov = np.array([[1.0, 0.0], [0.0, 1.0]])
+    masker = shap.maskers.Independent({"mean": mean, "cov": cov})
+    mock_block = MagicMock()
+    with patch("shap.maskers._tabular.Serializer") as serializer_cls:
+        serializer_cls.return_value.__enter__.return_value = mock_block
+        with tempfile.TemporaryFile() as f:
+            masker.save(f)
+    data_calls = [c.args for c in mock_block.save.call_args_list if c.args and c.args[0] == "data"]
+    assert len(data_calls) == 1
+    saved_mean, saved_cov = data_calls[0][1]
+    assert np.allclose(saved_mean, mean)
+    assert np.allclose(saved_cov, cov)
+
+
+def test_independent_integer_delta_mask_noop_chained_and_toggle():
+    """Integer delta masks: noop, main_effects-style chain, and double-toggle (targets _tabular.py:203-210, 230-265)."""
+    data = np.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+    x = np.array([10.0, 11.0, 12.0])
+    masker = shap.maskers.Independent(data)
+    noop = MaskedModel.delta_mask_noop_value
+
+    out_noop, v_noop = masker(np.array([noop, 0], dtype=np.int64), x)
+    assert out_noop[0].shape == (2 * data.shape[0], data.shape[1])
+    assert v_noop.shape == (2, data.shape[0])
+    assert np.all(v_noop[0, :])
+
+    inds = np.array([0, 1], dtype=np.int64)
+    masks_me = np.zeros(2 * len(inds), dtype=np.int64)
+    masks_me[0] = noop
+    last_ind = -1
+    for i in range(len(inds)):
+        if i > 0:
+            masks_me[2 * i] = -last_ind - 1
+        masks_me[2 * i + 1] = inds[i]
+        last_ind = inds[i]
+    out_me, v_me = masker(masks_me, x)
+    assert out_me[0].shape == (3 * data.shape[0], data.shape[1])
+    assert v_me.shape == (3, data.shape[0])
+    assert np.all(v_me[0, :])
+
+    out_tog, v_tog = masker(np.array([-1, 0], dtype=np.int64), x)
+    assert out_tog[0].shape == (data.shape[0], data.shape[1])
+    assert v_tog.shape == (1, data.shape[0])
+    assert np.allclose(out_tog[0], data)


### PR DESCRIPTION
Related to #3690

This PR improves test coverage for `shap/maskers/_tabular.py` by expanding
`tests/maskers/test_tabular.py` with focused, behaviour-driven tests.

Description of the changes proposed in this pull request:

- Added targeted tests for `Tabular` / `Independent` masker initialisation:
  - Raises `ValueError` when both `clustering` and `partition` are passed
  - Raises `InvalidClusteringError` for unsupported clustering types (parametrized)
  - Explicit `partition` without clustering stores correctly and clears clustering

- Added focused tests for masking behaviour:
  - Boolean masking with DataFrame-initialized masker returns a DataFrame with correct values
  - Integer delta masks: noop, main-effects chain, and double-toggle paths

- Added test for serialization:
  - `save()` persists dict-initialized data as `(mean, cov)` tuple correctly

- Kept scope limited to one test file and avoided unrelated feature changes.

**Note on coverage:** Lines 203–265 contain `@njit`-decorated code which
Coverage.py does not instrument under normal JIT. With `NUMBA_DISABLE_JIT=1`,
coverage reaches ~96%. Lines 341–347 are unreachable due to a pre-existing
`if data is dict` bug (flagged separately on #3690) and are intentionally
excluded from this PR.

Commands run locally:

- `pytest tests/maskers/test_tabular.py -v`
- `pytest tests/maskers/test_tabular.py --cov=shap/maskers/_tabular.py --cov-report=term-missing`
- `python -m pre_commit run --all-files`

Local coverage for `shap/maskers/_tabular.py`: **74% (JIT enabled) /
~96% (NUMBA_DISABLE_JIT=1)**

AI usage disclosure:

I used AI assistance (Cursor) to help draft and refine test scenarios and
improve branch coverage. I manually reviewed all changes, ran the checks
locally, and I take responsibility for the final code and PR content.



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
