### PR TITLE
Vendor slicer package to enable Python 3.12+ support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   'pandas',
   'tqdm>=4.27.0',
   'packaging>20.9',
-  'slicer==0.0.8',
   'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',  # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
   'numba; sys_platform != "darwin" or platform_machine != "x86_64"',
   'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"',  # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
@@ -180,7 +179,6 @@ module = [
   "pyspark.*",
   "scipy.*",
   "sklearn.*",
-  "slicer",
   "tensorflow.*",
   "transformers.*",
   "torch.*",

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -13,11 +13,11 @@ import scipy.cluster
 import scipy.sparse
 import scipy.spatial
 import sklearn
-from slicer import Alias, Obj, Slicer
 
 from .utils._clustering import hclust_ordering
 from .utils._exceptions import DimensionError
 from .utils._general import OpChain
+from .utils._slicer import Alias, Obj, Slicer
 
 op_chain_root = OpChain("shap.Explanation")
 

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -142,40 +142,32 @@ class Explanation(metaclass=MetaExplanation):
             assert num_names is not None, "Unexpected shape of values"
             output_names = [f"Output {i}" for i in range(num_names)]
 
-        if (
-            feature_names is not None and len(_compute_shape(feature_names)) == 1
-        ):  # TODO: should always be an alias once slicer supports per-row aliases
-            if len(values_shape) >= 2 and len(feature_names) == values_shape[1]:
-                feature_names = Alias(list(feature_names), 1)  # type: ignore[arg-type]
-            elif len(values_shape) >= 1 and len(feature_names) == values_shape[0]:
-                feature_names = Alias(list(feature_names), 0)  # type: ignore[arg-type]
+        if feature_names is not None and len(_compute_shape(feature_names)) == 1:
+            if len(values_shape) >= 2 and len(feature_names) == values_shape[1]:  # type: ignore[arg-type]
+                feature_names = Alias(list(feature_names), 1)  # type: ignore[assignment, arg-type]
+            elif len(values_shape) >= 1 and len(feature_names) == values_shape[0]:  # type: ignore[arg-type]
+                feature_names = Alias(list(feature_names), 0)  # type: ignore[assignment, arg-type]
 
-        if (
-            output_names is not None and len(_compute_shape(output_names)) == 1
-        ):  # TODO: should always be an alias once slicer supports per-row aliases
-            output_names = Alias(list(output_names), self.output_dims[0])  # type: ignore[arg-type]
-            # if len(values_shape) >= 1 and len(output_names) == values_shape[0]:
-            #     output_names = Alias(list(output_names), 0)
-            # elif len(values_shape) >= 2 and len(output_names) == values_shape[1]:
-            #     output_names = Alias(list(output_names), 1)
+        if output_names is not None and len(_compute_shape(output_names)) == 1:
+            output_names = Alias(list(output_names), self.output_dims[0])  # type: ignore[assignment, arg-type]
 
         if output_names is not None and not isinstance(output_names, Alias):
             output_names_order = len(_compute_shape(output_names))
             if output_names_order == 0:
                 pass
             elif output_names_order == 1:
-                output_names = Obj(output_names, self.output_dims)
+                output_names = Obj(output_names, self.output_dims)  # type: ignore[assignment]
             elif output_names_order == 2:
-                output_names = Obj(output_names, [0] + list(self.output_dims))
+                output_names = Obj(output_names, [0] + list(self.output_dims))  # type: ignore[assignment]
             else:
                 raise ValueError("shap.Explanation does not yet support output_names of order greater than 3!")
 
         if base_values is None or not hasattr(base_values, "__len__") or len(base_values) == 0:
             pass
         elif len(_compute_shape(base_values)) == len(self.output_dims):
-            base_values = Obj(base_values, list(self.output_dims))
+            base_values = Obj(base_values, list(self.output_dims))  # type: ignore[assignment]
         else:
-            base_values = Obj(base_values, [0] + list(self.output_dims))
+            base_values = Obj(base_values, [0] + list(self.output_dims))  # type: ignore[assignment]
 
         self._s = Slicer(
             values=values,

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -5,19 +5,17 @@ This is a unified, single-file version of the slicer library.
 
 import numbers
 from abc import abstractmethod
-from typing import Any, AnyStr
+from typing import Any
 
 
 class AtomicSlicer:
-    """Wrapping object that will unify slicing across data structures."""
-
-    def __init__(self, o: Any, max_dim: None | int | AnyStr = "auto"):
+    def __init__(self, o: Any, max_dim: None | int | str = "auto"):
         self.o = o
-        self.max_dim = max_dim
+        self.max_dim: None | int | str = max_dim
         if self.max_dim == "auto":
             self.max_dim = UnifiedDataHandler.max_dim(o)
 
-    def __repr__(self) -> AnyStr:
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.o.__repr__()})"
 
     def __getitem__(self, item: Any) -> Any:
@@ -70,7 +68,7 @@ def _normalize_slice_key(key: Any) -> tuple:
 def _handle_newaxis_ellipses(index_tup: tuple, max_dim: int) -> tuple:
     non_indexes = (None, Ellipsis)
     concrete_indices = sum(idx not in non_indexes for idx in index_tup)
-    index_list = []
+    index_list: list[Any] = []
     has_ellipsis = False
     int_count = 0
     for item in index_tup:
@@ -120,7 +118,7 @@ def _handle_aliases(index_tup: tuple, alias_lookup) -> tuple:
 class Tracked(AtomicSlicer):
     def __init__(self, o: Any, dim: int | list | tuple | None | str = "auto"):
         super().__init__(o)
-        self._name = None
+        self._name: str | None = None
         if dim == "auto":
             self.dim = list(range(self.max_dim))
         elif dim is None:
@@ -206,7 +204,7 @@ def resolve_dim(slicer_index: tuple, slicer_dim: list) -> list:
     return new_slicer_dim
 
 
-def reduced_o(tracked: Tracked) -> list | Any:
+def reduced_o(tracked: list[Tracked]) -> list | Any:
     os = [t.o for t in tracked]
     os = os[0] if len(os) == 1 else os
     return os
@@ -502,11 +500,11 @@ class Slicer:
 
     @classmethod
     def _init_slicer(cls, slicer_instance, *args, **kwargs):
-        slicer_instance._max_dim = 0
-        slicer_instance._anon = []
-        slicer_instance._objects = {}
-        slicer_instance._aliases = {}
-        slicer_instance._alias_lookup = None
+        slicer_instance._max_dim = 0  # type: int
+        slicer_instance._anon = []  # type: List[Tracked]
+        slicer_instance._objects = {}  # type: dict
+        slicer_instance._aliases = {}  # type: dict
+        slicer_instance._alias_lookup = None  # type: Union[AliasLookup, None]
 
         slicer_instance.__setattr__("o", args)
 
@@ -550,7 +548,7 @@ class Slicer:
 
     def __getattr__(self, item):
         if item.startswith("_"):
