### PR TITLE
FIX: Raise ValueError for unsupported method in shap/plots/_embedding.py

### DIFF
--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -52,7 +52,7 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
     elif hasattr(method, "shape") and method.shape[1] == 2:
         embedding_values = method
     else:
-        print("Unsupported embedding method:", method)
+        raise ValueError(f"Unsupported embedding method: {method!r}. Expected 'pca' or a (n_samples, 2) numpy array.")
 
     plt.scatter(embedding_values[:, 0], embedding_values[:, 1], c=cvals, cmap=colors.red_blue, alpha=alpha, linewidth=0)
     plt.axis("off")

--- a/tests/plots/test_embedding.py
+++ b/tests/plots/test_embedding.py
@@ -1,0 +1,15 @@
+"""Tests for the embedding plot."""
+
+import numpy as np
+import pytest
+
+import shap
+
+
+def test_embedding_unsupported_method_raises():
+    """Check that a ValueError is raised when an unsupported method is passed."""
+    rng = np.random.default_rng(0)
+    shap_values = rng.standard_normal((20, 5))
+    emsg = "Unsupported embedding method"
+    with pytest.raises(ValueError, match=emsg):
+        shap.plots.embedding(0, shap_values, method="tsne", show=False)


### PR DESCRIPTION
## Overview

Closes #4591

Passing an unsupported string to `shap.plots.embedding()` caused a
`NameError` because `embedding_values` was never assigned in the `else`
branch. Replaced the `print()` with `raise ValueError(...)` so the failure
is immediate and informative.

Added one test verifying the `ValueError` is raised with the correct message.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)