### PR TITLE
ENH: Add DataFrame export helper for shap.Explanation

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -648,6 +648,75 @@ class Explanation(metaclass=MetaExplanation):
 
         return hclust_ordering(X=values, metric=metric)
 
+    def to_dataframe(self, include_base_values: bool = False) -> pd.DataFrame:
+        """Convert this explanation into a pandas DataFrame.
+
+        The returned DataFrame is a convenient tabular view of the SHAP values.
+        It supports one-dimensional explanations and explanation matrices with
+        shape ``(n_rows, n_features)``.
+
+        Parameters
+        ----------
+        include_base_values : bool
+            If True, add a ``base_value`` column to the left side of the
+            DataFrame. When possible, a scalar base value is broadcast to all
+            rows.
+
+        Returns
+        -------
+        pandas.DataFrame
+            A DataFrame with one column per feature and one row per explanation.
+
+        Raises
+        ------
+        ValueError
+            If the explanation has more than two dimensions, or if the feature
+            names cannot be represented as a flat set of DataFrame columns.
+
+        """
+        values = np.asarray(self.values)
+        if values.ndim == 1:
+            values = values.reshape(1, -1)
+        elif values.ndim != 2:
+            raise ValueError(
+                "Explanation.to_dataframe() only supports one-dimensional explanations or two-dimensional "
+                "explanation matrices."
+            )
+
+        feature_names = self.feature_names
+        if feature_names is None:
+            columns = np.array([f"Feature {i}" for i in range(values.shape[1])], dtype=object)
+        else:
+            columns = np.asarray(feature_names)
+            if columns.ndim != 1:
+                raise ValueError(
+                    "Explanation.to_dataframe() only supports flat feature names. "
+                    "Try slicing a single output or flattening the explanation first."
+                )
+            if len(columns) != values.shape[1]:
+                raise ValueError("The number of feature names does not match the number of columns in the explanation.")
+
+        index = None
+        if self.instance_names is not None:
+            index = np.asarray(self.instance_names)
+            if index.ndim == 0:
+                index = np.asarray([index.item()])
+
+        out = pd.DataFrame(values, columns=columns, index=index)
+
+        if include_base_values and self.base_values is not None:
+            base_values = np.asarray(self.base_values)
+            if base_values.ndim == 0:
+                out.insert(0, "base_value", base_values.item())
+            elif base_values.ndim == 1 and base_values.shape[0] == len(out):
+                out.insert(0, "base_value", base_values)
+            else:
+                raise ValueError(
+                    "Explanation.to_dataframe() can only include base values when they are scalar or one value per row."
+                )
+
+        return out
+
     # =================== Utilities ===================
 
     def hstack(self, other: Explanation) -> Explanation:

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,33 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+def test_explanation_to_dataframe():
+    exp = shap.Explanation(
+        values=np.array([[0.1, -0.2], [0.3, 0.4]]),
+        base_values=np.array([0.5, 0.6]),
+        instance_names=["row-0", "row-1"],
+        feature_names=["f0", "f1"],
+    )
+
+    df = exp.to_dataframe(include_base_values=True)
+
+    assert list(df.columns) == ["base_value", "f0", "f1"]
+    assert list(df.index) == ["row-0", "row-1"]
+    assert np.allclose(df["base_value"].to_numpy(), [0.5, 0.6])
+    assert np.allclose(df[["f0", "f1"]].to_numpy(), exp.values)
+
+
+def test_explanation_to_dataframe_single_row():
+    exp = shap.Explanation(
+        values=np.array([0.1, -0.2, 0.3]),
+        base_values=0.25,
+        feature_names=["f0", "f1", "f2"],
+    )
+
+    df = exp.to_dataframe(include_base_values=True)
+
+    assert df.shape == (1, 4)
+    assert list(df.columns) == ["base_value", "f0", "f1", "f2"]
+    assert np.allclose(df.iloc[0].to_numpy(), [0.25, 0.1, -0.2, 0.3])


### PR DESCRIPTION
## Summary
Adds a new convenience API: `Explanation.to_dataframe()`.

This converts SHAP explanations into a pandas DataFrame for easier inspection, analysis, and export workflows.

Closes #4489.

## What changed
- Added `Explanation.to_dataframe(include_base_values: bool = False)`.
- Supports 1D and 2D explanations.
- Uses `feature_names` as DataFrame columns when available.
- Falls back to default names (`Feature 0`, `Feature 1`, ...) when feature names are missing.
- Uses `instance_names` as index when available.
- Optionally inserts a `base_value` column when base values are scalar or one-per-row.
- Raises clear `ValueError`s for unsupported shapes / metadata combinations.

## Tests
Added/updated tests in `tests/test_explanation.py`:
- `test_explanation_to_dataframe`
- `test_explanation_to_dataframe_single_row`

Validation run locally:
- `pytest tests/test_explanation.py -q`
- `pytest` (full suite)

## Scope
This PR is intentionally small and focused: one feature + unit tests only (no unrelated refactoring).

## AI usage disclosure
AI assistance was used for drafting code/tests and improving wording.
All changes were reviewed and validated manually, and I understand the final implementation and tests.
No copyrighted third-party code was copied into this PR.