### PR TITLE
FIX: pair even middle-size subsets in KernelExplainer random sampling

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -476,12 +476,14 @@ class KernelExplainer(Explainer):
             samples_left = self.nsamples - self.nsamplesAdded
             log.debug(f"{samples_left = }")
             if num_full_subsets != num_subset_sizes:
+                # For even M, the middle subset size (M/2) can also be complement-paired.
+                num_random_paired_subset_sizes = num_paired_subset_sizes + int(self.M % 2 == 0)
                 remaining_weight_vector = copy.copy(weight_vector)
-                remaining_weight_vector[:num_paired_subset_sizes] /= 2  # because we draw two samples each below
+                remaining_weight_vector[:num_random_paired_subset_sizes] /= 2  # because we draw two samples each below
                 remaining_weight_vector = remaining_weight_vector[num_full_subsets:]
                 remaining_weight_vector /= np.sum(remaining_weight_vector)
                 log.info(f"{remaining_weight_vector = }")
-                log.info(f"{num_paired_subset_sizes = }")
+                log.info(f"{num_random_paired_subset_sizes = }")
                 ind_set = np.random.choice(len(remaining_weight_vector), 4 * samples_left, p=remaining_weight_vector)
                 ind_set_pos = 0
                 used_masks = {}
@@ -495,9 +497,7 @@ class KernelExplainer(Explainer):
                     # only add the sample if we have not seen it before, otherwise just
                     # increment a previous sample's weight
                     mask_tuple = tuple(mask)
-                    new_sample = False
                     if mask_tuple not in used_masks:
-                        new_sample = True
                         used_masks[mask_tuple] = self.nsamplesAdded
                         samples_left -= 1
                         self.addsample(instance.x, mask, 1.0)
@@ -505,17 +505,18 @@ class KernelExplainer(Explainer):
                         self.kernelWeights[used_masks[mask_tuple]] += 1.0
 
                     # add the compliment sample
-                    if samples_left > 0 and subset_size <= num_paired_subset_sizes:
+                    if samples_left > 0 and subset_size <= num_random_paired_subset_sizes:
                         mask[:] = np.abs(mask - 1)
+                        complement_mask_tuple = tuple(mask)
 
                         # only add the sample if we have not seen it before, otherwise just
                         # increment a previous sample's weight
-                        if new_sample:
+                        if complement_mask_tuple not in used_masks:
                             samples_left -= 1
+                            used_masks[complement_mask_tuple] = self.nsamplesAdded
                             self.addsample(instance.x, mask, 1.0)
                         else:
-                            # we know the compliment sample is the next one after the original sample, so + 1
-                            self.kernelWeights[used_masks[mask_tuple] + 1] += 1.0
+                            self.kernelWeights[used_masks[complement_mask_tuple]] += 1.0
 
                 # normalize the kernel weights for the random samples to equal the weight left after
                 # the fixed enumerated samples have been already counted

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -391,31 +391,22 @@ def test_explainer_non_number_dtype(dt):
     np.testing.assert_allclose(shap_values.values.max(), 0.26548, rtol=1e-2)
 
 
-def test_kernel_even_feature_middle_subset_is_paired(monkeypatch):
+def test_kernel_even_feature_middle_subset_is_paired():
     """For even feature counts, random sampling should pair middle-size subsets with complements."""
     X_background = np.zeros((1, 6))
     X_eval = np.ones((1, 6))
 
-    # Force random sampling to choose subset_size=3 repeatedly (the even middle size for M=6).
-    def _fixed_choice(a, size, p):
-        return np.full(size, 2, dtype=int)
-
-    # Always select the first 3 feature indices.
-    def _fixed_permutation(n):
-        return np.arange(n)
-
-    monkeypatch.setattr(np.random, "choice", _fixed_choice)
-    monkeypatch.setattr(np.random, "permutation", _fixed_permutation)
+    # Use a fixed seed that naturally samples the even middle subset size (M/2) in random sampling.
+    np.random.seed(4)
 
     explainer = shap.KernelExplainer(lambda data: data.sum(axis=1), X_background)
-    explainer.shap_values(X_eval, nsamples=2)
+    explainer.shap_values(X_eval, nsamples=2, silent=True)
 
     masks = explainer.maskMatrix[: explainer.nsamplesAdded]
-    middle_subset_mask = np.array([1, 1, 1, 0, 0, 0], dtype=float)
-    complement_mask = 1.0 - middle_subset_mask
+    middle_masks = masks[np.sum(masks, axis=1) == 3]
 
-    assert np.any(np.all(masks == middle_subset_mask, axis=1))
-    assert np.any(np.all(masks == complement_mask, axis=1))
+    np.testing.assert_allclose(middle_masks.shape[0], 2)
+    np.testing.assert_allclose(middle_masks[1], 1.0 - middle_masks[0])
 
 
 @compare_numpy_outputs_against_baseline(func_file=__file__)

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -391,6 +391,33 @@ def test_explainer_non_number_dtype(dt):
     np.testing.assert_allclose(shap_values.values.max(), 0.26548, rtol=1e-2)
 
 
+def test_kernel_even_feature_middle_subset_is_paired(monkeypatch):
+    """For even feature counts, random sampling should pair middle-size subsets with complements."""
+    X_background = np.zeros((1, 6))
+    X_eval = np.ones((1, 6))
+
+    # Force random sampling to choose subset_size=3 repeatedly (the even middle size for M=6).
+    def _fixed_choice(a, size, p):
+        return np.full(size, 2, dtype=int)
+
+    # Always select the first 3 feature indices.
+    def _fixed_permutation(n):
+        return np.arange(n)
+
+    monkeypatch.setattr(np.random, "choice", _fixed_choice)
+    monkeypatch.setattr(np.random, "permutation", _fixed_permutation)
+
+    explainer = shap.KernelExplainer(lambda data: data.sum(axis=1), X_background)
+    explainer.shap_values(X_eval, nsamples=2)
+
+    masks = explainer.maskMatrix[: explainer.nsamplesAdded]
+    middle_subset_mask = np.array([1, 1, 1, 0, 0, 0], dtype=float)
+    complement_mask = 1.0 - middle_subset_mask
+
+    assert np.any(np.all(masks == middle_subset_mask, axis=1))
+    assert np.any(np.all(masks == complement_mask, axis=1))
+
+
 @compare_numpy_outputs_against_baseline(func_file=__file__)
 def test_serialization():
     model, data = common.basic_sklearn_scenario()


### PR DESCRIPTION
## Overview

Closes #4117.

Fixes even-feature paired sampling in `KernelExplainer.explain()` random sampling.

## Changes

- Include the even-`M` middle subset size in random paired sampling.
- Update random-stage weight handling accordingly.
- Replace implicit complement `+1` indexing with explicit complement-mask lookup.
- Add regression test: `test_kernel_even_feature_middle_subset_is_paired`.

## Validation

- `python -m pytest -q tests/explainers/test_kernel.py`


## Checklist
- [x] All pre-commit checks pass
- [x] Unit test added (bug fix)

