### PR TITLE
MAINT: support transformers v5 by fixing offset_mapping KeyError and updating test expectations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
   "ngboost",
   "pyspark",
   "pyod",
-  "transformers < 4.54.0",  # TODO: fix once tests pass for 4.54.0
+  "transformers",
   "tf-keras",
   "protobuf",  # See GH #3046
   'torch; python_version < "3.14"',  # TODO: pending 3.14 support

--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -178,6 +178,8 @@ class Text(Masker):
         """Returns the substrings associated with each token in the given string."""
         try:
             token_data = self.tokenizer(s, return_offsets_mapping=True)
+            if "offset_mapping" not in token_data:
+                raise NotImplementedError
             offsets = token_data["offset_mapping"]
             offsets = [(0, 0) if o is None else o for o in offsets]
             parts = [s[offsets[i][0] : max(offsets[i][1], offsets[i + 1][0])] for i in range(len(offsets) - 1)]

--- a/tests/maskers/test_text.py
+++ b/tests/maskers/test_text.py
@@ -20,7 +20,7 @@ def test_method_token_segments_pretrained_tokenizer():
 
     test_text = "I ate a Cannoli"
     output_token_segments, _ = masker.token_segments(test_text)
-    correct_token_segments = ["", " I", " ate", " a", " Can", "no", "li", ""]
+    correct_token_segments = ["", "I ", "ate ", "a ", "Can", "no", "li", ""]
 
     assert output_token_segments == correct_token_segments
 
@@ -50,7 +50,7 @@ def test_masker_call_pretrained_tokenizer():
     test_input_mask = np.array([True, False, True, True, False, True, True, True])
 
     output_masked_text = masker(test_input_mask, test_text)
-    correct_masked_text = "[MASK] ate a [MASK]noli"
+    correct_masked_text = "[MASK]ate a [MASK]noli"
 
     assert output_masked_text[0] == correct_masked_text
 


### PR DESCRIPTION
## Overview

Closes #4526

`transformers` was pinned to `< 4.54.0` in `pyproject.toml` with a TODO comment because upgrading broke 3 tests. I dug into each failure, found the root causes, and fixed them. The pin is now removed and all tests pass on `transformers==5.5.4`.

## What I found and fixed

### 1. `KeyError: 'offset_mapping'` — `shap/maskers/_text.py`

I found that `token_segments()` accesses `token_data["offset_mapping"]` directly, relying on tokenizers raising `NotImplementedError` when they don't support `return_offsets_mapping`. In v5, MarianMT stopped raising and just returns the dict without the key — so the fallback never triggers and it crashes. I fixed it by adding a guard: if `"offset_mapping"` is missing, raise `NotImplementedError` manually to fall through to the existing fallback.

### 2. Stale test expectations — `tests/maskers/test_text.py`

I found that two tests with `use_fast=False` expected leading-space segments (`" I"`, `" ate"`), which was the output of the fallback path in v4 since slow tokenizers didn't support `return_offsets_mapping`. In v5 they do, so the main offset-mapping path runs instead and produces trailing-space segments (`"I "`, `"ate "`), same as fast tokenizers always have. I updated both expected values to reflect the correct new behavior.


## Changes

| File | What changed |
|------|-------------|
| `shap/maskers/_text.py` | Guard for missing `offset_mapping` key |
| `tests/maskers/test_text.py` | Updated 2 expected values |
| `pyproject.toml` | Removed `transformers < 4.54.0` upper pin |


## Checklist

- [x] All pre-commit checks pass
- [x] Existing tests updated to reflect correct new behavior