### PR TITLE
DOCS: Clarify sample alignment requirement for shap_values additivity

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -558,6 +558,9 @@ class TreeExplainer(Explainer):
                a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
                to the sum.
 
+               Furthermore, the additivity formula requires SHAP values and model
+               predictions to be computed on the same samples in the same order.
+
             The shape of the returned array depends on the number of model outputs:
 
             * one output: array of shape ``(#num_samples, *X.shape[1:])``.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -544,10 +544,19 @@ class TreeExplainer(Explainer):
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
             For each output, the SHAP values (summed across all features) plus the
-            expected value equals the model's output for that sample:
+            expected value equals the model's output in the space of the ``model_output``
+            argument for that sample:
 
-            * Single output: ``shap_values[i, :].sum() + expected_value = model_output[i]``
-            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = model_output[i, j]``
+            * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
+            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
+
+            .. note:: 
+               The ``explainer_model_output`` is NOT necessarily what ``model.predict()`` 
+               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default 
+               ``model_output="raw"``, the explainer returns log-odds (margins). 
+               To compare this mathematically against ``predict_proba()`` probabilities,
+               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
+               to the sum.
 
             The shape of the returned array depends on the number of model outputs:
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -550,12 +550,12 @@ class TreeExplainer(Explainer):
             * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
             * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
 
-            .. note:: 
-               The ``explainer_model_output`` is NOT necessarily what ``model.predict()`` 
-               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default 
-               ``model_output="raw"``, the explainer returns log-odds (margins). 
+            .. note::
+               The ``explainer_model_output`` is NOT necessarily what ``model.predict()``
+               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default
+               ``model_output="raw"``, the explainer returns log-odds (margins).
                To compare this mathematically against ``predict_proba()`` probabilities,
-               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
+               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied
                to the sum.
 
                Furthermore, the additivity formula requires SHAP values and model


### PR DESCRIPTION
**What does this PR do?**
It adds a note to the `TreeExplainer.shap_values` docstring clarifying that the additivity formula strictly requires SHAP values and model predictions to be computed on the exact same samples in the exact same order.

**What problem does it solve?**
Closes #4414.
In issue #4414, users reported assertion failures when computing SHAP values on a subset of samples (e.g. `X_train`) and comparing against model predictions from a different batch (e.g. `X_val`). The additivity math is fully correct—the root cause is simply sample index misalignment by the user.

**Checklist**
- [x] I have read the CONTRIBUTING.md
- [x] Branch is up to date with master
- [x] Pre-commit hooks pass
- [x] Documentation builds cleanly
- [x] No new tests required (documentation-only change)
