### PR TITLE
FIX: Replace bare assert with ValueError in violin()

### DIFF
--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -126,7 +126,9 @@ def violin(
         emsg = f"plot_type: Expected one of ('violin','layered_violin'), received {plot_type} instead."
         raise ValueError(emsg)
 
-    assert len(shap_values.shape) != 1, "Violin summary plots need a matrix of shap_values, not a vector."
+    if len(shap_values.shape) == 1:
+        emsg = "Violin summary plots need a matrix of shap_values, not a vector."
+        raise ValueError(emsg)
 
     # default color:
     if color is None:

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -9,6 +9,7 @@ import pandas as pd
 from packaging import version
 from scipy.stats import gaussian_kde
 
+from .. import Explanation
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels
@@ -106,7 +107,7 @@ def violin(
     if title is not None:
         warnings.warn("The `title` argument is unused and will be removed in a future release.", DeprecationWarning)
     # support passing an explanation object
-    if str(type(shap_values)).endswith("Explanation'>"):
+    if isinstance(shap_values, Explanation):
         shap_exp = shap_values
         shap_values = shap_exp.values
         if features is None:
@@ -126,7 +127,7 @@ def violin(
         emsg = f"plot_type: Expected one of ('violin','layered_violin'), received {plot_type} instead."
         raise ValueError(emsg)
 
-    if len(shap_values.shape) == 1:
+    if shap_values.ndim < 2:
         emsg = "Violin summary plots need a matrix of shap_values, not a vector."
         raise ValueError(emsg)
 

--- a/tests/plots/test_violin.py
+++ b/tests/plots/test_violin.py
@@ -11,6 +11,12 @@ def test_violin_with_invalid_plot_type():
         shap.plots.violin(np.random.randn(20, 5), plot_type="nonsense")
 
 
+def test_violin_1d_shap_values_raises():
+    """Check that a 1-D shap_values array raises ValueError, not AssertionError."""
+    with pytest.raises(ValueError, match="matrix of shap_values"):
+        shap.plots.violin(np.random.randn(5), show=False)
+
+
 def test_violin_wrong_features_shape():
     """Checks that DimensionError is raised if the features data matrix
     has an incompatible shape with the shap_values matrix.

--- a/tests/plots/test_violin.py
+++ b/tests/plots/test_violin.py
@@ -13,8 +13,9 @@ def test_violin_with_invalid_plot_type():
 
 def test_violin_1d_shap_values_raises():
     """Check that a 1-D shap_values array raises ValueError, not AssertionError."""
+    rng = np.random.default_rng(0)
     with pytest.raises(ValueError, match="matrix of shap_values"):
-        shap.plots.violin(np.random.randn(5), show=False)
+        shap.plots.violin(rng.standard_normal(5), show=False)
 
 
 def test_violin_wrong_features_shape():


### PR DESCRIPTION
## Overview

Closes #4463 

Replaced the bare `assert` on line 129 of `shap/plots/_violin.py` with a`raise ValueError` to match the pattern already used at lines 121 and 127 of the same file.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)