### PR TITLE
Establish scikit-buiild-core as sole backend

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,9 +18,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies for dataset download
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system '.[download_datasets]'
       - name: Pre-download datasets
         run: python tests/datasets_to_cache.py
@@ -37,42 +38,14 @@ jobs:
           path: /tmp/test_data_cache
           retention-days: 1
 
-  generate-wheels-matrix:
-    # Create a matrix of all architectures & versions to build.
-    # This enables the next step to run cibuildwheel in parallel.
-    # From https://iscinumpy.dev/post/cibuildwheel-2-10-0/#only-210
-    name: Generate wheels matrix
-    runs-on: ubuntu-latest
-    outputs:
-      include: ${{ steps.set-matrix.outputs.include }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install cibuildwheel
-      # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==3.2.1
-      - name: Print all build identifiers
-        run: cibuildwheel --print-build-identifiers
-      - id: set-matrix
-        run: |
-          MATRIX=$(
-            {
-              cibuildwheel --print-build-identifiers --platform linux \
-              | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos \
-              | jq -nRc '{"only": inputs, "os": "macos-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform windows \
-              | jq -nRc '{"only": inputs, "os": "windows-latest"}'
-            } | jq -sc
-          )
-          echo "include=$MATRIX" >> $GITHUB_OUTPUT
-
   build_wheels:
-    name: Build ${{ matrix.only }}
-    needs: [generate-wheels-matrix, prepare_data]
+    name: Build ${{ matrix.os }} wheels
+    needs: [prepare_data]
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest]
+
     runs-on: ${{ matrix.os }}
     steps:
       # Ensure all git tags are present so version number is extracted.
@@ -93,17 +66,15 @@ jobs:
           name: test-data-cache
           path: ${{ runner.temp }}/test_data_cache
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v7
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1
-        with:
-          only: ${{ matrix.only }}
         env:
