### PR TITLE
fix: use os.path.join in make_dir to prevent FileNotFoundError on path concatenation

### DIFF
--- a/shap/utils/image.py
+++ b/shap/utils/image.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from textwrap import wrap
 
 import cv2
@@ -40,7 +41,11 @@ def make_dir(path):
         if os.listdir(path):
             # if exists, empty directory
             for file in os.listdir(path):
-                os.remove(path + file)
+                file_path = os.path.join(path, file)
+                if os.path.isfile(file_path) or os.path.islink(file_path):
+                    os.remove(file_path)
+                elif os.path.isdir(file_path):
+                    shutil.rmtree(file_path)
 
 
 def add_sample_images(path):


### PR DESCRIPTION
## What does this PR do?

Fixes #4500 — incorrect string concatenation in `make_dir()` in
`shap/utils/image.py` that produces malformed file paths on all platforms.

## Root Cause

Line 43 used raw string concatenation to build the file path:
```python
os.remove(path + file)  # produces "test_dirfile.txt" instead of "test_dir/file.txt"
