### PR TITLE
FIX: Prevent memory over-allocation in PermutationExplainer for constant features

### DIFF
--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -236,13 +236,7 @@ class PermutationExplainer(Explainer):
             expected_value = outputs[0]
             row_values = np.zeros((len(fm),) + outputs.shape[1:])
             if error_bounds:
-                row_values_history = np.zeros(
-                    (
-                        2 * npermutations,
-                        len(fm),
-                    )
-                    + outputs.shape[1:]
-                )
+                row_values_history = None  # No varying inputs, no history to track
 
         return {
             "values": row_values / (2 * npermutations),  # type: ignore[operator]

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -163,10 +163,6 @@ class PermutationExplainer(Explainer):
         masks = np.zeros(2 * len(inds) + 1, dtype=int)
         masks[0] = MaskedModel.delta_mask_noop_value
         npermutations = max_evals // (2 * len(inds) + 1)
-        # When there are no varying inputs, there's only one evaluation, so set npermutations to 1
-        # to avoid massive memory over-allocation of row_values_history
-        if len(inds) == 0:
-            npermutations = 1
         row_values = None
         row_values_history = None
         history_pos = 0

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -163,6 +163,10 @@ class PermutationExplainer(Explainer):
         masks = np.zeros(2 * len(inds) + 1, dtype=int)
         masks[0] = MaskedModel.delta_mask_noop_value
         npermutations = max_evals // (2 * len(inds) + 1)
+        # When there are no varying inputs, there's only one evaluation, so set npermutations to 1
+        # to avoid massive memory over-allocation of row_values_history
+        if len(inds) == 0:
+            npermutations = 1
         row_values = None
         row_values_history = None
         history_pos = 0


### PR DESCRIPTION
## What does this PR do?
Prevents incorrect memory allocation and misleading error output in `PermutationExplainer.explain_row()` when there are no varying input features (i.e., when all input features are identical to the background data).

## What problem does it solve?
Closes #4527 

When `len(inds) == 0` (no features vary from background) and 
`error_bounds = True`:

- `npermutations` was calculated as `max_evals // (2 * 0 + 1)` = 500
- `row_values_history` was allocated as `(2 * 500, num_features)` = `(1000, num_features)`
- The code only evaluates the model once when there are no varying inputs (the history loop never executes)
- The history array remained all zeros and was never populated
- `error_std` was computed from this uninitialized array, producing misleading zeros. A user cannot distinguish between genuine zero variance and uncomputed variance
- 99.8% of allocated memory was wasted

## Fix
Set `row_values_history = None` directly in the `else` branch instead of allocating an unused array. The return statement already handles `None` correctly:

    "error_std": None if row_values_history is None else row_values_history.std(0)

This produces `error_std=None` instead of a misleading array of zeros, which is semantically correct, error bounds cannot be computed when there are no varying inputs.

## Evidence
Before fix:
- `row_values_history.shape`: (1000, 3) — allocated but never written
- `error_std`: array of zeros — misleading

After fix:
- `row_values_history`: None — no allocation
- `error_std`: None — correctly signals uncomputed

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] Branch is up to date with master
- [x] Pre-commit hooks pass
- [x] test_permutation.py passes