### PR TITLE
Vendor slicer to unblock Python 3.12+ support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   'pandas',
   'tqdm>=4.27.0',
   'packaging>20.9',
-  'slicer==0.0.8',
   'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',  # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
   'numba; sys_platform != "darwin" or platform_machine != "x86_64"',
   'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"',  # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
@@ -180,7 +179,6 @@ module = [
   "pyspark.*",
   "scipy.*",
   "sklearn.*",
-  "slicer",
   "tensorflow.*",
   "transformers.*",
   "torch.*",
@@ -278,6 +276,7 @@ convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 # Don't apply linting/formatting to vendored code
 "shap/explainers/other/_maple.py" = ["ALL"]
+"shap/utils/_slicer.py" = ["ALL"]
 
 # Ignore notebooks in user_studies, which are not maintained
 "docs/user_studies/*.ipynb" = ["ALL"]

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -13,7 +13,7 @@ import scipy.cluster
 import scipy.sparse
 import scipy.spatial
 import sklearn
-from slicer import Alias, Obj, Slicer
+from .utils._slicer import Alias, Obj, Slicer
 
 from .utils._clustering import hclust_ordering
 from .utils._exceptions import DimensionError

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -164,18 +164,18 @@ class Explanation(metaclass=MetaExplanation):
             if output_names_order == 0:
                 pass
             elif output_names_order == 1:
-                output_names = Obj(output_names, self.output_dims)
+                output_names = Obj(output_names, self.output_dims)  # type: ignore[assignment]
             elif output_names_order == 2:
-                output_names = Obj(output_names, [0] + list(self.output_dims))
+                output_names = Obj(output_names, [0] + list(self.output_dims))  # type: ignore[assignment]
             else:
                 raise ValueError("shap.Explanation does not yet support output_names of order greater than 3!")
 
         if base_values is None or not hasattr(base_values, "__len__") or len(base_values) == 0:
             pass
         elif len(_compute_shape(base_values)) == len(self.output_dims):
-            base_values = Obj(base_values, list(self.output_dims))
+            base_values = Obj(base_values, list(self.output_dims))  # type: ignore[assignment]
         else:
-            base_values = Obj(base_values, [0] + list(self.output_dims))
+            base_values = Obj(base_values, [0] + list(self.output_dims))  # type: ignore[assignment]
 
         self._s = Slicer(
             values=values,

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -145,9 +145,9 @@ class Explanation(metaclass=MetaExplanation):
         if (
             feature_names is not None and len(_compute_shape(feature_names)) == 1
         ):  # TODO: should always be an alias once slicer supports per-row aliases
-            if len(values_shape) >= 2 and len(feature_names) == values_shape[1]:
+            if len(values_shape) >= 2 and len(feature_names) == values_shape[1]:  # type: ignore[arg-type]
                 feature_names = Alias(list(feature_names), 1)  # type: ignore[arg-type]
-            elif len(values_shape) >= 1 and len(feature_names) == values_shape[0]:
+            elif len(values_shape) >= 1 and len(feature_names) == values_shape[0]:  # type: ignore[arg-type]
                 feature_names = Alias(list(feature_names), 0)  # type: ignore[arg-type]
 
         if (

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -13,11 +13,11 @@ import scipy.cluster
 import scipy.sparse
 import scipy.spatial
 import sklearn
-from .utils._slicer import Alias, Obj, Slicer
 
 from .utils._clustering import hclust_ordering
 from .utils._exceptions import DimensionError
 from .utils._general import OpChain
+from .utils._slicer import Alias, Obj, Slicer
 
 op_chain_root = OpChain("shap.Explanation")
 

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -1,0 +1,881 @@
+""" Lower level layer for slicer.
+Mom's spaghetti.
+"""
+# TODO: Consider boolean array indexing.
+
+from typing import Any, AnyStr, Union, List, Tuple
+from abc import abstractmethod
+import numbers
+
+
+class AtomicSlicer:
+    """ Wrapping object that will unify slicing across data structures.
+
+    What we support:
+        Basic indexing (return references):
+        - (start:stop:step) slicing
+        - support ellipses
+        Advanced indexing (return references):
+        - integer array indexing
+
+    Numpy Reference:
+        Basic indexing (return views):
+        - (start:stop:step) slicing
+        - support ellipses and newaxis (alias for None)
+        Advanced indexing (return copy):
+        - integer array indexing, i.e. X[[1,2], [3,4]]
+        - boolean array indexing
+        - mixed array indexing (has integer array, ellipses, newaxis in same slice)
+    """
+
+    def __init__(self, o: Any, max_dim: Union[None, int, AnyStr] = "auto"):
+        """ Provides a consistent slicing API to the object provided.
+
+        Args:
+            o: Object to enable consistent slicing.
+                Currently supports numpy dense arrays, recursive lists ending with list or numpy.
+            max_dim: Max number of dimensions the wrapped object has.
+                If set to "auto", max dimensions will be inferred. This comes at compute cost.
+        """
+        self.o = o
+        self.max_dim = max_dim
+        if self.max_dim == "auto":
+            self.max_dim = UnifiedDataHandler.max_dim(o)
+
+    def __repr__(self) -> AnyStr:
+        """ Override default repr for human readability.
+
+        Returns:
+            String to display.
+        """
+        return f"{self.__class__.__name__}({self.o.__repr__()})"
+
+    def __getitem__(self, item: Any) -> Any:
+        """ Consistent slicing into wrapped object.
+
+        Args:
+            item: Slicing key of type integer or slice.
+
+        Returns:
+            Sliced object.
+
+        Raises:
+            ValueError: If slicing is not compatible with wrapped object.
+        """
+        # Turn item into tuple if not already.
+        index_tup = unify_slice(item, self.max_dim)
+
+        # Slice according to object type.
+        return UnifiedDataHandler.slice(self.o, index_tup, self.max_dim)
+
+
+def unify_slice(item: Any, max_dim: int, alias_lookup=None) -> Tuple:
+    """ Resolves aliases and ellipses in a slice item.
+
+    Args:
+        item: Slicing key that is passed to __getitem__.
+        max_dim: Max dimension of object to be sliced.
+        alias_lookup: AliasLookup structure.
+
+    Returns:
+        A tuple representation of the item.
+    """
+    item = _normalize_slice_key(item)
+    index_tup = _normalize_subkey_types(item)
+    index_tup = _handle_newaxis_ellipses(index_tup, max_dim)
+    if alias_lookup:
+        index_tup = _handle_aliases(index_tup, alias_lookup)
+    return index_tup
+
+
+def _normalize_subkey_types(index_tup: Tuple) -> Tuple:
+    """ Casts subkeys into basic types such as int.
+
+    Args:
+        key: Slicing key that is passed within __getitem__.
+
+    Returns:
+        Tuple with subkeys casted to basic types.
+    """
+    new_index_tup = []  # Gets casted to tuple at the end
+
+    np_int_types = {
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+    }
+    for subkey in index_tup:
+        if _safe_isinstance(subkey, "numpy", np_int_types):
+            new_subkey = int(subkey)
+        elif _safe_isinstance(subkey, "numpy", "ndarray"):
+            if len(subkey.shape) == 1:
+                new_subkey = subkey.tolist()
+            else:
+                raise ValueError(f"Cannot use array of shape {subkey.shape} as subkey.")
+        else:
+            new_subkey = subkey
+
+        new_index_tup.append(new_subkey)
+    return tuple(new_index_tup)
+
+
+def _normalize_slice_key(key: Any) -> Tuple:
+    """ Normalizes slice key into always being a top-level tuple.
+
+    Args:
+        key: Slicing key that is passed within __getitem__.
+
+    Returns:
+        Expanded slice as a tuple.
+    """
+    if not isinstance(key, tuple):
+        return (key,)
+    else:
+        return key
+
+
+def _handle_newaxis_ellipses(index_tup: Tuple, max_dim: int) -> Tuple:
+    """ Expands newaxis and ellipses within a slice for simplification.
+    This code is mostly adapted from: https://github.com/clbarnes/h5py_like/blob/master/h5py_like/shape_utils.py#L111
+
+    Args:
+        index_tup: Slicing key as a tuple.
+        max_dim: Maximum number of dimensions in the respective sliceable object.
+
+    Returns:
+        Expanded slice as a tuple.
+    """
+    non_indexes = (None, Ellipsis)
+    concrete_indices = sum(idx not in non_indexes for idx in index_tup)
+    index_list = []
+    # newaxis_at = []
+    has_ellipsis = False
+    int_count = 0
+    for item in index_tup:
+        if isinstance(item, numbers.Number):
+            int_count += 1
+
+        # NOTE: If we need locations of new axis, re-enable this.
+        if item is None:  # pragma: no cover
+            pass
+            # newaxis_at.append(len(index_list) + len(newaxis_at) - int_count)
+        elif item == Ellipsis:
+            if has_ellipsis:  # pragma: no cover
+                raise IndexError("an index can only have a single ellipsis ('...')")
+            has_ellipsis = True
+            initial_len = len(index_list)
+            while len(index_list) + (concrete_indices - initial_len) < max_dim:
+                index_list.append(slice(None))
+        else:
+            index_list.append(item)
+
+    if len(index_list) > max_dim:  # pragma: no cover
+        raise IndexError("too many indices for array")
+    while len(index_list) < max_dim:
+        index_list.append(slice(None))
+
+    # return index_list, newaxis_at
+    return tuple(index_list)
+
+
+def _handle_aliases(index_tup: Tuple, alias_lookup) -> Tuple:
+    new_index_tup = []
+
+    def resolve(item, dim):
+        if isinstance(item, slice):
+            return item
+        # Replace element if in alias lookup, otherwise use original.
+        item = alias_lookup.get(dim, item, item)
+        return item
+
+    # Go through each element within the index and resolve if needed.
+    for dim, item in enumerate(index_tup):
+        if isinstance(item, list):
+            new_item = []
+            for sub_item in item:
+                new_item.append(resolve(sub_item, dim))
+        else:
+            new_item = resolve(item, dim)
+        new_index_tup.append(new_item)
+
+    return tuple(new_index_tup)
+
+
+class Tracked(AtomicSlicer):
+    """ Tracked defines an object that slicer wraps."""
+
+    def __init__(self, o: Any, dim: Union[int, List, tuple, None, str] = "auto"):
+        """ Defines an object that will be wrapped by slicer.
+
+        Args:
+            o: Object that will be tracked for slicer.
+            dim: Target dimension(s) slicer will index on for this object.
+        """
+        super().__init__(o)
+
+        # Protected attribute that can be overriden.
+        self._name = None
+
+        # Place dim into coordinate form.
+        if dim == "auto":
+            self.dim = list(range(self.max_dim))
+        elif dim is None:
+            self.dim = []
+        elif isinstance(dim, int):
+            self.dim = [dim]
+        elif isinstance(dim, list):
+            self.dim = dim
+        elif isinstance(dim, tuple):
+            self.dim = list(dim)
+        else:  # pragma: no cover
+            raise ValueError(f"Cannot handle dim of type: {type(dim)}")
+
+
+class Obj(Tracked):
+    """ An object that slicer wraps. """
+    def __init__(self, o, dim="auto"):
+        super().__init__(o, dim)
+
+
+class Alias(Tracked):
+    """ Defines a tracked object as well as additional __getitem__ keys. """
+    def __init__(self, o, dim):
+        if not (
+            isinstance(dim, int) or (isinstance(dim, (list, tuple)) and len(dim) <= 1)
+        ):  # pragma: no cover
+            raise ValueError("Aliases must track a single dimension")
+        super().__init__(o, dim)
+
+
+class AliasLookup:
+    def __init__(self, aliases):
+        self._lookup = {}
+
+        # Populate lookup and merge indexes.
+        for _, alias in aliases.items():
+            self.update(alias)
+
+    def update(self, alias):
+        if alias.dim is None or len(alias.dim) == 0:
+            return
+
+        dim = alias.dim[0]
+        if dim not in self._lookup:
+            self._lookup[dim] = {}
+
+        dim_lookup = self._lookup[dim]
+        # NOTE: Alias must be backed by either a list or dictionary.
+        itr = enumerate(alias.o) if isinstance(alias.o, list) else alias.o.items()
+        for i, x in itr:
+            if x not in dim_lookup:
+                dim_lookup[x] = set()
+            dim_lookup[x].add(i)
+
+    def delete(self, alias):
+        '''Delete an alias that exists from lookup'''
+        dim = alias.dim[0]
+        dim_lookup = self._lookup[dim]
+        # NOTE: Alias must be backed by either a list or dictionary.
+        itr = enumerate(alias.o) if isinstance(alias.o, list) else alias.o.items()
+        for i, x in itr:
+            del dim_lookup[x]
+
+    def get(self, dim, target, default=None):
+        if dim not in self._lookup:
+            return default
+
+        indexes = self._lookup[dim].get(target, None)
+        if indexes is None:
+            return default
+
+        if len(indexes) == 1:
+            return next(iter(indexes))
+        else:
+            return list(indexes)
+
+
+def resolve_dim(slicer_index: Tuple, slicer_dim: List) -> List:
+    """ Extracts new dim after applying slicing index and maps it back to the original index list. """
+
+    new_slicer_dim = []
+    reduced_mask = []
+
+    for _, curr_idx in enumerate(slicer_index):
+        if isinstance(curr_idx, (tuple, list, slice)):
+            reduced_mask.append(0)
+        else:
+            reduced_mask.append(1)
+
+    for curr_dim in slicer_dim:
+        if reduced_mask[curr_dim] == 0:
+            new_slicer_dim.append(curr_dim - sum(reduced_mask[:curr_dim]))
+
+    return new_slicer_dim
+
+
+def reduced_o(tracked: Tracked) -> Union[List, Any]:
+    os = [t.o for t in tracked]
+    os = os[0] if len(os) == 1 else os
+    return os
+
+
+class BaseHandler:
+    @classmethod
+    @abstractmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        raise NotImplementedError()  # pragma: no cover
+
+    @classmethod
+    @abstractmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        raise NotImplementedError()  # pragma: no cover
+
+    @classmethod
+    @abstractmethod
+    def max_dim(cls, o):
+        raise NotImplementedError()  # pragma: no cover
+
+    @classmethod
+    def default_alias(cls, o):
+        return []
+
+
+class SeriesHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        head_index = index_tup[0]
+        is_element = True if isinstance(head_index, int) else False
+        sliced_o = o.iloc[head_index]
+
+        return is_element, sliced_o, 1
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        # NOTE: Series only has one dimension,
+        #       call slicer again to end the recursion.
+        return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+
+    @classmethod
+    def max_dim(cls, o):
+        return len(o.shape)
+
+    @classmethod
+    def default_alias(cls, o):
+        index_alias = Alias(o.index.to_list(), 0)
+        index_alias._name = "index"
+        return [index_alias]
+
+
+class DataFrameHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        # NOTE: At head slice, we know there are two fixed dimensions.
+        cut_index = index_tup
+        is_element = True if isinstance(cut_index[-1], int) else False
+        sliced_o = o.iloc[cut_index]
+
+        return is_element, sliced_o, 2
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        # NOTE: Dataframe has fixed dimensions,
+        #       call slicer again to end the recursion.
+        return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+
+    @classmethod
+    def max_dim(cls, o):
+        return len(o.shape)
+
+    @classmethod
+    def default_alias(cls, o):
+        index_alias = Alias(o.index.to_list(), 0)
+        index_alias._name = "index"
+        column_alias = Alias(o.columns.to_list(), 1)
+        column_alias._name = "columns"
+        return [index_alias, column_alias]
+
+
+class ArrayHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        # Check if head is string
+        head_index, tail_index = index_tup[0], index_tup[1:]
+        cut = 1
+
+        for sub_index in tail_index:
+            if isinstance(sub_index, str) or cut == len(o.shape):
+                break
+            cut += 1
+
+        # Process native array dimensions
+        cut_index = index_tup[:cut]
+        is_element = any([True if isinstance(x, int) else False for x in cut_index])
+        sliced_o = o[cut_index]
+
+        return is_element, sliced_o, cut
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        if flatten:
+            # NOTE: If we're dealing with a scipy matrix,
+            #       we have to manually flatten it ourselves
+            #       to keep consistent to the rest of slicer's API.
+            if _safe_isinstance(o, "scipy.sparse.csc", "csc_matrix"):
+                return AtomicSlicer(o.toarray().flatten(), max_dim=max_dim)[tail_index]
+            elif _safe_isinstance(o, "scipy.sparse.csr", "csr_matrix"):
+                return AtomicSlicer(o.toarray().flatten(), max_dim=max_dim)[tail_index]
+            elif _safe_isinstance(o, "scipy.sparse.dok", "dok_matrix"):
+                return AtomicSlicer(o.toarray().flatten(), max_dim=max_dim)[tail_index]
+            elif _safe_isinstance(o, "scipy.sparse.lil", "lil_matrix"):
+                return AtomicSlicer(o.toarray().flatten(), max_dim=max_dim)[tail_index]
+            else:
+                return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+        else:
+            inner = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
+            if _safe_isinstance(o, "numpy", "ndarray"):
+                import numpy
+                if len(inner) > 0 and hasattr(inner[0], "__len__"):
+                    ragged = not all(len(x) == len(inner[0]) for x in inner)
+                else:
+                    ragged = False
+                if ragged:
+                    return numpy.array(inner, dtype=object)
+                else:
+                    return numpy.array(inner)
+            elif _safe_isinstance(o, "torch", "Tensor"):
+                import torch
+
+                if len(inner) > 0 and isinstance(inner[0], torch.Tensor):
+                    return torch.stack(inner)
+                else:
+                    return torch.tensor(inner)
+            elif _safe_isinstance(o, "scipy.sparse.csc", "csc_matrix"):
+                from scipy.sparse import vstack
+                out = vstack(inner, format='csc')
+                return out
+            elif _safe_isinstance(o, "scipy.sparse.csr", "csr_matrix"):
+                from scipy.sparse import vstack
+                out = vstack(inner, format='csr')
+                return out
+            elif _safe_isinstance(o, "scipy.sparse.dok", "dok_matrix"):
+                from scipy.sparse import vstack
+                out = vstack(inner, format='dok')
+                return out
+            elif _safe_isinstance(o, "scipy.sparse.lil", "lil_matrix"):
+                from scipy.sparse import vstack
+                out = vstack(inner, format='lil')
+                return out
+            else:
+                raise ValueError(f"Cannot handle type {type(o)}.")  # pragma: no cover
+
+    @classmethod
+    def max_dim(cls, o):
+        if _safe_isinstance(o, "numpy", "ndarray") and o.dtype == "object":
+            return max([UnifiedDataHandler.max_dim(x) for x in o], default=-1) + 1
+        else:
+            return len(o.shape)
+
+
+class DictHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        head_index = index_tup[0]
+        if isinstance(head_index, (tuple, list)) and len(index_tup) == 0:
+            return False, o, 1
+
+        if isinstance(head_index, (list, tuple)):
+            return (
+                False,
+                {
+                    sub_index: AtomicSlicer(o, max_dim=max_dim)[sub_index]
+                    for sub_index in head_index
+                },
+                1,
+            )
+        elif isinstance(head_index, slice):
+            if head_index == slice(None, None, None):
+                return False, o, 1
+            return False, o[head_index], 1
+        else:
+            return True, o[head_index], 1
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        if flatten:
+            return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+        else:
+            return {
+                k: AtomicSlicer(e, max_dim=max_dim)[tail_index] for k, e in o.items()
+            }
+
+    @classmethod
+    def max_dim(cls, o):
+        return max([UnifiedDataHandler.max_dim(x) for x in o.values()], default=-1) + 1
+
+
+class ListTupleHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        head_index = index_tup[0]
+        if isinstance(head_index, (tuple, list)) and len(index_tup) == 0:
+            return False, o, 1
+
+        if isinstance(head_index, (list, tuple)):
+            if len(head_index) == 0:
+                return False, o, 1
+            else:
+                results = [
+                    AtomicSlicer(o, max_dim=max_dim)[sub_index]
+                    for sub_index in head_index
+                ]
+                results = tuple(results) if isinstance(o, tuple) else results
+                return False, results, 1
+        elif isinstance(head_index, slice):
+            return False, o[head_index], 1
+        elif isinstance(head_index, int):
+            return True, o[head_index], 1
+        else:  # pragma: no cover
+            raise ValueError(f"Invalid key {head_index} for {o}")
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        if flatten:
+            return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+        else:
+            results = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
+            return tuple(results) if isinstance(o, tuple) else results
+
+    @classmethod
+    def max_dim(cls, o):
+        return max([UnifiedDataHandler.max_dim(x) for x in o], default=-1) + 1
+
+
+class UnifiedDataHandler:
+    """ Registry that maps types to their unified slice calls."""
+
+    """ Class attribute that maps type to their unified slice calls."""
+    type_map = {
+        ("builtins", "list"): ListTupleHandler,
+        ("builtins", "tuple"): ListTupleHandler,
+        ("builtins", "dict"): DictHandler,
+        ("torch", "Tensor"): ArrayHandler,
+        ("numpy", "ndarray"): ArrayHandler,
+        ("scipy.sparse.csc", "csc_matrix"): ArrayHandler,
+        ("scipy.sparse.csr", "csr_matrix"): ArrayHandler,
+        ("scipy.sparse.dok", "dok_matrix"): ArrayHandler,
+        ("scipy.sparse.lil", "lil_matrix"): ArrayHandler,
+        ("pandas.core.frame", "DataFrame"): DataFrameHandler,
+        ("pandas.core.series", "Series"): SeriesHandler,
+    }
+
+    @classmethod
+    def slice(cls, o, index_tup, max_dim):
+        # NOTE: Unified handles base cases such as empty tuples, which
+        #       specialized handlers do not.
+        if isinstance(index_tup, (tuple, list)) and len(index_tup) == 0:
+            return o
+
+        # Slice as delegated by data handler.
+        o_type = _type_name(o)
+        head_slice = cls.type_map[o_type].head_slice
+        tail_slice = cls.type_map[o_type].tail_slice
+
+        is_element, sliced_o, cut = head_slice(o, index_tup, max_dim)
+        out = tail_slice(sliced_o, index_tup[cut:], max_dim - cut, is_element)
+        return out
+
+    @classmethod
+    def max_dim(cls, o):
+        o_type = _type_name(o)
+        if o_type not in cls.type_map:
+            return 0
+        return cls.type_map[o_type].max_dim(o)
+
+    @classmethod
+    def default_alias(cls, o):
+        o_type = _type_name(o)
+        if o_type not in cls.type_map:
+            return {}
+        return cls.type_map[o_type].default_alias(o)
+
+
+def _type_name(o: object) -> Tuple[str, str]:
+    return _handle_module_aliases(o.__class__.__module__), o.__class__.__name__
+
+
+def _safe_isinstance(
+    o: object, module_name: str, type_name: Union[str, set, tuple]
+) -> bool:
+    o_module, o_type = _type_name(o)
+    if isinstance(type_name, str):
+        return o_module == module_name and o_type == type_name
+    else:
+        return o_module == module_name and o_type in type_name
+
+
+def _handle_module_aliases(module_name):
+    # scipy modules such as "scipy.sparse.csc" were renamed to "scipy.sparse._csc" in v1.8
+    # Standardise by removing underscores for compatibility with either name
+    # Else just pass module name unchanged
+    module_map = {
+        "scipy.sparse._csc": "scipy.sparse.csc",
+        "scipy.sparse._csr": "scipy.sparse.csr",
+        "scipy.sparse._dok": "scipy.sparse.dok",
+        "scipy.sparse._lil": "scipy.sparse.lil",
+    }
+    return module_map.get(module_name, module_name)
+
+
+class Slicer:
+    """ Provides unified slicing to tensor-like objects. """
+
+    def __init__(self, *args, **kwargs):
+        """ Wraps objects in args and provides unified numpy-like slicing.
+
+        Currently supports (with arbitrary nesting):
+
+        - lists and tuples
+        - dictionaries
+        - numpy arrays
+        - pandas dataframes and series
+        - pytorch tensors
+
+        Args:
+            *args: Unnamed tensor-like objects.
+            **kwargs: Named tensor-like objects.
+
+        Examples:
+
+            Basic anonymous slicing:
+
+            >>> from slicer import Slicer as S
+            >>> li = [[1, 2, 3], [4, 5, 6]]
+            >>> S(li)[:, 0:2].o
+            [[1, 2], [4, 5]]
+            >>> di = {'x': [1, 2, 3], 'y': [4, 5, 6]}
+            >>> S(di)[:, 0:2].o
+            {'x': [1, 2], 'y': [4, 5]}
+
+            Basic named slicing:
+
+            >>> import pandas as pd
+            >>> import numpy as np
+            >>> df = pd.DataFrame({'A': [1, 3], 'B': [2, 4]})
+            >>> ar = np.array([[5, 6], [7, 8]])
+            >>> sliced = S(first=df, second=ar)[0, :]
+            >>> sliced.first
+            A    1
+            B    2
+            Name: 0, dtype: int64
+            >>> sliced.second
+            array([5, 6])
+
+        """
+        self.__class__._init_slicer(self, *args, **kwargs)
+
+    @classmethod
+    def from_slicer(cls, *args, **kwargs):
+        """ Alternative to SUPER SLICE
+        Args:
+            *args:
+            **kwargs:
+
+        Returns:
+
+        """
+        slicer_instance = cls.__new__(cls)
+        cls._init_slicer(slicer_instance, *args, **kwargs)
+        return slicer_instance
+
+    @classmethod
+    def _init_slicer(cls, slicer_instance, *args, **kwargs):
+        # NOTE: Protected attributes.
+        slicer_instance._max_dim = 0
+
+        # NOTE: Private attributes.
+        slicer_instance._anon = []
+        slicer_instance._objects = {}
+        slicer_instance._aliases = {}
+        slicer_instance._alias_lookup = None
+
+        # Go through unnamed objects / aliases
+        slicer_instance.__setattr__("o", args)
+
+        # Go through named objects / aliases
+        for key, value in kwargs.items():
+            slicer_instance.__setattr__(key, value)
+
+        # Generate default aliases only if one object and no aliases exist
+        objects_len = len(slicer_instance._objects)
+        anon_len = len(slicer_instance._anon)
+        aliases_len = len(slicer_instance._aliases)
+        if ((objects_len == 1) ^ (anon_len == 1)) and aliases_len == 0:
+            obj = None
+            for _, t in slicer_instance._iter_tracked():
+                obj = t
+
+            generated_aliases = UnifiedDataHandler.default_alias(obj.o)
+            for generated_alias in generated_aliases:
+                slicer_instance.__setattr__(generated_alias._name, generated_alias)
+
+    def __getitem__(self, item):
+        index_tup = unify_slice(item, self._max_dim, self._alias_lookup)
+        new_args = []
+        new_kwargs = {}
+        for name, tracked in self._iter_tracked(include_aliases=True):
+            if len(tracked.dim) == 0:  # No slice on empty dim
+                new_tracked = tracked
+            else:
+                index_slicer = AtomicSlicer(index_tup, max_dim=1)
+                slicer_index = index_slicer[tracked.dim]
+                sliced_o = tracked[slicer_index]
+                sliced_dim = resolve_dim(index_tup, tracked.dim)
+
+                new_tracked = tracked.__class__(sliced_o, sliced_dim)
+                new_tracked._name = tracked._name
+
+            if name == "o":
+                new_args.append(new_tracked)
+            else:
+                new_kwargs[name] = new_tracked
+
+        return self.__class__.from_slicer(*new_args, **new_kwargs)
+
+    def __getattr__(self, item):
+        """ Override default getattr to return tracked attribute.
+
+        Args:
+            item: Name of tracked attribute.
+        Returns:
+            Corresponding object.
+        """
+        if item.startswith("_"):
+            return super(Slicer, self).__getattr__(item)
+
+        if item == "o":
+            return reduced_o(self._anon)
+        else:
+            tracked = self._objects.get(item, None)
+            if tracked is None:
+                tracked = self._aliases.get(item, None)
+
+            if tracked is None:
+                raise AttributeError(f"Attribute '{item}' does not exist.")
+
+            return tracked.o
+
+    def __setattr__(self, key, value):
+        """ Override default setattr to sync tracking of slicer.
+
+        Args:
+            key: Name of tracked attribute.
+            value: Either an Obj, Alias or Python Object.
+        """
+        if key.startswith("_"):
+            return super(Slicer, self).__setattr__(key, value)
+
+        # Grab previous objects if they exist:
+        old_obj = self._objects.get(key, None)
+        old_alias = self._aliases.get(key, None)
+
+        # For existing attributes, honor Alias status and dimension unless specified otherwise
+        if getattr(self, key, None) is not None and key != "o":
+            if not isinstance(value, Tracked):
+                if old_obj:
+                    value = Obj(value, dim=old_obj.dim)
+                elif old_alias:
+                    value = Alias(value, dim=old_alias.dim)
+
+        if isinstance(value, Alias):
+            value._name = key
+            self._aliases[key] = value
+            
+            if old_obj: # If object previously existed as an object, clean up all references.
+                del self._objects[key]
+
+            # Build lookup (for perf)
+            if self._alias_lookup is None:
+                self._alias_lookup = AliasLookup(self._aliases)
+            else:
+                if old_alias:
+                    self._alias_lookup.delete(old_alias)
+                self._alias_lookup.update(value)
+        else:
+            if key == "o":
+                tracked = [Obj(x) if not isinstance(x, Obj) else x for x in value]
+                self._anon = tracked
+                for t in tracked:
+                    self._update_max_dim(t)
+
+                os = reduced_o(self._anon)
+                super(Slicer, self).__setattr__(key, os)
+            else:
+                if old_alias: # If object previously existed as an alias, clean up all references.
+                    self._alias_lookup.delete(old_alias) 
+                    del self._aliases[key]
+                
+                value = Obj(value) if not isinstance(value, Obj) else value
+                value._name = key
+                self._objects[key] = value
+                self._update_max_dim(value)
+                super(Slicer, self).__setattr__(key, value.o)
+
+    def __delattr__(self, item):
+        """ Override default delattr to remove tracked attribute.
+
+        Args:
+            item: Name of tracked attribute to delete.
+        """
+        if item.startswith("_"):
+            return super(Slicer, self).__delattr__(item)
+
+        # Sync private attributes that help track
+        self._objects.pop(item, None)
+        self._aliases.pop(item, None)
+        if item == "o":
+            self._anon.clear()
+
+        # Recompute max_dim
+        self._recompute_max_dim()
+
+        # Recompute alias lookup
+        # NOTE: This doesn't use diff-style deletes, but we don't care (not a perf target).
+        self._alias_lookup = AliasLookup(self._aliases)
+
+        # TODO: Mutate and check interactively what it does
+        super(Slicer, self).__delattr__(item)
+
+    def __repr__(self):
+        """ Override default repr for human readability.
+
+        Returns:
+            String to display.
+        """
+        orig = self.__dict__
+        di = {}
+        for key, value in orig.items():
+            if not key.startswith("_"):
+                di[key] = value
+        return f"{self.__class__.__name__}({str(di)})"
+
+    def _update_max_dim(self, tracked):
+        self._max_dim = max(self._max_dim, max(tracked.dim, default=-1) + 1)
+
+    def _iter_tracked(self, include_aliases=False):
+        for tracked in self._anon:
+            yield "o", tracked
+        for name, tracked in self._objects.items():
+            yield name, tracked
+        if include_aliases:
+            for name, tracked in self._aliases.items():
+                yield name, tracked
+
+    def _recompute_max_dim(self):
+        self._max_dim = max(
+            [max(o.dim, default=-1) + 1 for _, o in self._iter_tracked()], default=0
+        )

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -6,6 +6,7 @@ Mom's spaghetti.
 from typing import Any, AnyStr, Union, List, Tuple
 from abc import abstractmethod
 import numbers
+from typing import Sequence
 
 
 class AtomicSlicer:
@@ -28,7 +29,7 @@ class AtomicSlicer:
         - mixed array indexing (has integer array, ellipses, newaxis in same slice)
     """
 
-    def __init__(self, o: Any, max_dim: Union[None, int, AnyStr] = "auto"):
+    def __init__(self, o: Any, max_dim: Union[None, int, str] = "auto"):
         """Provides a consistent slicing API to the object provided.
 
         Args:
@@ -38,11 +39,11 @@ class AtomicSlicer:
                 If set to "auto", max dimensions will be inferred. This comes at compute cost.
         """
         self.o = o
-        self.max_dim = max_dim
+        self.max_dim: Union[None, int, str] = max_dim
         if self.max_dim == "auto":
             self.max_dim = UnifiedDataHandler.max_dim(o)
 
-    def __repr__(self) -> AnyStr:
+    def __repr__(self) -> str:
         """Override default repr for human readability.
 
         Returns:
@@ -62,6 +63,8 @@ class AtomicSlicer:
         Raises:
             ValueError: If slicing is not compatible with wrapped object.
         """
+        assert isinstance(self.max_dim, int)
+
         # Turn item into tuple if not already.
         index_tup = unify_slice(item, self.max_dim)
 
@@ -152,7 +155,7 @@ def _handle_newaxis_ellipses(index_tup: Tuple, max_dim: int) -> Tuple:
     """
     non_indexes = (None, Ellipsis)
     concrete_indices = sum(idx not in non_indexes for idx in index_tup)
-    index_list = []
+    index_list: List[Any] = []
     # newaxis_at = []
     has_ellipsis = False
     int_count = 0
@@ -219,10 +222,11 @@ class Tracked(AtomicSlicer):
         super().__init__(o)
 
         # Protected attribute that can be overriden.
-        self._name = None
+        self._name: Union[str, None] = None
 
         # Place dim into coordinate form.
         if dim == "auto":
+            assert isinstance(self.max_dim, int)
             self.dim = list(range(self.max_dim))
         elif dim is None:
             self.dim = []
@@ -318,7 +322,7 @@ def resolve_dim(slicer_index: Tuple, slicer_dim: List) -> List:
     return new_slicer_dim
 
 
-def reduced_o(tracked: Tracked) -> Union[List, Any]:
+def reduced_o(tracked: Sequence[Tracked]) -> Union[List, Any]:
     os = [t.o for t in tracked]
     os = os[0] if len(os) == 1 else os
     return os
@@ -529,9 +533,9 @@ class ListTupleHandler(BaseHandler):
             if len(head_index) == 0:
                 return False, o, 1
             else:
-                results = [AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index]
-                results = tuple(results) if isinstance(o, tuple) else results
-                return False, results, 1
+                list_results: List[Any] = [AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index]
+                final_results = tuple(list_results) if isinstance(o, tuple) else list_results
+                return False, final_results, 1
         elif isinstance(head_index, slice):
             return False, o[head_index], 1
         elif isinstance(head_index, int):
@@ -544,8 +548,8 @@ class ListTupleHandler(BaseHandler):
         if flatten:
             return AtomicSlicer(o, max_dim=max_dim)[tail_index]
         else:
-            results = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
-            return tuple(results) if isinstance(o, tuple) else results
+            list_results = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
+            return tuple(list_results) if isinstance(o, tuple) else list_results
 
     @classmethod
     def max_dim(cls, o):
@@ -628,6 +632,12 @@ def _handle_module_aliases(module_name):
 
 class Slicer:
     """Provides unified slicing to tensor-like objects."""
+
+    _max_dim: int
+    _anon: list[Any]
+    _objects: dict[str, Any]
+    _aliases: dict[str, Any]
+    _alias_lookup: Union["AliasLookup", None]
 
     def __init__(self, *args, **kwargs):
         """Wraps objects in args and provides unified numpy-like slicing.
@@ -713,10 +723,10 @@ class Slicer:
             obj = None
             for _, t in slicer_instance._iter_tracked():
                 obj = t
-
-            generated_aliases = UnifiedDataHandler.default_alias(obj.o)
-            for generated_alias in generated_aliases:
-                slicer_instance.__setattr__(generated_alias._name, generated_alias)
+            if obj is not None:
+                generated_aliases = UnifiedDataHandler.default_alias(obj.o)
+                for generated_alias in generated_aliases:
+                    slicer_instance.__setattr__(generated_alias._name, generated_alias)
 
     def __getitem__(self, item):
         index_tup = unify_slice(item, self._max_dim, self._alias_lookup)
@@ -750,7 +760,7 @@ class Slicer:
             Corresponding object.
         """
         if item.startswith("_"):
-            return super(Slicer, self).__getattr__(item)
+            return super(Slicer, self).__getattribute__(item)
 
         if item == "o":
             return reduced_o(self._anon)
@@ -811,7 +821,8 @@ class Slicer:
                 super(Slicer, self).__setattr__(key, os)
             else:
                 if old_alias:  # If object previously existed as an alias, clean up all references.
-                    self._alias_lookup.delete(old_alias)
+                    if self._alias_lookup is not None:
+                        self._alias_lookup.delete(old_alias)
                     del self._aliases[key]
 
                 value = Obj(value) if not isinstance(value, Obj) else value

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -576,6 +576,8 @@ class UnifiedDataHandler:
 
     @classmethod
     def slice(cls, o, index_tup, max_dim):
+        import numpy as np
+
         # NOTE: Unified handles base cases such as empty tuples, which
         #       specialized handlers do not.
         if isinstance(index_tup, (tuple, list)) and len(index_tup) == 0:
@@ -583,6 +585,18 @@ class UnifiedDataHandler:
 
         # Slice as delegated by data handler.
         o_type = _type_name(o)
+
+        if o_type[0].startswith("scipy.sparse"):
+            return o[index_tup[:2]]
+
+        if not isinstance(o, dict):
+            ndim = getattr(o, "ndim", None)
+            if ndim is None and isinstance(o, (list, tuple)):
+                ndim = np.ndim(o)
+
+            if ndim is not None and isinstance(index_tup, tuple) and len(index_tup) > ndim:
+                index_tup = index_tup[:ndim]
+
         head_slice = cls.type_map[o_type].head_slice
         tail_slice = cls.type_map[o_type].tail_slice
 
@@ -770,6 +784,9 @@ class Slicer:
                 tracked = self._aliases.get(item, None)
 
             if tracked is None:
+                underlying_obj = reduced_o(self._anon)
+                if hasattr(underlying_obj, item):
+                    return getattr(underlying_obj, item)
                 raise AttributeError(f"Attribute '{item}' does not exist.")
 
             return tracked.o

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -1,4 +1,4 @@
-""" Lower level layer for slicer.
+"""Lower level layer for slicer.
 Mom's spaghetti.
 """
 # TODO: Consider boolean array indexing.
@@ -9,7 +9,7 @@ import numbers
 
 
 class AtomicSlicer:
-    """ Wrapping object that will unify slicing across data structures.
+    """Wrapping object that will unify slicing across data structures.
 
     What we support:
         Basic indexing (return references):
@@ -29,7 +29,7 @@ class AtomicSlicer:
     """
 
     def __init__(self, o: Any, max_dim: Union[None, int, AnyStr] = "auto"):
-        """ Provides a consistent slicing API to the object provided.
+        """Provides a consistent slicing API to the object provided.
 
         Args:
             o: Object to enable consistent slicing.
@@ -43,7 +43,7 @@ class AtomicSlicer:
             self.max_dim = UnifiedDataHandler.max_dim(o)
 
     def __repr__(self) -> AnyStr:
-        """ Override default repr for human readability.
+        """Override default repr for human readability.
 
         Returns:
             String to display.
@@ -51,7 +51,7 @@ class AtomicSlicer:
         return f"{self.__class__.__name__}({self.o.__repr__()})"
 
     def __getitem__(self, item: Any) -> Any:
-        """ Consistent slicing into wrapped object.
+        """Consistent slicing into wrapped object.
 
         Args:
             item: Slicing key of type integer or slice.
@@ -70,7 +70,7 @@ class AtomicSlicer:
 
 
 def unify_slice(item: Any, max_dim: int, alias_lookup=None) -> Tuple:
-    """ Resolves aliases and ellipses in a slice item.
+    """Resolves aliases and ellipses in a slice item.
 
     Args:
         item: Slicing key that is passed to __getitem__.
@@ -89,7 +89,7 @@ def unify_slice(item: Any, max_dim: int, alias_lookup=None) -> Tuple:
 
 
 def _normalize_subkey_types(index_tup: Tuple) -> Tuple:
-    """ Casts subkeys into basic types such as int.
+    """Casts subkeys into basic types such as int.
 
     Args:
         key: Slicing key that is passed within __getitem__.
@@ -125,7 +125,7 @@ def _normalize_subkey_types(index_tup: Tuple) -> Tuple:
 
 
 def _normalize_slice_key(key: Any) -> Tuple:
-    """ Normalizes slice key into always being a top-level tuple.
+    """Normalizes slice key into always being a top-level tuple.
 
     Args:
         key: Slicing key that is passed within __getitem__.
@@ -140,7 +140,7 @@ def _normalize_slice_key(key: Any) -> Tuple:
 
 
 def _handle_newaxis_ellipses(index_tup: Tuple, max_dim: int) -> Tuple:
-    """ Expands newaxis and ellipses within a slice for simplification.
+    """Expands newaxis and ellipses within a slice for simplification.
     This code is mostly adapted from: https://github.com/clbarnes/h5py_like/blob/master/h5py_like/shape_utils.py#L111
 
     Args:
@@ -207,10 +207,10 @@ def _handle_aliases(index_tup: Tuple, alias_lookup) -> Tuple:
 
 
 class Tracked(AtomicSlicer):
-    """ Tracked defines an object that slicer wraps."""
+    """Tracked defines an object that slicer wraps."""
 
     def __init__(self, o: Any, dim: Union[int, List, tuple, None, str] = "auto"):
-        """ Defines an object that will be wrapped by slicer.
+        """Defines an object that will be wrapped by slicer.
 
         Args:
             o: Object that will be tracked for slicer.
@@ -237,17 +237,17 @@ class Tracked(AtomicSlicer):
 
 
 class Obj(Tracked):
-    """ An object that slicer wraps. """
+    """An object that slicer wraps."""
+
     def __init__(self, o, dim="auto"):
         super().__init__(o, dim)
 
 
 class Alias(Tracked):
-    """ Defines a tracked object as well as additional __getitem__ keys. """
+    """Defines a tracked object as well as additional __getitem__ keys."""
+
     def __init__(self, o, dim):
-        if not (
-            isinstance(dim, int) or (isinstance(dim, (list, tuple)) and len(dim) <= 1)
-        ):  # pragma: no cover
+        if not (isinstance(dim, int) or (isinstance(dim, (list, tuple)) and len(dim) <= 1)):  # pragma: no cover
             raise ValueError("Aliases must track a single dimension")
         super().__init__(o, dim)
 
@@ -277,7 +277,7 @@ class AliasLookup:
             dim_lookup[x].add(i)
 
     def delete(self, alias):
-        '''Delete an alias that exists from lookup'''
+        """Delete an alias that exists from lookup"""
         dim = alias.dim[0]
         dim_lookup = self._lookup[dim]
         # NOTE: Alias must be backed by either a list or dictionary.
@@ -300,7 +300,7 @@ class AliasLookup:
 
 
 def resolve_dim(slicer_index: Tuple, slicer_dim: List) -> List:
-    """ Extracts new dim after applying slicing index and maps it back to the original index list. """
+    """Extracts new dim after applying slicing index and maps it back to the original index list."""
 
     new_slicer_dim = []
     reduced_mask = []
@@ -439,6 +439,7 @@ class ArrayHandler(BaseHandler):
             inner = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
             if _safe_isinstance(o, "numpy", "ndarray"):
                 import numpy
+
                 if len(inner) > 0 and hasattr(inner[0], "__len__"):
                     ragged = not all(len(x) == len(inner[0]) for x in inner)
                 else:
@@ -456,19 +457,23 @@ class ArrayHandler(BaseHandler):
                     return torch.tensor(inner)
             elif _safe_isinstance(o, "scipy.sparse.csc", "csc_matrix"):
                 from scipy.sparse import vstack
-                out = vstack(inner, format='csc')
+
+                out = vstack(inner, format="csc")
                 return out
             elif _safe_isinstance(o, "scipy.sparse.csr", "csr_matrix"):
                 from scipy.sparse import vstack
-                out = vstack(inner, format='csr')
+
+                out = vstack(inner, format="csr")
                 return out
             elif _safe_isinstance(o, "scipy.sparse.dok", "dok_matrix"):
                 from scipy.sparse import vstack
-                out = vstack(inner, format='dok')
+
+                out = vstack(inner, format="dok")
                 return out
             elif _safe_isinstance(o, "scipy.sparse.lil", "lil_matrix"):
                 from scipy.sparse import vstack
-                out = vstack(inner, format='lil')
+
+                out = vstack(inner, format="lil")
                 return out
             else:
                 raise ValueError(f"Cannot handle type {type(o)}.")  # pragma: no cover
@@ -491,10 +496,7 @@ class DictHandler(BaseHandler):
         if isinstance(head_index, (list, tuple)):
             return (
                 False,
-                {
-                    sub_index: AtomicSlicer(o, max_dim=max_dim)[sub_index]
-                    for sub_index in head_index
-                },
+                {sub_index: AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index},
                 1,
             )
         elif isinstance(head_index, slice):
@@ -509,9 +511,7 @@ class DictHandler(BaseHandler):
         if flatten:
             return AtomicSlicer(o, max_dim=max_dim)[tail_index]
         else:
-            return {
-                k: AtomicSlicer(e, max_dim=max_dim)[tail_index] for k, e in o.items()
-            }
+            return {k: AtomicSlicer(e, max_dim=max_dim)[tail_index] for k, e in o.items()}
 
     @classmethod
     def max_dim(cls, o):
@@ -529,10 +529,7 @@ class ListTupleHandler(BaseHandler):
             if len(head_index) == 0:
                 return False, o, 1
             else:
-                results = [
-                    AtomicSlicer(o, max_dim=max_dim)[sub_index]
-                    for sub_index in head_index
-                ]
+                results = [AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index]
                 results = tuple(results) if isinstance(o, tuple) else results
                 return False, results, 1
         elif isinstance(head_index, slice):
@@ -556,7 +553,7 @@ class ListTupleHandler(BaseHandler):
 
 
 class UnifiedDataHandler:
-    """ Registry that maps types to their unified slice calls."""
+    """Registry that maps types to their unified slice calls."""
 
     """ Class attribute that maps type to their unified slice calls."""
     type_map = {
@@ -608,9 +605,7 @@ def _type_name(o: object) -> Tuple[str, str]:
     return _handle_module_aliases(o.__class__.__module__), o.__class__.__name__
 
 
-def _safe_isinstance(
-    o: object, module_name: str, type_name: Union[str, set, tuple]
-) -> bool:
+def _safe_isinstance(o: object, module_name: str, type_name: Union[str, set, tuple]) -> bool:
     o_module, o_type = _type_name(o)
     if isinstance(type_name, str):
         return o_module == module_name and o_type == type_name
@@ -632,10 +627,10 @@ def _handle_module_aliases(module_name):
 
 
 class Slicer:
-    """ Provides unified slicing to tensor-like objects. """
+    """Provides unified slicing to tensor-like objects."""
 
     def __init__(self, *args, **kwargs):
-        """ Wraps objects in args and provides unified numpy-like slicing.
+        """Wraps objects in args and provides unified numpy-like slicing.
 
         Currently supports (with arbitrary nesting):
 
@@ -680,7 +675,7 @@ class Slicer:
 
     @classmethod
     def from_slicer(cls, *args, **kwargs):
-        """ Alternative to SUPER SLICE
+        """Alternative to SUPER SLICE
         Args:
             *args:
             **kwargs:
@@ -747,7 +742,7 @@ class Slicer:
         return self.__class__.from_slicer(*new_args, **new_kwargs)
 
     def __getattr__(self, item):
-        """ Override default getattr to return tracked attribute.
+        """Override default getattr to return tracked attribute.
 
         Args:
             item: Name of tracked attribute.
@@ -770,7 +765,7 @@ class Slicer:
             return tracked.o
 
     def __setattr__(self, key, value):
-        """ Override default setattr to sync tracking of slicer.
+        """Override default setattr to sync tracking of slicer.
 
         Args:
             key: Name of tracked attribute.
@@ -794,8 +789,8 @@ class Slicer:
         if isinstance(value, Alias):
             value._name = key
             self._aliases[key] = value
-            
-            if old_obj: # If object previously existed as an object, clean up all references.
+
+            if old_obj:  # If object previously existed as an object, clean up all references.
                 del self._objects[key]
 
             # Build lookup (for perf)
@@ -815,10 +810,10 @@ class Slicer:
                 os = reduced_o(self._anon)
                 super(Slicer, self).__setattr__(key, os)
             else:
-                if old_alias: # If object previously existed as an alias, clean up all references.
-                    self._alias_lookup.delete(old_alias) 
+                if old_alias:  # If object previously existed as an alias, clean up all references.
+                    self._alias_lookup.delete(old_alias)
                     del self._aliases[key]
-                
+
                 value = Obj(value) if not isinstance(value, Obj) else value
                 value._name = key
                 self._objects[key] = value
@@ -826,7 +821,7 @@ class Slicer:
                 super(Slicer, self).__setattr__(key, value.o)
 
     def __delattr__(self, item):
-        """ Override default delattr to remove tracked attribute.
+        """Override default delattr to remove tracked attribute.
 
         Args:
             item: Name of tracked attribute to delete.
@@ -851,7 +846,7 @@ class Slicer:
         super(Slicer, self).__delattr__(item)
 
     def __repr__(self):
-        """ Override default repr for human readability.
+        """Override default repr for human readability.
 
         Returns:
             String to display.
@@ -876,6 +871,4 @@ class Slicer:
                 yield name, tracked
 
     def _recompute_max_dim(self):
-        self._max_dim = max(
-            [max(o.dim, default=-1) + 1 for _, o in self._iter_tracked()], default=0
-        )
+        self._max_dim = max([max(o.dim, default=-1) + 1 for _, o in self._iter_tracked()], default=0)

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -20,12 +20,18 @@ def coerced(o: Any):
     if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
         o = o.toarray()
 
-    import torch
+    to_list_types = [np.ndarray, pd.core.series.Series]
 
-    to_list_collections = tuple([np.ndarray, torch.Tensor, pd.core.series.Series])
+    try:
+        import torch
+
+        to_list_types.append(torch.Tensor)
+    except ImportError:
+        pass
+
     if isinstance(o, (list, tuple)):
         return o
-    elif isinstance(o, to_list_collections):
+    elif isinstance(o, tuple(to_list_types)):
         return o.tolist()
     elif isinstance(o, pd.core.frame.DataFrame):
         return o.values.tolist()
@@ -44,12 +50,15 @@ def is_close(a: int | float, b: int | float, rel_tol: float = 1e-09, abs_tol: fl
 
 def ctr_eq(c1: Any, c2: Any):
 
-    import torch
+    try:
+        import torch
 
-    if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
-        c1 = c1.item()
-    if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
-        c2 = c2.item()
+        if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
+            c1 = c1.item()
+        if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
+            c2 = c2.item()
+    except ImportError:
+        pass
 
     if isinstance(c1, (int, float, np.number)) and isinstance(c2, (int, float, np.number)):
         return is_close(c1, c2)  # type: ignore[arg-type]
@@ -370,7 +379,7 @@ def test_tracked_dim_arg_smoke():
 
 
 def test_operations_1d():
-    import torch
+    torch = pytest.importorskip("torch")
 
     elements = [1, 2, 3, 4]
     li = elements
@@ -440,7 +449,7 @@ def test_operations_2d():
 
 def test_operations_3d():
     # 3-dimensional fixed dimension case
-    import torch
+    torch = pytest.importorskip("torch")
 
     elements = [
         [[1, 2, 3], [4, 5, 6]],

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -1,20 +1,21 @@
-""" Basic tests for slicer.
+"""Basic tests for slicer.
 An unholy balance of use cases and test coverage.
 """
 
-from typing import Any
 import numbers
-import pytest
+from typing import Any
+
 import numpy as np
 import pandas as pd
+import pytest
 import torch
 from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, lil_matrix
 
-from shap.utils._slicer import AtomicSlicer
-from shap.utils._slicer import Slicer as S
 from shap.utils._slicer import Alias as A
+from shap.utils._slicer import AtomicSlicer, _handle_newaxis_ellipses
 from shap.utils._slicer import Obj as O
-from shap.utils._slicer import _handle_newaxis_ellipses
+from shap.utils._slicer import Slicer as S
+
 
 def coerced(o: Any):
     if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
@@ -35,10 +36,10 @@ def coerced(o: Any):
     else:
         raise ValueError(f"Object {o} of {type(o)} is not a list, tuple nor array.")
 
-def is_close(
-    a: numbers.Number, b: numbers.Number, rel_tol: float = 1e-09, abs_tol: float = 0.0
-):
+
+def is_close(a: numbers.Number, b: numbers.Number, rel_tol: float = 1e-09, abs_tol: float = 0.0):
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
 
 def ctr_eq(c1: Any, c2: Any):
     if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
@@ -56,13 +57,12 @@ def ctr_eq(c1: Any, c2: Any):
 
 
 def test_slicer_ragged_numpy():
-    values = np.array([
-        np.array([0, 1]),
-        np.array([2, 3, 4])
-    ], dtype=object)
-    data = np.array([
-        np.array([5, 6, 7]),
-    ])
+    values = np.array([np.array([0, 1]), np.array([2, 3, 4])], dtype=object)
+    data = np.array(
+        [
+            np.array([5, 6, 7]),
+        ]
+    )
 
     slicer = S(values=values, data=data)
     sliced = slicer[0, 1]
@@ -337,17 +337,16 @@ def test_slicer_pandas():
 
 
 def test_handle_newaxis_ellipses():
-    from shap.utils._slicer import _handle_newaxis_ellipses
 
     index_tup = (1,)
     max_dim = 3
 
     expanded_index_tup = _handle_newaxis_ellipses(index_tup, max_dim)
     assert expanded_index_tup == (1, slice(None), slice(None))
-    
-    
+
+
 def test_tracked_dim_arg_smoke():
-    li = ['A', 'B']
+    li = ["A", "B"]
     _ = A(li, dim=0)
     _ = A(li, dim=[0])
     _ = A(li, dim=(0,))
@@ -357,7 +356,7 @@ def test_tracked_dim_arg_smoke():
         _ = A(li, dim=None)
 
     with pytest.raises(Exception):
-        _ = A(li, dim=[0,1])
+        _ = A(li, dim=[0, 1])
 
     _ = O(li, dim=0)
     _ = O(li, dim=[0])
@@ -499,9 +498,8 @@ def test_operations_3d():
                 cols.append(elements[i][j][1])
             rows.append(cols)
         assert ctr_eq(slicer[..., 1], rows)
-        assert ctr_eq(
-            slicer[0, ..., 1], [elements[0][i][1] for i in range(len(elements[0]))]
-        )
+        assert ctr_eq(slicer[0, ..., 1], [elements[0][i][1] for i in range(len(elements[0]))])
+
 
 def test_attribute_assignment():
     data = [[1, 2], [3, 4]]
@@ -520,15 +518,15 @@ def test_attribute_assignment():
         full_name=full_name,
     )
 
-    exp.feature_names = ['f3', 'f4']
+    exp.feature_names = ["f3", "f4"]
 
-    assert exp.feature_names == ['f3', 'f4']
-    assert exp[:, 0].feature_names == 'f3'
-    
+    assert exp.feature_names == ["f3", "f4"]
+    assert exp[:, 0].feature_names == "f3"
+
     with pytest.raises(Exception):
-        _ = exp[:, 'f1'] # f1 should no longer exist as valid alias
+        _ = exp[:, "f1"]  # f1 should no longer exist as valid alias
 
-    exp.feature_names = A(['f5', 'f6'], dim=0)
+    exp.feature_names = A(["f5", "f6"], dim=0)
 
-    assert exp.feature_names == ['f5', 'f6']
-    assert exp[1, :].feature_names == 'f6' # feature_names now tracks dim 0
+    assert exp.feature_names == ["f5", "f6"]
+    assert exp[1, :].feature_names == "f6"  # feature_names now tracks dim 0

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -7,7 +7,6 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
-import torch
 from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, lil_matrix
 
 from shap.utils._slicer import Alias as A
@@ -17,8 +16,11 @@ from shap.utils._slicer import Slicer as S
 
 
 def coerced(o: Any):
+
     if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
         o = o.toarray()
+
+    import torch
 
     to_list_collections = tuple([np.ndarray, torch.Tensor, pd.core.series.Series])
     if isinstance(o, (list, tuple)):
@@ -41,6 +43,9 @@ def is_close(a: int | float, b: int | float, rel_tol: float = 1e-09, abs_tol: fl
 
 
 def ctr_eq(c1: Any, c2: Any):
+
+    import torch
+
     if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
         c1 = c1.item()
     if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
@@ -365,6 +370,8 @@ def test_tracked_dim_arg_smoke():
 
 
 def test_operations_1d():
+    import torch
+
     elements = [1, 2, 3, 4]
     li = elements
     tup = tuple(elements)
@@ -433,6 +440,8 @@ def test_operations_2d():
 
 def test_operations_3d():
     # 3-dimensional fixed dimension case
+    import torch
+
     elements = [
         [[1, 2, 3], [4, 5, 6]],
         [[7, 8, 9], [10, 11, 12]],

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -2,7 +2,6 @@
 An unholy balance of use cases and test coverage.
 """
 
-import numbers
 from typing import Any
 
 import numpy as np
@@ -37,7 +36,7 @@ def coerced(o: Any):
         raise ValueError(f"Object {o} of {type(o)} is not a list, tuple nor array.")
 
 
-def is_close(a: numbers.Number, b: numbers.Number, rel_tol: float = 1e-09, abs_tol: float = 0.0):
+def is_close(a: int | float, b: int | float, rel_tol: float = 1e-09, abs_tol: float = 0.0):
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
@@ -47,8 +46,8 @@ def ctr_eq(c1: Any, c2: Any):
     if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
         c2 = c2.item()
 
-    if isinstance(c1, numbers.Number) and isinstance(c2, numbers.Number):
-        return is_close(c1, c2)
+    if isinstance(c1, (int, float, np.number)) and isinstance(c2, (int, float, np.number)):
+        return is_close(c1, c2)  # type: ignore[arg-type]
 
     c1 = coerced(c1)
     c2 = coerced(c2)
@@ -242,12 +241,12 @@ def test_numpy_subkeys():
     subkey = np.int64(1)
     assert slicer[subkey].data == 2
 
-    subkey = np.array([0, 1])
-    assert ctr_eq(slicer[subkey].data, [1, 2])
+    subkey_arr_1d = np.array([0, 1])
+    assert ctr_eq(slicer[subkey_arr_1d].data, [1, 2])
 
-    subkey = np.array([[0, 1], [3, 4]])
+    subkey_arr_2d = np.array([[0, 1], [3, 4]])
     with pytest.raises(ValueError):
-        _ = slicer[subkey]
+        _ = slicer[subkey_arr_2d]
 
 
 def test_repr_smoke():

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -317,7 +317,7 @@ def test_slicer_sparse():
 
 
 def test_slicer_torch():
-    import torch
+    torch = pytest.importorskip("torch")
 
     data = torch.tensor([[1, 2], [3, 4]])
     values = torch.tensor([[5, 6], [7, 8]])

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -1,0 +1,534 @@
+""" Basic tests for slicer.
+An unholy balance of use cases and test coverage.
+"""
+
+from typing import Any
+import numbers
+import pytest
+import numpy as np
+import pandas as pd
+import torch
+from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, lil_matrix
+
+from shap.utils._slicer import AtomicSlicer
+from shap.utils._slicer import Slicer as S
+from shap.utils._slicer import Alias as A
+from shap.utils._slicer import Obj as O
+from shap.utils._slicer import _handle_newaxis_ellipses
+
+def coerced(o: Any):
+    if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
+        o = o.toarray()
+
+    to_list_collections = tuple([np.ndarray, torch.Tensor, pd.core.series.Series])
+    if isinstance(o, (list, tuple)):
+        return o
+    elif isinstance(o, to_list_collections):
+        return o.tolist()
+    elif isinstance(o, pd.core.frame.DataFrame):
+        return o.values.tolist()
+    elif isinstance(o, dict):
+        li = [np.nan] * len(o)
+        for k, v in o.items():
+            li[k] = v
+        return li
+    else:
+        raise ValueError(f"Object {o} of {type(o)} is not a list, tuple nor array.")
+
+def is_close(
+    a: numbers.Number, b: numbers.Number, rel_tol: float = 1e-09, abs_tol: float = 0.0
+):
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+def ctr_eq(c1: Any, c2: Any):
+    if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
+        c1 = c1.item()
+    if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
+        c2 = c2.item()
+
+    if isinstance(c1, numbers.Number) and isinstance(c2, numbers.Number):
+        return is_close(c1, c2)
+
+    c1 = coerced(c1)
+    c2 = coerced(c2)
+
+    return all([ctr_eq(c1[i], c2[i]) for i in range(max(len(c1), len(c2)))])
+
+
+def test_slicer_ragged_numpy():
+    values = np.array([
+        np.array([0, 1]),
+        np.array([2, 3, 4])
+    ], dtype=object)
+    data = np.array([
+        np.array([5, 6, 7]),
+    ])
+
+    slicer = S(values=values, data=data)
+    sliced = slicer[0, 1]
+
+    assert ctr_eq(sliced.data, data[0][1])
+    assert ctr_eq(sliced.values, values[0][1])
+
+
+def test_slicer_basic():
+    data = [[1, 2], [3, 4]]
+    values = [[5, 6], [7, 8]]
+    identifiers = ["id1", "id1"]
+    instance_names = ["r1", "r2"]
+    feature_names = ["f1", "f2"]
+    full_name = "A"
+
+    slicer = S(
+        data=data,
+        values=values,
+        identifiers=A(identifiers, 0),
+        instance_names=A(instance_names, 0),
+        feature_names=A(feature_names, 1),
+        full_name=full_name,
+    )
+
+    colon_actual = slicer[:, 1]
+    assert colon_actual.data == [2, 4]
+    assert colon_actual.instance_names == ["r1", "r2"]
+    assert colon_actual.feature_names == "f2"
+    assert colon_actual.values == [6, 8]
+
+    ellipses_actual = slicer[..., 1]
+    assert ellipses_actual.data == [2, 4]
+    assert ellipses_actual.instance_names == ["r1", "r2"]
+    assert ellipses_actual.feature_names == "f2"
+    assert ellipses_actual.values == [6, 8]
+
+    array_index_actual = slicer[[0, 1], 1]
+    assert array_index_actual.data == [2, 4]
+    assert array_index_actual.feature_names == "f2"
+    assert array_index_actual.instance_names == ["r1", "r2"]
+    assert array_index_actual.values == [6, 8]
+
+    alias_actual = slicer["r1", "f2"]
+    assert alias_actual.data == 2
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == "r1"
+    assert alias_actual.values == 6
+
+    alias_actual = slicer["id1", "f2"]
+    assert alias_actual.data == [2, 4]
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == ["r1", "r2"]
+    assert alias_actual.values == [6, 8]
+
+    chained_actual = slicer[:][:, 1]
+    assert chained_actual.data == [2, 4]
+    assert chained_actual.feature_names == "f2"
+    assert chained_actual.instance_names == ["r1", "r2"]
+    assert chained_actual.values == [6, 8]
+
+    alias_actual = slicer["id1"][:, "f2"]
+    assert alias_actual.data == [2, 4]
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == ["r1", "r2"]
+    assert alias_actual.values == [6, 8]
+
+    alias_actual = slicer["r1"]
+    alias_actual = alias_actual["f2"]
+    assert alias_actual.data == 2
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == "r1"
+    assert alias_actual.values == 6
+
+
+def test_slicer_unnamed():
+    a = [1, 2, 3]
+    b = [4, 5, 6]
+
+    slicer = S(a, b)
+    actual_a, actual_b = slicer[1].o
+    assert actual_a == 2
+    assert actual_b == 5
+
+    df1 = pd.DataFrame([[1, 2], [3, 4]])
+    df2 = pd.DataFrame([[5, 6], [7, 8]])
+    slicer = S(df1, df2)
+    actual_1, actual_2 = slicer[:, 0].o
+
+    assert ctr_eq(actual_1.values, [1, 3])
+    assert ctr_eq(actual_2.values, [5, 7])
+
+
+def test_slicer_crud():
+    data = [[1, 2], [3, 4]]
+    values = [[5, 6], [7, 8]]
+    extra = [[9, 10], [11, 12]]
+    overridden = [[13, 14], [15, 16]]
+
+    slicer = S(data=data, values=values)
+    slicer.extra = extra  # Create
+    slicer.data = overridden  # Update
+    del slicer.values  # Delete
+
+    sliced = slicer[0, 1]  # Read
+    assert sliced.data == 14
+    with pytest.raises(Exception):
+        _ = sliced.values
+
+    assert sliced.extra == 10
+
+    del slicer.o
+    assert slicer.o == []
+
+
+def test_slicer_default_alias():
+
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+    slicer = S(df)
+    assert getattr(slicer, "index", None)
+    assert getattr(slicer, "columns", None)
+    actual = slicer[:, "A"].o
+    assert ctr_eq(actual, [1, 3])
+
+
+def test_slicer_anon_dict():
+    di = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    slicer = S(di)
+
+    result = slicer["a", 1].o
+    assert result == 2
+
+
+def test_slicer_3d():
+    data_2d = [[1, 2], [3, 4], [5, 6]]
+    values_3d = [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[13, 14, 15], [16, 17, 18]],
+    ]
+    names = ["a", "b", "c"]
+
+    slicer = S(data=data_2d, values=values_3d, names=A(names, 2))
+    actual = slicer[..., 1]
+    assert ctr_eq(actual.data, data_2d)
+    assert actual.names == "b"
+
+    actual = slicer[0, :, 1]
+    assert ctr_eq(actual.data, data_2d[0])
+    assert actual.names == "b"
+
+    actual = slicer[0, :][:, 1]
+    assert ctr_eq(actual.data, data_2d[0])
+    assert actual.names == "b"
+
+
+def test_untracked():
+    data = [1, 2, 3, 4]
+    primitive = 1
+    collection = [[8, 9]]
+    slicer = S(data=data, primitive=O(primitive, None), collection=O(collection, None))
+    actual = slicer[:2]
+    assert actual.data == data[:2]
+    assert actual.primitive == primitive
+    assert ctr_eq(actual.collection, collection)
+
+
+def test_partial_untracked():
+    s = S(a=np.zeros((4, 5, 6)), b=O(np.ones((4, 2, 2)), [0]))
+    assert s[:, :, 1].b.shape == (4, 2, 2)
+
+
+def test_numpy_subkeys():
+    data = [1, 2, 3, 4]
+    slicer = S(data=data)
+
+    subkey = np.int64(1)
+    assert slicer[subkey].data == 2
+
+    subkey = np.array([0, 1])
+    assert ctr_eq(slicer[subkey].data, [1, 2])
+
+    subkey = np.array([[0, 1], [3, 4]])
+    with pytest.raises(ValueError):
+        _ = slicer[subkey]
+
+
+def test_repr_smoke():
+    slicer = S([1, 2], ["a", "b"], named=[3, 4])
+    print(slicer)
+
+    atomic = AtomicSlicer([1, 2, 3, 4])
+    print(atomic)
+
+
+def test_slicer_simple_di():
+    di = {"A": [1, 2], "B": [3, 4], "C": [5, 6]}
+    slicer = S(di)
+    actual = slicer["B", 0]
+    actual = actual.o
+    assert ctr_eq(actual, 3)
+
+    nested_di = {"X": di, "Y": di}
+    actual = S(nested_di)["X", "B", 0].o
+    assert ctr_eq(actual, 3)
+
+
+def test_slicer_sparse():
+    array = np.array([[1, 0, 4], [0, 0, 5], [2, 3, 6]])
+    csc_array = csc_matrix(array)
+    csr_array = csr_matrix(array)
+    dok_array = dok_matrix(array)
+    lil_array = lil_matrix(array)
+
+    candidates = [csc_array, csr_array, dok_array, lil_array]
+    for candidate in candidates:
+        print("testing:", type(candidate))
+        slicer = S(candidate)
+        actual = slicer[0, 0]
+        assert ctr_eq(actual.o, 1)
+        actual = slicer[1, 1]
+        assert ctr_eq(actual.o, 0)
+
+        actual = slicer[0]
+        expected = np.array([1, 0, 4])
+        assert ctr_eq(actual.o, expected)
+
+        actual = slicer[:, 1]
+        expected = np.array([0, 0, 3])
+        assert ctr_eq(actual.o, expected)
+
+        actual = slicer[:, :]
+        expected = np.array([[1, 0, 4], [0, 0, 5], [2, 3, 6]])
+        assert ctr_eq(actual.o, expected)
+
+        actual = slicer[0, :]
+        expected = np.array([1, 0, 4])
+        assert ctr_eq(actual.o, expected)
+
+
+def test_slicer_torch():
+    import torch
+
+    data = torch.tensor([[1, 2], [3, 4]])
+    values = torch.tensor([[5, 6], [7, 8]])
+    alias = ["f1", "f2"]
+
+    slicer = S(data=data, values=values, alias=A(alias, 1))
+    sliced = slicer[0, "f2"]
+    assert sliced.data == 2
+    assert sliced.values == 6
+
+
+def test_slicer_pandas():
+    di = {"A": [1, 2], "B": [3, 4], "C": [5, 6]}
+    df = pd.DataFrame(di)
+
+    slicer = S(df)
+    assert slicer[0, "A"].o == 1
+    assert ctr_eq(slicer[:, "A"].o, [1, 2])
+    assert ctr_eq(slicer[0, :].o, [1, 3, 5])
+
+    df = pd.DataFrame(di, index=["X", "Y"])
+    slicer = S(df)
+    assert slicer["X", "A"].o == 1
+    assert slicer[0, "A"].o == 1
+    assert slicer[0, 0].o == 1
+    slicer = S(df["A"])
+    assert slicer["X"].o == 1
+    assert slicer[0].o == 1
+    assert ctr_eq(slicer[:].o, [1, 2])
+
+
+def test_handle_newaxis_ellipses():
+    from shap.utils._slicer import _handle_newaxis_ellipses
+
+    index_tup = (1,)
+    max_dim = 3
+
+    expanded_index_tup = _handle_newaxis_ellipses(index_tup, max_dim)
+    assert expanded_index_tup == (1, slice(None), slice(None))
+    
+    
+def test_tracked_dim_arg_smoke():
+    li = ['A', 'B']
+    _ = A(li, dim=0)
+    _ = A(li, dim=[0])
+    _ = A(li, dim=(0,))
+
+    # Aliases must have a single dim
+    with pytest.raises(Exception):
+        _ = A(li, dim=None)
+
+    with pytest.raises(Exception):
+        _ = A(li, dim=[0,1])
+
+    _ = O(li, dim=0)
+    _ = O(li, dim=[0])
+    _ = O(li, dim=(0,))
+
+    assert True
+
+
+def test_operations_1d():
+    elements = [1, 2, 3, 4]
+    li = elements
+    tup = tuple(elements)
+    di = {i: x for i, x in enumerate(elements)}
+    series = pd.Series(elements)
+    array = np.array(elements)
+    torch_array = torch.tensor(elements)
+    containers = [li, tup, array, torch_array, di, series]
+    for ctr in containers:
+        print("testing:", type(ctr))
+        slicer = AtomicSlicer(ctr)
+
+        assert ctr_eq(slicer[0], elements[0])
+
+        # Array
+        assert ctr_eq(slicer[[0, 1, 2, 3]], elements)
+        assert ctr_eq(slicer[[0, 1, 2]], elements[:-1])
+
+        # All
+        assert ctr_eq(slicer[:], elements[:])
+        assert ctr_eq(slicer[tuple()], elements)
+
+        # Ranged slicing
+        if not isinstance(ctr, dict):  # Do not test on dictionaries.
+            assert ctr_eq(slicer[-1], elements[-1])
+            assert ctr_eq(slicer[0:3:2], elements[0:3:2])
+
+
+def test_operations_2d():
+    elements = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    li = elements
+    df = pd.DataFrame(elements, columns=["A", "B", "C"])
+
+    sparse_csc = csc_matrix(elements)
+    sparse_csr = csr_matrix(elements)
+    sparse_dok = dok_matrix(elements)
+    sparse_lil = lil_matrix(elements)
+
+    containers = [li, df, sparse_csc, sparse_csr, sparse_dok, sparse_lil]
+    for ctr in containers:
+        print("testing:", type(ctr))
+        slicer = AtomicSlicer(ctr)
+
+        assert ctr_eq(slicer[0], elements[0])
+
+        # Ranged slicing
+        if not isinstance(ctr, dict):
+            assert ctr_eq(slicer[-1], elements[-1])
+            assert ctr_eq(slicer[0, 0:3:2], elements[0][0:3:2])
+
+        # Array
+        assert ctr_eq(slicer[[0, 1, 2], :], elements)
+
+        # All
+        assert ctr_eq(slicer[:], elements)
+        assert ctr_eq(slicer[tuple()], elements)
+
+        assert ctr_eq(slicer[:, 0], [elements[i][0] for i, _ in enumerate(elements)])
+        assert ctr_eq(slicer[[0, 1], 0], [elements[i][0] for i in [0, 1]])
+        assert ctr_eq(slicer[[0, 1], 1], [elements[i][1] for i in [0, 1]])
+        assert ctr_eq(slicer[0, :], elements[0])
+        assert ctr_eq(slicer[0, 1], elements[0][1])
+
+        assert ctr_eq(slicer[..., 0], [elements[i][0] for i, _ in enumerate(elements)])
+
+
+def test_operations_3d():
+    # 3-dimensional fixed dimension case
+    elements = [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[13, 14, 15], [16, 17, 18]],
+    ]
+    tuple_elements = (
+        ((1, 2, 3), (4, 5, 6)),
+        ((7, 8, 9), (10, 11, 12)),
+        ((13, 14, 15), (16, 17, 18)),
+    )
+    torch_array = torch.tensor(elements)
+    multi_array = np.array(elements)
+    list_of_lists = elements
+    tuples_of_tuples = tuple_elements
+    list_of_multi_arrays = [
+        np.array(elements[0]),
+        np.array(elements[1]),
+        np.array(elements[2]),
+    ]
+    di_of_multi_arrays = {
+        0: np.array(elements[0]),
+        1: np.array(elements[1]),
+        2: np.array(elements[2]),
+    }
+
+    containers = [
+        torch_array,
+        multi_array,
+        tuples_of_tuples,
+        list_of_lists,
+        list_of_multi_arrays,
+        di_of_multi_arrays,
+    ]
+    for ctr in containers:
+        print("testing:", type(ctr))
+        slicer = AtomicSlicer(ctr)
+
+        assert ctr_eq(slicer[0], elements[0])
+
+        # Ranged slicing
+        if not isinstance(ctr, dict):
+            assert ctr_eq(slicer[-1], elements[-1])
+            assert ctr_eq(slicer[0, 0:3:2], elements[0][0:3:2])
+
+        # Array
+        assert ctr_eq(slicer[[0, 1, 2], :], elements)
+
+        # All
+        assert ctr_eq(slicer[:], elements)
+        assert ctr_eq(slicer[tuple()], elements)
+
+        assert ctr_eq(slicer[:, 0], [elements[i][0] for i, _ in enumerate(elements)])
+        assert ctr_eq(slicer[[0, 1], 0], [elements[i][0] for i in [0, 1]])
+        assert ctr_eq(slicer[[0, 1], 1], [elements[i][1] for i in [0, 1]])
+        assert ctr_eq(slicer[0, :], elements[0])
+        assert ctr_eq(slicer[0, 1], elements[0][1])
+
+        rows = []
+        for i, _ in enumerate(elements):
+            cols = []
+            for j, _ in enumerate(elements[i]):
+                cols.append(elements[i][j][1])
+            rows.append(cols)
+        assert ctr_eq(slicer[..., 1], rows)
+        assert ctr_eq(
+            slicer[0, ..., 1], [elements[0][i][1] for i in range(len(elements[0]))]
+        )
+
+def test_attribute_assignment():
+    data = [[1, 2], [3, 4]]
+    values = [[5, 6], [7, 8]]
+    identifiers = ["id1", "id1"]
+    instance_names = ["r1", "r2"]
+    feature_names = ["f1", "f2"]
+    full_name = "A"
+
+    exp = S(
+        data=data,
+        values=values,
+        identifiers=A(identifiers, 0),
+        instance_names=A(instance_names, 0),
+        feature_names=A(feature_names, 1),
+        full_name=full_name,
+    )
+
+    exp.feature_names = ['f3', 'f4']
+
+    assert exp.feature_names == ['f3', 'f4']
+    assert exp[:, 0].feature_names == 'f3'
+    
+    with pytest.raises(Exception):
+        _ = exp[:, 'f1'] # f1 should no longer exist as valid alias
+
+    exp.feature_names = A(['f5', 'f6'], dim=0)
+
+    assert exp.feature_names == ['f5', 'f6']
+    assert exp[1, :].feature_names == 'f6' # feature_names now tracks dim 0


### PR DESCRIPTION
As discussed in #4623, slicer is no longer maintained and is blocking support for Python 3.12+. In this PR, I vendors the necessary parts of the package directly into `utils` so we can drop the external dependency.

I used the code from [slicer](https://github.com/interpretml/slicer) repository into `_slicer.py` and `test_slicer.py` and also updated `pyproject.toml` and `_explainer.py`.  
