### PR TITLE
FIX: move unreachable large-background-data warning into correct branch in TreeExplainer

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -267,18 +267,17 @@ class TreeExplainer(Explainer):
                     FutureWarning,
                 )
                 feature_perturbation = "tree_path_dependent"
+            elif self.data.shape[0] > 1_000:
+                wmsg = (
+                    f"Passing {self.data.shape[0]} background samples may lead to slow runtimes. Consider "
+                    "using shap.sample(data, 100) to create a smaller background data set."
+                )
+                warnings.warn(wmsg)
         elif feature_perturbation != "tree_path_dependent":
             raise InvalidFeaturePerturbationError(
                 "feature_perturbation must be 'auto', 'interventional', or 'tree_path_dependent'. "
                 f"Got {feature_perturbation} instead."
             )
-
-        elif feature_perturbation == "interventional" and self.data.shape[0] > 1_000:
-            wmsg = (
-                f"Passing {self.data.shape[0]} background samples may lead to slow runtimes. Consider "
-                "using shap.sample(data, 100) to create a smaller background data set."
-            )
-            warnings.warn(wmsg)
 
         _safe_check_tree_instance_experimental(model)
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -2073,6 +2073,13 @@ def test_feature_perturbation_refactoring():
     with pytest.raises(shap.utils._exceptions.InvalidFeaturePerturbationError, match=err_msg):
         explainer = shap.explainers.Tree(model, feature_perturbation=feature_perturbation)  # type: ignore[arg-type]
 
+    # check that we warn when >1000 background samples are passed with interventional perturbation (closes #4385)
+    X_large, y_large = sklearn.datasets.make_regression(n_samples=1_001, n_features=10, random_state=0)
+    model_large = sklearn.ensemble.RandomForestRegressor().fit(X_large, y_large)
+    warn_msg_large = "background samples may lead to slow runtimes"
+    with pytest.warns(UserWarning, match=warn_msg_large):
+        shap.explainers.Tree(model_large, data=X_large, feature_perturbation="interventional")  # type: ignore[arg-type]
+
 
 # the expected results can be found in the paper "Consistent Individualized Feature Attribution for Tree Ensembles",
 # https://arxiv.org/abs/1802.03888


### PR DESCRIPTION
## Overview

Closes #4385

In `TreeExplainer.__init__`, the warning about passing more than 1 000
background samples was placed in a dead `elif` branch:

```python
elif feature_perturbation != "tree_path_dependent":
    raise InvalidFeaturePerturbationError(...)   # catches all non-tpd values

elif feature_perturbation == "interventional" and ...:  # NEVER reached
    warnings.warn(...)
```

By the time execution reached the second `elif`, the only remaining
possibility for `feature_perturbation` was `"tree_path_dependent"`, so
`feature_perturbation == "interventional"` was always `False`.  The
large-dataset warning was therefore never issued.

**Fix:** move the warning inside the `elif feature_perturbation == "interventional":`
branch, as a second `elif` of the `data is None` check — i.e., warn
when the caller explicitly requests interventional perturbation *and*
supplies more than 1 000 background samples.

Add a regression test that passes 1 001 background samples and asserts
the `UserWarning` is now emitted.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)