### PR TITLE
tests(explainers): add Coefficient explainer tests and raise module coverage to 100%

### DIFF
--- a/tests/explainers/other/test_coefficient.py
+++ b/tests/explainers/other/test_coefficient.py
@@ -1,0 +1,37 @@
+"""Tests for the Coefficient explainer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shap.explainers.other._coefficient import Coefficient
+
+
+class _LinearLikeModel:
+    def __init__(self, coef):
+        self.coef_ = np.asarray(coef)
+
+
+def test_coefficient_requires_model_with_coef_attribute():
+    with pytest.raises(AssertionError, match="does not have a coef_ attribute"):
+        Coefficient(model=object())
+
+
+def test_coefficient_attributions_tiles_coefficients_by_num_rows():
+    model = _LinearLikeModel([0.5, -1.0, 2.0])
+    explainer = Coefficient(model)
+
+    X = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ]
+    )
+
+    attributions = explainer.attributions(X)
+
+    expected = np.tile(model.coef_, (X.shape[0], 1))
+    np.testing.assert_allclose(attributions, expected)


### PR DESCRIPTION
## Overview
Related to #3690  

## Description of the changes proposed in this pull request:
- Added a dedicated test module for `_coefficient.py`: `test_coefficient.py`.  
- Added coverage for constructor validation by asserting an error when the model does not expose `coef_`.  
- Added coverage for attribution behavior by verifying coefficients are correctly tiled across all input rows.  
- This is a tests-only change; no production code was modified.  

## Validation
- New tests pass: 2/2.  
- Coverage for `_coefficient.py`: 100% (8/8 statements).  
- Pre-commit checks pass across all files.  

## Checklist
- [x] All pre-commit checks pass.  
- [x] Unit tests added (if fixing a bug or adding a new feature).  