+          CIBW_ARCHS_LINUX: ${{ contains(matrix.os, '-arm') && 'aarch64' || 'x86_64' }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2
           # Pass the cache location to cibuildwheel tests
           CIBW_BEFORE_TEST: |
             python -c "import os, shutil; cache_path = os.environ.get('CACHE_PATH', '${{ runner.temp }}/test_data_cache'); home = os.path.expanduser('~'); sklearn_cache = os.path.join(home, 'scikit_learn_data'); os.makedirs(sklearn_cache, exist_ok=True); shutil.copytree(os.path.join(cache_path, 'scikit_learn_data'), sklearn_cache, dirs_exist_ok=True) if os.path.exists(os.path.join(cache_path, 'scikit_learn_data')) else None"
@@ -117,11 +88,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: bdist_files_${{ matrix.only }}
+          name: bdist_files_${{ matrix.os }}
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       # Ensure all git tags are present so version number is extracted.
       # https://github.com/actions/checkout/issues/1471
@@ -140,10 +111,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Build sdist (pep517)
         run: |
-          python -m pip install build setuptools>=70.1
-          python -m build --sdist
+          uv build --sdist
+
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,10 +9,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    # TODO: remove "move-to-nanobind" branch before merge
+    branches: [ "master", "move-to-nanobind" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "master", "move-to-nanobind" ]
     paths:
       - "shap/**"
       - "javascript/**"

--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - "move-to-nanobind"
   pull_request:
     branches:
       - master
+      - "move-to-nanobind"
     paths:
       - "shap/**"
       - "notebooks/**"

--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -15,6 +15,7 @@ on:
       - ".github/workflows/run_notebooks.yml"
       - "scripts/**"
       - "pyproject.toml"
+      - "CMakeLists.txt"
       - "setup.py"
   workflow_dispatch:
 
@@ -32,6 +33,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade uv

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,12 +37,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies for dataset download
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system '.[download_datasets]'
-          uv pip install --system nanobind
-          make build_cutils
       - name: Pre-download datasets
         run: python tests/datasets_to_cache.py
       - name: Create unified cache directory
@@ -64,7 +63,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # The total number of matrix jobs should match codecov.yml `after_n_builds`.
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         extras: ["test"]
         include:
           # Test on windows/mac, just one job each
@@ -111,13 +110,12 @@ jobs:
       - name: Install libomp (macOS)
         if: matrix.os == 'macos-latest'
         run: brew install libomp
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         # Do regular install NOT editable install: see GH #3020
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system '.[${{ matrix.extras }},plots]'
-          uv pip install --system nanobind
-          make build_cutils
       - name: Download pre-cached datasets
         uses: actions/download-artifact@v4
         with:
@@ -181,12 +179,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system numpy==2.0 '.[test-core,plots]'
-          uv pip install --system nanobind
-          make build_cutils
       - name: Test with pytest
         run: pytest --durations=20 --import-mode=append
 
@@ -200,12 +197,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.13
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade uv
           uv pip install --system '.[test-core]'
+          # TODO: consider removing requirements.ci.txt and use pyproject.toml extras instead
           uv pip install --system --reinstall -r requirements.ci.txt
-          uv pip install --system nanobind
-          make build_cutils
       - name: Run mypy
         run: mypy shap tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,11 +3,14 @@ name: tests
 on:
   workflow_dispatch:
   push:
+    # TODO: remove "move-to-nanobind" branch before merge
     branches:
       - master
+      - "move-to-nanobind"
   pull_request:
     branches:
       - master
+      - "move-to-nanobind"
     paths:
       - "shap/**"
       - "tests/**"
@@ -15,6 +18,7 @@ on:
       - "javascript/**"  # Include JS changes that affect bundle.js
       - ".github/workflows/run_tests.yml"
       - "pyproject.toml"
+      - "CMakeLists.txt"
       - "setup.py"
 
 concurrency:

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -6,11 +6,14 @@ name: test_js
 
 on:
   push:
+    # TODO: remove "move-to-nanobind" branch before merge
     branches:
       - master
+      - "move-to-nanobind"
   pull_request:
     branches:
       - master
+      - "move-to-nanobind"
     paths:
       - "javascript/**"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,16 +7,17 @@ build:
     python: "3.12"
   jobs:
     # cf. https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
-    setup_uv:
+    pre_create_environment:
       - asdf plugin add uv
       - asdf install uv latest
       - asdf global uv latest
-    create_env:
+    create_environment:
       - uv venv
       - uv sync
     install:
       - uv pip install -r docs/requirements-docs.txt
-    build_docs:
-      - >-
-        uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-        docs $READTHEDOCS_OUTPUT/html
+    build:
+      html:
+        - >-
+          uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
+          docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,18 +2,21 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
-  commands:
+  jobs:
     # cf. https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv venv
-    - uv pip install -r docs/requirements-docs.txt
-    - uv pip install setuptools cython
-    - .venv/bin/python setup.py build_ext --inplace
-    - >-
-      .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-      docs $READTHEDOCS_OUTPUT/html
+    setup_uv:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_env:
+      - uv venv
+      - uv sync
+    install:
+      - uv pip install -r docs/requirements-docs.txt
+    build_docs:
+      - >-
+        uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
+        docs $READTHEDOCS_OUTPUT/html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,86 @@
 # Followed https://nanobind.readthedocs.io/en/latest/building.html
-cmake_minimum_required(VERSION 3.26)
-project(cutils) # Replace 'my_project' with the name of your project
+cmake_minimum_required(VERSION 3.15...3.27)
+project(cutils LANGUAGES CXX)
 
-if (CMAKE_VERSION VERSION_LESS 4.2)
+if (NOT SKBUILD)
+  message(FATAL_ERROR "\
+  This CMakeLists.txt is meant to be used with scikit-build.
+  Please use 'python -m pip install .', not 'cmake'.")
+endif()
+
+# Find the Python interpreter and development components.
+if (CMAKE_VERSION VERSION_LESS 3.18)
   set(DEV_MODULE Development)
 else()
   set(DEV_MODULE Development.Module)
 endif()
 
-find_package(Python COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+find_package(Python 3.12
+  COMPONENTS Interpreter ${DEV_MODULE} REQUIRED
+  OPTIONAL_COMPONENTS Development.SABIModule)
 
+# Perform an optimized release build unless otherwise specified
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
+# ==============================================================================
+# Build the nanobind extension module (cutils)
+# ==============================================================================
+
 # Detect the installed nanobind package and import it into CMake
-execute_process(
-  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
-  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
 find_package(nanobind CONFIG REQUIRED)
 
-# do we need the relative path to the source file?
-nanobind_add_module(cutils shap/cutils/cutils.cpp)
+# Create the cutils module using nanobind
+nanobind_add_module(
+  cutils
+
+  # This extension is free-threaded
+  FREE_THREADED
+
+  # Target the stable ABI of Python 3.12+, reducing the number of binary wheels
+  STABLE_ABI
+
+  # Build libnanobind as a static library and link it into the module
+  NB_STATIC
+
+  # Sources for the cutils module
+  shap/cutils/cutils.cpp
+)
+
+# Install the module to shap
+install(TARGETS cutils LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
+
+# ==============================================================================
+# Build the Tree Logic extension module (cext)
+# ==============================================================================
+
+# Check if the SABI version is being requested
+if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
+  set(USE_SABI USE_SABI ${SKBUILD_SABI_VERSION})
+endif()
+
+python_add_library(
+  _cext
+  MODULE
+
+  # Use the SABI if requested
+  WITH_SOABI ${USE_SABI}
+
+  # Sources for the cext module
+  shap/cext/_cext.cc
+)
+
+# Get the include directory for NumPy and add it to the include path
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}"
+    -c "import numpy; print(numpy.get_include())"
+    OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+target_include_directories(_cext PUBLIC ${NUMPY_INCLUDE_DIR})
+
+# Install directive for scikit-build-core
+install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,10 @@ if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
 endif()
 
 python_add_library(
-  _cext
-  MODULE
+  _cext MODULE
 
-  # Use the SABI if requested
-  WITH_SOABI ${USE_SABI}
+  # Target the stable ABI of Python 3.12+, reducing the number of binary wheels
+  ${USE_SABI} WITH_SOABI
 
   # Sources for the cext module
   shap/cext/_cext.cc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,21 @@
 [build-system]
 # Note for maintainers: this numpy constraint is specific to wheels for PyPI. See:
 # https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-abi-handling
-requires = ["setuptools>=61.0", "setuptools-scm>=8.0", "numpy>=2.0", "packaging>20.9",
-            "cython>=3.0.11", "nanobind>=2.0"]
-build-backend = "setuptools.build_meta"
+requires = [
+  "scikit-build-core>=0.10.0",
+  "numpy>=2.0",
+  "packaging>20.9",
+  "cython>=3.0.11",
+  "nanobind>=2.0.0",
+]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "shap"
 description = "A unified approach to explain the output of any machine learning model."
 readme = "README.md"
-license = {text = "MIT License"}
-authors = [
-  {name = "Scott Lundberg", email = "slund1@cs.washington.edu"},
-]
+license = { text = "MIT License" }
+authors = [{ name = "Scott Lundberg", email = "slund1@cs.washington.edu" }]
 requires-python = ">=3.12"
 dependencies = [
   'numpy>=2',
@@ -22,9 +25,9 @@ dependencies = [
   'tqdm>=4.27.0',
   'packaging>20.9',
   'slicer==0.0.8',
-  'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',  # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
+  'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',    # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
   'numba; sys_platform != "darwin" or platform_machine != "x86_64"',
-  'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"',  # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
+  'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"', # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
   'llvmlite; sys_platform != "darwin" or platform_machine != "x86_64"',
   'cloudpickle',
   'typing-extensions',
@@ -64,38 +67,33 @@ docs = [
   "sphinx_github_changelog",
   "myst-parser",
   "requests",
-  "ipywidgets",  # For tqdm in notebooks
+  "ipywidgets",              # For tqdm in notebooks
 ]
-test-core = [
-  "pytest",
-  "pytest-mpl",
-  "pytest-cov",
-  "mypy",
-]
+test-core = ["pytest", "pytest-mpl", "pytest-cov", "mypy"]
 test = [
   "pytest",
   "pytest-mpl",
   "pytest-cov",
   "xgboost",
   "lightgbm",
-  'catboost; python_version < "3.14"',  # TODO: pending 3.14 support
-  'gpboost==1.6.3.1; python_version < "3.14"',  # TODO: pending 3.14 support, see GH #4210
+  'catboost; python_version < "3.14"',         # TODO: pending 3.14 support
+  'gpboost==1.6.3.1; python_version < "3.14"', # TODO: pending 3.14 support, see GH #4210
   "ngboost",
   "pyspark",
   "pyod",
-  "transformers < 4.54.0",  # TODO: fix once tests pass for 4.54.0
+  "transformers < 4.54.0",                     # TODO: fix once tests pass for 4.54.0
   "tf-keras",
-  "protobuf",  # See GH #3046
-  'torch; python_version < "3.14"',  # TODO: pending 3.14 support
-  'torchvision; python_version < "3.14"',  # TODO: pending 3.14 support
-  'tensorflow; python_version < "3.14"',  # TODO: pending 3.14 support
+  "protobuf",                                  # See GH #3046
+  'torch; python_version < "3.14"',            # TODO: pending 3.14 support
+  'torchvision; python_version < "3.14"',      # TODO: pending 3.14 support
+  'tensorflow; python_version < "3.14"',       # TODO: pending 3.14 support
   "sentencepiece",
   "opencv-python",
   # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
   # See GH #3707, #3768, 3922
   "numpy>=2.0",
   "causalml>=0.15.5",
-  "selenium",  # needed to test the javascript based plots
+  "selenium",         # needed to test the javascript based plots
 ]
 
 build = ["nanobind>=2.12"]
@@ -110,16 +108,51 @@ test_notebooks = [
   "keras",
 ]
 
-nbtest = [
-  "nbtest-plugin",
-  "nbtest-gen",
-  "nbtest-lab-extension"
+nbtest = ["nbtest-plugin", "nbtest-gen", "nbtest-lab-extension"]
+
+[dependency-groups]
+core = ["pytest", "pytest-mpl", "pytest-cov", "mypy", "pre-commit"]
+test = [
+  "pytest",
+  "pytest-mpl",
+  "pytest-cov",
+  "xgboost",
+  "lightgbm",
+  'catboost; python_version < "3.14"',         # TODO: pending 3.14 support
+  'gpboost==1.6.3.1; python_version < "3.14"', # TODO: pending 3.14 support, see GH #4210
+  "ngboost",
+  "pyspark",
+  "pyod",
+  "transformers < 4.54.0",                     # TODO: fix once tests pass for 4.54.0
+  "tf-keras",
+  "protobuf",                                  # See GH #3046
+  'torch; python_version < "3.14"',            # TODO: pending 3.14 support
+  'torchvision; python_version < "3.14"',      # TODO: pending 3.14 support
+  'tensorflow; python_version < "3.14"',       # TODO: pending 3.14 support
+  "sentencepiece",
+  "opencv-python",
+  # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
+  # See GH #3707, #3768, 3922
+  "numpy>=2.0",
+  "causalml>=0.15.5",
+  "selenium",         # needed to test the javascript based plots
 ]
+notebooks = ["jupyter", "nbconvert", "nbformat"]
 
 [project.urls]
 Repository = 'http://github.com/shap/shap'
 Documentation = 'https://shap.readthedocs.io/en/latest/index.html'
 "Release Notes" = 'https://shap.readthedocs.io/en/latest/release_notes.html'
+
+[tool.uv]
+cache-keys = [
+  { file = "shap/cext/*.cc" },
+  { file = "shap/cext/*.cu" },
+  { file = "shap/cext/*.h" },
+  { file = "shap/cutils/*.cpp" },
+  { file = "shap/cutils/*.h" },
+  { file = "CMakeLists.txt" },
+]
 
 [tool.mypy]
 check_untyped_defs = true
@@ -206,7 +239,7 @@ packages = [
   'shap.maskers',
   'shap.utils',
   'shap.actions',
-  'shap.models'
+  'shap.models',
 ]
 
 [tool.setuptools_scm]
@@ -224,7 +257,9 @@ filterwarnings = [
   "ignore:.*is_datetime64tz_dtype is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*'force_all_finite' was renamed to 'ensure_all_finite' in 1.6.*:FutureWarning:.*sklearn.*",
 ]
-markers = ["xslow: mark test as extremely slow (not run unless explicitly requested)"]
+markers = [
+  "xslow: mark test as extremely slow (not run unless explicitly requested)",
+]
 
 [tool.ruff]
 # Careful: when running on pre-commit, ruff's "include" and "exclude" config
@@ -236,17 +271,17 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-  "F",  # pyflakes
-  "I",  # isort
-  "ISC",  # string literal concatenation.
-  "UP",  # pyupgrade
-  "E",  # pycodestyle
-  "W",  # warning
-  "D",  # pydocstyle
-  "NPY",  # Numpy
-  "SIM101",  # flake8-simplify
-  "FA",  # future annotations
-  "TCH",  # Move type only imports to type-checking condition.
+  "F",      # pyflakes
+  "I",      # isort
+  "ISC",    # string literal concatenation.
+  "UP",     # pyupgrade
+  "E",      # pycodestyle
+  "W",      # warning
+  "D",      # pydocstyle
+  "NPY",    # Numpy
+  "SIM101", # flake8-simplify
+  "FA",     # future annotations
+  "TCH",    # Move type only imports to type-checking condition.
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [
@@ -261,17 +296,17 @@ ignore = [
   "W191",
 
   # pydocstyle issues not yet fixed
-  "D100",  # Missing docstring in public module
-  "D101",  # Missing docstring in public class
-  "D102",  # Missing docstring in public method
-  "D103",  # Missing docstring in public function
-  "D104",  # Missing docstring in public package
-  "D105",  # Missing docstring in magic method
-  "D205",  # 1 blank line required between summary line and description
-  "D400",  # First line should end with a period
-  "D401",  # First line of docstring should be in imperative mood: "A basic partial dependence plot function."
-  "D404",  # First word of the docstring should not be "This"
-  "NPY002",  # Allow numpy RandomState objects in tests
+  "D100",   # Missing docstring in public module
+  "D101",   # Missing docstring in public class
+  "D102",   # Missing docstring in public method
+  "D103",   # Missing docstring in public function
+  "D104",   # Missing docstring in public package
+  "D105",   # Missing docstring in magic method
+  "D205",   # 1 blank line required between summary line and description
+  "D400",   # First line should end with a period
+  "D401",   # First line of docstring should be in imperative mood: "A basic partial dependence plot function."
+  "D404",   # First word of the docstring should not be "This"
+  "NPY002", # Allow numpy RandomState objects in tests
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -285,10 +320,14 @@ convention = "numpy"
 "docs/user_studies/*.ipynb" = ["ALL"]
 
 # Ignore SHAP Paper, as it is an unmaintained record of a published paper
-"notebooks/tabular_examples/tree_based_models/tree_shap_paper/*"  = ["ALL"]
+"notebooks/tabular_examples/tree_based_models/tree_shap_paper/*" = ["ALL"]
 
 # Disable some unwanted rules on Jupyter notebooks
-"*.ipynb" = ["D", "E703", "E402"]  # Allow trailing semicolons, allow imports not at top
+"*.ipynb" = [
+  "D",
+  "E703",
+  "E402",
+] # Allow trailing semicolons, allow imports not at top
 
 # Ignore pycodestyle in tests
 "tests/*py" = ["D"]
@@ -306,7 +345,12 @@ combine = ["shap", "*/site-packages/shap"]
 # skip cp38-musllinux_x86_64 since numpy never provided cp38 musllinux wheels
 #  they introduced musllinux in 1.25 when they already dropped cp38
 # skip *t (free-threaded builds) since dependencies like llvmlite don't support it yet
-skip = ["cp314-macosx_x86_64", "cp314t-manylinux_x86_64", "cp314t-macosx_x86_64", "cp314t-win_amd64"]
+skip = [
+  "cp314-macosx_x86_64",
+  "cp314t-manylinux_x86_64",
+  "cp314t-macosx_x86_64",
+  "cp314t-win_amd64",
+]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 # https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-abi-handling
 requires = [
   "scikit-build-core>=0.10.0",
+  "setuptools-scm>=8.0",
   "numpy>=2.0",
   "packaging>20.9",
   "cython>=3.0.11",
@@ -225,8 +226,14 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.setuptools]
-packages = [
+[tool.setuptools_scm]
+version_file = "shap/_version.py"
+# Use "no-local-version" so dev releases are compatibile with PyPI
+local_scheme = "no-local-version"
+
+[tool.scikit-build]
+# List of packages to include in the wheel
+wheel.packages = [
   'shap',
   'shap.cext',
   'shap.explainers',
@@ -242,10 +249,18 @@ packages = [
   'shap.models',
 ]
 
-[tool.setuptools_scm]
-version_file = "shap/_version.py"
-# Use "no-local-version" so dev releases are compatibile with PyPI
-local_scheme = "no-local-version"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["shap/_version.py"]
+
+# Protect the configuration against future changes in scikit-build-core
+minimum-version = "build-system.requires"
+
+# Setuptools-style build caching in a local directory
+build-dir = "build/{wheel_tag}"
+
+# Build stable ABI wheels for CPython 3.12+
+wheel.py-api = "cp312"
+
 
 [tool.pytest.ini_options]
 addopts = "--mpl -m 'not xslow'"
@@ -340,10 +355,10 @@ omit = ["shap/benchmark/*"]
 combine = ["shap", "*/site-packages/shap"]
 
 [tool.cibuildwheel]
+# TODO: Should we use uv as build frontend for faster builds?
+# build-frontend = "uv"
+
 # Restrict the set of builds to mirror the wheels available in scipy. See #3028
-# skip *-musllinux_aarch64 since numpy doesn't provid those wheels
-# skip cp38-musllinux_x86_64 since numpy never provided cp38 musllinux wheels
-#  they introduced musllinux in 1.25 when they already dropped cp38
 # skip *t (free-threaded builds) since dependencies like llvmlite don't support it yet
 skip = [
   "cp314-macosx_x86_64",
@@ -359,13 +374,19 @@ test-extras = ["test-core", "plots"]
 # skip tests on emulated architectures, as they are very slow
 # skip tests on *-macosx_arm64 , as cibuildwheel does not support tests on arm64 (yet)
 # skip tests on *-musllinux*" since llvmlite and numba do not provide musllinux wheels
-test-skip = "cp314-macosx_x86_64 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-musllinux*"
+test-skip = "cp314-macosx_x86_64 *-*linux_{aarch64} *-macosx_arm64 *-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
 
 [tool.cibuildwheel.windows]
+# TODO: Should we support Windows ARM64 too?
 archs = ["AMD64"]
 
 [tool.cibuildwheel.macos]
+# TODO: Should we build universal2 wheels for macOS to reduce wheel count?
 archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.macos.environment]
+# Needed for C++17 support
+MACOSX_DEPLOYMENT_TARGET = "10.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,10 @@ build-backend = "scikit_build_core.build"
 name = "shap"
 description = "A unified approach to explain the output of any machine learning model."
 readme = "README.md"
-license = { text = "MIT License" }
-authors = [{ name = "Scott Lundberg", email = "slund1@cs.washington.edu" }]
+license = {text = "MIT License"}
+authors = [
+  {name = "Scott Lundberg", email = "slund1@cs.washington.edu"},
+]
 requires-python = ">=3.12"
 dependencies = [
   'numpy>=2',
@@ -26,9 +28,9 @@ dependencies = [
   'tqdm>=4.27.0',
   'packaging>20.9',
   'slicer==0.0.8',
-  'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',    # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
+  'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',  # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
   'numba; sys_platform != "darwin" or platform_machine != "x86_64"',
-  'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"', # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
+  'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"',  # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
   'llvmlite; sys_platform != "darwin" or platform_machine != "x86_64"',
   'cloudpickle',
   'typing-extensions',
@@ -50,6 +52,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+
 [project.optional-dependencies]
 plots = ["matplotlib", "ipython"]
 others = ["lime"]
@@ -68,33 +71,38 @@ docs = [
   "sphinx_github_changelog",
   "myst-parser",
   "requests",
-  "ipywidgets",              # For tqdm in notebooks
+  "ipywidgets",  # For tqdm in notebooks
 ]
-test-core = ["pytest", "pytest-mpl", "pytest-cov", "mypy"]
+test-core = [
+  "pytest",
+  "pytest-mpl",
+  "pytest-cov",
+  "mypy",
+]
 test = [
   "pytest",
   "pytest-mpl",
   "pytest-cov",
   "xgboost",
   "lightgbm",
-  'catboost; python_version < "3.14"',         # TODO: pending 3.14 support
-  'gpboost==1.6.3.1; python_version < "3.14"', # TODO: pending 3.14 support, see GH #4210
+  'catboost; python_version < "3.14"',  # TODO: pending 3.14 support
+  'gpboost==1.6.3.1; python_version < "3.14"',  # TODO: pending 3.14 support, see GH #4210
   "ngboost",
   "pyspark",
   "pyod",
-  "transformers < 4.54.0",                     # TODO: fix once tests pass for 4.54.0
+  "transformers < 4.54.0",  # TODO: fix once tests pass for 4.54.0
   "tf-keras",
-  "protobuf",                                  # See GH #3046
-  'torch; python_version < "3.14"',            # TODO: pending 3.14 support
-  'torchvision; python_version < "3.14"',      # TODO: pending 3.14 support
-  'tensorflow; python_version < "3.14"',       # TODO: pending 3.14 support
+  "protobuf",  # See GH #3046
+  'torch; python_version < "3.14"',  # TODO: pending 3.14 support
+  'torchvision; python_version < "3.14"',  # TODO: pending 3.14 support
+  'tensorflow; python_version < "3.14"',  # TODO: pending 3.14 support
   "sentencepiece",
   "opencv-python",
   # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
   # See GH #3707, #3768, 3922
   "numpy>=2.0",
   "causalml>=0.15.5",
-  "selenium",         # needed to test the javascript based plots
+  "selenium",  # needed to test the javascript based plots
 ]
 
 build = ["nanobind>=2.12"]
@@ -109,7 +117,11 @@ test_notebooks = [
   "keras",
 ]
 
-nbtest = ["nbtest-plugin", "nbtest-gen", "nbtest-lab-extension"]
+nbtest = [
+  "nbtest-plugin",
+  "nbtest-gen",
+  "nbtest-lab-extension"
+]
 
 [dependency-groups]
 core = ["pytest", "pytest-mpl", "pytest-cov", "mypy", "pre-commit"]
@@ -272,9 +284,7 @@ filterwarnings = [
   "ignore:.*is_datetime64tz_dtype is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*'force_all_finite' was renamed to 'ensure_all_finite' in 1.6.*:FutureWarning:.*sklearn.*",
 ]
-markers = [
-  "xslow: mark test as extremely slow (not run unless explicitly requested)",
-]
+markers = ["xslow: mark test as extremely slow (not run unless explicitly requested)"]
 
 [tool.ruff]
 # Careful: when running on pre-commit, ruff's "include" and "exclude" config
@@ -286,17 +296,17 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-  "F",      # pyflakes
-  "I",      # isort
-  "ISC",    # string literal concatenation.
-  "UP",     # pyupgrade
-  "E",      # pycodestyle
-  "W",      # warning
-  "D",      # pydocstyle
-  "NPY",    # Numpy
-  "SIM101", # flake8-simplify
-  "FA",     # future annotations
-  "TCH",    # Move type only imports to type-checking condition.
+  "F",  # pyflakes
+  "I",  # isort
+  "ISC",  # string literal concatenation.
+  "UP",  # pyupgrade
+  "E",  # pycodestyle
+  "W",  # warning
+  "D",  # pydocstyle
+  "NPY",  # Numpy
+  "SIM101",  # flake8-simplify
+  "FA",  # future annotations
+  "TCH",  # Move type only imports to type-checking condition.
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [
@@ -311,17 +321,17 @@ ignore = [
   "W191",
 
   # pydocstyle issues not yet fixed
-  "D100",   # Missing docstring in public module
-  "D101",   # Missing docstring in public class
-  "D102",   # Missing docstring in public method
-  "D103",   # Missing docstring in public function
-  "D104",   # Missing docstring in public package
-  "D105",   # Missing docstring in magic method
-  "D205",   # 1 blank line required between summary line and description
-  "D400",   # First line should end with a period
-  "D401",   # First line of docstring should be in imperative mood: "A basic partial dependence plot function."
-  "D404",   # First word of the docstring should not be "This"
-  "NPY002", # Allow numpy RandomState objects in tests
+  "D100",  # Missing docstring in public module
+  "D101",  # Missing docstring in public class
+  "D102",  # Missing docstring in public method
+  "D103",  # Missing docstring in public function
+  "D104",  # Missing docstring in public package
+  "D105",  # Missing docstring in magic method
+  "D205",  # 1 blank line required between summary line and description
+  "D400",  # First line should end with a period
+  "D401",  # First line of docstring should be in imperative mood: "A basic partial dependence plot function."
+  "D404",  # First word of the docstring should not be "This"
+  "NPY002",  # Allow numpy RandomState objects in tests
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -335,14 +345,10 @@ convention = "numpy"
 "docs/user_studies/*.ipynb" = ["ALL"]
 
 # Ignore SHAP Paper, as it is an unmaintained record of a published paper
-"notebooks/tabular_examples/tree_based_models/tree_shap_paper/*" = ["ALL"]
+"notebooks/tabular_examples/tree_based_models/tree_shap_paper/*"  = ["ALL"]
 
 # Disable some unwanted rules on Jupyter notebooks
-"*.ipynb" = [
-  "D",
-  "E703",
-  "E402",
-] # Allow trailing semicolons, allow imports not at top
+"*.ipynb" = ["D", "E703", "E402"]  # Allow trailing semicolons, allow imports not at top
 
 # Ignore pycodestyle in tests
 "tests/*py" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
   "setuptools-scm>=8.0",
   "numpy>=2.0",
   "packaging>20.9",
-  "cython>=3.0.11",
   "nanobind>=2.0.0",
 ]
 build-backend = "scikit_build_core.build"

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -17,8 +17,7 @@ static PyMethodDef module_methods[] = {
     {"dense_tree_update_weights", _cext_dense_tree_update_weights, METH_VARARGS, "C implementation of tree node weight compuatations."},
     {"dense_tree_saabas", _cext_dense_tree_saabas, METH_VARARGS, "C implementation of Saabas (rough fast approximation to Tree SHAP)."},
     {"compute_expectations", _cext_compute_expectations, METH_VARARGS, "Compute expectations of internal nodes."},
-    {NULL, NULL, 0, NULL}
-};
+    {NULL, NULL, 0, NULL}};
 
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
@@ -30,8 +29,7 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL,
     NULL,
-    NULL
-};
+    NULL};
 #endif
 
 #if PY_MAJOR_VERSION >= 3
@@ -40,20 +38,22 @@ PyMODINIT_FUNC PyInit__cext(void)
 PyMODINIT_FUNC init_cext(void)
 #endif
 {
-    #if PY_MAJOR_VERSION >= 3
-        PyObject *module = PyModule_Create(&moduledef);
-        if (!module) return NULL;
-    #else
-        PyObject *module = Py_InitModule("_cext", module_methods);
-        if (!module) return;
-    #endif
+#if PY_MAJOR_VERSION >= 3
+    PyObject *module = PyModule_Create(&moduledef);
+    if (!module)
+        return NULL;
+#else
+    PyObject *module = Py_InitModule("_cext", module_methods);
+    if (!module)
+        return;
+#endif
 
     /* Load `numpy` functionality. */
     import_array();
 
-    #if PY_MAJOR_VERSION >= 3
-        return module;
-    #endif
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#endif
 }
 
 static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
@@ -65,23 +65,24 @@ static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOO", &children_left_obj, &children_right_obj, &node_sample_weight_obj, &values_obj
-    )) return NULL;
+            args, "OOOO", &children_left_obj, &children_right_obj, &node_sample_weight_obj, &values_obj))
+        return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *node_sample_weight_array = (PyArrayObject *)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     /* If that didn't work, throw an exception. */
     if (children_left_array == NULL || children_right_array == NULL ||
-        values_array == NULL || node_sample_weight_array == NULL) {
-        Py_XDECREF(children_left_array);
-        Py_XDECREF(children_right_array);
-        //PyArray_ResolveWritebackIfCopy(values_array);
-        Py_XDECREF(values_array);
-        Py_XDECREF(node_sample_weight_array);
+        values_array == NULL || node_sample_weight_array == NULL)
+    {
+        Py_XDECREF((PyObject *)children_left_array);
+        Py_XDECREF((PyObject *)children_right_array);
+        // PyArray_ResolveWritebackIfCopy(values_array);
+        Py_XDECREF((PyObject *)values_array);
+        Py_XDECREF((PyObject *)node_sample_weight_array);
         return NULL;
     }
 
@@ -91,24 +92,23 @@ static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
     tree.num_outputs = PyArray_DIM(values_array, 1);
 
     /* Get pointers to the data as C-types. */
-    tree.children_left = (int*)PyArray_DATA(children_left_array);
-    tree.children_right = (int*)PyArray_DATA(children_right_array);
-    tree.values = (tfloat*)PyArray_DATA(values_array);
-    tree.node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weight_array);
+    tree.children_left = (int *)PyArray_DATA(children_left_array);
+    tree.children_right = (int *)PyArray_DATA(children_right_array);
+    tree.values = (tfloat *)PyArray_DATA(values_array);
+    tree.node_sample_weights = (tfloat *)PyArray_DATA(node_sample_weight_array);
 
     const int max_depth = compute_expectations(tree);
 
     // clean up the created python objects
-    Py_XDECREF(children_left_array);
-    Py_XDECREF(children_right_array);
-    //PyArray_ResolveWritebackIfCopy(values_array);
-    Py_XDECREF(values_array);
-    Py_XDECREF(node_sample_weight_array);
+    Py_XDECREF((PyObject *)children_left_array);
+    Py_XDECREF((PyObject *)children_right_array);
+    // PyArray_ResolveWritebackIfCopy(values_array);
+    Py_XDECREF((PyObject *)values_array);
+    Py_XDECREF((PyObject *)node_sample_weight_array);
 
     PyObject *ret = Py_BuildValue("i", max_depth);
     return ret;
 }
-
 
 static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 {
@@ -135,53 +135,60 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
-        &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
-        &out_contribs_obj, &feature_dependence, &model_output, &interactions
-    )) return NULL;
+            args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
+            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
+            &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
+            &out_contribs_obj, &feature_dependence, &model_output, &interactions))
+        return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weights_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *node_sample_weights_array = (PyArrayObject *)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (y_obj != Py_None)
+        y_array = (PyArrayObject *)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *R_array = NULL;
-    if (R_obj != Py_None) R_array = (PyArrayObject*)PyArray_FROM_OTF(R_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (R_obj != Py_None)
+        R_array = (PyArrayObject *)PyArray_FROM_OTF(R_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *R_missing_array = NULL;
-    if (R_missing_obj != Py_None) R_missing_array = (PyArrayObject*)PyArray_FROM_OTF(R_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_contribs_array = (PyArrayObject*)PyArray_FROM_OTF(out_contribs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    if (R_missing_obj != Py_None)
+        R_missing_array = (PyArrayObject *)PyArray_FROM_OTF(R_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *out_contribs_array = (PyArrayObject *)PyArray_FROM_OTF(out_contribs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *base_offset_array = (PyArrayObject *)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
         values_array == NULL || node_sample_weights_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_contribs_array == NULL) {
-        Py_XDECREF(children_left_array);
-        Py_XDECREF(children_right_array);
-        Py_XDECREF(children_default_array);
-        Py_XDECREF(features_array);
-        Py_XDECREF(thresholds_array);
-        Py_XDECREF(threshold_types_array);
-        Py_XDECREF(values_array);
-        Py_XDECREF(node_sample_weights_array);
-        Py_XDECREF(X_array);
-        Py_XDECREF(X_missing_array);
-        if (y_array != NULL) Py_XDECREF(y_array);
-        if (R_array != NULL) Py_XDECREF(R_array);
-        if (R_missing_array != NULL) Py_XDECREF(R_missing_array);
-        //PyArray_ResolveWritebackIfCopy(out_contribs_array);
-        Py_XDECREF(out_contribs_array);
-        Py_XDECREF(base_offset_array);
+        X_missing_array == NULL || out_contribs_array == NULL)
+    {
+        Py_XDECREF((PyObject *)children_left_array);
+        Py_XDECREF((PyObject *)children_right_array);
+        Py_XDECREF((PyObject *)children_default_array);
+        Py_XDECREF((PyObject *)features_array);
+        Py_XDECREF((PyObject *)thresholds_array);
+        Py_XDECREF((PyObject *)threshold_types_array);
+        Py_XDECREF((PyObject *)values_array);
+        Py_XDECREF((PyObject *)node_sample_weights_array);
+        Py_XDECREF((PyObject *)X_array);
+        Py_XDECREF((PyObject *)X_missing_array);
+        if (y_array != NULL)
+            Py_XDECREF((PyObject *)y_array);
+        if (R_array != NULL)
+            Py_XDECREF((PyObject *)R_array);
+        if (R_missing_array != NULL)
+            Py_XDECREF((PyObject *)R_missing_array);
+        // PyArray_ResolveWritebackIfCopy(out_contribs_array);
+        Py_XDECREF((PyObject *)out_contribs_array);
+        Py_XDECREF((PyObject *)base_offset_array);
         return NULL;
     }
 
@@ -190,35 +197,38 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     const unsigned max_nodes = PyArray_DIM(values_array, 1);
     const unsigned num_outputs = PyArray_DIM(values_array, 2);
     unsigned num_R = 0;
-    if (R_array != NULL) num_R = PyArray_DIM(R_array, 0);
+    if (R_array != NULL)
+        num_R = PyArray_DIM(R_array, 0);
 
     // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weights_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
+    int *children_left = (int *)PyArray_DATA(children_left_array);
+    int *children_right = (int *)PyArray_DATA(children_right_array);
+    int *children_default = (int *)PyArray_DATA(children_default_array);
+    int *features = (int *)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat *)PyArray_DATA(values_array);
+    tfloat *node_sample_weights = (tfloat *)PyArray_DATA(node_sample_weights_array);
+    tfloat *X = (tfloat *)PyArray_DATA(X_array);
+    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
     tfloat *y = NULL;
-    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
+    if (y_array != NULL)
+        y = (tfloat *)PyArray_DATA(y_array);
     tfloat *R = NULL;
-    if (R_array != NULL) R = (tfloat*)PyArray_DATA(R_array);
+    if (R_array != NULL)
+        R = (tfloat *)PyArray_DATA(R_array);
     bool *R_missing = NULL;
-    if (R_missing_array != NULL) R_missing = (bool*)PyArray_DATA(R_missing_array);
-    tfloat *out_contribs = (tfloat*)PyArray_DATA(out_contribs_array);
-    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
+    if (R_missing_array != NULL)
+        R_missing = (bool *)PyArray_DATA(R_missing_array);
+    tfloat *out_contribs = (tfloat *)PyArray_DATA(out_contribs_array);
+    tfloat *base_offset = (tfloat *)PyArray_DATA(base_offset_array);
 
     // these are just a wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
         node_sample_weights, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs
-    );
+        max_nodes, num_outputs);
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, R, R_missing, num_X, M, num_R);
 
     dense_tree_shap(trees, data, out_contribs, feature_dependence, model_output, interactions);
@@ -227,28 +237,30 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     tfloat ret_value = (double)values[0];
 
     // clean up the created python objects
-    Py_XDECREF(children_left_array);
-    Py_XDECREF(children_right_array);
-    Py_XDECREF(children_default_array);
-    Py_XDECREF(features_array);
-    Py_XDECREF(thresholds_array);
-    Py_XDECREF(threshold_types_array);
-    Py_XDECREF(values_array);
-    Py_XDECREF(node_sample_weights_array);
-    Py_XDECREF(X_array);
-    Py_XDECREF(X_missing_array);
-    if (y_array != NULL) Py_XDECREF(y_array);
-    if (R_array != NULL) Py_XDECREF(R_array);
-    if (R_missing_array != NULL) Py_XDECREF(R_missing_array);
-    //PyArray_ResolveWritebackIfCopy(out_contribs_array);
-    Py_XDECREF(out_contribs_array);
-    Py_XDECREF(base_offset_array);
+    Py_XDECREF((PyObject *)children_left_array);
+    Py_XDECREF((PyObject *)children_right_array);
+    Py_XDECREF((PyObject *)children_default_array);
+    Py_XDECREF((PyObject *)features_array);
+    Py_XDECREF((PyObject *)thresholds_array);
+    Py_XDECREF((PyObject *)threshold_types_array);
+    Py_XDECREF((PyObject *)values_array);
+    Py_XDECREF((PyObject *)node_sample_weights_array);
+    Py_XDECREF((PyObject *)X_array);
+    Py_XDECREF((PyObject *)X_missing_array);
+    if (y_array != NULL)
+        Py_XDECREF((PyObject *)y_array);
+    if (R_array != NULL)
+        Py_XDECREF((PyObject *)R_array);
+    if (R_missing_array != NULL)
+        Py_XDECREF((PyObject *)R_missing_array);
+    // PyArray_ResolveWritebackIfCopy(out_contribs_array);
+    Py_XDECREF((PyObject *)out_contribs_array);
+    Py_XDECREF((PyObject *)base_offset_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", ret_value);
     return ret;
 }
-
 
 static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 {
@@ -270,44 +282,47 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
-        &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
-    )) return NULL;
+            args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+            &X_obj, &X_missing_obj, &y_obj, &out_pred_obj))
+        return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *base_offset_array = (PyArrayObject *)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_pred_array = (PyArrayObject*)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    if (y_obj != Py_None)
+        y_array = (PyArrayObject *)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *out_pred_array = (PyArrayObject *)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
         values_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_pred_array == NULL) {
-        Py_XDECREF(children_left_array);
-        Py_XDECREF(children_right_array);
-        Py_XDECREF(children_default_array);
-        Py_XDECREF(features_array);
-        Py_XDECREF(thresholds_array);
-        Py_XDECREF(threshold_types_array);
-        Py_XDECREF(values_array);
-        Py_XDECREF(base_offset_array);
-        Py_XDECREF(X_array);
-        Py_XDECREF(X_missing_array);
-        if (y_array != NULL) Py_XDECREF(y_array);
-        //PyArray_ResolveWritebackIfCopy(out_pred_array);
-        Py_XDECREF(out_pred_array);
+        X_missing_array == NULL || out_pred_array == NULL)
+    {
+        Py_XDECREF((PyObject *)children_left_array);
+        Py_XDECREF((PyObject *)children_right_array);
+        Py_XDECREF((PyObject *)children_default_array);
+        Py_XDECREF((PyObject *)features_array);
+        Py_XDECREF((PyObject *)thresholds_array);
+        Py_XDECREF((PyObject *)threshold_types_array);
+        Py_XDECREF((PyObject *)values_array);
+        Py_XDECREF((PyObject *)base_offset_array);
+        Py_XDECREF((PyObject *)X_array);
+        Py_XDECREF((PyObject *)X_missing_array);
+        if (y_array != NULL)
+            Py_XDECREF((PyObject *)y_array);
+        // PyArray_ResolveWritebackIfCopy(out_pred_array);
+        Py_XDECREF((PyObject *)out_pred_array);
         return NULL;
     }
 
