### PR TITLE
FIX: explicit return in hclust (RET503) closes #4600

### DIFF
--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -289,7 +289,7 @@ def hclust(
                 dist_list.append(min(dist_full[i, j], dist_full[j, i]))
             elif linkage == "complete":
                 dist_list.append(max(dist_full[i, j], dist_full[j, i]))
-            elif linkage == "average":
+            else:
                 dist_list.append((dist_full[i, j] + dist_full[j, i]) / 2)
         dist: npt.NDArray[Any] = np.array(dist_list)
 
@@ -309,5 +309,5 @@ def hclust(
         return scipy.cluster.hierarchy.single(dist)
     elif linkage == "complete":
         return scipy.cluster.hierarchy.complete(dist)
-    elif linkage == "average":
+    else:
         return scipy.cluster.hierarchy.average(dist)


### PR DESCRIPTION
Changes final `elif linkage == "average":` to `else:` in `shap/utils/_clustering.py`.

Fixes:
- ruff RET503 (implicit None return)
- Makes final branch explicit

Local checks:
- pre-commit: ✅
- ruff: ✅  
- pytest: ✅

Closes #4600