### PR TITLE
Add branch-focused tests for shap.plots._force_matplotlib

### DIFF
--- a/tests/plots/test_force_matplotlib.py
+++ b/tests/plots/test_force_matplotlib.py
@@ -1,0 +1,42 @@
+import matplotlib.pyplot as plt
+import pytest
+
+import shap.plots._force_matplotlib as force_mpl
+
+
+def _sample_plot_data(link):
+    return {
+        "features": {
+            0: {"effect": -0.2, "value": "v0"},
+            1: {"effect": 0.3, "value": "v1"},
+        },
+        "featureNames": ["f0", "f1"],
+        "outNames": ["out"],
+        "outValue": 0.15,
+        "baseValue": 0.05,
+        "link": link,
+    }
+
+
+def test_format_data_invalid_link_raises_value_error():
+    with pytest.raises(ValueError, match="Unrecognized link function"):
+        force_mpl.format_data(_sample_plot_data("unknown"))
+
+
+def test_draw_additive_plot_logit_scale_and_show_branch(monkeypatch):
+    xscale_calls = []
+    show_calls = []
+
+    monkeypatch.setattr(force_mpl, "draw_bars", lambda *args, **kwargs: ([], []))
+    monkeypatch.setattr(force_mpl, "draw_labels", lambda fig, ax, *args, **kwargs: (fig, ax))
+    monkeypatch.setattr(force_mpl, "draw_higher_lower_element", lambda *args, **kwargs: None)
+    monkeypatch.setattr(force_mpl, "draw_base_element", lambda *args, **kwargs: None)
+    monkeypatch.setattr(force_mpl, "draw_output_element", lambda *args, **kwargs: None)
+    monkeypatch.setattr(force_mpl, "update_axis_limits", lambda *args, **kwargs: None)
+    monkeypatch.setattr(plt, "xscale", lambda scale: xscale_calls.append(scale))
+    monkeypatch.setattr(plt, "show", lambda: show_calls.append(True))
+
+    force_mpl.draw_additive_plot(_sample_plot_data("logit"), figsize=(4, 2), show=True)
+
+    assert xscale_calls == ["logit"]
+    assert show_calls == [True]


### PR DESCRIPTION
## Overview
Related to #3690  

## Description of the changes proposed in this pull request:
- Added a dedicated test module for `_force_matplotlib.py`: `test_force_matplotlib.py`.  
- Added a test for `format_data` error handling to cover the unsupported link-function branch (`ValueError` path).  
- Added a test for `draw_additive_plot` to cover:
  - the logit-axis scaling branch (`plt.xscale("logit")`, formatter/tick formatting path),  
  - the `show=True` branch (explicit `plt.show()` path).  
- Used lightweight monkeypatching of rendering helpers to keep the tests deterministic and fast while still executing the missing control-flow paths.  
- This is a tests-only change; no production code was modified.  

## Validation
- New test module passes: 2/2 tests.  
- Combined force-plot tests pass: 13/13 tests.  
- Coverage for `_force_matplotlib.py`: 100% (210/210 statements).  
- Pre-commit checks pass for `test_force_matplotlib.py`.  

## Checklist
- [x] All pre-commit checks pass.  
- [x] Unit tests added (if fixing a bug or adding a new feature).  