### PR TITLE
FIX: Replace bare assert statements with DimensionError in shap/plots/_scatter.py

### DIFF
--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -245,12 +245,14 @@ def scatter(
         figsize = (7.5, 5) if interaction_index != ind and interaction_index is not None else (6, 5)
         _, ax = plt.subplots(figsize=figsize)
 
-    assert shap_values_arr.shape[0] == features.shape[0], (
-        "'shap_values_arr' and 'features' values must have the same number of rows!"
-    )
-    assert shap_values_arr.shape[1] == features.shape[1], (
-        "'shap_values_arr' must have the same number of columns as 'features'!"
-    )
+    if shap_values_arr.shape[0] != features.shape[0]:
+        raise DimensionError(
+            "'shap_values_arr' and 'features' values must have the same number of rows!"
+        )
+    if shap_values_arr.shape[1] != features.shape[1]:
+        raise DimensionError(
+            "'shap_values_arr' must have the same number of columns as 'features'!"
+        )
 
     # get both the raw and display feature values
     oinds = np.arange(
@@ -680,12 +682,14 @@ def dependence_legacy(
             plt.show()
         return
 
-    assert shap_values.shape[0] == features.shape[0], (
-        "'shap_values' and 'features' values must have the same number of rows!"
-    )
-    assert shap_values.shape[1] == features.shape[1], (
-        "'shap_values' must have the same number of columns as 'features'!"
-    )
+    if shap_values.shape[0] != features.shape[0]:
+        raise DimensionError(
+            "'shap_values' and 'features' values must have the same number of rows!"
+        )
+    if shap_values.shape[1] != features.shape[1]:
+        raise DimensionError(
+            "'shap_values' must have the same number of columns as 'features'!"
+        )
 
     # get both the raw and display feature values
     oinds = np.arange(

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -246,13 +246,9 @@ def scatter(
         _, ax = plt.subplots(figsize=figsize)
 
     if shap_values_arr.shape[0] != features.shape[0]:
-        raise DimensionError(
-            "'shap_values_arr' and 'features' values must have the same number of rows!"
-        )
+        raise DimensionError("'shap_values_arr' and 'features' values must have the same number of rows!")
     if shap_values_arr.shape[1] != features.shape[1]:
-        raise DimensionError(
-            "'shap_values_arr' must have the same number of columns as 'features'!"
-        )
+        raise DimensionError("'shap_values_arr' must have the same number of columns as 'features'!")
 
     # get both the raw and display feature values
     oinds = np.arange(
@@ -683,13 +679,9 @@ def dependence_legacy(
         return
 
     if shap_values.shape[0] != features.shape[0]:
-        raise DimensionError(
-            "'shap_values' and 'features' values must have the same number of rows!"
-        )
+        raise DimensionError("'shap_values' and 'features' values must have the same number of rows!")
     if shap_values.shape[1] != features.shape[1]:
-        raise DimensionError(
-            "'shap_values' must have the same number of columns as 'features'!"
-        )
+        raise DimensionError("'shap_values' must have the same number of columns as 'features'!")
 
     # get both the raw and display feature values
     oinds = np.arange(

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 import shap
+from shap.utils._exceptions import DimensionError
 
 
 @pytest.mark.mpl_image_compare
@@ -112,3 +113,30 @@ def test_scatter_plot_value_input(input):
     shap.plots.scatter(explanations, show=False)
     plt.tight_layout()
     return plt.gcf()
+
+
+def test_scatter_mismatched_rows_raises():
+    """scatter() raises DimensionError when shap_values and features have different row counts."""
+    sv = shap.Explanation(
+        values=np.random.randn(10, 3),
+        data=np.random.randn(5, 3),
+        feature_names=["a", "b", "c"],
+    )
+    with pytest.raises(DimensionError, match="same number of rows"):
+        shap.plots.scatter(sv[:, 0], show=False)
+
+
+def test_dependence_legacy_mismatched_rows_raises():
+    """dependence_legacy() raises DimensionError when shap_values and features row counts differ."""
+    shap_values = np.random.randn(10, 3)
+    features = np.random.randn(5, 3)
+    with pytest.raises(DimensionError, match="same number of rows"):
+        shap.plots._scatter.dependence_legacy(0, shap_values=shap_values, features=features, show=False)
+
+
+def test_dependence_legacy_mismatched_cols_raises():
+    """dependence_legacy() raises DimensionError when shap_values and features column counts differ."""
+    shap_values = np.random.randn(10, 3)
+    features = np.random.randn(10, 2)
+    with pytest.raises(DimensionError, match="same number of columns"):
+        shap.plots._scatter.dependence_legacy(0, shap_values=shap_values, features=features, show=False)


### PR DESCRIPTION
## Overview

Closes #4465 

`shap/plots/_scatter.py` had four bare `assert` statements in `scatter()` and `dependence_legacy()` validating shape compatibility between shap values and features. `assert` is stripped in optimized mode (`python -O`) and produces `AssertionError` instead of an informative exception.

Replaced all four with `if / raise DimensionError(...)`, matching the pattern already used in `_violin.py` and `_beeswarm.py`. `DimensionError` was already imported — no new imports needed. Error messages are unchanged.

Added three tests covering row and column mismatch paths in both functions.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)