@@ -317,57 +332,58 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     const unsigned num_outputs = PyArray_DIM(values_array, 2);
 
     const unsigned num_offsets = PyArray_DIM(base_offset_array, 0);
-    if (num_offsets != num_outputs) {
+    if (num_offsets != num_outputs)
+    {
         std::cerr << "The passed base_offset array does that have the same number of outputs as the values array: " << num_offsets << " vs. " << num_outputs << std::endl;
         return NULL;
     }
 
     // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
+    int *children_left = (int *)PyArray_DATA(children_left_array);
+    int *children_right = (int *)PyArray_DATA(children_right_array);
+    int *children_default = (int *)PyArray_DATA(children_default_array);
+    int *features = (int *)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat *)PyArray_DATA(values_array);
+    tfloat *base_offset = (tfloat *)PyArray_DATA(base_offset_array);
+    tfloat *X = (tfloat *)PyArray_DATA(X_array);
+    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
     tfloat *y = NULL;
-    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
-    tfloat *out_pred = (tfloat*)PyArray_DATA(out_pred_array);
+    if (y_array != NULL)
+        y = (tfloat *)PyArray_DATA(y_array);
+    tfloat *out_pred = (tfloat *)PyArray_DATA(out_pred_array);
 
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
         NULL, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs
-    );
+        max_nodes, num_outputs);
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
 
     dense_tree_predict(out_pred, trees, data, model_output);
 
     // clean up the created python objects
