### PR TITLE
FIX: two bugs in shap.plots.heatmap (OpChain IndexError and zero-division)

### DIFF
--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -80,6 +80,8 @@ def heatmap(
         feature_order = np.argsort(-feature_values)
     elif issubclass(type(feature_order), OpChain):
         feature_order = feature_order.apply(Explanation(values))
+        if issubclass(type(feature_order), Explanation):
+            feature_order = feature_order.values
     elif not hasattr(feature_order, "__len__"):
         raise Exception(f"Unsupported feature_order: {str(feature_order)}!")
     xlabel = "Instances"
@@ -154,16 +156,18 @@ def heatmap(
     # plot the f(x) line chart above the heat map
     ax.axhline(-1.5, color="#aaaaaa", linestyle="--", linewidth=0.5)
     fx = values.T.sum(0)
+    fx_max = np.abs(fx).max()
     ax.plot(
-        -fx / np.abs(fx).max() - 1.5,
+        -fx / fx_max - 1.5 if fx_max > 0 else np.full_like(fx, -1.5),
         color="#000000",
         linewidth=1,
     )
 
     # plot the bar plot on the right spine of the heat map
+    fv_max = np.abs(feature_values).max()
     bar_container = ax.barh(
         heatmap_yticks_pos,
-        (feature_values / np.abs(feature_values).max()) * values.shape[0] / 20,
+        (feature_values / fv_max) * values.shape[0] / 20 if fv_max > 0 else np.zeros_like(feature_values),
         height=0.7,
         align="center",
         color="#000000",

--- a/tests/plots/test_heatmap.py
+++ b/tests/plots/test_heatmap.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 import shap
+from shap import Explanation
 
 
 @pytest.mark.mpl_image_compare
@@ -25,3 +26,28 @@ def test_heatmap_feature_order(explainer):
     )
     plt.tight_layout()
     return fig
+
+
+def test_heatmap_opchain_feature_order(explainer):
+    """Heatmap should not raise IndexError when feature_order is an OpChain (closes #4460)."""
+    shap_values = explainer(explainer.data)
+    ax = shap.plots.heatmap(shap_values, feature_order=Explanation.abs.mean(0).argsort, show=False)
+    plt.close("all")
+    assert ax is not None
+
+
+def test_heatmap_all_zero_shap_values():
+    """Heatmap should render without error when all SHAP values are zero (closes #4448)."""
+    n_samples, n_features = 20, 5
+    values = np.zeros((n_samples, n_features))
+    data = np.random.default_rng(0).random((n_samples, n_features))
+    feature_names = [f"f{i}" for i in range(n_features)]
+    shap_values = Explanation(
+        values=values,
+        base_values=np.zeros(n_samples),
+        data=data,
+        feature_names=feature_names,
+    )
+    ax = shap.plots.heatmap(shap_values, show=False)
+    plt.close("all")
+    assert ax is not None


### PR DESCRIPTION
## Overview

Closes #4460
Closes #4448

### Bug 1 — IndexError when `feature_order` is an OpChain (#4460)

`OpChain.apply()` wraps its result in an `Explanation` object, not a
raw numpy array.  After

```python
feature_order = feature_order.apply(Explanation(values))
```

`feature_order` was still an `Explanation`, so using it as an array
index on the next line raised `IndexError`.

Fix: add the same `Explanation → .values` extraction that was already
applied to `feature_values`:

```python
if issubclass(type(feature_order), Explanation):
    feature_order = feature_order.values
```

### Bug 2 — `RuntimeWarning: invalid value encountered in divide` when all SHAP values are zero (#4448)

When every SHAP value is 0, `np.abs(fx).max()` and
`np.abs(feature_values).max()` are both 0, producing `NaN` for the
f(x) line positions and bar widths.

Fix: guard each division; when the max is 0, render a flat f(x) line
at `-1.5` and zero-width bars instead.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)