### PR TITLE
Support tuple-output liquid-style PyTorch models in deep/gradien

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -8,6 +8,19 @@ from .deep_utils import _check_additivity
 
 
 class PyTorchDeep(Explainer):
+    @staticmethod
+    def _primary_output(outputs):
+        """Return the primary tensor output when a model returns auxiliary state.
+
+        Some recurrent architectures (including liquid-style models) return
+        tuples/lists like ``(predictions, hidden_state)``.
+        """
+        if isinstance(outputs, (tuple, list)):
+            if len(outputs) == 0:
+                raise ValueError("Model returned an empty output tuple/list.")
+            return outputs[0]
+        return outputs
+
     def __init__(self, model, data):
         import torch
 
@@ -50,7 +63,7 @@ class PyTorchDeep(Explainer):
         self.multi_output = False
         self.num_outputs = 1
         with torch.no_grad():
-            outputs = model(*data)
+            outputs = self._primary_output(model(*data))
 
             # also get the device everything is running on
             self.device = outputs.device
@@ -99,7 +112,7 @@ class PyTorchDeep(Explainer):
 
         self.model.zero_grad()
         X = [x.requires_grad_() for x in inputs]
-        outputs = self.model(*X)
+        outputs = self._primary_output(self.model(*X))
         selected = [val for val in outputs[:, idx]]
         grads = []
         if self.interim:
@@ -145,7 +158,7 @@ class PyTorchDeep(Explainer):
 
         if ranked_outputs is not None and self.multi_output:
             with torch.no_grad():
-                model_output_values = self.model(*X)
+                model_output_values = self._primary_output(self.model(*X))
             # rank and determine the model outputs that we will explain
             if output_rank_order == "max":
                 _, model_output_ranks = torch.sort(model_output_values, descending=True)
@@ -221,7 +234,7 @@ class PyTorchDeep(Explainer):
         if check_additivity:
             if model_output_values is None:
                 with torch.no_grad():
-                    model_output_values = self.model(*X)
+                    model_output_values = self._primary_output(self.model(*X))
 
             _check_additivity(self, model_output_values.cpu(), output_phis)
 

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -475,6 +475,15 @@ class _PyTorchGradient(Explainer):
     multi_output: bool
     gradients: list[Any]
 
+    @staticmethod
+    def _primary_output(outputs: Any) -> Any:
+        """Return predictions when forward() also returns auxiliary state."""
+        if isinstance(outputs, (tuple, list)):
+            if len(outputs) == 0:
+                raise ValueError("Model returned an empty output tuple/list.")
+            return outputs[0]
+        return outputs
+
     def __init__(
         self,
         model: Any,
@@ -527,7 +536,7 @@ class _PyTorchGradient(Explainer):
         self.model = model.eval()
 
         multi_output = False
-        outputs = self.model(*self.model_inputs)
+        outputs = self._primary_output(self.model(*self.model_inputs))
         if len(outputs.shape) > 1 and outputs.shape[1] > 1:
             multi_output = True
         self.multi_output = multi_output
@@ -542,7 +551,7 @@ class _PyTorchGradient(Explainer):
 
         self.model.zero_grad()
         X = [x.requires_grad_() for x in inputs]
-        outputs = self.model(*X)
+        outputs = self._primary_output(self.model(*X))
         selected = [val for val in outputs[:, idx]]
         if self.input_handle is not None:
             interim_inputs = self.layer.target_input  # type: ignore[union-attr]
@@ -594,7 +603,7 @@ class _PyTorchGradient(Explainer):
 
         if ranked_outputs is not None and self.multi_output:
             with torch.no_grad():
-                model_output_values = self.model(*X)
+                model_output_values = self._primary_output(self.model(*X))
             # rank and determine the model outputs that we will explain
             if output_rank_order == "max":
                 _, model_output_ranks = torch.sort(model_output_values, descending=True)

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -446,6 +446,46 @@ def test_pytorch_mnist_cnn_call(torch_device, interim):
     reason="Skipping on MacOS due to torch segmentation error, see GH #4075.",
 )
 @pytest.mark.parametrize("torch_device", TORCH_DEVICES)
