### PR TITLE
FIX: Expose output_names in PermutationExplainer

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -432,13 +432,20 @@ class Explainer(Serializable):
             else:
                 sliced_labels = None
         else:
-            assert output_indices is not None, (
-                "You have passed a list for output_names but the model seems to not have multiple outputs!"
-            )
             labels = np.array(self.output_names)
-            sliced_labels = [labels[index_list] for index_list in output_indices]  # type: ignore[assignment]
-            if not ragged_outputs:
-                sliced_labels = np.array(sliced_labels)
+            if output_indices is not None:
+                # Check if we have enough names to satisfy the indices we found
+                max_idx = max([max(index_list) for index_list in output_indices if len(index_list) > 0], default=0)
+                assert len(labels) > max_idx, (
+                    f"You passed {len(labels)} output_names, but the model indexed output {max_idx}. "
+                    "The list of output_names must be long enough to cover all output indices."
+                )
+
+                sliced_labels = [labels[index_list] for index_list in output_indices]  # type: ignore[assignment]
+                if not ragged_outputs:
+                    sliced_labels = np.array(sliced_labels)
+            else:
+                sliced_labels = labels
 
         if isinstance(sliced_labels, np.ndarray) and len(sliced_labels.shape) == 2:
             if np.all(sliced_labels[0, :] == sliced_labels):

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -32,6 +32,7 @@ class PermutationExplainer(Explainer):
         masker: Any,
         link: Any = links.identity,
         feature_names: list[str] | None = None,
+        output_names: list[str] | None = None,
         linearize_link: bool = True,
         seed: int | None = None,
         **call_args: Any,
@@ -64,7 +65,14 @@ class PermutationExplainer(Explainer):
         if masker is None:
             raise ValueError("masker cannot be None.")
 
-        super().__init__(model, masker, link=link, linearize_link=linearize_link, feature_names=feature_names)
+        super().__init__(
+            model,
+            masker,
+            link=link,
+            linearize_link=linearize_link,
+            feature_names=feature_names,
+            output_names=output_names,
+        )
 
         if not isinstance(self.model, Model):
             self.model = Model(self.model)

--- a/tests/explainers/test_permutation.py
+++ b/tests/explainers/test_permutation.py
@@ -3,6 +3,7 @@
 import pickle
 
 import numpy as np
+import pytest
 
 import shap
 
@@ -102,3 +103,37 @@ def test_serialization_custom_model_save():
         atol=0.05,
         max_evals=100000,
     )
+
+
+def test_permutation_explainer_output_names_passthrough():
+
+    # Simple dummy model that returns 2 columns
+    def dummy_model(x):
+        return np.ones((x.shape[0], 2))
+
+    X = np.zeros((5, 3))
+    names = ["Class A", "Class B"]
+
+    # Initialize with output_names
+    explainer = shap.PermutationExplainer(dummy_model, X, output_names=names)
+    explanation = explainer(X[:1])
+
+    assert list(explanation.output_names) == names, f"Expected {names}, but got {explanation.output_names}"
+
+
+def test_permutation_explainer_slicing_by_output_name():
+
+    def dummy_model(x):
+        return np.random.rand(x.shape[0], 3)
+
+    X = np.random.rand(10, 4)
+    names = ["Setosa", "Versicolor", "Virginica"]
+
+    explainer = shap.PermutationExplainer(dummy_model, X, output_names=names)
+    explanation = explainer(X[:2])
+
+    try:
+        sliced_ext = explanation[:, :, "Versicolor"]
+        assert sliced_ext.shape == (2, 4)
+    except KeyError:
+        pytest.fail("Explanation could not be sliced by output_name. Metadata mapping failed.")


### PR DESCRIPTION
## Overview

Closes #3454   <!--Add issue number here, or delete as appropriate-->

- Added the `output_names` parameter to the `__init__()` signature of `PermutationExplainer`, allowing users to provide custom label at initialization
- While doing so I encountered another issue in `_explainer.py` where it strictly asserted that `output_indices` must be present if `output_names` were provided. However in many scenarios (like PermutationExplainer on raw functions), `output_indices` remains `None`, creating a structural deadlock that prevented custom naming, raising an assertion error.
- Fixed that by adding a conditional assertion 
  -  If indices exist: We validate that the provided `output_names` list is long enough to cover the found indices.
  -  If indices do not exist: We trust the user's provided names and attach them directly to the Explanation object.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)

### AI Usage
- used Gemini to generate unit tests.
