### PR TITLE
FIX: use np.random.get_state/set_state to correctly save and restore RNG state

### DIFF
--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -104,7 +104,7 @@ class ExplanationError:
 
         # it is important that we choose the same permutations for the different explanations we are comparing
         # so as to avoid needless noise
-        old_seed = np.random.seed()
+        old_state = np.random.get_state()
         np.random.seed(self.seed)
 
         pbar = None
@@ -186,6 +186,6 @@ class ExplanationError:
         svals = np.array(svals)
 
         # reset the random seed so we don't mess up the caller
-        np.random.seed(old_seed)
+        np.random.set_state(old_state)
 
         return BenchmarkResult("explanation error", name, value=np.sqrt(np.sum(total_values) / len(total_values)))

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -421,19 +421,19 @@ def to_array(*args):
 
 def const_rand(size, seed=23980):
     """Generate a random array with a fixed seed."""
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(seed)
     out = np.random.rand(size)
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
     return out
 
 
 def const_shuffle(arr, seed=23980):
     """Shuffle an array in-place with a fixed seed."""
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(seed)
     np.random.shuffle(arr)
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
 
 def strip_list(attrs):

--- a/shap/benchmark/metrics.py
+++ b/shap/benchmark/metrics.py
@@ -24,7 +24,7 @@ def runtime(X, y, model_generator, method_name):
     transform = "negate_log"
     sort_order = 2
     """
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(3293)
 
     # average the method scores over several train/test splits
@@ -48,7 +48,7 @@ def runtime(X, y, model_generator, method_name):
         # we always normalize the explain time as though we were explaining 1000 samples
         # even if to reduce the runtime of the benchmark we do less (like just 100)
         method_reps.append(build_time + explain_time * 1000.0 / X_test.shape[0])
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return None, np.mean(method_reps)
 
@@ -502,7 +502,7 @@ def __score_method(
     except NameError:
         raise ImportError("The 'dill' package could not be loaded and is needed for the benchmark!")
 
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(3293)
 
     # average the method scores over several train/test splits
@@ -547,7 +547,7 @@ def __score_method(
         else:
             method_reps.append(score(None))
 
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
     return np.array(method_reps).mean(0)
 
 

--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -528,7 +528,7 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
 
     """
     # set a constant seed
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -564,7 +564,7 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
     y = f(X) + np.random.randn(N) * 1e-2
 
     # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 
@@ -599,7 +599,7 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
 
     """
     # set a constant seed
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -618,7 +618,7 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
     y = f(X) + np.random.randn(N) * 1e-2
 
     # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 


### PR DESCRIPTION
## Overview

Closes #4403

`np.random.seed()` called with **no arguments** returns `None`, not the
current random state.  Multiple functions in SHAP used this pattern:

```python
old_seed = np.random.seed()   # stores None
np.random.seed(fixed_value)
# ... work ...
np.random.seed(old_seed)      # equivalent to np.random.seed(None)
                              # re-seeds from OS entropy — caller's state is lost
```

This means the global NumPy RNG was never restored to its original
state, making any code that relied on the RNG state after calling these
functions non-reproducible.

**Fix:** replace every instance of this pattern with:

```python
old_state = np.random.get_state()
np.random.seed(fixed_value)
# ... work ...
np.random.set_state(old_state)
```

Affected files:
- `shap/benchmark/_explanation_error.py`
- `shap/benchmark/measures.py`
- `shap/benchmark/metrics.py`
- `shap/datasets.py`

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)