### PR TITLE
Fix PriorityQueue comparison issue in ActionOptimizer

### DIFF
--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -30,9 +30,11 @@ class ActionOptimizer:
 
     def __call__(self, *args, max_evals=10000):
         # init our queue with all the least costly actions
-        q: queue.PriorityQueue[tuple[float, list[Action]]] = queue.PriorityQueue()
+        q: queue.PriorityQueue[tuple[float, int, list[Action]]] = queue.PriorityQueue()
+        counter = 0
         for group in self.action_groups:
-            q.put((group[0].cost, [group[0]]))
+            q.put((group[0].cost, counter, [group[0]]))
+            counter += 1
 
         nevals = 0
         while not q.empty():
@@ -44,7 +46,7 @@ class ActionOptimizer:
                 )
 
             # get the next cheapest set of actions we can do
-            cost, actions = q.get()
+            cost, _, actions = q.get()
 
             # apply those actions
             args_tmp = copy.deepcopy(args)
@@ -83,4 +85,5 @@ class ActionOptimizer:
 
                     # add the new option to our queue
                     if new_actions is not None:
-                        q.put((sum([a.cost for a in new_actions]), new_actions))
+                        q.put((sum([a.cost for a in new_actions]), counter, new_actions))
+                        counter += 1

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,0 +1,41 @@
+import pytest
+
+try:
+    import tensorflow as tf
+    from shap.utils._keras import clone_keras_layers, split_keras_model
+    TF_AVAILABLE = True
+except ImportError:
+    TF_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
+
+
+def create_simple_model():
+    return tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(8, activation="relu"),
+        tf.keras.layers.Dense(2)
+    ])
+
+
+def test_clone_keras_layers_basic():
+    model = create_simple_model()
+    new_model = clone_keras_layers(model, 0, len(model.layers) - 1)
+
+    assert new_model is not None
+    assert isinstance(new_model, tf.keras.Model)
+
+
+def test_split_keras_model_basic():
+    model = create_simple_model()
+    model1, model2 = split_keras_model(model, 1)
+
+    assert isinstance(model1, tf.keras.Model)
+    assert isinstance(model2, tf.keras.Model)
+
+
+def test_split_keras_model_invalid_layer():
+    model = create_simple_model()
+
+    with pytest.raises(Exception):
+        split_keras_model(model, 100)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -2,7 +2,9 @@ import pytest
 
 try:
     import tensorflow as tf
+
     from shap.utils._keras import clone_keras_layers, split_keras_model
+
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
@@ -11,11 +13,9 @@ pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not install
 
 
 def create_simple_model():
-    return tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(8, activation="relu"),
-        tf.keras.layers.Dense(2)
-    ])
+    return tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(8, activation="relu"), tf.keras.layers.Dense(2)]
+    )
 
 
 def test_clone_keras_layers_basic():


### PR DESCRIPTION
Hi! 👋

This PR addresses a potential issue in ActionOptimizer related to how items are pushed into the PriorityQueue.

### Problem
Currently, queue entries are inserted as:
(cost, actions)

When two entries have the same cost, Python attempts to compare the second element (i.e., a list of Action objects). Since Action objects are not inherently comparable, this can lead to a runtime error:
TypeError: '<' not supported between instances of 'Action'

### Solution
To avoid this, a tie-breaker counter has been added to the queue entries:
(cost, counter, actions)

This ensures a consistent ordering in the PriorityQueue and prevents comparisons between non-comparable objects.

### Changes
- Added a counter to queue entries
- Updated both `q.put` calls to include the counter
- Adjusted `q.get()` unpacking accordingly
- Updated type annotations for clarity

Fixes #4580

Happy to make any changes if needed 🙂