-    Py_XDECREF(children_left_array);
-    Py_XDECREF(children_right_array);
-    Py_XDECREF(children_default_array);
-    Py_XDECREF(features_array);
-    Py_XDECREF(thresholds_array);
-    Py_XDECREF(threshold_types_array);
-    Py_XDECREF(values_array);
-    Py_XDECREF(base_offset_array);
-    Py_XDECREF(X_array);
-    Py_XDECREF(X_missing_array);
-    if (y_array != NULL) Py_XDECREF(y_array);
-    //PyArray_ResolveWritebackIfCopy(out_pred_array);
-    Py_XDECREF(out_pred_array);
+    Py_XDECREF((PyObject *)children_left_array);
+    Py_XDECREF((PyObject *)children_right_array);
+    Py_XDECREF((PyObject *)children_default_array);
+    Py_XDECREF((PyObject *)features_array);
+    Py_XDECREF((PyObject *)thresholds_array);
+    Py_XDECREF((PyObject *)threshold_types_array);
+    Py_XDECREF((PyObject *)values_array);
+    Py_XDECREF((PyObject *)base_offset_array);
+    Py_XDECREF((PyObject *)X_array);
+    Py_XDECREF((PyObject *)X_missing_array);
+    if (y_array != NULL)
+        Py_XDECREF((PyObject *)y_array);
+    // PyArray_ResolveWritebackIfCopy(out_pred_array);
+    Py_XDECREF((PyObject *)out_pred_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", (double)values[0]);
     return ret;
 }
