### PR TITLE
FIX: assign result of np.flipud() in AdditiveForceArrayVisualizer

### DIFF
--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -541,7 +541,7 @@ class AdditiveForceArrayVisualizer(BaseVisualizer):
 
         # make sure that we put the higher predictions first...just for consistency
         if sum(arr[clustOrder[0]].effects) < sum(arr[clustOrder[-1]].effects):
-            np.flipud(clustOrder)  # reverse
+            clustOrder = np.flipud(clustOrder)  # reverse
 
         # build the json data
         clustOrder = np.argsort(clustOrder)  # inverse permutation


### PR DESCRIPTION
## Overview

Closes #4370
Closes #4342

`np.flipud()` returns a new reversed array; it does not modify the
input in-place.  In `AdditiveForceArrayVisualizer.__init__` the call

```python
np.flipud(clustOrder)  # reverse
```

discarded the reversed array, so the higher-prediction-first ordering
was never applied to `clustOrder`.  The `simIndex` values assigned to
each explanation were therefore computed from the unmodified
(lower-first) order, producing an incorrect sample ordering in the
rendered force plot.

Fix: assign the return value back.

```python
clustOrder = np.flipud(clustOrder)  # reverse
```

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)