+def test_pytorch_deep_tuple_output_lnn_style(torch_device):
+    """DeepExplainer should support models returning (prediction, state)."""
+    torch = pytest.importorskip("torch")
+    from torch import nn
+
+    class LiquidLikeNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.in_proj = nn.Linear(3, 5)
+            self.state_proj = nn.Linear(5, 5)
+            self.out_proj = nn.Linear(5, 2)
+
+        def forward(self, x, state=None):
+            if state is None:
+                state = torch.zeros((x.shape[0], 5), device=x.device)
+            next_state = torch.tanh(self.in_proj(x) + self.state_proj(state))
+            output = self.out_proj(next_state)
+            return output, next_state
+
+    model = LiquidLikeNet().to(torch_device)
+    background = torch.zeros(10, 3, device=torch_device)
+    to_explain = torch.randn(4, 3, device=torch_device)
+
+    explainer = shap.DeepExplainer(model, background)
+    shap_values = explainer.shap_values(to_explain)
+
+    model.eval()
+    with torch.no_grad():
+        outputs, _ = model(to_explain)
+        expected_value = model(background)[0].mean(0).detach().cpu().numpy()
+
+    sums = shap_values.sum(axis=1)
+    np.testing.assert_allclose(sums + expected_value, outputs.detach().cpu().numpy(), atol=2e-2)
+
+
+@pytest.mark.skipif(
+    platform.system() == "Darwin",
+    reason="Skipping on MacOS due to torch segmentation error, see GH #4075.",
+)
+@pytest.mark.parametrize("torch_device", TORCH_DEVICES)
 def test_pytorch_custom_nested_models(torch_device):
     """Testing single outputs"""
     torch = pytest.importorskip("torch")

--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -450,6 +450,47 @@ def test_pytorch_multiple_inputs_multiple_outputs(random_seed):
     np.testing.assert_allclose(sums + expected_value, outputs, atol=1e-5)
 
 
+@pytest.mark.skipif(
+    platform.system() == "Darwin",
+    reason="Skipping on MacOS due to torch segmentation error, see GH #4075.",
+)
+def test_pytorch_tuple_output_lnn_style(random_seed):
+    """GradientExplainer should support models that return (prediction, state)."""
+    torch = pytest.importorskip("torch")
+    from torch import nn
+
+    torch.manual_seed(random_seed)
+
+    class LiquidLikeNet(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.in_proj = nn.Linear(3, 4)
+            self.state_proj = nn.Linear(4, 4)
+            self.out_proj = nn.Linear(4, 2)
+
+        def forward(self, x, state=None):
+            if state is None:
+                state = torch.zeros((x.shape[0], 4), device=x.device)
+            next_state = torch.tanh(self.in_proj(x) + self.state_proj(state))
+            output = self.out_proj(next_state)
+            return output, next_state
+
+    model = LiquidLikeNet()
+    background = torch.zeros(8, 3)
+    to_explain = torch.randn(4, 3)
+
+    explainer = shap.GradientExplainer(model, background)
+    shap_values = explainer.shap_values(to_explain, nsamples=200)
+
+    model.eval()
+    with torch.no_grad():
+        outputs, _ = model(to_explain)
+        expected_value = model(background)[0].mean(0).detach().cpu().numpy()
+
+    sums = shap_values.sum(axis=1)
+    np.testing.assert_allclose(sums + expected_value, outputs.detach().cpu().numpy(), atol=2e-2)
+
+
 @pytest.mark.parametrize("input_type", ["numpy", "dataframe"])
 def test_tf_input(random_seed, input_type):
     """Test tabular (batch_size, features) pd.DataFrame and numpy input."""


### PR DESCRIPTION
Added tuple/list output handling in shap/explainers/_deep/deep_pytorch.py.
Added tuple/list output handling in shap/explainers/_gradient.py.
Added regression test in tests/explainers/test_deep.py.
Added regression test in tests/explainers/test_gradient.py.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature).
