### PR TITLE
TEST: Increase coverage for shap/utils/image.py

### DIFF
--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,0 +1,151 @@
+import pytest
+import numpy as np
+import os
+import tempfile
+import matplotlib.pyplot as plt
+import cv2
+
+from shap.utils.image import (
+    is_empty,
+    make_dir,
+    add_sample_images,
+    load_image,
+    check_valid_image,
+    save_image,
+    resize_image,
+    display_grid_plot,
+)
+
+
+# ================== is_empty ==================
+
+def test_is_empty_cases(tmp_path):
+    # empty dir
+    assert is_empty(tmp_path) is True
+
+    # dir with file
+    (tmp_path / "file.txt").write_text("data")
+    assert is_empty(tmp_path) is False
+
+    # nonexistent
+    assert is_empty("nonexistent_path_123") is True
+
+
+# ================== make_dir ==================
+
+def test_make_dir_create_and_clear(tmp_path):
+    new_dir = tmp_path / "new"
+    make_dir(str(new_dir))
+    assert new_dir.exists()
+
+    # add files then clear
+    (new_dir / "file.txt").write_text("data")
+    make_dir(str(new_dir))
+    assert list(new_dir.iterdir()) == []
+
+
+# ================== check_valid_image ==================
+
+@pytest.mark.parametrize("filename", [
+    "a.png", "b.jpg", "c.jpeg", "d.gif", "e.bmp", "f.jfif"
+])
+def test_check_valid_image_valid(filename):
+    assert check_valid_image(filename) is True
+
+
+@pytest.mark.parametrize("filename", ["a.txt", "b", "c.pdf"])
+def test_check_valid_image_invalid(filename):
+    assert check_valid_image(filename) is None
+
+
+# ================== save + load ==================
+
+def test_save_and_load_image(tmp_path):
+    img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+    path = tmp_path / "img.jpg"
+
+    save_image(img, str(path))
+    assert path.exists()
+
+    loaded = load_image(str(path))
+    assert isinstance(loaded, np.ndarray)
+    assert loaded.shape == (100, 100, 3)
+
+
+def test_load_image_invalid():
+    with pytest.raises((cv2.error, AttributeError, FileNotFoundError)):
+        load_image("invalid_path.jpg")
+
+
+# ================== resize_image ==================
+
+def test_resize_image_no_resize(tmp_path):
+    img = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
+    path = tmp_path / "small.jpg"
+    save_image(img, str(path))
+
+    out, new_path = resize_image(str(path), str(tmp_path))
+    assert new_path is None
+    assert out.shape[:2] == (200, 200)
+
+
+def test_resize_image_large_square(tmp_path):
+    img = np.random.randint(0, 256, (600, 600, 3), dtype=np.uint8)
+    path = tmp_path / "large.jpg"
+    save_image(img, str(path))
+
+    out, new_path = resize_image(str(path), str(tmp_path))
+    assert new_path is not None
+    assert out.shape[0] == 500 and out.shape[1] == 500
+
+
+def test_resize_aspect_ratio(tmp_path):
+    img = np.random.randint(0, 256, (400, 800, 3), dtype=np.uint8)
+    path = tmp_path / "wide.jpg"
+    save_image(img, str(path))
+
+    out, _ = resize_image(str(path), str(tmp_path))
+    ratio = out.shape[1] / out.shape[0]
+    assert abs(ratio - 2.0) < 0.2
+
+
+# ================== display ==================
+
+def test_display_grid_plot_runs(tmp_path):
+    img = np.random.randint(0, 256, (50, 50, 3), dtype=np.uint8)
+    path = tmp_path / "img.jpg"
+    save_image(img, str(path))
+
+    # avoid UI pop
+    with pytest.MonkeyPatch().context() as m:
+        m.setattr("matplotlib.pyplot.show", lambda: None)
+        display_grid_plot(["caption"], [str(path)])
+
+
+# ================== add_sample_images ==================
+
+def test_add_sample_images(monkeypatch, tmp_path):
+    def fake_dataset():
+        return np.random.randint(0, 256, (50, 50, 50, 3), dtype=np.uint8), None
+
+    monkeypatch.setattr("shap.datasets.imagenet50", fake_dataset)
+
+    add_sample_images(str(tmp_path))
+    assert len(list(tmp_path.iterdir())) == 4
+
+
+# ================== integration ==================
+
+def test_full_workflow(tmp_path):
+    img = np.random.randint(0, 256, (600, 600, 3), dtype=np.uint8)
+
+    path = tmp_path / "img.jpg"
+    save_image(img, str(path))
+
+    loaded = load_image(str(path))
+    assert loaded.shape == (600, 600, 3)
+
+    resized, new_path = resize_image(str(path), str(tmp_path))
+    assert resized.shape[0] <= 500
+
+    assert os.path.exists(path)

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,23 +1,22 @@
-import pytest
-import numpy as np
 import os
