### PR TITLE
Fix TreeExplainer crash when input is provided as Python list

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -449,6 +449,7 @@ class TreeExplainer(Explainer):
         check_additivity: bool,
     ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | pd.Series | None, npt.NDArray[np.bool_], bool, int, bool]:
         import numpy as np
+
         if not hasattr(X, "shape"):
             X = np.array(X)
         # see if we have a default tree_limit in place.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -448,6 +448,9 @@ class TreeExplainer(Explainer):
         tree_limit: int | None,
         check_additivity: bool,
     ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | pd.Series | None, npt.NDArray[np.bool_], bool, int, bool]:
+        import numpy as np
+        if not hasattr(X, "shape"):
+            X = np.array(X)
         # see if we have a default tree_limit in place.
         if tree_limit is None:
             tree_limit = -1 if self.model.tree_limit is None else self.model.tree_limit


### PR DESCRIPTION
## Overview

Closes #4473

Fixes a crash in TreeExplainer when input is provided as a Python list instead of an array-like object.
 
## Changes
Currently, passing a list (e.g. list(X[0])) to TreeExplainer.shap_values() results in:
`AttributeError: 'list' object has no attribute 'shape'`
this happens because _validate_inputs assumes the input has a .shape attribute.

This PR adds a simple input validation step to convert array-like inputs (such as Python lists) into numpy arrays before further processing by
```
if not hasattr(X, "shape"):	
	X = np.array(X)
```

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
