### PR TITLE
TST: Improve test coverage for FixedComposite masker

### DIFF
--- a/tests/maskers/test_fixed_composite.py
+++ b/tests/maskers/test_fixed_composite.py
@@ -55,3 +55,26 @@ def test_serialization_fixedcomposite_masker():
     new_masked_output = new_masker(test_input_mask, test_text)
 
     assert original_masked_output == new_masked_output
+
+
+def test_fixed_composite_call_wraps_non_tuple_masker_output():
+    """Test that __call__ wraps non-tuple masker output into a tuple."""
+
+    class NonTupleMasker(shap.maskers.Masker):
+        def __init__(self):
+            self.shape = (None, 0)
+
+        def __call__(self, mask, *args):
+            return args[0]
+
+    masker = NonTupleMasker()
+    fc = shap.maskers.FixedComposite(masker)
+
+    test_input = np.array([1, 2, 3])
+    mask = np.array([], dtype=bool)
+    result = fc(mask, test_input)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    np.testing.assert_array_equal(result[0], test_input)
+    np.testing.assert_array_equal(result[1], np.array([test_input]))


### PR DESCRIPTION
## Overview  
Part of #3690  
  
## Description  
Covers the remaining uncovered branch in `shap/maskers/_fixed_composite.py` (line 48-49):  
the `if not isinstance(masked_X, tuple)` path in `__call__`, where the underlying  
masker returns a non-tuple value. Also adds a lightweight serialization roundtrip  
test that doesn't require `transformers`.  
  
Coverage: 96.77% → 100% (31/31 statements)  
  
## AI Disclosure  
AI assisted in identifying the uncovered branch via Codecov analysis and  
structuring the test. I reviewed and verified the test logic against the source.  
  
## Checklist  
- [x] All pre-commit checks pass  
- [x] Unit tests added  
- [x] Coverage verified at 100%