### PR TITLE
FIX: Correct file path handling in make_dir (image.py)

### DIFF
--- a/shap/utils/image.py
+++ b/shap/utils/image.py
@@ -40,7 +40,7 @@ def make_dir(path):
         if os.listdir(path):
             # if exists, empty directory
             for file in os.listdir(path):
-                os.remove(path + file)
+                os.remove(os.path.join(path, file))
 
 
 def add_sample_images(path):


### PR DESCRIPTION
## Overview
Closes #4500 
Fixes incorrect path construction in `make_dir` within `shap/utils/image.py`.

The function was removing files using string concatenation:

```python
os.remove(path + file)
```

## Fix :-  
Replaced string concatenation with proper path joining:
```python
os.remove(os.path.join(path, file))
```
## Validations done :-   
- Reproduced the bug using a directory containing files
- Verified that files are correctly removed after the fix
- Confirmed no errors are raised during execution
## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
Tests for this fix will be added in the follow up PR. I encountered this issue while creating tests for image.py so flagged this first and now will make the follow up PR for it.

## AI usage disclosure 
I used no AI for the fixation. I ran the tests in PR #4503 and encountered this error so I fixed it then and there and raised this PR. 
