### PR TITLE
FIX: replace bare assert statements with DimensionError in scatter.py

### DIFF
--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -245,12 +245,10 @@ def scatter(
         figsize = (7.5, 5) if interaction_index != ind and interaction_index is not None else (6, 5)
         _, ax = plt.subplots(figsize=figsize)
 
-    assert shap_values_arr.shape[0] == features.shape[0], (
-        "'shap_values_arr' and 'features' values must have the same number of rows!"
-    )
-    assert shap_values_arr.shape[1] == features.shape[1], (
-        "'shap_values_arr' must have the same number of columns as 'features'!"
-    )
+    if shap_values_arr.shape[0] != features.shape[0]:
+        raise DimensionError("'shap_values_arr' and 'features' values must have the same number of rows!")
+    if shap_values_arr.shape[1] != features.shape[1]:
+        raise DimensionError("'shap_values_arr' must have the same number of columns as 'features'!")
 
     # get both the raw and display feature values
     oinds = np.arange(
@@ -680,12 +678,10 @@ def dependence_legacy(
             plt.show()
         return
 
-    assert shap_values.shape[0] == features.shape[0], (
-        "'shap_values' and 'features' values must have the same number of rows!"
-    )
-    assert shap_values.shape[1] == features.shape[1], (
-        "'shap_values' must have the same number of columns as 'features'!"
-    )
+    if shap_values.shape[0] != features.shape[0]:
+        raise DimensionError("'shap_values' and 'features' values must have the same number of rows!")
+    if shap_values.shape[1] != features.shape[1]:
+        raise DimensionError("'shap_values' must have the same number of columns as 'features'!")
 
     # get both the raw and display feature values
     oinds = np.arange(

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -112,3 +112,36 @@ def test_scatter_plot_value_input(input):
     shap.plots.scatter(explanations, show=False)
     plt.tight_layout()
     return plt.gcf()
+
+
+def test_scatter_mismatched_rows_raises_dimension_error():
+    """Mismatched row counts should raise DimensionError, not AssertionError (closes #4465)."""
+    from shap.plots._scatter import dependence_legacy
+    from shap.utils._exceptions import DimensionError
+
+    # Exercise the legacy dependence_legacy path where DimensionError was previously a bare assert
+    with pytest.raises(DimensionError, match="same number of rows"):
+        dependence_legacy(
+            0,
+            shap_values=np.array([[1.0], [2.0], [3.0]]),
+            features=np.array([[0.5], [0.6]]),
+            feature_names=["f1"],
+            show=False,
+        )
+    plt.close("all")
+
+
+def test_scatter_mismatched_cols_raises_dimension_error():
+    """Mismatched column counts should raise DimensionError, not AssertionError (closes #4465)."""
+    from shap.plots._scatter import dependence_legacy
+    from shap.utils._exceptions import DimensionError
+
+    with pytest.raises(DimensionError, match="same number of columns"):
+        dependence_legacy(
+            0,
+            shap_values=np.array([[1.0, 2.0]]),
+            features=np.array([[0.5]]),
+            feature_names=["f1", "f2"],
+            show=False,
+        )
+    plt.close("all")


### PR DESCRIPTION
## Overview

Closes #4465

`shap/plots/_scatter.py` used four bare `assert` statements to validate
that `shap_values` and `features` have matching shapes (two in
`scatter()`, two in `dependence_legacy()`).

Bare asserts are:
1. **silently disabled** when Python runs in optimised mode (`-O` flag), so callers would get confusing errors downstream instead.
2. **not informative** — `AssertionError` gives no guidance on what went wrong or how to fix it.

The rest of the SHAP codebase (e.g. `_kernel.py`, `_tree.py`,
`_linear.py`, `_tabular.py`) uses `DimensionError` for this purpose.
This PR follows that pattern.

**Changes:**
- All four `assert` statements replaced with explicit `DimensionError` raises.
- Two regression tests added to `tests/plots/test_scatter.py` that
  verify `DimensionError` is raised (not `AssertionError`) for
  mismatched row and column counts via the `dependence_legacy` path.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)