### PR TITLE
MAINT: remove transformers version cap, tests pass with 5.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
   "ngboost",
   "pyspark",
   "pyod",
-  "transformers < 4.54.0",  # TODO: fix once tests pass for 4.54.0
+  "transformers",
   "tf-keras",
   "protobuf",  # See GH #3046
   'torch; python_version < "3.14"',  # TODO: pending 3.14 support


### PR DESCRIPTION
## What does this PR do?
Removes the `transformers < 4.54.0` upper version cap from test dependencies in `pyproject.toml`.

## What problem does it solve?
Closes #4526

The cap was added with a TODO comment to fix once tests passed for 4.54.0. Tests have been verified to pass with both 4.54.0 and the latest 5.5.3.

## Evidence
- `test_tf_deep_imbdb_transformers` passed with 5.5.3
- `test_transformers_label_to_id_mapping_enforces_ints` passed with 5.5.3

## Checklist
- [x] I have read CONTRIBUTING.md
- [x] Branch is up to date with master
- [x] Pre-commit hooks pass