### PR TITLE
ENH: Migrate _exp_val to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.15...3.26)
+
+project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
+
+if (NOT SKBUILD)
+  message(WARNING "\
+  This CMake file is meant to be executed using 'scikit-build'. Running
+  it directly will almost certainly not produce the desired result. If
+  you are a user trying to install this package, please use the command
+  below, which will install all necessary build dependencies, compile
+  the package in an isolated environment, and then install it.
+  =====================================================================
+   $ pip install .
+  =====================================================================
+  If you are a software developer, and this is your own package, then
+  it is usually much more efficient to install the build dependencies
+  in your environment once and use the following command that avoids
+  a costly creation of a new virtual environment at every compilation:
+  =====================================================================
+   $ pip install nanobind scikit-build-core[pyproject]
+   $ pip install --no-build-isolation -ve .
+  =====================================================================
+  You may optionally add -Ceditable.rebuild=true to auto-rebuild when
+  the package is imported. Otherwise, you need to re-run the above
+  after editing C++ files.")
+endif()
+
+# Try to import all Python components potentially needed by nanobind
+find_package(Python 3.12
+  REQUIRED COMPONENTS Interpreter Development.Module
+  OPTIONAL_COMPONENTS Development.SABIModule)
+
+# Import nanobind through CMake's find_package mechanism
+find_package(nanobind CONFIG REQUIRED)
+
+include_directories(include)
+
+# We are now ready to compile the actual extension module
+nanobind_add_module(
+  # Name of the extension
+  _ext
+
+  # Target the stable ABI for Python 3.12+, which reduces
+  # the number of binary wheels that must be built. This
+  # does nothing on older Python versions
+  STABLE_ABI
+
+  # Build libnanobind statically and merge it into the
+  # extension (which itself remains a shared library)
+  #
+  # If your project builds multiple extensions, you can
+  # replace this flag by NB_SHARED to conserve space by
+  # reusing a shared libnanobind across libraries
+  NB_STATIC
+
+  # Source code goes here
+  src/bind.cpp
+  src/kernel.cpp
+)
+
+# Install directive for scikit-build-core
+install(TARGETS _ext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+namespace nb = nanobind;
+
+namespace kernel
+{
+    nb::tuple exp_val(
+        int nsamples_run,
+        int nsamples_added,
+        int D,
+        int N,
+        nb::ndarray<nb::numpy, double, nb::ndim<1>> weights,
+        nb::ndarray<nb::numpy, double, nb::ndim<2>> y,
+        nb::ndarray<nb::numpy, double, nb::ndim<2>> ey);
+}

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -11,13 +11,14 @@ import numpy.typing as npt
 import pandas as pd
 import scipy.sparse
 import sklearn
-from shap._ext import _exp_val
 from packaging import version
 from scipy.special import binom
 from sklearn.linear_model import Lasso, LassoLarsIC, lars_path
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
+
+from shap._ext import _exp_val
 
 from .._explanation import Explanation
 from ..utils import safe_isinstance

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -11,7 +11,7 @@ import numpy.typing as npt
 import pandas as pd
 import scipy.sparse
 import sklearn
-from _kernel_lib import _exp_val
+from shap._ext import _exp_val
 from packaging import version
 from scipy.special import binom
 from sklearn.linear_model import Lasso, LassoLarsIC, lars_path

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -1,0 +1,21 @@
+#include <nanobind/nanobind.h>
+#include "kernel.h"
+
+namespace nb = nanobind;
+
+using namespace nb::literals;
+
+NB_MODULE(_ext, m)
+{
+    m.doc() = "Internal C++ implementation of SHAP algorithms";
+    m.def(
+        "_exp_val",
+        &kernel::exp_val,
+        "nsamples_run"_a,
+        "nsamples_added"_a,
+        "D"_a,
+        "N"_a,
+        "weights"_a,
+        "y"_a,
+        "ey"_a);
+}

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -1,0 +1,64 @@
+#include "kernel.h"
+
+namespace kernel
+{
+    nb::tuple exp_val(
+        int nsamples_run,
+        int nsamples_added,
+        int D,
+        int N,
+        nb::ndarray<nb::numpy, double, nb::ndim<1>> weights,
+        nb::ndarray<nb::numpy, double, nb::ndim<2>> y,
+        nb::ndarray<nb::numpy, double, nb::ndim<2>> ey)
+    {
+        auto weights_view = weights.view<double, nb::ndim<1>>();
+        auto y_view = y.view<double, nb::ndim<2>>();
+        auto ey_view = ey.view<double, nb::ndim<2>>();
+
+        if (D < 0 || N < 0 || nsamples_run < 0 || nsamples_added < 0)
+        {
+            throw nb::value_error("D, N, nsamples_run, and nsamples_added must be non-negative");
+        }
+        if (nsamples_run > nsamples_added)
+        {
+            throw nb::value_error("nsamples_run cannot be greater than nsamples_added");
+        }
+        if (weights_view.shape(0) != static_cast<size_t>(N))
+        {
+            throw nb::value_error("weights length does not match N");
+        }
+        if (y_view.shape(1) != static_cast<size_t>(D))
+        {
+            throw nb::value_error("y second dimension does not match D");
+        }
+        if (ey_view.shape(1) != static_cast<size_t>(D))
+        {
+            throw nb::value_error("ey second dimension does not match D");
+        }
+        const size_t required_y_rows = static_cast<size_t>(nsamples_added) * static_cast<size_t>(N);
+        if (y_view.shape(0) < required_y_rows)
+        {
+            throw nb::value_error("y first dimension is smaller than nsamples_added * N");
+        }
+        if (ey_view.shape(0) < static_cast<size_t>(nsamples_added))
+        {
+            throw nb::value_error("ey first dimension is smaller than nsamples_added");
+        }
+
+        for (int i = nsamples_run; i < nsamples_added; ++i)
+        {
+            for (int k = 0; k < D; ++k)
+            {
+                double value = 0.0;
+                for (int j = 0; j < N; ++j)
+                {
+                    value += y_view(i * N + j, k) * weights_view(j);
+                }
+                ey_view(i, k) = value;
+            }
+            nsamples_run += 1;
+        }
+
+        return nb::make_tuple(ey, nsamples_run);
+    }
+}


### PR DESCRIPTION
## Overview

Closes #4327  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:

Converted the [_exp_val](https://github.com/shap/shap/blob/71d04ab53d3e74b6b47e7709aabfc1ef479adee3/shap/explainers/_kernel_lib.pyx#L13) functions to C++. In [src/kernel.cpp](https://github.com/axif0/shap/blob/c8587532fa3ffe805863637617876be92886e79e/src/kernel.cpp) translating the old Cython `_exp_val` into C++ (same math, nanobind ndarray views, bound checks) and binding it in _ext.” ?

I set up nanobind using the same approach as #4328

## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [] Unit tests added (if fixing a bug or adding a new feature)