-            return super().__getattr__(item)
+            return object.__getattribute__(self, item)
 
         if item == "o":
             return reduced_o(self._anon)

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -1,0 +1,648 @@
+"""
+Vendored from: https://github.com/non-maintained-slicer-repo/slicer
+This is a unified, single-file version of the slicer library.
+"""
+
+import numbers
+from abc import abstractmethod
+from typing import Any, AnyStr
+
+
+class AtomicSlicer:
+    """Wrapping object that will unify slicing across data structures."""
+
+    def __init__(self, o: Any, max_dim: None | int | AnyStr = "auto"):
+        self.o = o
+        self.max_dim = max_dim
+        if self.max_dim == "auto":
+            self.max_dim = UnifiedDataHandler.max_dim(o)
+
+    def __repr__(self) -> AnyStr:
+        return f"{self.__class__.__name__}({self.o.__repr__()})"
+
+    def __getitem__(self, item: Any) -> Any:
+        index_tup = unify_slice(item, self.max_dim)
+        return UnifiedDataHandler.slice(self.o, index_tup, self.max_dim)
+
+
+def unify_slice(item: Any, max_dim: int, alias_lookup=None) -> tuple:
+    item = _normalize_slice_key(item)
+    index_tup = _normalize_subkey_types(item)
+    index_tup = _handle_newaxis_ellipses(index_tup, max_dim)
+    if alias_lookup:
+        index_tup = _handle_aliases(index_tup, alias_lookup)
+    return index_tup
+
+
+def _normalize_subkey_types(index_tup: tuple) -> tuple:
+    new_index_tup = []
+    np_int_types = {
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+    }
+    for subkey in index_tup:
+        if _safe_isinstance(subkey, "numpy", np_int_types):
+            new_subkey = int(subkey)
+        elif _safe_isinstance(subkey, "numpy", "ndarray"):
+            if len(subkey.shape) == 1:
+                new_subkey = subkey.tolist()
+            else:
+                raise ValueError(f"Cannot use array of shape {subkey.shape} as subkey.")
+        else:
+            new_subkey = subkey
+        new_index_tup.append(new_subkey)
+    return tuple(new_index_tup)
+
+
+def _normalize_slice_key(key: Any) -> tuple:
+    if not isinstance(key, tuple):
+        return (key,)
+    else:
+        return key
+
+
+def _handle_newaxis_ellipses(index_tup: tuple, max_dim: int) -> tuple:
+    non_indexes = (None, Ellipsis)
+    concrete_indices = sum(idx not in non_indexes for idx in index_tup)
+    index_list = []
+    has_ellipsis = False
+    int_count = 0
+    for item in index_tup:
+        if isinstance(item, numbers.Number):
+            int_count += 1
+        if item is None:
+            pass
+        elif item == Ellipsis:
+            if has_ellipsis:
+                raise IndexError("an index can only have a single ellipsis ('...')")
+            has_ellipsis = True
+            initial_len = len(index_list)
+            while len(index_list) + (concrete_indices - initial_len) < max_dim:
+                index_list.append(slice(None))
+        else:
+            index_list.append(item)
+
+    if len(index_list) > max_dim:
+        raise IndexError("too many indices for array")
+    while len(index_list) < max_dim:
+        index_list.append(slice(None))
+
+    return tuple(index_list)
+
+
+def _handle_aliases(index_tup: tuple, alias_lookup) -> tuple:
+    new_index_tup = []
+
+    def resolve(item, dim):
+        if isinstance(item, slice):
+            return item
+        item = alias_lookup.get(dim, item, item)
+        return item
+
+    for dim, item in enumerate(index_tup):
+        if isinstance(item, list):
+            new_item = []
+            for sub_item in item:
+                new_item.append(resolve(sub_item, dim))
+        else:
+            new_item = resolve(item, dim)
+        new_index_tup.append(new_item)
+
+    return tuple(new_index_tup)
+
+
+class Tracked(AtomicSlicer):
+    def __init__(self, o: Any, dim: int | list | tuple | None | str = "auto"):
+        super().__init__(o)
+        self._name = None
+        if dim == "auto":
+            self.dim = list(range(self.max_dim))
+        elif dim is None:
+            self.dim = []
+        elif isinstance(dim, int):
+            self.dim = [dim]
+        elif isinstance(dim, list):
+            self.dim = dim
+        elif isinstance(dim, tuple):
+            self.dim = list(dim)
+        else:
+            raise ValueError(f"Cannot handle dim of type: {type(dim)}")
+
+
+class Obj(Tracked):
+    def __init__(self, o, dim="auto"):
+        super().__init__(o, dim)
+
+
+class Alias(Tracked):
+    def __init__(self, o, dim):
+        if not (isinstance(dim, int) or (isinstance(dim, (list, tuple)) and len(dim) <= 1)):
+            raise ValueError("Aliases must track a single dimension")
+        super().__init__(o, dim)
+
+
+class AliasLookup:
+    def __init__(self, aliases):
+        self._lookup = {}
+        for _, alias in aliases.items():
+            self.update(alias)
+
+    def update(self, alias):
+        if alias.dim is None or len(alias.dim) == 0:
+            return
+
+        dim = alias.dim[0]
+        if dim not in self._lookup:
+            self._lookup[dim] = {}
+
+        dim_lookup = self._lookup[dim]
+        itr = enumerate(alias.o) if isinstance(alias.o, list) else alias.o.items()
+        for i, x in itr:
+            if x not in dim_lookup:
+                dim_lookup[x] = set()
+            dim_lookup[x].add(i)
+
+    def delete(self, alias):
+        dim = alias.dim[0]
+        dim_lookup = self._lookup[dim]
+        itr = enumerate(alias.o) if isinstance(alias.o, list) else alias.o.items()
+        for i, x in itr:
+            del dim_lookup[x]
+
+    def get(self, dim, target, default=None):
+        if dim not in self._lookup:
+            return default
+
+        indexes = self._lookup[dim].get(target, None)
+        if indexes is None:
+            return default
+
+        if len(indexes) == 1:
+            return next(iter(indexes))
+        else:
+            return list(indexes)
+
+
+def resolve_dim(slicer_index: tuple, slicer_dim: list) -> list:
+    new_slicer_dim = []
+    reduced_mask = []
+
+    for _, curr_idx in enumerate(slicer_index):
+        if isinstance(curr_idx, (tuple, list, slice)):
+            reduced_mask.append(0)
+        else:
+            reduced_mask.append(1)
+
+    for curr_dim in slicer_dim:
+        if reduced_mask[curr_dim] == 0:
+            new_slicer_dim.append(curr_dim - sum(reduced_mask[:curr_dim]))
+
+    return new_slicer_dim
+
+
+def reduced_o(tracked: Tracked) -> list | Any:
+    os = [t.o for t in tracked]
+    os = os[0] if len(os) == 1 else os
+    return os
+
+
+class BaseHandler:
+    @classmethod
+    @abstractmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def max_dim(cls, o):
+        raise NotImplementedError()
+
+    @classmethod
+    def default_alias(cls, o):
+        return []
+
+
+class SeriesHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        head_index = index_tup[0]
+        is_element = True if isinstance(head_index, int) else False
+        sliced_o = o.iloc[head_index]
+        return is_element, sliced_o, 1
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+
+    @classmethod
+    def max_dim(cls, o):
+        return len(o.shape)
+
+    @classmethod
+    def default_alias(cls, o):
+        index_alias = Alias(o.index.to_list(), 0)
+        index_alias._name = "index"
+        return [index_alias]
+
+
+class DataFrameHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        cut_index = index_tup
+        is_element = True if isinstance(cut_index[-1], int) else False
+        sliced_o = o.iloc[cut_index]
+        return is_element, sliced_o, 2
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+
+    @classmethod
+    def max_dim(cls, o):
+        return len(o.shape)
+
+    @classmethod
+    def default_alias(cls, o):
+        index_alias = Alias(o.index.to_list(), 0)
+        index_alias._name = "index"
+        column_alias = Alias(o.columns.to_list(), 1)
+        column_alias._name = "columns"
+        return [index_alias, column_alias]
+
+
+class ArrayHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        tail_index = index_tup[1:]
+        cut = 1
+
+        for sub_index in tail_index:
+            if isinstance(sub_index, str) or cut == len(o.shape):
+                break
+            cut += 1
+
+        cut_index = index_tup[:cut]
+        is_element = any([True if isinstance(x, int) else False for x in cut_index])
+        sliced_o = o[cut_index]
+
+        return is_element, sliced_o, cut
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        if flatten:
+            if (
+                _safe_isinstance(o, "scipy.sparse.csc", "csc_matrix")
+                or _safe_isinstance(o, "scipy.sparse.csr", "csr_matrix")
+                or _safe_isinstance(o, "scipy.sparse.dok", "dok_matrix")
+                or _safe_isinstance(o, "scipy.sparse.lil", "lil_matrix")
+            ):
+                return AtomicSlicer(o.toarray().flatten(), max_dim=max_dim)[tail_index]
+            else:
+                return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+        else:
+            inner = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
+            if _safe_isinstance(o, "numpy", "ndarray"):
+                import numpy
+
+                if len(inner) > 0 and hasattr(inner[0], "__len__"):
+                    ragged = not all(len(x) == len(inner[0]) for x in inner)
+                else:
+                    ragged = False
+                if ragged:
+                    return numpy.array(inner, dtype=object)
+                else:
+                    return numpy.array(inner)
+            elif _safe_isinstance(o, "torch", "Tensor"):
+                import torch
+
+                if len(inner) > 0 and isinstance(inner[0], torch.Tensor):
+                    return torch.stack(inner)
+                else:
+                    return torch.tensor(inner)
+            elif _safe_isinstance(o, "scipy.sparse.csc", "csc_matrix"):
+                from scipy.sparse import vstack
+
+                return vstack(inner, format="csc")
+            elif _safe_isinstance(o, "scipy.sparse.csr", "csr_matrix"):
+                from scipy.sparse import vstack
+
+                return vstack(inner, format="csr")
+            elif _safe_isinstance(o, "scipy.sparse.dok", "dok_matrix"):
+                from scipy.sparse import vstack
+
+                return vstack(inner, format="dok")
+            elif _safe_isinstance(o, "scipy.sparse.lil", "lil_matrix"):
+                from scipy.sparse import vstack
+
+                return vstack(inner, format="lil")
+            else:
+                raise ValueError(f"Cannot handle type {type(o)}.")
+
+    @classmethod
+    def max_dim(cls, o):
+        if _safe_isinstance(o, "numpy", "ndarray") and o.dtype == "object":
+            return max([UnifiedDataHandler.max_dim(x) for x in o], default=-1) + 1
+        else:
+            return len(o.shape)
+
+
+class DictHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        head_index = index_tup[0]
+        if isinstance(head_index, (tuple, list)) and len(index_tup) == 0:
+            return False, o, 1
+
+        if isinstance(head_index, (list, tuple)):
+            return (
+                False,
+                {sub_index: AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index},
+                1,
+            )
+        elif isinstance(head_index, slice):
+            if head_index == slice(None, None, None):
+                return False, o, 1
+            return False, o[head_index], 1
+        else:
+            return True, o[head_index], 1
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        if flatten:
+            return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+        else:
+            return {k: AtomicSlicer(e, max_dim=max_dim)[tail_index] for k, e in o.items()}
+
+    @classmethod
+    def max_dim(cls, o):
+        return max([UnifiedDataHandler.max_dim(x) for x in o.values()], default=-1) + 1
+
+
+class ListTupleHandler(BaseHandler):
+    @classmethod
+    def head_slice(cls, o, index_tup, max_dim):
+        head_index = index_tup[0]
+        if isinstance(head_index, (tuple, list)) and len(index_tup) == 0:
+            return False, o, 1
+
+        if isinstance(head_index, (list, tuple)):
+            if len(head_index) == 0:
+                return False, o, 1
+            else:
+                results = [AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index]
+                results = tuple(results) if isinstance(o, tuple) else results
+                return False, results, 1
+        elif isinstance(head_index, slice):
+            return False, o[head_index], 1
+        elif isinstance(head_index, int):
+            return True, o[head_index], 1
+        else:
+            raise ValueError(f"Invalid key {head_index} for {o}")
+
+    @classmethod
+    def tail_slice(cls, o, tail_index, max_dim, flatten=True):
+        if flatten:
+            return AtomicSlicer(o, max_dim=max_dim)[tail_index]
+        else:
+            results = [AtomicSlicer(e, max_dim=max_dim)[tail_index] for e in o]
+            return tuple(results) if isinstance(o, tuple) else results
+
+    @classmethod
+    def max_dim(cls, o):
+        return max([UnifiedDataHandler.max_dim(x) for x in o], default=-1) + 1
+
+
+class UnifiedDataHandler:
+    type_map = {
+        ("builtins", "list"): ListTupleHandler,
+        ("builtins", "tuple"): ListTupleHandler,
+        ("builtins", "dict"): DictHandler,
+        ("torch", "Tensor"): ArrayHandler,
+        ("numpy", "ndarray"): ArrayHandler,
+        ("scipy.sparse.csc", "csc_matrix"): ArrayHandler,
+        ("scipy.sparse.csr", "csr_matrix"): ArrayHandler,
+        ("scipy.sparse.dok", "dok_matrix"): ArrayHandler,
+        ("scipy.sparse.lil", "lil_matrix"): ArrayHandler,
+        ("pandas.core.frame", "DataFrame"): DataFrameHandler,
+        ("pandas.core.series", "Series"): SeriesHandler,
+    }
+
+    @classmethod
+    def slice(cls, o, index_tup, max_dim):
+        if isinstance(index_tup, (tuple, list)) and len(index_tup) == 0:
+            return o
+
+        o_type = _type_name(o)
+        head_slice = cls.type_map[o_type].head_slice
+        tail_slice = cls.type_map[o_type].tail_slice
+
+        is_element, sliced_o, cut = head_slice(o, index_tup, max_dim)
+        out = tail_slice(sliced_o, index_tup[cut:], max_dim - cut, is_element)
+        return out
+
+    @classmethod
+    def max_dim(cls, o):
+        o_type = _type_name(o)
+        if o_type not in cls.type_map:
+            return 0
+        return cls.type_map[o_type].max_dim(o)
+
+    @classmethod
+    def default_alias(cls, o):
+        o_type = _type_name(o)
+        if o_type not in cls.type_map:
+            return {}
+        return cls.type_map[o_type].default_alias(o)
+
+
+def _type_name(o: object) -> tuple[str, str]:
+    return _handle_module_aliases(o.__class__.__module__), o.__class__.__name__
+
+
+def _safe_isinstance(o: object, module_name: str, type_name: str | set | tuple) -> bool:
+    o_module, o_type = _type_name(o)
+    if isinstance(type_name, str):
+        return o_module == module_name and o_type == type_name
+    else:
+        return o_module == module_name and o_type in type_name
+
+
+def _handle_module_aliases(module_name):
+    module_map = {
+        "scipy.sparse._csc": "scipy.sparse.csc",
+        "scipy.sparse._csr": "scipy.sparse.csr",
+        "scipy.sparse._dok": "scipy.sparse.dok",
+        "scipy.sparse._lil": "scipy.sparse.lil",
+    }
+    return module_map.get(module_name, module_name)
+
+
+class Slicer:
+    """Provides unified slicing to tensor-like objects."""
+
+    def __init__(self, *args, **kwargs):
+        self.__class__._init_slicer(self, *args, **kwargs)
+
+    @classmethod
+    def from_slicer(cls, *args, **kwargs):
+        slicer_instance = cls.__new__(cls)
+        cls._init_slicer(slicer_instance, *args, **kwargs)
+        return slicer_instance
+
+    @classmethod
+    def _init_slicer(cls, slicer_instance, *args, **kwargs):
+        slicer_instance._max_dim = 0
+        slicer_instance._anon = []
+        slicer_instance._objects = {}
+        slicer_instance._aliases = {}
+        slicer_instance._alias_lookup = None
+
+        slicer_instance.__setattr__("o", args)
+
+        for key, value in kwargs.items():
+            slicer_instance.__setattr__(key, value)
+
+        objects_len = len(slicer_instance._objects)
+        anon_len = len(slicer_instance._anon)
+        aliases_len = len(slicer_instance._aliases)
+        if ((objects_len == 1) ^ (anon_len == 1)) and aliases_len == 0:
+            obj = None
+            for _, t in slicer_instance._iter_tracked():
+                obj = t
+
+            generated_aliases = UnifiedDataHandler.default_alias(obj.o)
+            for generated_alias in generated_aliases:
+                slicer_instance.__setattr__(generated_alias._name, generated_alias)
+
+    def __getitem__(self, item):
+        index_tup = unify_slice(item, self._max_dim, self._alias_lookup)
+        new_args = []
+        new_kwargs = {}
+        for name, tracked in self._iter_tracked(include_aliases=True):
+            if len(tracked.dim) == 0:
+                new_tracked = tracked
+            else:
+                index_slicer = AtomicSlicer(index_tup, max_dim=1)
+                slicer_index = index_slicer[tracked.dim]
+                sliced_o = tracked[slicer_index]
+                sliced_dim = resolve_dim(index_tup, tracked.dim)
+
+                new_tracked = tracked.__class__(sliced_o, sliced_dim)
+                new_tracked._name = tracked._name
+
+            if name == "o":
+                new_args.append(new_tracked)
+            else:
+                new_kwargs[name] = new_tracked
+
+        return self.__class__.from_slicer(*new_args, **new_kwargs)
+
+    def __getattr__(self, item):
+        if item.startswith("_"):
+            return super().__getattr__(item)
+
+        if item == "o":
+            return reduced_o(self._anon)
+        else:
+            tracked = self._objects.get(item, None)
+            if tracked is None:
+                tracked = self._aliases.get(item, None)
+
+            if tracked is None:
+                raise AttributeError(f"Attribute '{item}' does not exist.")
+
+            return tracked.o
+
+    def __setattr__(self, key, value):
+        if key.startswith("_"):
+            return super().__setattr__(key, value)
+
+        old_obj = self._objects.get(key, None)
+        old_alias = self._aliases.get(key, None)
+
+        if getattr(self, key, None) is not None and key != "o":
+            if not isinstance(value, Tracked):
+                if old_obj:
+                    value = Obj(value, dim=old_obj.dim)
+                elif old_alias:
+                    value = Alias(value, dim=old_alias.dim)
+
+        if isinstance(value, Alias):
+            value._name = key
+            self._aliases[key] = value
+
+            if old_obj:
+                del self._objects[key]
+
+            if self._alias_lookup is None:
+                self._alias_lookup = AliasLookup(self._aliases)
+            else:
+                if old_alias:
+                    self._alias_lookup.delete(old_alias)
+                self._alias_lookup.update(value)
+        else:
+            if key == "o":
+                tracked = [Obj(x) if not isinstance(x, Obj) else x for x in value]
+                self._anon = tracked
+                for t in tracked:
+                    self._update_max_dim(t)
+
+                os = reduced_o(self._anon)
+                super().__setattr__(key, os)
+            else:
+                if old_alias:
+                    self._alias_lookup.delete(old_alias)
+                    del self._aliases[key]
+
+                value = Obj(value) if not isinstance(value, Obj) else value
+                value._name = key
+                self._objects[key] = value
+                self._update_max_dim(value)
+                super().__setattr__(key, value.o)
+
+    def __delattr__(self, item):
+        if item.startswith("_"):
+            return super().__delattr__(item)
+
+        self._objects.pop(item, None)
+        self._aliases.pop(item, None)
+        if item == "o":
+            self._anon.clear()
+
+        self._recompute_max_dim()
+        self._alias_lookup = AliasLookup(self._aliases)
+        super().__delattr__(item)
+
+    def __repr__(self):
+        orig = self.__dict__
+        di = {}
+        for key, value in orig.items():
+            if not key.startswith("_"):
+                di[key] = value
+        return f"{self.__class__.__name__}({str(di)})"
+
+    def _update_max_dim(self, tracked):
+        self._max_dim = max(self._max_dim, max(tracked.dim, default=-1) + 1)
+
+    def _iter_tracked(self, include_aliases=False):
+        for tracked in self._anon:
+            yield "o", tracked
+        for name, tracked in self._objects.items():
+            yield name, tracked
+        if include_aliases:
+            for name, tracked in self._aliases.items():
+                yield name, tracked
+
+    def _recompute_max_dim(self):
+        self._max_dim = max([max(o.dim, default=-1) + 1 for _, o in self._iter_tracked()], default=0)