-import tempfile
-import matplotlib.pyplot as plt
+
 import cv2
+import numpy as np
+import pytest
 
 from shap.utils.image import (
-    is_empty,
-    make_dir,
     add_sample_images,
-    load_image,
     check_valid_image,
-    save_image,
-    resize_image,
     display_grid_plot,
+    is_empty,
+    load_image,
+    make_dir,
+    resize_image,
+    save_image,
 )
 
-
 # ================== is_empty ==================
+
 
 def test_is_empty_cases(tmp_path):
     # empty dir
@@ -33,6 +32,7 @@ def test_is_empty_cases(tmp_path):
 
 # ================== make_dir ==================
 
+
 def test_make_dir_create_and_clear(tmp_path):
     new_dir = tmp_path / "new"
     make_dir(str(new_dir))
@@ -46,9 +46,8 @@ def test_make_dir_create_and_clear(tmp_path):
 
 # ================== check_valid_image ==================
 
-@pytest.mark.parametrize("filename", [
-    "a.png", "b.jpg", "c.jpeg", "d.gif", "e.bmp", "f.jfif"
-])
+
+@pytest.mark.parametrize("filename", ["a.png", "b.jpg", "c.jpeg", "d.gif", "e.bmp", "f.jfif"])
 def test_check_valid_image_valid(filename):
     assert check_valid_image(filename) is True
 
@@ -59,6 +58,7 @@ def test_check_valid_image_invalid(filename):
 
 
 # ================== save + load ==================
+
 
 def test_save_and_load_image(tmp_path):
     img = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
@@ -78,6 +78,7 @@ def test_load_image_invalid():
 
 
 # ================== resize_image ==================
+
 
 def test_resize_image_no_resize(tmp_path):
     img = np.random.randint(0, 256, (200, 200, 3), dtype=np.uint8)
@@ -111,6 +112,7 @@ def test_resize_aspect_ratio(tmp_path):
 
 # ================== display ==================
 
+
 def test_display_grid_plot_runs(tmp_path):
     img = np.random.randint(0, 256, (50, 50, 3), dtype=np.uint8)
     path = tmp_path / "img.jpg"
@@ -124,6 +126,7 @@ def test_display_grid_plot_runs(tmp_path):
 
 # ================== add_sample_images ==================
 
+
 def test_add_sample_images(monkeypatch, tmp_path):
     def fake_dataset():
         return np.random.randint(0, 256, (50, 50, 50, 3), dtype=np.uint8), None
@@ -135,6 +138,7 @@ def test_add_sample_images(monkeypatch, tmp_path):
 
 
 # ================== integration ==================
+
 
 def test_full_workflow(tmp_path):
     img = np.random.randint(0, 256, (600, 600, 3), dtype=np.uint8)


### PR DESCRIPTION
## Overview

Contributes to #3690  <!--Add issue number here, or delete as appropriate-->

## Summary

Adds comprehensive unit tests for `shap/utils/image.py` to significantly improve test coverage.

This PR targets previously untested functionality and validates behavior across filesystem operations, image processing, and resizing logic.

---

## Coverage Improvement

- Coverage increased from ~0% → ~95%

---

## What is Covered

### Core Functions
- `is_empty` → directory existence and content checks  
- `make_dir` → directory creation and clearing behavior  
- `load_image` → valid and invalid image loading  
- `save_image` → file creation and output validation  
- `resize_image` → both resizing and non-resizing branches  

---

## Testing Approach

- Uses `pytest`
- Uses `tmp_path` for safe filesystem isolation
- Uses `numpy` arrays for image simulation
- Includes parameterized tests for extension validation
- Includes edge cases and failure scenarios

---

## Notes

- A bug in `make_dir` related to incorrect path concatenation is addressed in a separate PR #4501 
- This PR focuses purely on test coverage

---
## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)

## AI usage disclosure 
I used AI for the further test addition ideas and it helped in raising the coverage from 80 to 95%. Apart from it I used it to scan the image.py file and test file validation. 