### PR TITLE
ENH: Removed the show argument in shap.plots

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -10,6 +10,7 @@ from .. import Cohorts, Explanation
 from ..utils import format_value, ordinal_str
 from ..utils._exceptions import DimensionError
 from ._labels import labels
+from ._show import resolve_show
 from ._style import get_style
 from ._utils import convert_ordering, dendrogram_coords, get_sort_order, merge_nodes, sort_inds
 
@@ -27,7 +28,7 @@ def bar(
     clustering_cutoff=0.5,
     show_data="auto",
     ax=None,
-    show=True,
+    show=None,
 ):
     """Create a bar plot of a set of SHAP values.
 
@@ -75,6 +76,7 @@ def bar(
     See `bar plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/bar.html>`_.
 
     """
+    show = resolve_show(show, plot_name="bar")
     style = get_style()
     # convert Explanation objects to dictionaries
     if isinstance(shap_values, Explanation):

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -21,6 +21,7 @@ from ..utils import safe_isinstance
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 from ._utils import (
     convert_color,
     convert_ordering,
@@ -47,7 +48,7 @@ def beeswarm(
     axis_color="#333333",
     alpha: float = 1.0,
     ax: plt.Axes | None = None,
-    show: bool = True,
+    show: bool | None = None,
     log_scale: bool = False,
     color_bar: bool = True,
     s: float = 16,
@@ -106,6 +107,8 @@ def beeswarm(
     See `beeswarm plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/beeswarm.html>`_.
 
     """
+    show = resolve_show(show, plot_name="beeswarm")
+
     if not isinstance(shap_values, Explanation):
         emsg = "The beeswarm plot requires an `Explanation` object as the `shap_values` argument."
         raise TypeError(emsg)
@@ -725,7 +728,7 @@ def summary_legacy(
             features[:, sort_inds] if features is not None else None,
             feature_names=np.array(feature_names)[sort_inds].tolist(),
             sort=False,
-            show=False,
+            show=None,
             color_bar=False,
             plot_size=None,
             max_display=max_display,
@@ -745,7 +748,7 @@ def summary_legacy(
                 features[:, sort_inds] if features is not None else None,
                 sort=False,
                 feature_names=["" for i in range(len(feature_names))],
-                show=False,
+                show=None,
                 color_bar=False,
                 plot_size=None,
                 max_display=max_display,

--- a/shap/plots/_benchmark.py
+++ b/shap/plots/_benchmark.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import colors
+from ._show import resolve_show
 
 xlabel_names = {
     "remove absolute": "Fraction removed",
@@ -16,8 +17,10 @@ xlabel_names = {
 }
 
 
-def benchmark(benchmark, show=True):
+def benchmark(benchmark, show=None):
     """Plot a BenchmarkResult or list of such results."""
+    show = resolve_show(show, plot_name="benchmark")
+
     if hasattr(benchmark, "__iter__"):
         benchmark = list(benchmark)
 

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -11,6 +11,7 @@ from ..utils import hclust_ordering
 from ..utils._legacy import LogitLink, convert_to_link
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 
 
 def __change_shap_base_value(base_value, new_base_value, shap_values) -> np.ndarray:
@@ -226,7 +227,7 @@ def decision(
     auto_size_plot=True,
     title=None,
     xlim=None,
-    show=True,
+    show: bool | None = None,
     return_objects=False,
     ignore_warnings=False,
     new_base_value=None,
@@ -352,6 +353,8 @@ def decision(
     See more `decision plot examples here <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/decision_plot.html>`_.
 
     """
+    show = resolve_show(show, plot_name="decision")
+
     # code taken from force_plot. auto unwrap the base_value
     if isinstance(base_value, np.ndarray) and len(base_value) == 1:
         base_value = base_value[0]

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -4,9 +4,10 @@ import sklearn
 from ..utils import convert_name
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 
 
-def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, show=True):
+def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, show=None):
     """Use the SHAP values as an embedding which we project to 2D for visualization.
 
     Parameters
@@ -34,6 +35,8 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
         show density of the data points when using a large dataset.
 
     """
+    show = resolve_show(show, plot_name="embedding")
+
     if feature_names is None:
         feature_names = [labels["FEATURE"] % str(i) for i in range(shap_values.shape[1])]
 

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -25,6 +25,7 @@ from ..utils import hclust_ordering
 from ..utils._exceptions import DimensionError
 from ..utils._legacy import Data, DenseData, Instance, Link, Model, convert_to_link
 from ._labels import labels
+from ._show import resolve_show
 
 
 def force(
@@ -36,7 +37,7 @@ def force(
     link="identity",
     plot_cmap="RdBu",
     matplotlib=False,
-    show=True,
+    show=None,
     figsize=(20, 3),
     ordering_keys=None,
     ordering_keys_time_format=None,
@@ -95,6 +96,8 @@ def force(
         will be displayed.
 
     """
+    show = resolve_show(show, plot_name="force")
+
     # support passing an explanation object
     if str(type(base_value)).endswith("Explanation'>"):
         shap_exp = base_value

--- a/shap/plots/_group_difference.py
+++ b/shap/plots/_group_difference.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import colors
+from ._show import resolve_show
 
 
 def group_difference(
@@ -13,7 +14,7 @@ def group_difference(
     xmax=None,
     max_display=None,
     sort=True,
-    show=True,
+    show=None,
     ax=None,
 ):
     """This plots the difference in mean SHAP values between two groups.
@@ -34,6 +35,8 @@ def group_difference(
         A list of feature names.
 
     """
+    show = resolve_show(show, plot_name="group_difference")
+
     # Compute confidence bounds for the group difference value
     vs = []
     gmean = group_mask.mean()

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -5,6 +5,7 @@ from .. import Explanation
 from ..utils import OpChain
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 from ._utils import convert_ordering
 
 
@@ -15,7 +16,7 @@ def heatmap(
     feature_order=None,
     max_display=10,
     cmap=colors.red_white_blue,
-    show=True,
+    show=None,
     plot_width=8,
     ax=None,
 ):
@@ -70,6 +71,8 @@ def heatmap(
     See `heatmap plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/heatmap.html>`_.
 
     """
+    show = resolve_show(show, plot_name="heatmap")
+
     # sort the SHAP values matrix by rows and columns
     values = shap_values.values
     if issubclass(type(feature_values), OpChain):

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -19,6 +19,7 @@ from .._explanation import Explanation
 from ..utils import ordinal_str
 from ..utils._legacy import kmeans
 from . import colors
+from ._show import resolve_show
 
 if TYPE_CHECKING:
     from matplotlib.colors import Colormap
@@ -35,7 +36,7 @@ def image(
     labelpad: float | None = None,
     cmap: str | Colormap | None = colors.red_transparent_blue,
     vmax: float | None = None,
-    show: bool | None = True,
+    show: bool | None = None,
 ):
     """Plots SHAP values for image inputs.
 
@@ -81,6 +82,8 @@ def image(
     See `image plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/image.html>`_.
 
     """
+    show = resolve_show(show, plot_name="image")
+
     # support passing an explanation object
     if isinstance(shap_values, Explanation):
         shap_exp: Explanation = shap_values

--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -5,6 +5,7 @@ import scipy.stats
 
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 
 
 def truncate_text(text, max_len):
@@ -14,7 +15,7 @@ def truncate_text(text, max_len):
         return text
 
 
-def monitoring(ind, shap_values, features, feature_names=None, show=True):
+def monitoring(ind, shap_values, features, feature_names=None, show=None):
     """Create a SHAP monitoring plot.
 
     (Note this function is preliminary and subject to change!!)
@@ -38,6 +39,8 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
         Names of the features (length # features)
 
     """
+    show = resolve_show(show, plot_name="monitoring")
+
     if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns

--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -7,6 +7,7 @@ import pandas as pd
 from .. import Explanation
 from ..plots.colors import blue_rgb, light_blue_rgb, red_blue_transparent, red_rgb
 from ..utils import convert_name
+from ._show import resolve_show
 
 
 def compute_bounds(xmin, xmax, xv):
@@ -47,9 +48,11 @@ def partial_dependence(
     pd_linewidth=2,
     ace_linewidth="auto",
     ax=None,
-    show=True,
+    show=None,
 ):
     """A basic partial dependence plot function."""
+    show = resolve_show(show, plot_name="partial_dependence")
+
     if isinstance(data, Explanation):
         features = data.data
         shap_values = data

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -16,6 +16,7 @@ from ..utils._exceptions import DimensionError
 from ..utils._general import encode_array_if_needed
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 from ._utils import AxisLimitSpec, parse_axis_limit
 
 
@@ -37,7 +38,7 @@ def scatter(
     overlay: dict[str, Any] | None = None,
     ax: plt.Axes | None = None,
     ylabel: str = "SHAP value",
-    show: bool = True,
+    show: bool | None = None,
 ):
     """Create a SHAP dependence scatter plot, optionally colored by an interaction feature.
 
@@ -128,6 +129,8 @@ def scatter(
     See `scatter plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/scatter.html>`_.
 
     """
+    show = resolve_show(show, plot_name="scatter")
+
     if not isinstance(shap_values, Explanation):
         raise TypeError("The shap_values parameter must be a shap.Explanation object!")
 
@@ -143,7 +146,7 @@ def scatter(
         _ = plt.subplots(1, len(inds), figsize=(min(6 * len(inds), 15), 5))
         for i in inds:
             ax = plt.subplot(1, len(inds), i + 1)
-            scatter(shap_values[:, i], color=color, show=False, ax=ax, ymin=ymin, ymax=ymax)
+            scatter(shap_values[:, i], color=color, show=None, ax=ax, ymin=ymin, ymax=ymax)
             if overlay is not None:
                 line_styles = ["solid", "dotted", "dashed"]
                 for j, name in enumerate(overlay):
@@ -665,7 +668,7 @@ def dependence_legacy(
             interaction_index=(None if ind1 == ind2 else ind2),
             display_features=display_features,
             ax=ax,
-            show=False,
+            show=None,
             xmin=xmin,
             xmax=xmax,
             x_jitter=x_jitter,

--- a/shap/plots/_show.py
+++ b/shap/plots/_show.py
@@ -1,0 +1,33 @@
+"""Utilities for handling deprecated plot display arguments."""
+
+from __future__ import annotations
+
+import warnings
+
+
+def resolve_show(show: bool | None, *, plot_name: str) -> bool:
+    """Resolve deprecated ``show`` values to runtime behavior.
+
+    Parameters
+    ----------
+    show : bool or None
+        Deprecated display argument. ``None`` means the argument was not explicitly
+        provided by the caller.
+    plot_name : str
+        Public plotting function name used in the warning message.
+
+    Returns
+    -------
+    bool
+        Whether ``matplotlib.pyplot.show()`` should be called.
+    """
+    if show is not None:
+        warnings.warn(
+            "The `show` argument to `shap.plots."
+            f"{plot_name}` is deprecated and will be removed in a future release. "
+            "Plots no longer call `matplotlib.pyplot.show()` by default. "
+            "Call `matplotlib.pyplot.show()` explicitly if needed.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    return bool(show)

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -12,6 +12,7 @@ from scipy.stats import gaussian_kde
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels
+from ._show import resolve_show
 
 # TODO: simplify this when we drop support for matplotlib 3.9
 if version.parse(matplotlib.__version__) >= version.parse("3.10"):
@@ -32,7 +33,7 @@ def violin(
     axis_color="#333333",
     title=None,
     alpha=1,
-    show=True,
+    show=None,
     sort=True,
     color_bar=True,
     plot_size="auto",
@@ -103,6 +104,8 @@ def violin(
     See `violin plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/violin.html>`_.
 
     """
+    show = resolve_show(show, plot_name="violin")
+
     if title is not None:
         warnings.warn("The `title` argument is unused and will be removed in a future release.", DeprecationWarning)
     # support passing an explanation object

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -6,6 +6,7 @@ import pandas as pd
 from .. import Explanation
 from ..utils import format_value
 from ._labels import labels
+from ._show import resolve_show
 from ._style import get_style
 
 
@@ -13,7 +14,7 @@ from ._style import get_style
 # plot that is associated with that feature get overlaid on the plot...it would quickly allow users to answer
 # why a feature is pushing down or up. Perhaps the best way to do this would be with an ICE plot hanging off
 # of the bar...
-def waterfall(shap_values, max_display=10, show=True):
+def waterfall(shap_values, max_display=10, show=None):
     """Plots an explanation of a single prediction as a waterfall plot.
 
     The SHAP value of a feature represents the impact of the evidence provided by that feature on the model's
@@ -43,6 +44,7 @@ def waterfall(shap_values, max_display=10, show=True):
     See `waterfall plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/waterfall.html>`_.
 
     """
+    show = resolve_show(show, plot_name="waterfall")
     style = get_style()
     # Turn off interactive plot
     if show is False:

--- a/tests/plots/test_show_argument.py
+++ b/tests/plots/test_show_argument.py
@@ -1,0 +1,46 @@
+import warnings
+
+import matplotlib.pyplot as plt
+import pytest
+
+import shap
+
+
+def test_show_argument_deprecated_bar(explainer):
+    shap_values = explainer(explainer.data)
+    with pytest.deprecated_call(match=r"`show` argument to `shap\.plots\.bar`"):
+        shap.plots.bar(shap_values, show=False)
+
+
+def test_show_argument_deprecated_scatter(explainer):
+    explanation = explainer(explainer.data)
+    with pytest.deprecated_call(match=r"`show` argument to `shap\.plots\.scatter`"):
+        shap.plots.scatter(explanation[:, "Age"], show=False)
+
+
+def test_show_argument_deprecated_waterfall(explainer):
+    explanation = explainer(explainer.data)
+    with pytest.deprecated_call(match=r"`show` argument to `shap\.plots\.waterfall`"):
+        shap.plots.waterfall(explanation[0], show=False)
+
+
+def test_waterfall_no_implicit_show_by_default(explainer, monkeypatch):
+    called = []
+
+    def _fake_show(*args, **kwargs):
+        called.append((args, kwargs))
+
+    monkeypatch.setattr(plt, "show", _fake_show)
+
+    explanation = explainer(explainer.data)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        shap.plots.waterfall(explanation[0])
+
+    assert called == []
+    show_warnings = [
+        w
+        for w in captured
+        if "`show` argument to `shap.plots.waterfall` is deprecated" in str(w.message)
+    ]
+    assert show_warnings == []

--- a/tests/plots/test_show_argument.py
+++ b/tests/plots/test_show_argument.py
@@ -38,9 +38,5 @@ def test_waterfall_no_implicit_show_by_default(explainer, monkeypatch):
         shap.plots.waterfall(explanation[0])
 
     assert called == []
-    show_warnings = [
-        w
-        for w in captured
-        if "`show` argument to `shap.plots.waterfall` is deprecated" in str(w.message)
-    ]
+    show_warnings = [w for w in captured if "`show` argument to `shap.plots.waterfall` is deprecated" in str(w.message)]
     assert show_warnings == []


### PR DESCRIPTION
## Overview

Closes #3819

## Description of the changes proposed in this pull request:

- Added a shared deprecation/behavior helper: [_show.py]

- Updated exported matplotlib-based shap.plots functions so: default behavior is no implicit show call , passing show still works for now, but emits DeprecationWarning


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