--- a/shap/utils/_slicer.py
+++ b/shap/utils/_slicer.py
@@ -3,15 +3,22 @@ Vendored from: https://github.com/non-maintained-slicer-repo/slicer
 This is a unified, single-file version of the slicer library.
 """
 
+from __future__ import annotations
+
 import numbers
 from abc import abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class AtomicSlicer:
-    def __init__(self, o: Any, max_dim: None | int | str = "auto"):
+    """Wrapping object that will unify slicing across data structures."""
+
+    def __init__(self, o: Any, max_dim: int | str | None = "auto"):
         self.o = o
-        self.max_dim: None | int | str = max_dim
+        self.max_dim: int | str | None = max_dim
         if self.max_dim == "auto":
             self.max_dim = UnifiedDataHandler.max_dim(o)
 
@@ -19,8 +26,8 @@ class AtomicSlicer:
         return f"{self.__class__.__name__}({self.o.__repr__()})"
 
     def __getitem__(self, item: Any) -> Any:
-        index_tup = unify_slice(item, self.max_dim)
-        return UnifiedDataHandler.slice(self.o, index_tup, self.max_dim)
+        index_tup = unify_slice(item, cast("int", self.max_dim))
+        return UnifiedDataHandler.slice(self.o, index_tup, cast("int", self.max_dim))
 
 
 def unify_slice(item: Any, max_dim: int, alias_lookup=None) -> tuple:
@@ -120,7 +127,7 @@ class Tracked(AtomicSlicer):
         super().__init__(o)
         self._name: str | None = None
         if dim == "auto":
-            self.dim = list(range(self.max_dim))
+            self.dim = list(range(cast("int", self.max_dim)))
         elif dim is None:
             self.dim = []
         elif isinstance(dim, int):
@@ -204,7 +211,7 @@ def resolve_dim(slicer_index: tuple, slicer_dim: list) -> list:
     return new_slicer_dim
 
 
-def reduced_o(tracked: list[Tracked]) -> list | Any:
+def reduced_o(tracked: Sequence[Tracked]) -> list | Any:
     os = [t.o for t in tracked]
     os = os[0] if len(os) == 1 else os
     return os
@@ -399,8 +406,8 @@ class ListTupleHandler(BaseHandler):
                 return False, o, 1
             else:
                 results = [AtomicSlicer(o, max_dim=max_dim)[sub_index] for sub_index in head_index]
-                results = tuple(results) if isinstance(o, tuple) else results
-                return False, results, 1
+                out_results = tuple(results) if isinstance(o, tuple) else results
+                return False, out_results, 1
         elif isinstance(head_index, slice):
             return False, o[head_index], 1
         elif isinstance(head_index, int):
@@ -489,6 +496,12 @@ def _handle_module_aliases(module_name):
 class Slicer:
     """Provides unified slicing to tensor-like objects."""
 
+    _max_dim: int
+    _anon: list[Any]
+    _objects: dict
+    _aliases: dict
+    _alias_lookup: AliasLookup | None
+
     def __init__(self, *args, **kwargs):
         self.__class__._init_slicer(self, *args, **kwargs)
 
@@ -500,11 +513,11 @@ class Slicer:
 
     @classmethod
     def _init_slicer(cls, slicer_instance, *args, **kwargs):
-        slicer_instance._max_dim = 0  # type: int
-        slicer_instance._anon = []  # type: List[Tracked]
-        slicer_instance._objects = {}  # type: dict
-        slicer_instance._aliases = {}  # type: dict
-        slicer_instance._alias_lookup = None  # type: Union[AliasLookup, None]
+        slicer_instance._max_dim = 0
+        slicer_instance._anon = []
+        slicer_instance._objects = {}
+        slicer_instance._aliases = {}
+        slicer_instance._alias_lookup = None
 
         slicer_instance.__setattr__("o", args)
 
@@ -519,9 +532,10 @@ class Slicer:
             for _, t in slicer_instance._iter_tracked():
                 obj = t
 
-            generated_aliases = UnifiedDataHandler.default_alias(obj.o)
-            for generated_alias in generated_aliases:
-                slicer_instance.__setattr__(generated_alias._name, generated_alias)
+            if obj is not None:
+                generated_aliases = UnifiedDataHandler.default_alias(obj.o)
+                for generated_alias in generated_aliases:
+                    slicer_instance.__setattr__(generated_alias._name, generated_alias)
 
     def __getitem__(self, item):
         index_tup = unify_slice(item, self._max_dim, self._alias_lookup)
@@ -600,7 +614,8 @@ class Slicer:
                 super().__setattr__(key, os)
             else:
                 if old_alias:
-                    self._alias_lookup.delete(old_alias)
+                    if self._alias_lookup is not None:
+                        self._alias_lookup.delete(old_alias)
                     del self._aliases[key]
 
                 value = Obj(value) if not isinstance(value, Obj) else value

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -41,7 +41,7 @@ def explanation_multi_example(imagenet50_example) -> shap.Explanation:
     shap_values_multi = np.stack([shap_values_single for _ in range(n_classes)], axis=-1)
     assert shap_values_multi.shape[-1] == n_classes
 
-    explanation = shap.Explanation(values=shap_values_multi, data=images, output_names=[x for x in range(n_classes)])
+    explanation = shap.Explanation(values=shap_values_multi, data=images, output_names=[x for x in range(n_classes)])  # type: ignore[misc]
     return explanation
 
 

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -1,0 +1,507 @@
+import numbers
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, lil_matrix
+
+from shap.utils._slicer import Alias as A
+from shap.utils._slicer import AtomicSlicer
+from shap.utils._slicer import Obj as O
+from shap.utils._slicer import Slicer as S
+
+
+def coerced(o: Any):
+    if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
+        o = o.toarray()
+
+    to_list_collections = tuple([np.ndarray, torch.Tensor, pd.core.series.Series])
+    if isinstance(o, (list, tuple)):
+        return o
+    elif isinstance(o, to_list_collections):
+        return o.tolist()
+    elif isinstance(o, pd.core.frame.DataFrame):
+        return o.values.tolist()
+    elif isinstance(o, dict):
+        li = [np.nan] * len(o)
+        for k, v in o.items():
+            li[k] = v
+        return li
+    else:
+        raise ValueError(f"Object {o} of {type(o)} is not a list, tuple nor array.")
+
+
+def is_close(a: numbers.Number, b: numbers.Number, rel_tol: float = 1e-09, abs_tol: float = 0.0):
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+
+def ctr_eq(c1: Any, c2: Any):
+    if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
+        c1 = c1.item()
+    if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
+        c2 = c2.item()
+
+    if isinstance(c1, numbers.Number) and isinstance(c2, numbers.Number):
+        return is_close(c1, c2)
+
+    c1 = coerced(c1)
+    c2 = coerced(c2)
+
+    return all([ctr_eq(c1[i], c2[i]) for i in range(max(len(c1), len(c2)))])
+
+
+def test_slicer_ragged_numpy():
+    values = np.array([np.array([0, 1]), np.array([2, 3, 4])], dtype=object)
+    data = np.array(
+        [
+            np.array([5, 6, 7]),
+        ]
+    )
+
+    slicer = S(values=values, data=data)
+    sliced = slicer[0, 1]
+
+    assert ctr_eq(sliced.data, data[0][1])
+    assert ctr_eq(sliced.values, values[0][1])
+
+
+def test_slicer_basic():
+    data = [[1, 2], [3, 4]]
+    values = [[5, 6], [7, 8]]
+    identifiers = ["id1", "id1"]
+    instance_names = ["r1", "r2"]
+    feature_names = ["f1", "f2"]
+    full_name = "A"
+
+    slicer = S(
+        data=data,
+        values=values,
+        identifiers=A(identifiers, 0),
+        instance_names=A(instance_names, 0),
+        feature_names=A(feature_names, 1),
+        full_name=full_name,
+    )
+
+    colon_actual = slicer[:, 1]
+    assert colon_actual.data == [2, 4]
+    assert colon_actual.instance_names == ["r1", "r2"]
+    assert colon_actual.feature_names == "f2"
+    assert colon_actual.values == [6, 8]
+
+    ellipses_actual = slicer[..., 1]
+    assert ellipses_actual.data == [2, 4]
+    assert ellipses_actual.instance_names == ["r1", "r2"]
+    assert ellipses_actual.feature_names == "f2"
+    assert ellipses_actual.values == [6, 8]
+
+    array_index_actual = slicer[[0, 1], 1]
+    assert array_index_actual.data == [2, 4]
+    assert array_index_actual.feature_names == "f2"
+    assert array_index_actual.instance_names == ["r1", "r2"]
+    assert array_index_actual.values == [6, 8]
+
+    alias_actual = slicer["r1", "f2"]
+    assert alias_actual.data == 2
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == "r1"
+    assert alias_actual.values == 6
+
+    alias_actual = slicer["id1", "f2"]
+    assert alias_actual.data == [2, 4]
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == ["r1", "r2"]
+    assert alias_actual.values == [6, 8]
+
+    chained_actual = slicer[:][:, 1]
+    assert chained_actual.data == [2, 4]
+    assert chained_actual.feature_names == "f2"
+    assert chained_actual.instance_names == ["r1", "r2"]
+    assert chained_actual.values == [6, 8]
+
+    alias_actual = slicer["id1"][:, "f2"]
+    assert alias_actual.data == [2, 4]
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == ["r1", "r2"]
+    assert alias_actual.values == [6, 8]
+
+    alias_actual = slicer["r1"]
+    alias_actual = alias_actual["f2"]
+    assert alias_actual.data == 2
+    assert alias_actual.feature_names == "f2"
+    assert alias_actual.instance_names == "r1"
+    assert alias_actual.values == 6
+
+
+def test_slicer_unnamed():
+    a = [1, 2, 3]
+    b = [4, 5, 6]
+
+    slicer = S(a, b)
+    actual_a, actual_b = slicer[1].o
+    assert actual_a == 2
+    assert actual_b == 5
+
+    df1 = pd.DataFrame([[1, 2], [3, 4]])
+    df2 = pd.DataFrame([[5, 6], [7, 8]])
+    slicer = S(df1, df2)
+    actual_1, actual_2 = slicer[:, 0].o
+
+    assert ctr_eq(actual_1.values, [1, 3])
+    assert ctr_eq(actual_2.values, [5, 7])
+
+
+def test_slicer_crud():
+    data = [[1, 2], [3, 4]]
+    values = [[5, 6], [7, 8]]
+    extra = [[9, 10], [11, 12]]
+    overridden = [[13, 14], [15, 16]]
+
+    slicer = S(data=data, values=values)
+    slicer.extra = extra
+    slicer.data = overridden
+    del slicer.values
+
+    sliced = slicer[0, 1]
+    assert sliced.data == 14
+    with pytest.raises(Exception):
+        _ = sliced.values
+
+    assert sliced.extra == 10
+
+    del slicer.o
+    assert slicer.o == []
+
+
+def test_slicer_default_alias():
+    df = pd.DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
+    slicer = S(df)
+    assert getattr(slicer, "index", None)
+    assert getattr(slicer, "columns", None)
+    actual = slicer[:, "A"].o
+    assert ctr_eq(actual, [1, 3])
+
+
+def test_slicer_anon_dict():
+    di = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    slicer = S(di)
+
+    result = slicer["a", 1].o
+    assert result == 2
+
+
+def test_slicer_3d():
+    data_2d = [[1, 2], [3, 4], [5, 6]]
+    values_3d = [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[13, 14, 15], [16, 17, 18]],
+    ]
+    names = ["a", "b", "c"]
+
+    slicer = S(data=data_2d, values=values_3d, names=A(names, 2))
+    actual = slicer[..., 1]
+    assert ctr_eq(actual.data, data_2d)
+    assert actual.names == "b"
+
+    actual = slicer[0, :, 1]
+    assert ctr_eq(actual.data, data_2d[0])
+    assert actual.names == "b"
+
+    actual = slicer[0, :][:, 1]
+    assert ctr_eq(actual.data, data_2d[0])
+    assert actual.names == "b"
+
+
+def test_untracked():
+    data = [1, 2, 3, 4]
+    primitive = 1
+    collection = [[8, 9]]
+    slicer = S(data=data, primitive=O(primitive, None), collection=O(collection, None))
+    actual = slicer[:2]
+    assert actual.data == data[:2]
+    assert actual.primitive == primitive
+    assert ctr_eq(actual.collection, collection)
+
+
+def test_partial_untracked():
+    s = S(a=np.zeros((4, 5, 6)), b=O(np.ones((4, 2, 2)), [0]))
+    assert s[:, :, 1].b.shape == (4, 2, 2)
+
+
+def test_numpy_subkeys():
+    data = [1, 2, 3, 4]
+    slicer = S(data=data)
+
+    subkey = np.int64(1)
+    assert slicer[subkey].data == 2
+
+    subkey = np.array([0, 1])
+    assert ctr_eq(slicer[subkey].data, [1, 2])
+
+    subkey = np.array([[0, 1], [3, 4]])
+    with pytest.raises(ValueError):
+        _ = slicer[subkey]
+
+
+def test_repr_smoke():
+    slicer = S([1, 2], ["a", "b"], named=[3, 4])
+    print(slicer)
+
+    atomic = AtomicSlicer([1, 2, 3, 4])
+    print(atomic)
+
+
+def test_slicer_simple_di():
+    di = {"A": [1, 2], "B": [3, 4], "C": [5, 6]}
+    slicer = S(di)
+    actual = slicer["B", 0]
+    actual = actual.o
+    assert ctr_eq(actual, 3)
+
+    nested_di = {"X": di, "Y": di}
+    actual = S(nested_di)["X", "B", 0].o
+    assert ctr_eq(actual, 3)
+
+
+def test_slicer_sparse():
+    array = np.array([[1, 0, 4], [0, 0, 5], [2, 3, 6]])
+    csc_array = csc_matrix(array)
+    csr_array = csr_matrix(array)
+    dok_array = dok_matrix(array)
+    lil_array = lil_matrix(array)
+
+    candidates = [csc_array, csr_array, dok_array, lil_array]
+    for candidate in candidates:
+        slicer = S(candidate)
+        actual = slicer[0, 0]
+        assert ctr_eq(actual.o, 1)
+        actual = slicer[1, 1]
+        assert ctr_eq(actual.o, 0)
+
+        actual = slicer[0]
+        expected = np.array([1, 0, 4])
+        assert ctr_eq(actual.o, expected)
+
+        actual = slicer[:, 1]
+        expected = np.array([0, 0, 3])
+        assert ctr_eq(actual.o, expected)
+
+        actual = slicer[:, :]
+        expected = np.array([[1, 0, 4], [0, 0, 5], [2, 3, 6]])
+        assert ctr_eq(actual.o, expected)
+
+        actual = slicer[0, :]
+        expected = np.array([1, 0, 4])
+        assert ctr_eq(actual.o, expected)
+
+
+def test_slicer_torch():
+    import torch
+
+    data = torch.tensor([[1, 2], [3, 4]])
+    values = torch.tensor([[5, 6], [7, 8]])
+    alias = ["f1", "f2"]
+
+    slicer = S(data=data, values=values, alias=A(alias, 1))
+    sliced = slicer[0, "f2"]
+    assert sliced.data == 2
+    assert sliced.values == 6
+
+
+def test_slicer_pandas():
+    di = {"A": [1, 2], "B": [3, 4], "C": [5, 6]}
+    df = pd.DataFrame(di)
+
+    slicer = S(df)
+    assert slicer[0, "A"].o == 1
+    assert ctr_eq(slicer[:, "A"].o, [1, 2])
+    assert ctr_eq(slicer[0, :].o, [1, 3, 5])
+
+    df = pd.DataFrame(di, index=["X", "Y"])
+    slicer = S(df)
+    assert slicer["X", "A"].o == 1
+    assert slicer[0, "A"].o == 1
+    assert slicer[0, 0].o == 1
+    slicer = S(df["A"])
+    assert slicer["X"].o == 1
+    assert slicer[0].o == 1
+    assert ctr_eq(slicer[:].o, [1, 2])
+
+
+def test_handle_newaxis_ellipses():
+    from shap.utils._slicer import _handle_newaxis_ellipses
+
+    index_tup = (1,)
+    max_dim = 3
+
+    expanded_index_tup = _handle_newaxis_ellipses(index_tup, max_dim)
+    assert expanded_index_tup == (1, slice(None), slice(None))
+
+
+def test_tracked_dim_arg_smoke():
+    li = ["A", "B"]
+    _ = A(li, dim=0)
+    _ = A(li, dim=[0])
+    _ = A(li, dim=(0,))
+
+    with pytest.raises(Exception):
+        _ = A(li, dim=None)
+
+    with pytest.raises(Exception):
+        _ = A(li, dim=[0, 1])
+
+    _ = O(li, dim=0)
+    _ = O(li, dim=[0])
+    _ = O(li, dim=(0,))
+
+    assert True
+
+
+def test_operations_1d():
+    elements = [1, 2, 3, 4]
+    li = elements
+    tup = tuple(elements)
+    di = {i: x for i, x in enumerate(elements)}
+    series = pd.Series(elements)
+    array = np.array(elements)
+    torch_array = torch.tensor(elements)
+    containers = [li, tup, array, torch_array, di, series]
+    for ctr in containers:
+        slicer = AtomicSlicer(ctr)
+
+        assert ctr_eq(slicer[0], elements[0])
+        assert ctr_eq(slicer[[0, 1, 2, 3]], elements)
+        assert ctr_eq(slicer[[0, 1, 2]], elements[:-1])
+        assert ctr_eq(slicer[:], elements[:])
+        assert ctr_eq(slicer[tuple()], elements)
+
+        if not isinstance(ctr, dict):
+            assert ctr_eq(slicer[-1], elements[-1])
+            assert ctr_eq(slicer[0:3:2], elements[0:3:2])
+
+
+def test_operations_2d():
+    elements = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    li = elements
+    df = pd.DataFrame(elements, columns=["A", "B", "C"])
+
+    sparse_csc = csc_matrix(elements)
+    sparse_csr = csr_matrix(elements)
+    sparse_dok = dok_matrix(elements)
+    sparse_lil = lil_matrix(elements)
+
+    containers = [li, df, sparse_csc, sparse_csr, sparse_dok, sparse_lil]
+    for ctr in containers:
+        slicer = AtomicSlicer(ctr)
+
+        assert ctr_eq(slicer[0], elements[0])
+
+        if not isinstance(ctr, dict):
+            assert ctr_eq(slicer[-1], elements[-1])
+            assert ctr_eq(slicer[0, 0:3:2], elements[0][0:3:2])
+
+        assert ctr_eq(slicer[[0, 1, 2], :], elements)
+        assert ctr_eq(slicer[:], elements)
+        assert ctr_eq(slicer[tuple()], elements)
+        assert ctr_eq(slicer[:, 0], [elements[i][0] for i, _ in enumerate(elements)])
+        assert ctr_eq(slicer[[0, 1], 0], [elements[i][0] for i in [0, 1]])
+        assert ctr_eq(slicer[[0, 1], 1], [elements[i][1] for i in [0, 1]])
+        assert ctr_eq(slicer[0, :], elements[0])
+        assert ctr_eq(slicer[0, 1], elements[0][1])
+        assert ctr_eq(slicer[..., 0], [elements[i][0] for i, _ in enumerate(elements)])
+
+
+def test_operations_3d():
+    elements = [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+        [[13, 14, 15], [16, 17, 18]],
+    ]
+    tuple_elements = (
+        ((1, 2, 3), (4, 5, 6)),
+        ((7, 8, 9), (10, 11, 12)),
+        ((13, 14, 15), (16, 17, 18)),
+    )
+    torch_array = torch.tensor(elements)
+    multi_array = np.array(elements)
+    list_of_lists = elements
+    tuples_of_tuples = tuple_elements
+    list_of_multi_arrays = [
+        np.array(elements[0]),
+        np.array(elements[1]),
+        np.array(elements[2]),
+    ]
+    di_of_multi_arrays = {
+        0: np.array(elements[0]),
+        1: np.array(elements[1]),
+        2: np.array(elements[2]),
+    }
+
+    containers = [
+        torch_array,
+        multi_array,
+        tuples_of_tuples,
+        list_of_lists,
+        list_of_multi_arrays,
+        di_of_multi_arrays,
+    ]
+    for ctr in containers:
+        slicer = AtomicSlicer(ctr)
+
+        assert ctr_eq(slicer[0], elements[0])
+
+        if not isinstance(ctr, dict):
+            assert ctr_eq(slicer[-1], elements[-1])
+            assert ctr_eq(slicer[0, 0:3:2], elements[0][0:3:2])
+
+        assert ctr_eq(slicer[[0, 1, 2], :], elements)
+        assert ctr_eq(slicer[:], elements)
+        assert ctr_eq(slicer[tuple()], elements)
+
+        assert ctr_eq(slicer[:, 0], [elements[i][0] for i, _ in enumerate(elements)])
+        assert ctr_eq(slicer[[0, 1], 0], [elements[i][0] for i in [0, 1]])
+        assert ctr_eq(slicer[[0, 1], 1], [elements[i][1] for i in [0, 1]])
+        assert ctr_eq(slicer[0, :], elements[0])
+        assert ctr_eq(slicer[0, 1], elements[0][1])
+
+        rows = []
+        for i, _ in enumerate(elements):
+            cols = []
+            for j, _ in enumerate(elements[i]):
+                cols.append(elements[i][j][1])
+            rows.append(cols)
+        assert ctr_eq(slicer[..., 1], rows)
+        assert ctr_eq(slicer[0, ..., 1], [elements[0][i][1] for i in range(len(elements[0]))])
+
+
+def test_attribute_assignment():
+    data = [[1, 2], [3, 4]]
+    values = [[5, 6], [7, 8]]
+    identifiers = ["id1", "id1"]
+    instance_names = ["r1", "r2"]
+    feature_names = ["f1", "f2"]
+    full_name = "A"
+
+    exp = S(
+        data=data,
+        values=values,
+        identifiers=A(identifiers, 0),
+        instance_names=A(instance_names, 0),
+        feature_names=A(feature_names, 1),
+        full_name=full_name,
+    )
+
+    exp.feature_names = ["f3", "f4"]
+
+    assert exp.feature_names == ["f3", "f4"]
+    assert exp[:, 0].feature_names == "f3"
+
+    with pytest.raises(Exception):
+        _ = exp[:, "f1"]
+
+    exp.feature_names = A(["f5", "f6"], dim=0)
+
+    assert exp.feature_names == ["f5", "f6"]
+    assert exp[1, :].feature_names == "f6"

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -4,7 +4,12 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
-import torch
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
 from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, lil_matrix
 
 from shap.utils._slicer import Alias as A
@@ -17,10 +22,13 @@ def coerced(o: Any):
     if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
         o = o.toarray()
 
-    to_list_collections = tuple([np.ndarray, torch.Tensor, pd.core.series.Series])
+    to_list_collections = [np.ndarray, pd.core.series.Series]
+    if torch is not None:
+        to_list_collections.append(torch.Tensor)
+
     if isinstance(o, (list, tuple)):
         return o
-    elif isinstance(o, to_list_collections):
+    elif isinstance(o, tuple(to_list_collections)):
         return o.tolist()
     elif isinstance(o, pd.core.frame.DataFrame):
         return o.values.tolist()
@@ -33,15 +41,16 @@ def coerced(o: Any):
         raise ValueError(f"Object {o} of {type(o)} is not a list, tuple nor array.")
 
 
-def is_close(a: numbers.Number, b: numbers.Number, rel_tol: float = 1e-09, abs_tol: float = 0.0):
+def is_close(a: int | float, b: int | float, rel_tol: float = 1e-09, abs_tol: float = 0.0):
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
 def ctr_eq(c1: Any, c2: Any):
-    if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
-        c1 = c1.item()
-    if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
-        c2 = c2.item()
+    if torch is not None:
+        if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
+            c1 = c1.item()
+        if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
+            c2 = c2.item()
 
     if isinstance(c1, numbers.Number) and isinstance(c2, numbers.Number):
         return is_close(c1, c2)
@@ -234,15 +243,15 @@ def test_numpy_subkeys():
     data = [1, 2, 3, 4]
     slicer = S(data=data)
 
-    subkey = np.int64(1)
-    assert slicer[subkey].data == 2
+    subkey_int = np.int64(1)
+    assert slicer[subkey_int].data == 2
 
-    subkey = np.array([0, 1])
-    assert ctr_eq(slicer[subkey].data, [1, 2])
+    subkey_arr = np.array([0, 1])
+    assert ctr_eq(slicer[subkey_arr].data, [1, 2])
 
-    subkey = np.array([[0, 1], [3, 4]])
+    subkey_2d = np.array([[0, 1], [3, 4]])
     with pytest.raises(ValueError):
-        _ = slicer[subkey]
+        _ = slicer[subkey_2d]
 
 
 def test_repr_smoke():
@@ -297,9 +306,8 @@ def test_slicer_sparse():
         assert ctr_eq(actual.o, expected)
 
 
+@pytest.mark.skipif(torch is None, reason="PyTorch is not installed")
 def test_slicer_torch():
-    import torch
-
     data = torch.tensor([[1, 2], [3, 4]])
     values = torch.tensor([[5, 6], [7, 8]])
     alias = ["f1", "f2"]
@@ -366,8 +374,11 @@ def test_operations_1d():
     di = {i: x for i, x in enumerate(elements)}
     series = pd.Series(elements)
     array = np.array(elements)
-    torch_array = torch.tensor(elements)
-    containers = [li, tup, array, torch_array, di, series]
+
+    containers = [li, tup, array, di, series]
+    if torch is not None:
+        containers.append(torch.tensor(elements))
+
     for ctr in containers:
         slicer = AtomicSlicer(ctr)
 
@@ -424,7 +435,7 @@ def test_operations_3d():
         ((7, 8, 9), (10, 11, 12)),
         ((13, 14, 15), (16, 17, 18)),
     )
-    torch_array = torch.tensor(elements)
+
     multi_array = np.array(elements)
     list_of_lists = elements
     tuples_of_tuples = tuple_elements
@@ -440,13 +451,15 @@ def test_operations_3d():
     }
 
     containers = [
-        torch_array,
         multi_array,
         tuples_of_tuples,
         list_of_lists,
         list_of_multi_arrays,
         di_of_multi_arrays,
     ]
+    if torch is not None:
+        containers.append(torch.tensor(elements))
+
     for ctr in containers:
         slicer = AtomicSlicer(ctr)
 

--- a/tests/utils/test_slicer.py
+++ b/tests/utils/test_slicer.py
@@ -1,520 +1,110 @@
-import numbers
-from typing import Any
-
 import numpy as np
-import pandas as pd
 import pytest
 
-try:
-    import torch
-except ImportError:
-    torch = None
+from shap.utils._slicer import Alias, AtomicSlicer, Slicer, _handle_newaxis_ellipses, unify_slice
 
-from scipy.sparse import csc_matrix, csr_matrix, dok_matrix, lil_matrix
 
-from shap.utils._slicer import Alias as A
-from shap.utils._slicer import AtomicSlicer
-from shap.utils._slicer import Obj as O
-from shap.utils._slicer import Slicer as S
+class TestSlicerNormalizations:
+    """Tests for core index and slice normalization logic."""
 
+    def test_handle_newaxis_ellipses(self):
+        # Test filling max_dim with slice(None)
+        res = _handle_newaxis_ellipses((...,), max_dim=3)
+        assert res == (slice(None), slice(None), slice(None))
 
-def coerced(o: Any):
-    if isinstance(o, (csc_matrix, csr_matrix, dok_matrix, lil_matrix)):
-        o = o.toarray()
+        # Test concrete indices with ellipsis
+        res = _handle_newaxis_ellipses((1, ..., 2), max_dim=4)
+        assert res == (1, slice(None), slice(None), 2)
 
-    to_list_collections = [np.ndarray, pd.core.series.Series]
-    if torch is not None:
-        to_list_collections.append(torch.Tensor)
+        # Test multiple ellipses raise error
+        with pytest.raises(IndexError, match="an index can only have a single ellipsis"):
+            _handle_newaxis_ellipses((..., 1, ...), max_dim=3)
 
-    if isinstance(o, (list, tuple)):
-        return o
-    elif isinstance(o, tuple(to_list_collections)):
-        return o.tolist()
-    elif isinstance(o, pd.core.frame.DataFrame):
-        return o.values.tolist()
-    elif isinstance(o, dict):
-        li = [np.nan] * len(o)
-        for k, v in o.items():
-            li[k] = v
-        return li
-    else:
-        raise ValueError(f"Object {o} of {type(o)} is not a list, tuple nor array.")
+        # Test too many indices raise error
+        with pytest.raises(IndexError, match="too many indices for array"):
+            _handle_newaxis_ellipses((1, 2, 3), max_dim=2)
 
+    def test_unify_slice(self):
+        # Unify single int
+        assert unify_slice(1, max_dim=2) == (1, slice(None))
 
-def is_close(a: int | float, b: int | float, rel_tol: float = 1e-09, abs_tol: float = 0.0):
-    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+        # Unify tuple
+        assert unify_slice((1, 2), max_dim=2) == (1, 2)
 
 
-def ctr_eq(c1: Any, c2: Any):
-    if torch is not None:
-        if isinstance(c1, torch.Tensor) and c1.shape == torch.Size([]):
-            c1 = c1.item()
-        if isinstance(c2, torch.Tensor) and c2.shape == torch.Size([]):
-            c2 = c2.item()
+class TestAtomicSlicer:
+    """Tests for the base AtomicSlicer logic across data types."""
 
-    if isinstance(c1, numbers.Number) and isinstance(c2, numbers.Number):
-        return is_close(c1, c2)
+    def test_list_tuple_handler(self):
+        data = [[1, 2, 3], [4, 5, 6]]
+        s = AtomicSlicer(data)
 
-    c1 = coerced(c1)
-    c2 = coerced(c2)
+        assert s[0] == [1, 2, 3]
+        assert s[:, 1] == [2, 5]
+        assert s[1, 1:] == [5, 6]
 
-    return all([ctr_eq(c1[i], c2[i]) for i in range(max(len(c1), len(c2)))])
+    def test_dict_handler(self):
+        data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+        s = AtomicSlicer(data)
 
+        # Slicing by key (DictHandler treats keys as dimension 0)
+        assert s["a"] == [1, 2, 3]
 
-def test_slicer_ragged_numpy():
-    values = np.array([np.array([0, 1]), np.array([2, 3, 4])], dtype=object)
-    data = np.array(
-        [
-            np.array([5, 6, 7]),
-        ]
-    )
+        # Slicing the elements inside the dictionary values (dimension 1)
+        # slice(None) for keys, 0 for the first element in each array
+        assert s[:, 0] == {"a": 1, "b": 4}
+        assert s[:, 1:] == {"a": [2, 3], "b": [5, 6]}
 
-    slicer = S(values=values, data=data)
-    sliced = slicer[0, 1]
+    def test_numpy_array_handler(self):
+        data = np.array([[1, 2], [3, 4], [5, 6]])
+        s = AtomicSlicer(data)
 
-    assert ctr_eq(sliced.data, data[0][1])
-    assert ctr_eq(sliced.values, values[0][1])
+        np.testing.assert_array_equal(s[1:], np.array([[3, 4], [5, 6]]))
+        np.testing.assert_array_equal(s[:, 1], np.array([2, 4, 6]))
 
 
-def test_slicer_basic():
-    data = [[1, 2], [3, 4]]
-    values = [[5, 6], [7, 8]]
-    identifiers = ["id1", "id1"]
-    instance_names = ["r1", "r2"]
-    feature_names = ["f1", "f2"]
-    full_name = "A"
+class TestSlicerAPI:
+    """Tests for the main Slicer public API."""
 
-    slicer = S(
-        data=data,
-        values=values,
-        identifiers=A(identifiers, 0),
-        instance_names=A(instance_names, 0),
-        feature_names=A(feature_names, 1),
-        full_name=full_name,
-    )
+    def test_slicer_initialization(self):
+        # Test anonymous (positional) initialization
+        s = Slicer([1, 2, 3])
+        assert s.o == [1, 2, 3]
 
-    colon_actual = slicer[:, 1]
-    assert colon_actual.data == [2, 4]
-    assert colon_actual.instance_names == ["r1", "r2"]
-    assert colon_actual.feature_names == "f2"
-    assert colon_actual.values == [6, 8]
+        # Test kwargs initialization
+        s_kwargs = Slicer(x=[1, 2, 3], y=["a", "b", "c"])
+        assert s_kwargs.x == [1, 2, 3]
+        assert s_kwargs.y == ["a", "b", "c"]
 
-    ellipses_actual = slicer[..., 1]
-    assert ellipses_actual.data == [2, 4]
-    assert ellipses_actual.instance_names == ["r1", "r2"]
-    assert ellipses_actual.feature_names == "f2"
-    assert ellipses_actual.values == [6, 8]
+    def test_slicer_alias_lookup(self):
+        data = [10, 20, 30]
+        s = Slicer(data)
 
-    array_index_actual = slicer[[0, 1], 1]
-    assert array_index_actual.data == [2, 4]
-    assert array_index_actual.feature_names == "f2"
-    assert array_index_actual.instance_names == ["r1", "r2"]
-    assert array_index_actual.values == [6, 8]
+        # Add an alias tracking dimension 0
+        s.names = Alias(["first", "second", "third"], dim=0)
 
-    alias_actual = slicer["r1", "f2"]
-    assert alias_actual.data == 2
-    assert alias_actual.feature_names == "f2"
-    assert alias_actual.instance_names == "r1"
-    assert alias_actual.values == 6
+        # Test dictionary-like lookup using the alias
+        res = s["second"]
+        assert res.o == 20
 
-    alias_actual = slicer["id1", "f2"]
-    assert alias_actual.data == [2, 4]
-    assert alias_actual.feature_names == "f2"
-    assert alias_actual.instance_names == ["r1", "r2"]
-    assert alias_actual.values == [6, 8]
+        # Ensure we can still slice normally
+        res_normal = s[:2]
+        assert res_normal.o == [10, 20]
 
-    chained_actual = slicer[:][:, 1]
-    assert chained_actual.data == [2, 4]
-    assert chained_actual.feature_names == "f2"
-    assert chained_actual.instance_names == ["r1", "r2"]
-    assert chained_actual.values == [6, 8]
+    def test_slicer_dynamic_attribute_assignment(self):
+        s = Slicer([1, 2, 3])
+        s.y = [4, 5, 6]
 
-    alias_actual = slicer["id1"][:, "f2"]
-    assert alias_actual.data == [2, 4]
-    assert alias_actual.feature_names == "f2"
-    assert alias_actual.instance_names == ["r1", "r2"]
-    assert alias_actual.values == [6, 8]
+        assert s.y == [4, 5, 6]
+        res = s[1:]
+        assert res.o == [2, 3]
+        assert res.y == [5, 6]
 
-    alias_actual = slicer["r1"]
-    alias_actual = alias_actual["f2"]
-    assert alias_actual.data == 2
-    assert alias_actual.feature_names == "f2"
-    assert alias_actual.instance_names == "r1"
-    assert alias_actual.values == 6
+    def test_slicer_deletion(self):
+        s = Slicer(x=[1, 2], y=[3, 4])
+        del s.x
 
+        with pytest.raises(AttributeError):
+            _ = s.x
 
-def test_slicer_unnamed():
-    a = [1, 2, 3]
-    b = [4, 5, 6]
-
-    slicer = S(a, b)
-    actual_a, actual_b = slicer[1].o
-    assert actual_a == 2
-    assert actual_b == 5
-
-    df1 = pd.DataFrame([[1, 2], [3, 4]])
-    df2 = pd.DataFrame([[5, 6], [7, 8]])
-    slicer = S(df1, df2)
-    actual_1, actual_2 = slicer[:, 0].o
-
-    assert ctr_eq(actual_1.values, [1, 3])
-    assert ctr_eq(actual_2.values, [5, 7])
-
-
-def test_slicer_crud():
-    data = [[1, 2], [3, 4]]
-    values = [[5, 6], [7, 8]]
-    extra = [[9, 10], [11, 12]]
-    overridden = [[13, 14], [15, 16]]
-
-    slicer = S(data=data, values=values)
-    slicer.extra = extra
-    slicer.data = overridden
-    del slicer.values
-
-    sliced = slicer[0, 1]
-    assert sliced.data == 14
-    with pytest.raises(Exception):
-        _ = sliced.values
-
-    assert sliced.extra == 10
-
-    del slicer.o
-    assert slicer.o == []
-
-
-def test_slicer_default_alias():
-    df = pd.DataFrame([[1, 2], [3, 4]], columns=["A", "B"])
-    slicer = S(df)
-    assert getattr(slicer, "index", None)
-    assert getattr(slicer, "columns", None)
-    actual = slicer[:, "A"].o
-    assert ctr_eq(actual, [1, 3])
-
-
-def test_slicer_anon_dict():
-    di = {"a": [1, 2, 3], "b": [4, 5, 6]}
-    slicer = S(di)
-
-    result = slicer["a", 1].o
-    assert result == 2
-
-
-def test_slicer_3d():
-    data_2d = [[1, 2], [3, 4], [5, 6]]
-    values_3d = [
-        [[1, 2, 3], [4, 5, 6]],
-        [[7, 8, 9], [10, 11, 12]],
-        [[13, 14, 15], [16, 17, 18]],
-    ]
-    names = ["a", "b", "c"]
-
-    slicer = S(data=data_2d, values=values_3d, names=A(names, 2))
-    actual = slicer[..., 1]
-    assert ctr_eq(actual.data, data_2d)
-    assert actual.names == "b"
-
-    actual = slicer[0, :, 1]
-    assert ctr_eq(actual.data, data_2d[0])
-    assert actual.names == "b"
-
-    actual = slicer[0, :][:, 1]
-    assert ctr_eq(actual.data, data_2d[0])
-    assert actual.names == "b"
-
-
-def test_untracked():
-    data = [1, 2, 3, 4]
-    primitive = 1
-    collection = [[8, 9]]
-    slicer = S(data=data, primitive=O(primitive, None), collection=O(collection, None))
-    actual = slicer[:2]
-    assert actual.data == data[:2]
-    assert actual.primitive == primitive
-    assert ctr_eq(actual.collection, collection)
-
-
-def test_partial_untracked():
-    s = S(a=np.zeros((4, 5, 6)), b=O(np.ones((4, 2, 2)), [0]))
-    assert s[:, :, 1].b.shape == (4, 2, 2)
-
-
-def test_numpy_subkeys():
-    data = [1, 2, 3, 4]
-    slicer = S(data=data)
-
-    subkey_int = np.int64(1)
-    assert slicer[subkey_int].data == 2
-
-    subkey_arr = np.array([0, 1])
-    assert ctr_eq(slicer[subkey_arr].data, [1, 2])
-
-    subkey_2d = np.array([[0, 1], [3, 4]])
-    with pytest.raises(ValueError):
-        _ = slicer[subkey_2d]
-
-
-def test_repr_smoke():
-    slicer = S([1, 2], ["a", "b"], named=[3, 4])
-    print(slicer)
-
-    atomic = AtomicSlicer([1, 2, 3, 4])
-    print(atomic)
-
-
-def test_slicer_simple_di():
-    di = {"A": [1, 2], "B": [3, 4], "C": [5, 6]}
-    slicer = S(di)
-    actual = slicer["B", 0]
-    actual = actual.o
-    assert ctr_eq(actual, 3)
-
-    nested_di = {"X": di, "Y": di}
-    actual = S(nested_di)["X", "B", 0].o
-    assert ctr_eq(actual, 3)
-
-
-def test_slicer_sparse():
-    array = np.array([[1, 0, 4], [0, 0, 5], [2, 3, 6]])
-    csc_array = csc_matrix(array)
-    csr_array = csr_matrix(array)
-    dok_array = dok_matrix(array)
-    lil_array = lil_matrix(array)
-
-    candidates = [csc_array, csr_array, dok_array, lil_array]
-    for candidate in candidates:
-        slicer = S(candidate)
-        actual = slicer[0, 0]
-        assert ctr_eq(actual.o, 1)
-        actual = slicer[1, 1]
-        assert ctr_eq(actual.o, 0)
-
-        actual = slicer[0]
-        expected = np.array([1, 0, 4])
-        assert ctr_eq(actual.o, expected)
-
-        actual = slicer[:, 1]
-        expected = np.array([0, 0, 3])
-        assert ctr_eq(actual.o, expected)
-
-        actual = slicer[:, :]
-        expected = np.array([[1, 0, 4], [0, 0, 5], [2, 3, 6]])
-        assert ctr_eq(actual.o, expected)
-
-        actual = slicer[0, :]
-        expected = np.array([1, 0, 4])
-        assert ctr_eq(actual.o, expected)
-
-
-@pytest.mark.skipif(torch is None, reason="PyTorch is not installed")
-def test_slicer_torch():
-    data = torch.tensor([[1, 2], [3, 4]])
-    values = torch.tensor([[5, 6], [7, 8]])
-    alias = ["f1", "f2"]
-
-    slicer = S(data=data, values=values, alias=A(alias, 1))
-    sliced = slicer[0, "f2"]
-    assert sliced.data == 2
-    assert sliced.values == 6
-
-
-def test_slicer_pandas():
-    di = {"A": [1, 2], "B": [3, 4], "C": [5, 6]}
-    df = pd.DataFrame(di)
-
-    slicer = S(df)
-    assert slicer[0, "A"].o == 1
-    assert ctr_eq(slicer[:, "A"].o, [1, 2])
-    assert ctr_eq(slicer[0, :].o, [1, 3, 5])
-
-    df = pd.DataFrame(di, index=["X", "Y"])
-    slicer = S(df)
-    assert slicer["X", "A"].o == 1
-    assert slicer[0, "A"].o == 1
-    assert slicer[0, 0].o == 1
-    slicer = S(df["A"])
-    assert slicer["X"].o == 1
-    assert slicer[0].o == 1
-    assert ctr_eq(slicer[:].o, [1, 2])
-
-
-def test_handle_newaxis_ellipses():
-    from shap.utils._slicer import _handle_newaxis_ellipses
-
-    index_tup = (1,)
-    max_dim = 3
-
-    expanded_index_tup = _handle_newaxis_ellipses(index_tup, max_dim)
-    assert expanded_index_tup == (1, slice(None), slice(None))
-
-
-def test_tracked_dim_arg_smoke():
-    li = ["A", "B"]
-    _ = A(li, dim=0)
-    _ = A(li, dim=[0])
-    _ = A(li, dim=(0,))
-
-    with pytest.raises(Exception):
-        _ = A(li, dim=None)
-
-    with pytest.raises(Exception):
-        _ = A(li, dim=[0, 1])
-
-    _ = O(li, dim=0)
-    _ = O(li, dim=[0])
-    _ = O(li, dim=(0,))
-
-    assert True
-
-
-def test_operations_1d():
-    elements = [1, 2, 3, 4]
-    li = elements
-    tup = tuple(elements)
-    di = {i: x for i, x in enumerate(elements)}
-    series = pd.Series(elements)
-    array = np.array(elements)
-
-    containers = [li, tup, array, di, series]
-    if torch is not None:
-        containers.append(torch.tensor(elements))
-
-    for ctr in containers:
-        slicer = AtomicSlicer(ctr)
-
-        assert ctr_eq(slicer[0], elements[0])
-        assert ctr_eq(slicer[[0, 1, 2, 3]], elements)
-        assert ctr_eq(slicer[[0, 1, 2]], elements[:-1])
-        assert ctr_eq(slicer[:], elements[:])
-        assert ctr_eq(slicer[tuple()], elements)
-
-        if not isinstance(ctr, dict):
-            assert ctr_eq(slicer[-1], elements[-1])
-            assert ctr_eq(slicer[0:3:2], elements[0:3:2])
-
-
-def test_operations_2d():
-    elements = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    li = elements
-    df = pd.DataFrame(elements, columns=["A", "B", "C"])
-
-    sparse_csc = csc_matrix(elements)
-    sparse_csr = csr_matrix(elements)
-    sparse_dok = dok_matrix(elements)
-    sparse_lil = lil_matrix(elements)
-
-    containers = [li, df, sparse_csc, sparse_csr, sparse_dok, sparse_lil]
-    for ctr in containers:
-        slicer = AtomicSlicer(ctr)
-
-        assert ctr_eq(slicer[0], elements[0])
-
-        if not isinstance(ctr, dict):
-            assert ctr_eq(slicer[-1], elements[-1])
-            assert ctr_eq(slicer[0, 0:3:2], elements[0][0:3:2])
-
-        assert ctr_eq(slicer[[0, 1, 2], :], elements)
-        assert ctr_eq(slicer[:], elements)
-        assert ctr_eq(slicer[tuple()], elements)
-        assert ctr_eq(slicer[:, 0], [elements[i][0] for i, _ in enumerate(elements)])
-        assert ctr_eq(slicer[[0, 1], 0], [elements[i][0] for i in [0, 1]])
-        assert ctr_eq(slicer[[0, 1], 1], [elements[i][1] for i in [0, 1]])
-        assert ctr_eq(slicer[0, :], elements[0])
-        assert ctr_eq(slicer[0, 1], elements[0][1])
-        assert ctr_eq(slicer[..., 0], [elements[i][0] for i, _ in enumerate(elements)])
-
-
-def test_operations_3d():
-    elements = [
-        [[1, 2, 3], [4, 5, 6]],
-        [[7, 8, 9], [10, 11, 12]],
-        [[13, 14, 15], [16, 17, 18]],
-    ]
-    tuple_elements = (
-        ((1, 2, 3), (4, 5, 6)),
-        ((7, 8, 9), (10, 11, 12)),
-        ((13, 14, 15), (16, 17, 18)),
-    )
-
-    multi_array = np.array(elements)
-    list_of_lists = elements
-    tuples_of_tuples = tuple_elements
-    list_of_multi_arrays = [
-        np.array(elements[0]),
-        np.array(elements[1]),
-        np.array(elements[2]),
-    ]
-    di_of_multi_arrays = {
-        0: np.array(elements[0]),
-        1: np.array(elements[1]),
-        2: np.array(elements[2]),
-    }
-
-    containers = [
-        multi_array,
-        tuples_of_tuples,
-        list_of_lists,
-        list_of_multi_arrays,
-        di_of_multi_arrays,
-    ]
-    if torch is not None:
-        containers.append(torch.tensor(elements))
-
-    for ctr in containers:
-        slicer = AtomicSlicer(ctr)
-
-        assert ctr_eq(slicer[0], elements[0])
-
-        if not isinstance(ctr, dict):
-            assert ctr_eq(slicer[-1], elements[-1])
-            assert ctr_eq(slicer[0, 0:3:2], elements[0][0:3:2])
-
-        assert ctr_eq(slicer[[0, 1, 2], :], elements)
-        assert ctr_eq(slicer[:], elements)
-        assert ctr_eq(slicer[tuple()], elements)
-
-        assert ctr_eq(slicer[:, 0], [elements[i][0] for i, _ in enumerate(elements)])
-        assert ctr_eq(slicer[[0, 1], 0], [elements[i][0] for i in [0, 1]])
-        assert ctr_eq(slicer[[0, 1], 1], [elements[i][1] for i in [0, 1]])
-        assert ctr_eq(slicer[0, :], elements[0])
-        assert ctr_eq(slicer[0, 1], elements[0][1])
-
-        rows = []
-        for i, _ in enumerate(elements):
-            cols = []
-            for j, _ in enumerate(elements[i]):
-                cols.append(elements[i][j][1])
-            rows.append(cols)
-        assert ctr_eq(slicer[..., 1], rows)
-        assert ctr_eq(slicer[0, ..., 1], [elements[0][i][1] for i in range(len(elements[0]))])
-
-
-def test_attribute_assignment():
-    data = [[1, 2], [3, 4]]
-    values = [[5, 6], [7, 8]]
-    identifiers = ["id1", "id1"]
-    instance_names = ["r1", "r2"]
-    feature_names = ["f1", "f2"]
-    full_name = "A"
-
-    exp = S(
-        data=data,
-        values=values,
-        identifiers=A(identifiers, 0),
-        instance_names=A(instance_names, 0),
-        feature_names=A(feature_names, 1),
-        full_name=full_name,
-    )
-
-    exp.feature_names = ["f3", "f4"]
-
-    assert exp.feature_names == ["f3", "f4"]
-    assert exp[:, 0].feature_names == "f3"
-
-    with pytest.raises(Exception):
-        _ = exp[:, "f1"]
-
-    exp.feature_names = A(["f5", "f6"], dim=0)
-
-    assert exp.feature_names == ["f5", "f6"]
-    assert exp[1, :].feature_names == "f6"
+        assert s.y == [3, 4]


### PR DESCRIPTION
As discussed in #4623, slicer is no longer maintained and is blocking support for Python 3.12+. In this PR, I vendors the necessary parts of the package directly into `utils` so we can drop the external dependency.

I used the code from [slicer](https://github.com/interpretml/slicer) repository into `_slicer.py` and `test_slicer.py` and also updated `pyproject.toml` and `_explainer.py`.  
