### PR TITLE
Fix/make grid sentfix(benchmark): replace magic sentinel -28567 with np.nan in make_gridinel value

### DIFF
--- a/shap/benchmark/plots.py
+++ b/shap/benchmark/plots.py
@@ -413,13 +413,13 @@ def make_grid(scores, dataset, model, normalize=True, transform=True):
     col_keys = list(color_vals.keys())
     row_keys = list({v for k in col_keys for v in color_vals[k].keys()})
 
-    data = -28567 * np.ones((len(row_keys), len(col_keys)))
+    data = np.full((len(row_keys), len(col_keys)), np.nan)
 
     for i in range(len(row_keys)):
         for j in range(len(col_keys)):
             data[i, j] = color_vals[col_keys[j]][row_keys[i]]
 
-    assert np.sum(data == -28567) == 0, "There are missing data values!"
+    assert not np.any(np.isnan(data)), "There are missing data values!"
 
     if normalize:
         data = (data - data.min(0)) / (data.max(0) - data.min(0) + 1e-8)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,0 +1,41 @@
+import pytest
+
+try:
+    import tensorflow as tf
+    from shap.utils._keras import clone_keras_layers, split_keras_model
+    TF_AVAILABLE = True
+except ImportError:
+    TF_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
+
+
+def create_simple_model():
+    return tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(8, activation="relu"),
+        tf.keras.layers.Dense(2)
+    ])
+
+
+def test_clone_keras_layers_basic():
+    model = create_simple_model()
+    new_model = clone_keras_layers(model, 0, len(model.layers) - 1)
+
+    assert new_model is not None
+    assert isinstance(new_model, tf.keras.Model)
+
+
+def test_split_keras_model_basic():
+    model = create_simple_model()
+    model1, model2 = split_keras_model(model, 1)
+
+    assert isinstance(model1, tf.keras.Model)
+    assert isinstance(model2, tf.keras.Model)
+
+
+def test_split_keras_model_invalid_layer():
+    model = create_simple_model()
+
+    with pytest.raises(Exception):
+        split_keras_model(model, 100)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -2,7 +2,9 @@ import pytest
 
 try:
     import tensorflow as tf
+
     from shap.utils._keras import clone_keras_layers, split_keras_model
+
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
@@ -11,11 +13,9 @@ pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not install
 
 
 def create_simple_model():
-    return tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(8, activation="relu"),
-        tf.keras.layers.Dense(2)
-    ])
+    return tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(8, activation="relu"), tf.keras.layers.Dense(2)]
+    )
 
 
 def test_clone_keras_layers_basic():


### PR DESCRIPTION
## What
Replaces magic number `-28567` with `np.nan` in `make_grid`.

## Why
- Magic number is unclear to contributors
- Float `==` comparison is unreliable
- `np.nan` is the NumPy standard for missing values

## Changes
- `np.ones * -28567` → `np.full(..., np.nan)`
- `data == -28567` → `np.isnan()` check

Closes #4493