### PR TITLE
fix: use os.path.join in make_dir to avoid incorrect path concatenation

### DIFF
--- a/shap/utils/image.py
+++ b/shap/utils/image.py
@@ -40,7 +40,7 @@ def make_dir(path):
         if os.listdir(path):
             # if exists, empty directory
             for file in os.listdir(path):
-                os.remove(path + file)
+                os.remove(os.path.join(path, file))
 
 
 def add_sample_images(path):


### PR DESCRIPTION
The make_dir function used string concatenation (path + file) to construct file paths for removal, producing broken paths like "test_dirfile.txt" instead of "test_dir/file.txt" when the path doesn't end with a separator.

Replace with os.path.join(path, file) for correct cross-platform path handling.

Closes #4500

## Overview

Closes #XXXX  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:



## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