-
 
 static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 {
@@ -385,38 +401,39 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
-    )) return NULL;
+            args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj))
+        return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *node_sample_weight_array = (PyArrayObject *)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
 
     /* If that didn't work, throw an exception. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
         values_array == NULL || node_sample_weight_array == NULL || X_array == NULL ||
-        X_missing_array == NULL) {
-        Py_XDECREF(children_left_array);
-        Py_XDECREF(children_right_array);
-        Py_XDECREF(children_default_array);
-        Py_XDECREF(features_array);
-        Py_XDECREF(thresholds_array);
-        Py_XDECREF(threshold_types_array);
-        Py_XDECREF(values_array);
-        //PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
-        Py_XDECREF(node_sample_weight_array);
-        Py_XDECREF(X_array);
-        Py_XDECREF(X_missing_array);
+        X_missing_array == NULL)
+    {
+        Py_XDECREF((PyObject *)children_left_array);
+        Py_XDECREF((PyObject *)children_right_array);
+        Py_XDECREF((PyObject *)children_default_array);
+        Py_XDECREF((PyObject *)features_array);
+        Py_XDECREF((PyObject *)thresholds_array);
+        Py_XDECREF((PyObject *)threshold_types_array);
+        Py_XDECREF((PyObject *)values_array);
+        // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
+        Py_XDECREF((PyObject *)node_sample_weight_array);
+        Py_XDECREF((PyObject *)X_array);
+        Py_XDECREF((PyObject *)X_missing_array);
         std::cerr << "Found a NULL input array in _cext_dense_tree_update_weights!\n";
         return NULL;
     }
@@ -426,45 +443,43 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     const unsigned max_nodes = PyArray_DIM(values_array, 1);
 
     // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *node_sample_weight = (tfloat*)PyArray_DATA(node_sample_weight_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
+    int *children_left = (int *)PyArray_DATA(children_left_array);
+    int *children_right = (int *)PyArray_DATA(children_right_array);
+    int *children_default = (int *)PyArray_DATA(children_default_array);
+    int *features = (int *)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat *)PyArray_DATA(values_array);
+    tfloat *node_sample_weight = (tfloat *)PyArray_DATA(node_sample_weight_array);
+    tfloat *X = (tfloat *)PyArray_DATA(X_array);
+    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
 
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
-        node_sample_weight, 0, tree_limit, 0, max_nodes, 0
-    );
+        node_sample_weight, 0, tree_limit, 0, max_nodes, 0);
     ExplanationDataset data = ExplanationDataset(X, X_missing, NULL, NULL, NULL, num_X, M, 0);
 
     dense_tree_update_weights(trees, data);
 
     // clean up the created python objects
-    Py_XDECREF(children_left_array);
-    Py_XDECREF(children_right_array);
-    Py_XDECREF(children_default_array);
-    Py_XDECREF(features_array);
-    Py_XDECREF(thresholds_array);
-    Py_XDECREF(threshold_types_array);
-    Py_XDECREF(values_array);
+    Py_XDECREF((PyObject *)children_left_array);
+    Py_XDECREF((PyObject *)children_right_array);
+    Py_XDECREF((PyObject *)children_default_array);
+    Py_XDECREF((PyObject *)features_array);
+    Py_XDECREF((PyObject *)thresholds_array);
+    Py_XDECREF((PyObject *)threshold_types_array);
+    Py_XDECREF((PyObject *)values_array);
     // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
-    Py_XDECREF(node_sample_weight_array);
-    Py_XDECREF(X_array);
-    Py_XDECREF(X_missing_array);
+    Py_XDECREF((PyObject *)node_sample_weight_array);
+    Py_XDECREF((PyObject *)X_array);
+    Py_XDECREF((PyObject *)X_missing_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", 1);
     return ret;
 }
-
 
 static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
 {
@@ -484,47 +499,49 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyObject *y_obj;
     PyObject *out_pred_obj;
 
-
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
-        &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
-    )) return NULL;
+            args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+            &X_obj, &X_missing_obj, &y_obj, &out_pred_obj))
+        return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *base_offset_array = (PyArrayObject *)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_pred_array = (PyArrayObject*)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (y_obj != Py_None)
+        y_array = (PyArrayObject *)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *out_pred_array = (PyArrayObject *)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
 
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL ||
         values_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_pred_array == NULL) {
-        Py_XDECREF(children_left_array);
-        Py_XDECREF(children_right_array);
-        Py_XDECREF(children_default_array);
-        Py_XDECREF(features_array);
-        Py_XDECREF(thresholds_array);
-        Py_XDECREF(threshold_types_array);
-        Py_XDECREF(values_array);
-        Py_XDECREF(base_offset_array);
-        Py_XDECREF(X_array);
-        Py_XDECREF(X_missing_array);
-        if (y_array != NULL) Py_XDECREF(y_array);
-        //PyArray_ResolveWritebackIfCopy(out_pred_array);
-        Py_XDECREF(out_pred_array);
+        X_missing_array == NULL || out_pred_array == NULL)
+    {
+        Py_XDECREF((PyObject *)children_left_array);
+        Py_XDECREF((PyObject *)children_right_array);
+        Py_XDECREF((PyObject *)children_default_array);
+        Py_XDECREF((PyObject *)features_array);
+        Py_XDECREF((PyObject *)thresholds_array);
+        Py_XDECREF((PyObject *)threshold_types_array);
+        Py_XDECREF((PyObject *)values_array);
+        Py_XDECREF((PyObject *)base_offset_array);
+        Py_XDECREF((PyObject *)X_array);
+        Py_XDECREF((PyObject *)X_missing_array);
+        if (y_array != NULL)
+            Py_XDECREF((PyObject *)y_array);
+        // PyArray_ResolveWritebackIfCopy(out_pred_array);
+        Py_XDECREF((PyObject *)out_pred_array);
         return NULL;
     }
 
@@ -534,45 +551,46 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     const unsigned num_outputs = PyArray_DIM(values_array, 2);
 
     // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
+    int *children_left = (int *)PyArray_DATA(children_left_array);
+    int *children_right = (int *)PyArray_DATA(children_right_array);
+    int *children_default = (int *)PyArray_DATA(children_default_array);
+    int *features = (int *)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat *)PyArray_DATA(values_array);
+    tfloat *base_offset = (tfloat *)PyArray_DATA(base_offset_array);
+    tfloat *X = (tfloat *)PyArray_DATA(X_array);
+    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
     tfloat *y = NULL;
-    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
-    tfloat *out_pred = (tfloat*)PyArray_DATA(out_pred_array);
+    if (y_array != NULL)
+        y = (tfloat *)PyArray_DATA(y_array);
+    tfloat *out_pred = (tfloat *)PyArray_DATA(out_pred_array);
 
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
         NULL, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs
-    );
+        max_nodes, num_outputs);
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
 
     dense_tree_saabas(out_pred, trees, data);
 
     // clean up the created python objects
-    Py_XDECREF(children_left_array);
-    Py_XDECREF(children_right_array);
-    Py_XDECREF(children_default_array);
-    Py_XDECREF(features_array);
-    Py_XDECREF(thresholds_array);
-    Py_XDECREF(threshold_types_array);
-    Py_XDECREF(values_array);
-    Py_XDECREF(base_offset_array);
-    Py_XDECREF(X_array);
-    Py_XDECREF(X_missing_array);
-    if (y_array != NULL) Py_XDECREF(y_array);
-    //PyArray_ResolveWritebackIfCopy(out_pred_array);
-    Py_XDECREF(out_pred_array);
+    Py_XDECREF((PyObject *)children_left_array);
+    Py_XDECREF((PyObject *)children_right_array);
+    Py_XDECREF((PyObject *)children_default_array);
+    Py_XDECREF((PyObject *)features_array);
+    Py_XDECREF((PyObject *)thresholds_array);
+    Py_XDECREF((PyObject *)threshold_types_array);
+    Py_XDECREF((PyObject *)values_array);
+    Py_XDECREF((PyObject *)base_offset_array);
+    Py_XDECREF((PyObject *)X_array);
+    Py_XDECREF((PyObject *)X_missing_array);
+    if (y_array != NULL)
+        Py_XDECREF((PyObject *)y_array);
+    // PyArray_ResolveWritebackIfCopy(out_pred_array);
+    Py_XDECREF((PyObject *)out_pred_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", (double)values[0]);

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -17,7 +17,8 @@ static PyMethodDef module_methods[] = {
     {"dense_tree_update_weights", _cext_dense_tree_update_weights, METH_VARARGS, "C implementation of tree node weight compuatations."},
     {"dense_tree_saabas", _cext_dense_tree_saabas, METH_VARARGS, "C implementation of Saabas (rough fast approximation to Tree SHAP)."},
     {"compute_expectations", _cext_compute_expectations, METH_VARARGS, "Compute expectations of internal nodes."},
-    {NULL, NULL, 0, NULL}};
+    {NULL, NULL, 0, NULL}
+};
 
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
@@ -29,7 +30,8 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL,
     NULL,
-    NULL};
+    NULL
+};
 #endif
 
 #if PY_MAJOR_VERSION >= 3
@@ -38,22 +40,20 @@ PyMODINIT_FUNC PyInit__cext(void)
 PyMODINIT_FUNC init_cext(void)
 #endif
 {
-#if PY_MAJOR_VERSION >= 3
-    PyObject *module = PyModule_Create(&moduledef);
-    if (!module)
-        return NULL;
-#else
-    PyObject *module = Py_InitModule("_cext", module_methods);
-    if (!module)
-        return;
-#endif
+    #if PY_MAJOR_VERSION >= 3
+        PyObject *module = PyModule_Create(&moduledef);
+        if (!module) return NULL;
+    #else
+        PyObject *module = Py_InitModule("_cext", module_methods);
+        if (!module) return;
+    #endif
 
     /* Load `numpy` functionality. */
     import_array();
 
