### PR TITLE
docs: cleanup typos and StyleConfig modernization

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -558,6 +558,9 @@ class TreeExplainer(Explainer):
                a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
                to the sum.
 
+               Furthermore, the additivity formula requires SHAP values and model
+               predictions to be computed on the same samples in the same order.
+
             The shape of the returned array depends on the number of model outputs:
 
             * one output: array of shape ``(#num_samples, *X.shape[1:])``.

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -544,10 +544,19 @@ class TreeExplainer(Explainer):
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
             For each output, the SHAP values (summed across all features) plus the
-            expected value equals the model's output for that sample:
+            expected value equals the model's output in the space of the ``model_output``
+            argument for that sample:
 
-            * Single output: ``shap_values[i, :].sum() + expected_value = model_output[i]``
-            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = model_output[i, j]``
+            * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
+            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
+
+            .. note:: 
+               The ``explainer_model_output`` is NOT necessarily what ``model.predict()`` 
+               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default 
+               ``model_output="raw"``, the explainer returns log-odds (margins). 
+               To compare this mathematically against ``predict_proba()`` probabilities,
+               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
+               to the sum.
 
             The shape of the returned array depends on the number of model outputs:
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -554,7 +554,7 @@ class TreeExplainer(Explainer):
                or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default
                ``model_output="raw"``, the explainer returns log-odds (margins).
                To compare this mathematically against ``predict_proba()`` probabilities,
-               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
+               a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied
                to the sum.
 
                Furthermore, the additivity formula requires SHAP values and model

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -543,17 +543,16 @@ class TreeExplainer(Explainer):
         np.array
             Estimated SHAP values, usually of shape ``(# samples x # features)``.
 
-            For each output, the SHAP values (summed across all features) plus the
-            expected value equals the model's output in the space of the ``model_output``
-            argument for that sample:
+            For each output, the sum of the SHAP values plus the ``expected_value``
+            equals the model's output (in the specified output space):
 
-            * Single output: ``shap_values[i, :].sum() + expected_value = explainer_model_output[i]``
-            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = explainer_model_output[i, j]``
+            * Single output: ``shap_values[i, :].sum() + expected_value = f(x)[i]``
+            * Multiple outputs: ``shap_values[i, :, j].sum() + expected_value[j] = f(x)[i, j]``
 
-            .. note:: 
-               The ``explainer_model_output`` is NOT necessarily what ``model.predict()`` 
-               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default 
-               ``model_output="raw"``, the explainer returns log-odds (margins). 
+            .. note::
+               The ``f(x)`` value is NOT necessarily what ``model.predict()``
+               or ``model.predict_proba()`` returns. For example, for an XGBoost Classifier with the default
+               ``model_output="raw"``, the explainer returns log-odds (margins).
                To compare this mathematically against ``predict_proba()`` probabilities,
                a logistic inverse-transform (e.g., ``scipy.special.expit``) must be applied 
                to the sum.

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -16,7 +16,7 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
         If this is a string it is either the name of the feature, or it can have the
         form "rank(int)" to specify the feature with that rank (ordered by mean absolute
         SHAP value over all the samples), or "sum()" to mean the sum of all the SHAP values,
-        which is the model's output (minus it's expected value).
+        which is the model's output (minus its expected value).
 
     shap_values : numpy.array
         Matrix of SHAP values (# samples x # features).

--- a/shap/plots/_style.py
+++ b/shap/plots/_style.py
@@ -30,8 +30,7 @@ type RGBAColorType = (
 type ColorType = RGBColorType | RGBAColorType | np.ndarray
 
 
-# TODO: Use dataclass(kw_only=True) when we drop Python 3.9
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class StyleConfig:
     """A complete set of configuration options for matplotlib-based shap plots."""
 


### PR DESCRIPTION
Fulfilling a TODO in` _style.py` (`kw_only=True`) and fixing a possessive typo in` _embedding.py`