### PR TITLE
ENH: add default silent mode for KernelExplainer progress output (#4044) 

### DIFF
--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -78,6 +78,11 @@ class KernelExplainer(Explainer):
         If the model output is a probability, then "logit" can be used to transform the SHAP values
         into log-odds units.
 
+    silent : bool
+        If ``True``, hide the tqdm progress bar by default when explaining datasets with
+        multiple rows. This can be overridden per call by passing ``silent=...`` to
+        :meth:`shap_values` or :meth:`__call__`.
+
     Examples
     --------
     See :ref:`Kernel Explainer Examples <kernel_explainer_examples>`.
@@ -99,6 +104,7 @@ class KernelExplainer(Explainer):
     expected_value: float | npt.NDArray[np.floating[Any]]
     vector_out: bool
     D: int
+    silent: bool
     varyingInds: npt.NDArray[np.intp]
     varyingFeatureGroups: npt.NDArray[Any] | list[Any]
     M: int
@@ -129,6 +135,7 @@ class KernelExplainer(Explainer):
 
         # convert incoming inputs to standardized iml objects
         self.link = convert_to_link(link)
+        self.silent = kwargs.get("silent", False)
         self.keep_index = kwargs.get("keep_index", False)
         self.keep_index_ordered = kwargs.get("keep_index_ordered", False)
         self.model = convert_to_model(model, keep_index=self.keep_index)
@@ -199,7 +206,7 @@ class KernelExplainer(Explainer):
         self,
         X: npt.NDArray[Any] | pd.DataFrame | scipy.sparse.spmatrix,
         l1_reg: str | float | bool = "num_features(10)",
-        silent: bool = False,
+        silent: bool | None = None,
     ) -> Explanation:
         start_time = time.time()
 
@@ -208,6 +215,8 @@ class KernelExplainer(Explainer):
         else:
             feature_names = getattr(self, "data_feature_names", None)  # type: ignore[assignment]
 
+        if silent is None:
+            silent = self.silent
         v = self.shap_values(X, l1_reg=l1_reg, silent=silent)
         if isinstance(v, list):
             v = np.stack(v, axis=-1)  # put outputs at the end
@@ -259,7 +268,8 @@ class KernelExplainer(Explainer):
                 The default value changed from ``"auto"`` to ``"num_features(10)"``.
 
         silent: bool
-            If True, hide tqdm progress bar. Default False.
+            If True, hide tqdm progress bar. Defaults to the value set on the
+            explainer via ``KernelExplainer(..., silent=...)``.
 
         gc_collect : bool
            Run garbage collection after each explanation round. Sometime needed for memory intensive explanations (default False).
@@ -316,7 +326,7 @@ class KernelExplainer(Explainer):
         # explain the whole dataset
         elif len(X.shape) == 2:
             explanations = []
-            for i in tqdm(range(X.shape[0]), disable=kwargs.get("silent", False)):
+            for i in tqdm(range(X.shape[0]), disable=kwargs.get("silent", self.silent)):
                 data = X[i : i + 1, :]
                 if self.keep_index:
                     data = convert_to_instance_with_index(data, column_name, index_value[i : i + 1], index_name)

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -8,6 +8,7 @@ import sklearn
 from conftest import compare_numpy_outputs_against_baseline
 
 import shap
+from shap.explainers import _kernel as kernel_module
 
 from . import common
 
@@ -350,6 +351,29 @@ def test_kernel_multiclass_multiple_rows():
     explainer = shap.KernelExplainer(lr.predict_proba, X)
     shap_values = explainer(X.iloc[[0, 1], :])
     np.testing.assert_allclose(shap_values.values.sum(1) + explainer.expected_value, pred, atol=1e-04)
+
+
+def test_kernel_explainer_silent_default_and_override(monkeypatch):
+    tqdm_disable_values = []
+
+    def fake_tqdm(iterable, *args, **kwargs):
+        tqdm_disable_values.append(kwargs.get("disable"))
+        return iterable
+
+    monkeypatch.setattr(kernel_module, "tqdm", fake_tqdm)
+
+    X = np.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [2.0, -1.0]])
+    y = X[:, 0] - 2 * X[:, 1]
+    model = sklearn.linear_model.LinearRegression().fit(X, y)
+
+    explainer = shap.KernelExplainer(model.predict, X[:2], silent=True)
+
+    # Constructor-level default should suppress the progress bar.
+    explainer.shap_values(X[2:], nsamples=8)
+    # Call-level override should still be respected.
+    explainer.shap_values(X[2:], nsamples=8, silent=False)
+
+    assert tqdm_disable_values == [True, False]
 
 
 @pytest.mark.parametrize("nsamples", [3, 5, 10, 100])


### PR DESCRIPTION
## Overview

Closes #4044

Adds a constructor-level `silent` option to `KernelExplainer` so progress output can be suppressed by default in notebook workflows.

## Changes
- Supports `shap.KernelExplainer(..., silent=True)`
- Keeps per-call override (`silent=False` still shows progress)
- Updates docstrings
- Adds regression test for default + override behavior

Default behavior is unchanged unless `silent=True` is set.

## Checklist
- [x] All pre-commit checks pass
- [x] Unit tests added (adding a new feature)