-#if PY_MAJOR_VERSION >= 3
-    return module;
-#endif
+    #if PY_MAJOR_VERSION >= 3
+        return module;
+    #endif
 }
 
 static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
@@ -65,24 +65,23 @@ static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-            args, "OOOO", &children_left_obj, &children_right_obj, &node_sample_weight_obj, &values_obj))
-        return NULL;
+        args, "OOOO", &children_left_obj, &children_right_obj, &node_sample_weight_obj, &values_obj
+    )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weight_array = (PyArrayObject *)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     /* If that didn't work, throw an exception. */
     if (children_left_array == NULL || children_right_array == NULL ||
-        values_array == NULL || node_sample_weight_array == NULL)
-    {
-        Py_XDECREF((PyObject *)children_left_array);
-        Py_XDECREF((PyObject *)children_right_array);
-        // PyArray_ResolveWritebackIfCopy(values_array);
-        Py_XDECREF((PyObject *)values_array);
-        Py_XDECREF((PyObject *)node_sample_weight_array);
+        values_array == NULL || node_sample_weight_array == NULL) {
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        //PyArray_ResolveWritebackIfCopy(values_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)node_sample_weight_array);
         return NULL;
     }
 
@@ -92,23 +91,24 @@ static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
     tree.num_outputs = PyArray_DIM(values_array, 1);
 
     /* Get pointers to the data as C-types. */
-    tree.children_left = (int *)PyArray_DATA(children_left_array);
-    tree.children_right = (int *)PyArray_DATA(children_right_array);
-    tree.values = (tfloat *)PyArray_DATA(values_array);
-    tree.node_sample_weights = (tfloat *)PyArray_DATA(node_sample_weight_array);
+    tree.children_left = (int*)PyArray_DATA(children_left_array);
+    tree.children_right = (int*)PyArray_DATA(children_right_array);
+    tree.values = (tfloat*)PyArray_DATA(values_array);
+    tree.node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weight_array);
 
     const int max_depth = compute_expectations(tree);
 
     // clean up the created python objects
-    Py_XDECREF((PyObject *)children_left_array);
-    Py_XDECREF((PyObject *)children_right_array);
-    // PyArray_ResolveWritebackIfCopy(values_array);
-    Py_XDECREF((PyObject *)values_array);
-    Py_XDECREF((PyObject *)node_sample_weight_array);
+    Py_XDECREF((PyObject*)children_left_array);
+    Py_XDECREF((PyObject*)children_right_array);
+    //PyArray_ResolveWritebackIfCopy(values_array);
+    Py_XDECREF((PyObject*)values_array);
+    Py_XDECREF((PyObject*)node_sample_weight_array);
 
     PyObject *ret = Py_BuildValue("i", max_depth);
     return ret;
 }
+
 
 static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 {
@@ -135,60 +135,53 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-            args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
-            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
-            &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
-            &out_contribs_obj, &feature_dependence, &model_output, &interactions))
-        return NULL;
+        args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
+        &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
+        &out_contribs_obj, &feature_dependence, &model_output, &interactions
+    )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weights_array = (PyArrayObject *)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *node_sample_weights_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None)
-        y_array = (PyArrayObject *)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *R_array = NULL;
-    if (R_obj != Py_None)
-        R_array = (PyArrayObject *)PyArray_FROM_OTF(R_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (R_obj != Py_None) R_array = (PyArrayObject*)PyArray_FROM_OTF(R_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *R_missing_array = NULL;
-    if (R_missing_obj != Py_None)
-        R_missing_array = (PyArrayObject *)PyArray_FROM_OTF(R_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_contribs_array = (PyArrayObject *)PyArray_FROM_OTF(out_contribs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject *)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    if (R_missing_obj != Py_None) R_missing_array = (PyArrayObject*)PyArray_FROM_OTF(R_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *out_contribs_array = (PyArrayObject*)PyArray_FROM_OTF(out_contribs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
         values_array == NULL || node_sample_weights_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_contribs_array == NULL)
-    {
-        Py_XDECREF((PyObject *)children_left_array);
-        Py_XDECREF((PyObject *)children_right_array);
-        Py_XDECREF((PyObject *)children_default_array);
-        Py_XDECREF((PyObject *)features_array);
-        Py_XDECREF((PyObject *)thresholds_array);
-        Py_XDECREF((PyObject *)threshold_types_array);
-        Py_XDECREF((PyObject *)values_array);
-        Py_XDECREF((PyObject *)node_sample_weights_array);
-        Py_XDECREF((PyObject *)X_array);
-        Py_XDECREF((PyObject *)X_missing_array);
-        if (y_array != NULL)
-            Py_XDECREF((PyObject *)y_array);
-        if (R_array != NULL)
-            Py_XDECREF((PyObject *)R_array);
-        if (R_missing_array != NULL)
-            Py_XDECREF((PyObject *)R_missing_array);
-        // PyArray_ResolveWritebackIfCopy(out_contribs_array);
-        Py_XDECREF((PyObject *)out_contribs_array);
-        Py_XDECREF((PyObject *)base_offset_array);
+        X_missing_array == NULL || out_contribs_array == NULL) {
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)node_sample_weights_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+        if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
+        if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
+        //PyArray_ResolveWritebackIfCopy(out_contribs_array);
+        Py_XDECREF((PyObject*)out_contribs_array);
+        Py_XDECREF((PyObject*)base_offset_array);
         return NULL;
     }
 
@@ -197,38 +190,35 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     const unsigned max_nodes = PyArray_DIM(values_array, 1);
     const unsigned num_outputs = PyArray_DIM(values_array, 2);
     unsigned num_R = 0;
-    if (R_array != NULL)
-        num_R = PyArray_DIM(R_array, 0);
+    if (R_array != NULL) num_R = PyArray_DIM(R_array, 0);
 
     // Get pointers to the data as C-types
-    int *children_left = (int *)PyArray_DATA(children_left_array);
-    int *children_right = (int *)PyArray_DATA(children_right_array);
-    int *children_default = (int *)PyArray_DATA(children_default_array);
-    int *features = (int *)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat *)PyArray_DATA(values_array);
-    tfloat *node_sample_weights = (tfloat *)PyArray_DATA(node_sample_weights_array);
-    tfloat *X = (tfloat *)PyArray_DATA(X_array);
-    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
+    int *children_left = (int*)PyArray_DATA(children_left_array);
+    int *children_right = (int*)PyArray_DATA(children_right_array);
+    int *children_default = (int*)PyArray_DATA(children_default_array);
+    int *features = (int*)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat*)PyArray_DATA(values_array);
+    tfloat *node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weights_array);
+    tfloat *X = (tfloat*)PyArray_DATA(X_array);
+    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
     tfloat *y = NULL;
-    if (y_array != NULL)
-        y = (tfloat *)PyArray_DATA(y_array);
+    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
     tfloat *R = NULL;
-    if (R_array != NULL)
-        R = (tfloat *)PyArray_DATA(R_array);
+    if (R_array != NULL) R = (tfloat*)PyArray_DATA(R_array);
     bool *R_missing = NULL;
-    if (R_missing_array != NULL)
-        R_missing = (bool *)PyArray_DATA(R_missing_array);
-    tfloat *out_contribs = (tfloat *)PyArray_DATA(out_contribs_array);
-    tfloat *base_offset = (tfloat *)PyArray_DATA(base_offset_array);
+    if (R_missing_array != NULL) R_missing = (bool*)PyArray_DATA(R_missing_array);
+    tfloat *out_contribs = (tfloat*)PyArray_DATA(out_contribs_array);
+    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
 
     // these are just a wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
         node_sample_weights, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs);
