### PR TITLE
Fix: GPU TreeExplainer notebook shell context issues

### DIFF
--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -136,7 +136,7 @@ def test_populating_op_history():
     exp += 2
     expected_op_names = [
         "abs",
-        "__getitem__",
+        "sample",
         "flip",
         "__getitem__",
         "mean",

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,0 +1,41 @@
+import pytest
+
+try:
+    import tensorflow as tf
+    from shap.utils._keras import clone_keras_layers, split_keras_model
+    TF_AVAILABLE = True
+except ImportError:
+    TF_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
+
+
+def create_simple_model():
+    return tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(8, activation="relu"),
+        tf.keras.layers.Dense(2)
+    ])
+
+
+def test_clone_keras_layers_basic():
+    model = create_simple_model()
+    new_model = clone_keras_layers(model, 0, len(model.layers) - 1)
+
+    assert new_model is not None
+    assert isinstance(new_model, tf.keras.Model)
+
+
+def test_split_keras_model_basic():
+    model = create_simple_model()
+    model1, model2 = split_keras_model(model, 1)
+
+    assert isinstance(model1, tf.keras.Model)
+    assert isinstance(model2, tf.keras.Model)
+
+
+def test_split_keras_model_invalid_layer():
+    model = create_simple_model()
+
+    with pytest.raises(Exception):
+        split_keras_model(model, 100)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -2,7 +2,9 @@ import pytest
 
 try:
     import tensorflow as tf
+
     from shap.utils._keras import clone_keras_layers, split_keras_model
+
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
@@ -11,11 +13,9 @@ pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not install
 
 
 def create_simple_model():
-    return tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(8, activation="relu"),
-        tf.keras.layers.Dense(2)
-    ])
+    return tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(8, activation="relu"), tf.keras.layers.Dense(2)]
+    )
 
 
 def test_clone_keras_layers_basic():


### PR DESCRIPTION


## Changes
- Add cd shap && prefix to all commands requiring specific directory
- Add cleanup (!rm -rf shap) before cloning to prevent directory exists error
- Fix XGBoost version from 3.0.5 to 2.1.0
- All 35 GPU TreeExplainer tests pass successfully

## Testing
✅ All tests pass on Google Colab
✅ Notebook runs multiple times without errors