### PR TITLE
tests(maskers): cover non-tuple masker output path in OutputComposite

### DIFF
--- a/tests/maskers/test_output_composite.py
+++ b/tests/maskers/test_output_composite.py
@@ -223,3 +223,31 @@ def test_output_composite_image_data_flag():
 
     assert hasattr(output_composite, "image_data")
     assert output_composite.image_data is True
+
+
+def test_output_composite_wraps_non_tuple_masked_input():
+    """Test OutputComposite __call__ when masker returns non-tuple data."""
+
+    class NonTupleMasker(shap.maskers.Masker):
+        def __init__(self):
+            self.shape = (None, 0)
+
+        def __call__(self, mask, *args):  # type: ignore[override]
+            x = args[0]
+            return np.asarray(x) * 3
+
+    masker = NonTupleMasker()
+
+    def simple_model(x):
+        return np.sum(x)
+
+    output_composite = shap.maskers.OutputComposite(masker, simple_model)
+
+    test_input = np.array([1, 2, 3])
+    mask = np.array([], dtype=bool)
+    result = output_composite(mask, test_input)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    np.testing.assert_array_equal(result[0], np.array([3, 6, 9]))
+    assert result[1] == 6


### PR DESCRIPTION
## Overview
Related to #3690  

## Description of the changes proposed in this pull request:
- Added a focused unit test in `test_output_composite.py` to cover the non-tuple masker output wrapping branch in `_output_composite.py`.  
- The new test introduces a minimal custom masker that returns a non-tuple value, verifies wrapping behavior, and validates model output integration.  
- This is a tests-only change; no production logic was modified.  

## Validation
- Updated test module passes: 11/11 tests.  
- Coverage for `_output_composite.py`: 100% (32/32 statements).  
- Pre-commit checks pass across all files.  

## Checklist
- [x] All pre-commit checks pass.  
- [x] Unit tests added (if fixing a bug or adding a new feature).  