+        max_nodes, num_outputs
+    );
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, R, R_missing, num_X, M, num_R);
 
     dense_tree_shap(trees, data, out_contribs, feature_dependence, model_output, interactions);
@@ -237,30 +227,28 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     tfloat ret_value = (double)values[0];
 
     // clean up the created python objects
-    Py_XDECREF((PyObject *)children_left_array);
-    Py_XDECREF((PyObject *)children_right_array);
-    Py_XDECREF((PyObject *)children_default_array);
-    Py_XDECREF((PyObject *)features_array);
-    Py_XDECREF((PyObject *)thresholds_array);
-    Py_XDECREF((PyObject *)threshold_types_array);
-    Py_XDECREF((PyObject *)values_array);
-    Py_XDECREF((PyObject *)node_sample_weights_array);
-    Py_XDECREF((PyObject *)X_array);
-    Py_XDECREF((PyObject *)X_missing_array);
-    if (y_array != NULL)
-        Py_XDECREF((PyObject *)y_array);
-    if (R_array != NULL)
-        Py_XDECREF((PyObject *)R_array);
-    if (R_missing_array != NULL)
-        Py_XDECREF((PyObject *)R_missing_array);
-    // PyArray_ResolveWritebackIfCopy(out_contribs_array);
-    Py_XDECREF((PyObject *)out_contribs_array);
-    Py_XDECREF((PyObject *)base_offset_array);
+    Py_XDECREF((PyObject*)children_left_array);
+    Py_XDECREF((PyObject*)children_right_array);
+    Py_XDECREF((PyObject*)children_default_array);
+    Py_XDECREF((PyObject*)features_array);
+    Py_XDECREF((PyObject*)thresholds_array);
+    Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)values_array);
+    Py_XDECREF((PyObject*)node_sample_weights_array);
+    Py_XDECREF((PyObject*)X_array);
+    Py_XDECREF((PyObject*)X_missing_array);
+    if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+    if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
+    if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
+    //PyArray_ResolveWritebackIfCopy(out_contribs_array);
+    Py_XDECREF((PyObject*)out_contribs_array);
+    Py_XDECREF((PyObject*)base_offset_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", ret_value);
     return ret;
 }
+
 
 static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 {
@@ -282,47 +270,44 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-            args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
-            &X_obj, &X_missing_obj, &y_obj, &out_pred_obj))
-        return NULL;
+        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+        &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
+    )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject *)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None)
-        y_array = (PyArrayObject *)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_pred_array = (PyArrayObject *)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *out_pred_array = (PyArrayObject*)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
 
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
         values_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_pred_array == NULL)
-    {
-        Py_XDECREF((PyObject *)children_left_array);
-        Py_XDECREF((PyObject *)children_right_array);
-        Py_XDECREF((PyObject *)children_default_array);
-        Py_XDECREF((PyObject *)features_array);
-        Py_XDECREF((PyObject *)thresholds_array);
-        Py_XDECREF((PyObject *)threshold_types_array);
-        Py_XDECREF((PyObject *)values_array);
-        Py_XDECREF((PyObject *)base_offset_array);
-        Py_XDECREF((PyObject *)X_array);
-        Py_XDECREF((PyObject *)X_missing_array);
-        if (y_array != NULL)
-            Py_XDECREF((PyObject *)y_array);
-        // PyArray_ResolveWritebackIfCopy(out_pred_array);
-        Py_XDECREF((PyObject *)out_pred_array);
+        X_missing_array == NULL || out_pred_array == NULL) {
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)base_offset_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+        //PyArray_ResolveWritebackIfCopy(out_pred_array);
+        Py_XDECREF((PyObject*)out_pred_array);
         return NULL;
     }
 
@@ -332,58 +317,57 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     const unsigned num_outputs = PyArray_DIM(values_array, 2);
 
     const unsigned num_offsets = PyArray_DIM(base_offset_array, 0);
-    if (num_offsets != num_outputs)
-    {
+    if (num_offsets != num_outputs) {
         std::cerr << "The passed base_offset array does that have the same number of outputs as the values array: " << num_offsets << " vs. " << num_outputs << std::endl;
         return NULL;
     }
 
     // Get pointers to the data as C-types
-    int *children_left = (int *)PyArray_DATA(children_left_array);
-    int *children_right = (int *)PyArray_DATA(children_right_array);
-    int *children_default = (int *)PyArray_DATA(children_default_array);
-    int *features = (int *)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat *)PyArray_DATA(values_array);
-    tfloat *base_offset = (tfloat *)PyArray_DATA(base_offset_array);
-    tfloat *X = (tfloat *)PyArray_DATA(X_array);
-    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
+    int *children_left = (int*)PyArray_DATA(children_left_array);
+    int *children_right = (int*)PyArray_DATA(children_right_array);
+    int *children_default = (int*)PyArray_DATA(children_default_array);
+    int *features = (int*)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat*)PyArray_DATA(values_array);
+    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
+    tfloat *X = (tfloat*)PyArray_DATA(X_array);
+    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
     tfloat *y = NULL;
-    if (y_array != NULL)
-        y = (tfloat *)PyArray_DATA(y_array);
-    tfloat *out_pred = (tfloat *)PyArray_DATA(out_pred_array);
+    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
+    tfloat *out_pred = (tfloat*)PyArray_DATA(out_pred_array);
 
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
         NULL, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs);
+        max_nodes, num_outputs
+    );
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
 
     dense_tree_predict(out_pred, trees, data, model_output);
 
     // clean up the created python objects
-    Py_XDECREF((PyObject *)children_left_array);
-    Py_XDECREF((PyObject *)children_right_array);
-    Py_XDECREF((PyObject *)children_default_array);
-    Py_XDECREF((PyObject *)features_array);
-    Py_XDECREF((PyObject *)thresholds_array);
-    Py_XDECREF((PyObject *)threshold_types_array);
-    Py_XDECREF((PyObject *)values_array);
-    Py_XDECREF((PyObject *)base_offset_array);
-    Py_XDECREF((PyObject *)X_array);
-    Py_XDECREF((PyObject *)X_missing_array);
-    if (y_array != NULL)
-        Py_XDECREF((PyObject *)y_array);
-    // PyArray_ResolveWritebackIfCopy(out_pred_array);
-    Py_XDECREF((PyObject *)out_pred_array);
+    Py_XDECREF((PyObject*)children_left_array);
+    Py_XDECREF((PyObject*)children_right_array);
+    Py_XDECREF((PyObject*)children_default_array);
+    Py_XDECREF((PyObject*)features_array);
+    Py_XDECREF((PyObject*)thresholds_array);
+    Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)values_array);
+    Py_XDECREF((PyObject*)base_offset_array);
+    Py_XDECREF((PyObject*)X_array);
+    Py_XDECREF((PyObject*)X_missing_array);
+    if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+    //PyArray_ResolveWritebackIfCopy(out_pred_array);
+    Py_XDECREF((PyObject*)out_pred_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", (double)values[0]);
     return ret;
 }
