### PR TITLE
tests(maskers): increase coverage for base Masker mask standardization

### DIFF
--- a/tests/maskers/test_masker.py
+++ b/tests/maskers/test_masker.py
@@ -9,6 +9,18 @@ import numpy as np
 import shap
 
 
+class _TupleShapeMasker(shap.maskers.Masker):
+    def __init__(self):
+        self.shape = (None, 4)
+        self.clustering = None
+
+
+class _CallableShapeMasker(shap.maskers.Masker):
+    def __init__(self):
+        self.shape = lambda values: (None, len(values))
+        self.clustering = None
+
+
 def test_fixed_masker_with_true_mask():
     """Test Fixed masker with True mask (triggers _standardize_mask)."""
     masker = shap.maskers.Fixed()
@@ -64,3 +76,36 @@ def test_output_composite_with_false_mask():
 
     assert isinstance(result, tuple)
     assert len(result) == 2
+
+
+def test_standardize_mask_with_tuple_shape_for_true_and_false():
+    """Test _standardize_mask for tuple-defined shape with boolean masks."""
+    masker = _TupleShapeMasker()
+
+    true_mask = masker._standardize_mask(True, np.array([1, 2, 3, 4]))
+    false_mask = masker._standardize_mask(False, np.array([1, 2, 3, 4]))
+
+    np.testing.assert_array_equal(true_mask, np.array([True, True, True, True]))
+    np.testing.assert_array_equal(false_mask, np.array([False, False, False, False]))
+
+
+def test_standardize_mask_with_callable_shape_for_true_and_false():
+    """Test _standardize_mask for callable shape with boolean masks."""
+    masker = _CallableShapeMasker()
+
+    values = np.array([10, 20, 30])
+    true_mask = masker._standardize_mask(True, values)
+    false_mask = masker._standardize_mask(False, values)
+
+    np.testing.assert_array_equal(true_mask, np.array([True, True, True]))
+    np.testing.assert_array_equal(false_mask, np.array([False, False, False]))
+
+
+def test_standardize_mask_passthrough_for_explicit_mask_array():
+    """Test _standardize_mask returns explicit mask arrays unchanged."""
+    masker = _TupleShapeMasker()
+    explicit_mask = np.array([True, False, True, False])
+
+    standardized = masker._standardize_mask(explicit_mask, np.array([1, 2, 3, 4]))
+
+    np.testing.assert_array_equal(standardized, explicit_mask)


### PR DESCRIPTION
## Overview
Related to #3690  

## Description of the changes proposed in this pull request:
- Expanded tests in `test_masker.py` to cover uncovered branches in `_masker.py`.  
- Added focused tests for `_standardize_mask` with:
  - tuple-based shape and True/False shorthand masks  
  - callable shape and True/False shorthand masks  
  - explicit mask-array passthrough behavior  
- Kept changes tests-only; no production code modifications.  

## Validation
- Updated masker test module passes: 7/7 tests.  
- Coverage for `_masker.py`: 100% (18/18 statements).  
- Pre-commit checks pass across all files.  

## Checklist
- [x] All pre-commit checks pass.  
- [x] Unit tests added (if fixing a bug or adding a new feature).  