### PR TITLE
BUG: Fix benchmark framework issues (import, method call, and division by zero)

### DIFF
--- a/shap/benchmark/framework.py
+++ b/shap/benchmark/framework.py
@@ -4,13 +4,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from . import perturbation
+from . import _sequential as perturbation
 
 
 def update(model, attributions, X, y, masker, sort_order, perturbation_method, scores):
     metric = perturbation_method + " " + sort_order
     sp = perturbation.SequentialPerturbation(model, masker, sort_order, perturbation_method)
-    xs, ys, auc = sp.model_score(attributions, X, y=y)
+    xs, ys, auc = sp.score(attributions, X, y=y)
     scores["metrics"].append(metric)
     scores["values"][metric] = [xs, ys, auc]
 
@@ -94,7 +94,10 @@ def compare_plot(benchmarks):
         for explainer in explainers:
             scores = benchmarks[explainer]
             _, _, auc = scores["values"][metric]
-            aucs[explainer].append((auc - min_auc) / (max_auc - min_auc))
+            if max_auc == min_auc:
+                aucs[explainer].append(0.5)
+            else:
+                aucs[explainer].append((auc - min_auc) / (max_auc - min_auc))
 
     # plot common curves
     ax = plt.gca()


### PR DESCRIPTION
## Overview

Closes #4517   <!--Add issue number here, or delete as appropriate-->

## Summary

Fixes multiple issues in `shap/benchmark/framework.py` identified in #4517 .

---

## Fixes

### 1. Import fix

Replaced incorrect import of a non-existent module:

```python
import shap.benchmark.perturbation as perturbation
```
with:
```python
from . import _sequential as perturbation
```
### 2. Method Fix
Replaced invalid method call:
```python
sp.model_score(...)
```
with 
```python
sp.score(...)
```
### 3. Division by zero fix 
Added safeguard in `compare_plot`:
```python 
if max_auc == min_auc:
    normalized = 0.5
else:
    normalized = (auc - min_auc) / (max_auc - min_auc)
```

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
    Unit test will be added in the upcoming coverage PR 
