### PR TITLE
FIX: prevent C++ NULL pointer crash when TreeExplainer receives mixed datatypes

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -969,7 +969,20 @@ class TreeEnsemble:
         self.input_dtype = (
             np.float64
         )  # for sklearn we need to use np.float32 to always get exact matches to their predictions
-        self.data = data
+        if data is not None:
+            try:
+                # CRITICAL: We must overwrite the local `data` variable
+                # so the clean array gets passed down to the XGBoost/LightGBM parsers below.
+                data = np.asarray(data, dtype=np.float64)
+                self.data = data
+            except (ValueError, TypeError) as e:
+                raise ValueError(
+                    "Background data must be purely numeric. Please convert all "
+                    "features (including strings and booleans) to floats before "
+                    "passing them to SHAP."
+                ) from e
+        else:
+            self.data = None
         self.data_missing = data_missing
         self.fully_defined_weighting = (
             True  # does the background dataset land in every leaf (making it valid for the tree_path_dependent method)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3013,10 +3013,6 @@ def test_tree_explainer_mixed_castable_data():
     Addresses Issue #1844.
     """
     xgboost = pytest.importorskip("xgboost")
-    import pandas as pd
-
-    import shap
-
     # Train a dummy model on clean data
     X_train = pd.DataFrame({"age": [58.0, 59.0, 26.0], "sex": [0.0, 0.0, 0.0]})
     y_train = [0, 1, 0]
@@ -3041,10 +3037,6 @@ def test_tree_explainer_uncastable_data():
     un-castable types (like non-numeric strings), rather than failing silently in C++.
     """
     xgboost = pytest.importorskip("xgboost")
-    import pandas as pd
-
-    import shap
-
     X_train = pd.DataFrame({"age": [58.0, 59.0], "sex": [0.0, 0.0]})
     y_train = [0, 1]
     model = xgboost.XGBClassifier(n_estimators=2).fit(X_train, y_train)

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3004,3 +3004,59 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+
+def test_tree_explainer_mixed_castable_data():
+    """
+    Test that TreeExplainer safely casts mixed-type Pandas DataFrames (e.g., strings containing
+    numbers, booleans) to float64 without triggering a C++ NULL pointer crash.
+    Addresses Issue #1844.
+    """
+    xgboost = pytest.importorskip("xgboost")
+    import pandas as pd
+
+    import shap
+
+    # Train a dummy model on clean data
+    X_train = pd.DataFrame({"age": [58.0, 59.0, 26.0], "sex": [0.0, 0.0, 0.0]})
+    y_train = [0, 1, 0]
+    model = xgboost.XGBClassifier(n_estimators=2).fit(X_train, y_train)
+
+    # Mimic the user's issue: mixed types that can be safely cast by numpy
+    X_mixed = pd.DataFrame(
+        {
+            "age": [58, "59", 26],  # Contains a string
+            "sex": [False, False, False],  # Contains booleans
+        }
+    )
+
+    # This should initialize smoothly without a C++ array_dealloc SystemError
+    explainer = shap.TreeExplainer(model, data=X_mixed, feature_perturbation="interventional")
+    assert explainer is not None
+
+
+def test_tree_explainer_uncastable_data():
+    """
+    Test that TreeExplainer raises a clear ValueError when background data contains
+    un-castable types (like non-numeric strings), rather than failing silently in C++.
+    """
+    xgboost = pytest.importorskip("xgboost")
+    import pandas as pd
+
+    import shap
+
+    X_train = pd.DataFrame({"age": [58.0, 59.0], "sex": [0.0, 0.0]})
+    y_train = [0, 1]
+    model = xgboost.XGBClassifier(n_estimators=2).fit(X_train, y_train)
+
+    # Mimic completely un-castable data
+    X_bad = pd.DataFrame(
+        {
+            "age": [58, "Cat"],  # "Cat" cannot be cast to float64
+            "sex": [False, False],
+        }
+    )
+
+    # Verify that our specific Python ValueError is raised
+    with pytest.raises(ValueError, match="Background data must be purely numeric"):
+        shap.TreeExplainer(model, data=X_bad, feature_perturbation="interventional")


### PR DESCRIPTION
## Overview

Closes #1844 

**Description of the changes proposed in this pull request:**

This PR resolves a long-standing issue where passing mixed-type Pandas DataFrames (containing strings, booleans, or `Object` dtypes) to `TreeExplainer` causes a hard C++ interpreter crash (`SystemError` / `array_dealloc`).

**The Bug:**
When `TreeEnsemble.__init__` receives a background dataset (`data`), it passes it directly down to the model-specific parsers (XGBoost, LightGBM, etc.). Eventually, this raw Object array is handed to `_cext.dense_tree_update_weights`. The C++ layer expects a contiguous float array, receives invalid Object pointers instead, and panics with: `Found a NULL input array in _cext_dense_tree_update_weights!`.

**The Fix:**
Intercept and sanitize the `data` matrix at the top of `TreeEnsemble.__init__`. 
1. We attempt to safely cast the data to `np.float64`. (NumPy gracefully handles strings that contain valid numbers).
2. If the user passes un-castable data, we catch the `ValueError` / `TypeError` and raise a clear, helpful Python exception instructing the user to format their data, completely preventing the C++ system crash.
3. Crucially, we overwrite the local `data` variable so the sanitized `float64` array is successfully passed down to the subsequent tree loaders.

*(Note: Submitting this as part of my preparation for ESoC 2026!)*

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [] Unit tests added (if fixing a bug or adding a new feature)
- [x] pytest tests/explainers/test_tree.py pass with exception of tests unrelated to the code.

AI Usage: Gemini was used to understand the core issue since the error message from #1844 wasn't clear. The methods of handling the datatypes were thought by me.