### PR TITLE
Demangled pytorch and tensorflow dependencies

### DIFF
--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -266,10 +266,16 @@ def safe_isinstance(obj: Any, class_path_str: str | list[str]) -> bool:
 
         module = sys.modules[module_name]
 
-        # Get class
-        _class = getattr(module, class_name, None)
+        # Avoid triggering module-level __getattr__ (for example transformers lazy
+        # imports) since safe_isinstance must not import optional dependencies.
+        _class = getattr(module, "__dict__", {}).get(class_name, None)
 
         if _class is None:
+            # Some packages expose classes lazily at top-level modules. In that
+            # case, match by class name in the MRO without importing anything.
+            for parent in type(obj).mro():
+                if parent.__name__ == class_name and parent.__module__.startswith(module_name):
+                    return True
             continue
 
         if isinstance(obj, _class):

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -1,10 +1,11 @@
+import sys
+import types
+from typing import Any
+
 import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as ssp
-import sys
-import types
-from typing import Any
 
 import shap
 

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -2,6 +2,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as ssp
+import sys
+import types
+from typing import Any
 
 import shap
 
@@ -122,3 +125,61 @@ def test_format_value_string_input():
     # Test with string that starts with minus
     result = shap.utils._general.format_value("-123", "%0.03f")
     assert result == "\u2212" + "123"
+
+
+def test_safe_isinstance_does_not_trigger_module_getattr():
+    """Regression test for lazy-imported modules (see GH #3662)."""
+
+    module_name = "dummy_lazy_module"
+    module = types.ModuleType(module_name)
+
+    class LocalClass:
+        pass
+
+    setattr(module, "LocalClass", LocalClass)
+
+    def _module_getattr(_name: str) -> Any:
+        raise RuntimeError("module __getattr__ should not be called")
+
+    setattr(module, "__getattr__", _module_getattr)
+    sys.modules[module_name] = module
+    try:
+        obj = LocalClass()
+        assert shap.utils.safe_isinstance(obj, f"{module_name}.LocalClass")
+        assert not shap.utils.safe_isinstance(obj, f"{module_name}.MissingClass")
+    finally:
+        del sys.modules[module_name]
+
+
+def test_safe_isinstance_no_import_for_unloaded_module():
+    module_name = "definitely_not_loaded_dummy_module"
+    assert module_name not in sys.modules
+    assert not shap.utils.safe_isinstance(object(), f"{module_name}.SomeClass")
+
+
+def test_safe_isinstance_matches_lazy_exported_class_via_mro():
+    package_name = "dummy_lazy_package"
+
+    package = types.ModuleType(package_name)
+
+    class PreTrainedModel:
+        pass
+
+    # Mimic a class defined in a submodule but exposed lazily from top-level.
+    PreTrainedModel.__module__ = f"{package_name}.submodule"
+
+    class ConcreteModel(PreTrainedModel):
+        pass
+
+    ConcreteModel.__module__ = f"{package_name}.impl"
+
+    def _module_getattr(_name: str) -> Any:
+        raise RuntimeError("module __getattr__ should not be called")
+
+    setattr(package, "__getattr__", _module_getattr)
+    sys.modules[package_name] = package
+    try:
+        obj = ConcreteModel()
+        assert shap.utils.safe_isinstance(obj, f"{package_name}.PreTrainedModel")
+    finally:
+        del sys.modules[package_name]


### PR DESCRIPTION
## Overview

Closes #3662  
fixes #3662 

## Description of the changes proposed in this pull request:
Updated [_general.py:266] in safe_isinstance:
- Avoids module getattr-based class lookup that can trigger lazy imports.
- Uses module dictionary lookup first.
- Adds an MRO-based fallback so lazily exported classes are still recognized without importing optional dependencies.
Added regression tests in [test_general.py:129]:
- Verifies safe_isinstance does not trigger module getattr.
- Verifies unloaded modules are not imported.
- Verifies lazy-exported class matching still works via MRO fallback.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