+
 
 static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 {
@@ -401,39 +385,38 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-            args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj))
-        return NULL;
+        args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
+    )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weight_array = (PyArrayObject *)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
 
     /* If that didn't work, throw an exception. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
         values_array == NULL || node_sample_weight_array == NULL || X_array == NULL ||
-        X_missing_array == NULL)
-    {
-        Py_XDECREF((PyObject *)children_left_array);
-        Py_XDECREF((PyObject *)children_right_array);
-        Py_XDECREF((PyObject *)children_default_array);
-        Py_XDECREF((PyObject *)features_array);
-        Py_XDECREF((PyObject *)thresholds_array);
-        Py_XDECREF((PyObject *)threshold_types_array);
-        Py_XDECREF((PyObject *)values_array);
-        // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
-        Py_XDECREF((PyObject *)node_sample_weight_array);
-        Py_XDECREF((PyObject *)X_array);
-        Py_XDECREF((PyObject *)X_missing_array);
+        X_missing_array == NULL) {
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)values_array);
+        //PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
+        Py_XDECREF((PyObject*)node_sample_weight_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
         std::cerr << "Found a NULL input array in _cext_dense_tree_update_weights!\n";
         return NULL;
     }
@@ -443,43 +426,45 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     const unsigned max_nodes = PyArray_DIM(values_array, 1);
 
     // Get pointers to the data as C-types
-    int *children_left = (int *)PyArray_DATA(children_left_array);
-    int *children_right = (int *)PyArray_DATA(children_right_array);
-    int *children_default = (int *)PyArray_DATA(children_default_array);
-    int *features = (int *)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat *)PyArray_DATA(values_array);
-    tfloat *node_sample_weight = (tfloat *)PyArray_DATA(node_sample_weight_array);
-    tfloat *X = (tfloat *)PyArray_DATA(X_array);
-    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
+    int *children_left = (int*)PyArray_DATA(children_left_array);
+    int *children_right = (int*)PyArray_DATA(children_right_array);
+    int *children_default = (int*)PyArray_DATA(children_default_array);
+    int *features = (int*)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat*)PyArray_DATA(values_array);
+    tfloat *node_sample_weight = (tfloat*)PyArray_DATA(node_sample_weight_array);
+    tfloat *X = (tfloat*)PyArray_DATA(X_array);
+    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
 
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
-        node_sample_weight, 0, tree_limit, 0, max_nodes, 0);
+        node_sample_weight, 0, tree_limit, 0, max_nodes, 0
+    );
     ExplanationDataset data = ExplanationDataset(X, X_missing, NULL, NULL, NULL, num_X, M, 0);
 
     dense_tree_update_weights(trees, data);
 
     // clean up the created python objects
-    Py_XDECREF((PyObject *)children_left_array);
-    Py_XDECREF((PyObject *)children_right_array);
-    Py_XDECREF((PyObject *)children_default_array);
-    Py_XDECREF((PyObject *)features_array);
-    Py_XDECREF((PyObject *)thresholds_array);
-    Py_XDECREF((PyObject *)threshold_types_array);
-    Py_XDECREF((PyObject *)values_array);
+    Py_XDECREF((PyObject*)children_left_array);
+    Py_XDECREF((PyObject*)children_right_array);
+    Py_XDECREF((PyObject*)children_default_array);
+    Py_XDECREF((PyObject*)features_array);
+    Py_XDECREF((PyObject*)thresholds_array);
+    Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)values_array);
     // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
-    Py_XDECREF((PyObject *)node_sample_weight_array);
-    Py_XDECREF((PyObject *)X_array);
-    Py_XDECREF((PyObject *)X_missing_array);
+    Py_XDECREF((PyObject*)node_sample_weight_array);
+    Py_XDECREF((PyObject*)X_array);
+    Py_XDECREF((PyObject*)X_missing_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", 1);
     return ret;
 }
+
 
 static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
 {
@@ -499,49 +484,47 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyObject *y_obj;
     PyObject *out_pred_obj;
 
+
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-            args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-            &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
-            &X_obj, &X_missing_obj, &y_obj, &out_pred_obj))
-        return NULL;
+        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+        &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
+    )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject *)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject *)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject *)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject *)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject *)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject *)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject *)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject *)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject *)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject *)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None)
-        y_array = (PyArrayObject *)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_pred_array = (PyArrayObject *)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *out_pred_array = (PyArrayObject*)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
 
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL ||
         values_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_pred_array == NULL)
-    {
-        Py_XDECREF((PyObject *)children_left_array);
-        Py_XDECREF((PyObject *)children_right_array);
-        Py_XDECREF((PyObject *)children_default_array);
-        Py_XDECREF((PyObject *)features_array);
-        Py_XDECREF((PyObject *)thresholds_array);
-        Py_XDECREF((PyObject *)threshold_types_array);
-        Py_XDECREF((PyObject *)values_array);
-        Py_XDECREF((PyObject *)base_offset_array);
-        Py_XDECREF((PyObject *)X_array);
-        Py_XDECREF((PyObject *)X_missing_array);
-        if (y_array != NULL)
-            Py_XDECREF((PyObject *)y_array);
-        // PyArray_ResolveWritebackIfCopy(out_pred_array);
-        Py_XDECREF((PyObject *)out_pred_array);
+        X_missing_array == NULL || out_pred_array == NULL) {
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)base_offset_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+        //PyArray_ResolveWritebackIfCopy(out_pred_array);
+        Py_XDECREF((PyObject*)out_pred_array);
         return NULL;
     }
 
@@ -551,46 +534,45 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     const unsigned num_outputs = PyArray_DIM(values_array, 2);
 
     // Get pointers to the data as C-types
-    int *children_left = (int *)PyArray_DATA(children_left_array);
-    int *children_right = (int *)PyArray_DATA(children_right_array);
-    int *children_default = (int *)PyArray_DATA(children_default_array);
-    int *features = (int *)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat *)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int *)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat *)PyArray_DATA(values_array);
-    tfloat *base_offset = (tfloat *)PyArray_DATA(base_offset_array);
-    tfloat *X = (tfloat *)PyArray_DATA(X_array);
-    bool *X_missing = (bool *)PyArray_DATA(X_missing_array);
+    int *children_left = (int*)PyArray_DATA(children_left_array);
+    int *children_right = (int*)PyArray_DATA(children_right_array);
+    int *children_default = (int*)PyArray_DATA(children_default_array);
+    int *features = (int*)PyArray_DATA(features_array);
+    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
+    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    tfloat *values = (tfloat*)PyArray_DATA(values_array);
+    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
+    tfloat *X = (tfloat*)PyArray_DATA(X_array);
+    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
     tfloat *y = NULL;
-    if (y_array != NULL)
-        y = (tfloat *)PyArray_DATA(y_array);
-    tfloat *out_pred = (tfloat *)PyArray_DATA(out_pred_array);
+    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
+    tfloat *out_pred = (tfloat*)PyArray_DATA(out_pred_array);
 
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
         children_left, children_right, children_default, features, thresholds, threshold_types, values,
         NULL, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs);
+        max_nodes, num_outputs
+    );
     ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
 
     dense_tree_saabas(out_pred, trees, data);
 
     // clean up the created python objects
-    Py_XDECREF((PyObject *)children_left_array);
-    Py_XDECREF((PyObject *)children_right_array);
-    Py_XDECREF((PyObject *)children_default_array);
-    Py_XDECREF((PyObject *)features_array);
-    Py_XDECREF((PyObject *)thresholds_array);
-    Py_XDECREF((PyObject *)threshold_types_array);
-    Py_XDECREF((PyObject *)values_array);
-    Py_XDECREF((PyObject *)base_offset_array);
-    Py_XDECREF((PyObject *)X_array);
-    Py_XDECREF((PyObject *)X_missing_array);
-    if (y_array != NULL)
-        Py_XDECREF((PyObject *)y_array);
-    // PyArray_ResolveWritebackIfCopy(out_pred_array);
-    Py_XDECREF((PyObject *)out_pred_array);
+    Py_XDECREF((PyObject*)children_left_array);
+    Py_XDECREF((PyObject*)children_right_array);
+    Py_XDECREF((PyObject*)children_default_array);
+    Py_XDECREF((PyObject*)features_array);
+    Py_XDECREF((PyObject*)thresholds_array);
+    Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)values_array);
+    Py_XDECREF((PyObject*)base_offset_array);
+    Py_XDECREF((PyObject*)X_array);
+    Py_XDECREF((PyObject*)X_missing_array);
+    if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
+    //PyArray_ResolveWritebackIfCopy(out_pred_array);
+    Py_XDECREF((PyObject*)out_pred_array);
 
     /* Build the output tuple */
     PyObject *ret = Py_BuildValue("d", (double)values[0]);

--- a/shap/cutils/cutils.cpp
+++ b/shap/cutils/cutils.cpp
@@ -5,8 +5,9 @@
 
 namespace nb = nanobind;
 
-NB_MODULE(cutils, m) {
-    m.def("_compute_grey_code_row_values", &compute_grey_code_row_values_1d);
-    m.def("_compute_grey_code_row_values", &compute_grey_code_row_values_2d);
-    m.def("_compute_exp_val", &compute_exp_val);
+NB_MODULE(cutils, m)
+{
+    m.def("compute_grey_code_row_values", &compute_grey_code_row_values_1d);
+    m.def("compute_grey_code_row_values", &compute_grey_code_row_values_2d);
+    m.def("compute_exp_val", &compute_exp_val);
 }

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy.typing as npt
 from numba import njit  # type: ignore[attr-defined]
 
-from shap.cutils.cutils import _compute_grey_code_row_values
+from shap.cutils import compute_grey_code_row_values
 
 from .. import links
 from ..models import Model
@@ -177,7 +177,7 @@ class ExactExplainer(Explainer):
                 row_values = np.zeros((len(fm),) + outputs.shape[1:])
                 mask = np.zeros(len(fm), dtype=bool)
 
-                _compute_grey_code_row_values(
+                compute_grey_code_row_values(
                     row_values, mask, inds, outputs, coeff, extended_delta_indexes, MaskedModel.delta_mask_noop_value
                 )
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -18,7 +18,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
 
-from shap.cutils.cutils import _compute_exp_val as _exp_val
+from shap.cutils import compute_exp_val
 
 from .._explanation import Explanation
 from ..utils import safe_isinstance
@@ -684,7 +684,7 @@ class KernelExplainer(Explainer):
         self.y[self.nsamplesRun * self.N : self.nsamplesAdded * self.N, :] = np.reshape(modelOut, (num_to_run, self.D))
 
         # find the expected value of each output
-        self.nsamplesRun = _exp_val(
+        self.nsamplesRun = compute_exp_val(
             self.nsamplesRun, self.nsamplesAdded, self.D, self.N, self.data.weights, self.y, self.ey
         )
 


### PR DESCRIPTION
## Overview

Stage 1 of #4327: **Establish scikit-build-core as sole backend**

Description of the changes proposed in this pull request:

This PR uses scikit-build-core as the sole build backend, and drops setuptools as backend. 

**Major changes include:**
- Build `shap` for Python 3.12+ stable ABI, which would reduce the number of binary wheels for distribution.
- Compile nanobind extension `cutils` and numpy extension `cext` jointly in `CMakeLists.txt`.
- Mark `shap.cutils` as free-threaded, but it has not been tested yet!
- Cast `PyArrayObject*` to `PyObject*` before calling `Py_XDECREF` (release reference to the array). This has to be done to support Python 3.12+ ABI.
- Drop `_*` prefix from `shap.cutils` (nanobind) functions, e.g., `_compute_grey_code_row_values` becomes `compute_grey_code_row_values`.
- Target macOS build for 10.13+, which is required by nanobind as it uses C++ 17.

**Results:**
1. Running `uv build` locally on macOS 26, Python 3.13 produce two files:
```
Successfully built dist/shap-0.51.1.dev44.tar.gz
Successfully built dist/shap-0.51.1.dev44-cp312-abi3-macosx_26_0_arm64.whl
```
2. Running `uv run pytest tests/explainers/test_kernel.py` and `uv run pytest tests/explainers/test_exact.py` without any fails locally. More unit tests need to be run on CIs.

**What's still missing:**
- `build_wheels` CI has not been updated.
- GPU Tree logic is not being compiled in `CMakeLists.txt`. To enable CUDA build, we would need to transfer the logic in `setup.py` to `CMakeLists.txt`.
- Other CIs like readthedocs have not been updated:

**TODO list:**
- [x] Update readthedocs CI.
- [ ] Trigger CIs on the current branch "move-to-nanobind".
- [ ] Update `run_tests` CI.
- [ ] Update `run_notebooks` CI.
- [ ] ...

**Discussion points:**
- **uv build frontend:** `cibuildwheel` uses pip as default build frontend. Should we switch to uv for faster setup and build?
- **`shap.cutils` visibility:** I suggest renaming the extension to `shap._cutils`.
- **C++ source files:** It is customary to not bundle C++ source files in binary wheels. Should we move `cutils` out of `shap` folder and move into the root folder? We can still distribute the source files in sdist. In the long term, I would also suggest moving `cext` out of `shap` folder.
- **Stable ABI:** nanobind supports building for stable ABI from Python 3.12+. I've enabled it to reduce the number of binary wheels for distribution. Do you agree with the decision here?
- **Free threading:** I have marked the `cutils` extension as `FREE_THREADED`. But this might need to be validated more carefully! For context, [numba v0.65.0](https://numba.readthedocs.io/en/stable/release/0.65.0-notes.html) now supports free threading, so building a fully free-threaded shap is possible. Should we disable the free-threading support for now?
- **Universal macOS build:** macOS can bundle `x86_64` and `arm64` binaries into one `universal2` format, but at the cost of increased size (`shap` binary is less than 1MB actually). Should we enable it?
- **Windows ARM64 support:** Windows on ARM64 is becoming more popular. Should we enable the build support too?

A little bit more context on the Stable ABI and `universal2`, if we opt into Stable ABI, we can reduce 30+ binaries to as few as just six:
- Linux: (x86_64, aarch64) x (manylinux_2_28, musllinux_1_2)
- Windows: AMD64 (+ARM64?)
- macOS: universal2

@CloseChoice Let me know what you think on those points. Thanks.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
