### PR TITLE
Distribute GPU extension for Linux builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -66,12 +66,6 @@ jobs:
           name: test-data-cache
           path: ${{ runner.temp }}/test_data_cache
 
-      - name: Set up CUDA toolkit (Linux only)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y nvidia-cuda-toolkit
-
       - name: "Install uv"
         uses: astral-sh/setup-uv@v7
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -66,6 +66,12 @@ jobs:
           name: test-data-cache
           path: ${{ runner.temp }}/test_data_cache
 
+      - name: Set up CUDA toolkit (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nvidia-cuda-toolkit
+
       - name: "Install uv"
         uses: astral-sh/setup-uv@v7
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 # Enabled via: SHAP_ENABLE_CUDA=1 pip install .
 # ==============================================================================
 
+OPTION(SHAP_CUDA_ARCHITECTURES "CUDA architectures to target (e.g., 70;75;80;86)" "native")
+
 if(DEFINED ENV{SHAP_ENABLE_CUDA})
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)
@@ -125,7 +127,7 @@ if(DEFINED ENV{SHAP_ENABLE_CUDA})
   target_link_libraries(_cext_gpu PRIVATE CUDA::cudart)
 
   set_target_properties(_cext_gpu PROPERTIES
-    CUDA_ARCHITECTURES "60;70;75;80"
+    CUDA_ARCHITECTURES ${SHAP_CUDA_ARCHITECTURES}
     CUDA_STANDARD 14
     CUDA_EXTENSIONS ON
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 OPTION(SHAP_CUDA_ARCHITECTURES "CUDA architectures to target (e.g., 70;75;80;86)" "native")
 
 if(DEFINED ENV{SHAP_ENABLE_CUDA})
+  message(STATUS "SHAP_ENABLE_CUDA is set. Building the GPU extension module.")
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)
 
@@ -124,7 +125,7 @@ if(DEFINED ENV{SHAP_ENABLE_CUDA})
   )
 
   target_include_directories(_cext_gpu PUBLIC ${NUMPY_INCLUDE_DIR})
-  target_link_libraries(_cext_gpu PRIVATE CUDA::cudart)
+  # target_link_libraries(_cext_gpu CUDA::cudart)
 
   set_target_properties(_cext_gpu PROPERTIES
     CUDA_ARCHITECTURES ${SHAP_CUDA_ARCHITECTURES}
@@ -141,4 +142,6 @@ if(DEFINED ENV{SHAP_ENABLE_CUDA})
   )
 
   install(TARGETS _cext_gpu LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
+else()
+  message(STATUS "SHAP_ENABLE_CUDA is not set. Skipping the GPU extension module.")
 endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,6 +370,7 @@ skip = [
   "cp314t-manylinux_x86_64",
   "cp314t-macosx_x86_64",
   "cp314t-win_amd64",
+  "*-musllinux*", # not supported by llvmlite and numba
 ]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
@@ -383,6 +384,11 @@ test-skip = "cp314-macosx_x86_64 *-*linux_{aarch64} *-macosx_arm64 *-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]
+before-all = [
+  "yum config-manager --add-repo http://developer.download.nvidia.com/compute/cuda/repos/rhel8/$(uname -m)/cuda-rhel8.repo",
+  "yum -y install cuda-toolkit",
+  "nvcc --version",
+]
 
 [tool.cibuildwheel.windows]
 # TODO: Should we support Windows ARM64 too?
@@ -398,5 +404,5 @@ MACOSX_DEPLOYMENT_TARGET = "10.13"
 
 [tool.cibuildwheel.linux.environment]
 # Build CUDA extensions for distribution
-SHAP_CUDA_BUILD = "1"
+SHAP_ENABLE_CUDA = "1"
 SHAP_CUDA_ARCHITECTURES = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,3 +395,9 @@ archs = ["x86_64", "arm64"]
 [tool.cibuildwheel.macos.environment]
 # Needed for C++17 support
 MACOSX_DEPLOYMENT_TARGET = "10.13"
+
+[tool.cibuildwheel.linux.environment]
+# Build CUDA extensions for distribution
+SHAP_CUDA_BUILD = "1"
+SHAP_CUDA_ARCHITECTURES = "all"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,4 +400,3 @@ MACOSX_DEPLOYMENT_TARGET = "10.13"
 # Build CUDA extensions for distribution
 SHAP_CUDA_BUILD = "1"
 SHAP_CUDA_ARCHITECTURES = "all"
-


### PR DESCRIPTION
## Overview

Closes #XXXX  <!--Add issue number here, or delete as appropriate-->

Add-on to #4366 

Description of the changes proposed in this pull request:

I think with the new CMake backend, it is possible to build and distribute GPU extension for Linux builds so most users won't have to build from scratch.

**Disclaimer:**
- This is just a draft. I have built successfully on CPU-only Ubuntu but yet to test it on GPU systems.
- Same idea might apply to Windows builds, but I have not tested it yet.

@CloseChoice 



## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
