### PR TITLE
fix: _heatmap.py works with opchain feature order

### DIFF
--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -79,7 +79,7 @@ def heatmap(
     if feature_order is None:
         feature_order = np.argsort(-feature_values)
     elif issubclass(type(feature_order), OpChain):
-        feature_order = feature_order.apply(Explanation(values))
+        feature_order = feature_order.apply(Explanation(values)).values
     elif not hasattr(feature_order, "__len__"):
         raise Exception(f"Unsupported feature_order: {str(feature_order)}!")
     xlabel = "Instances"


### PR DESCRIPTION
## Overview

Closes #4460  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:

Used the values from the Explanation object created when feature order is of opchain type, instead of using the obejct directly, which caused IndexError

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
