### PR TITLE
DOCS: Fix Simple Kernel SHAP notebook

### DIFF
--- a/notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb
+++ b/notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "vscode": {
      "languageId": "sql"
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
     "scrolled": false,
     "vscode": {

--- a/notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb
+++ b/notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb
@@ -3,6 +3,11 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Simple Kernel SHAP\n",
     "\n",
@@ -18,8 +23,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "vscode": {
+     "languageId": "sql"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -28,8 +37,8 @@
       "  reference = [0. 0. 0. 0.]\n",
       "          x = [ 1.62434536 -0.61175641 -0.52817175 -1.07296862]\n",
       "shap_values = [ 0.89146267 -0.43752168 -0.31836259 -0.58464256]\n",
-      " base_value = 10.000000000000002\n",
-      "   sum(phi) = 9.55093584213122\n",
+      " base_value = 10.000000000000005\n",
+      "   sum(phi) = 9.550935842131222\n",
       "       f(x) = 9.55093584213122\n"
      ]
     }
@@ -104,9 +113,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {
-    "scrolled": false
+    "scrolled": false,
+    "vscode": {
+     "languageId": "sql"
+    }
    },
    "outputs": [
     {
@@ -131,7 +143,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "shap-env",
    "language": "python",
    "name": "python3"
   },
@@ -145,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes `notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb` 
as part of #3036.

- Fixed TqdmWarning by ensuring ipywidgets compatibility
- Verified all cells run cleanly from top to bottom
