### PR TITLE
ENH: Remove unused typing-extensions dependency

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -251,7 +251,6 @@ traitlets==5.14.3
     #   nbsphinx
 typing-extensions==4.15.0
     # via
-    #   shap (pyproject.toml)
     #   beautifulsoup4
     #   referencing
 urllib3==2.6.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"',  # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
   'llvmlite; sys_platform != "darwin" or platform_machine != "x86_64"',
   'cloudpickle',
-  'typing-extensions',
 ]
 classifiers = [
   "Operating System :: Microsoft :: Windows",

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -48,5 +48,4 @@ six==1.17.0
 slicer==0.0.8
 threadpoolctl==3.6.0
 tqdm==4.67.1
-typing-extensions==4.12.2
 tzdata==2025.2


### PR DESCRIPTION
## Overview

Fixes #4628
As discussed in #4623, `typing-extensions` appears to be an unused dependency. 

Description of the changes proposed in this pull request:

Went ahead and removed typing-extensions from requirement files wherever present, including `pyproject.toml`, `requirements.ci.txt` and removed the direct requirement trace in `docs/requirements-docs.txt`.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
