### PR TITLE
ENH: Migrate clustering functions to C++ via nanobind

### DIFF
--- a/shap/cutils/clustering_utils.h
+++ b/shap/cutils/clustering_utils.h
@@ -8,6 +8,24 @@
 namespace nb = nanobind;
 using namespace nb::literals;
 
+namespace detail {
+
+inline int row_delta(
+    const nb::ndarray<bool, nb::shape<-1, -1>, nb::device::cpu>& masks,
+    int64_t row_a,
+    int64_t row_b
+) {
+    auto m = masks.view();
+    int score = 0;
+    for (size_t k = 0; k < masks.shape(1); k++) {
+        score += m(row_a, k) ^ m(row_b, k);
+    }
+    return score;
+}
+
+} // namespace detail
+
+
 void reverse_window(
     nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& order,
     const int start,
@@ -33,6 +51,21 @@ int mask_delta_score(
         score += m1(i) ^ m2(i);
     }
     return score;
+}
+
+int reverse_window_score_gain(
+    const nb::ndarray<bool, nb::shape<-1, -1>, nb::device::cpu>& masks,
+    const nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& order,
+    const int start,
+    const int length
+) {
+    assert(start >= 1);
+    assert(start + length < (int)order.shape(0));
+    int forward_score = detail::row_delta(masks, order(start - 1), order(start))
+                      + detail::row_delta(masks, order(start + length - 1), order(start + length));
+    int reverse_score = detail::row_delta(masks, order(start - 1), order(start + length - 1))
+                      + detail::row_delta(masks, order(start), order(start + length));
+    return forward_score - reverse_score;
 }
 
 #endif // CLUSTERING_UTILS_H

--- a/shap/cutils/clustering_utils.h
+++ b/shap/cutils/clustering_utils.h
@@ -1,0 +1,38 @@
+#ifndef CLUSTERING_UTILS_H
+#define CLUSTERING_UTILS_H
+
+#include <cassert>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+void reverse_window(
+    nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& order,
+    const int start,
+    const int length
+) {
+    assert(length >= 0);
+    assert(start >= 0);
+    assert((size_t)start + (size_t)length <= order.shape(0));
+    for (size_t i = 0; i < (size_t)length / 2; i++) {
+        int64_t tmp = order(start + i);
+        order(start + i) = order(start + length - i - 1);
+        order(start + length - i - 1) = tmp;
+    }
+}
+
+int mask_delta_score(
+    const nb::ndarray<bool, nb::shape<-1>, nb::device::cpu>& m1,
+    const nb::ndarray<bool, nb::shape<-1>, nb::device::cpu>& m2
+) {
+    assert(m1.shape(0) == m2.shape(0));
+    int score = 0;
+    for (size_t i = 0; i < m1.shape(0); i++) {
+        score += m1(i) ^ m2(i);
+    }
+    return score;
+}
+
+#endif // CLUSTERING_UTILS_H

--- a/shap/cutils/clustering_utils.h
+++ b/shap/cutils/clustering_utils.h
@@ -2,6 +2,7 @@
 #define CLUSTERING_UTILS_H
 
 #include <cassert>
+#include <algorithm>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 
@@ -66,6 +67,42 @@ int reverse_window_score_gain(
     int reverse_score = detail::row_delta(masks, order(start - 1), order(start + length - 1))
                       + detail::row_delta(masks, order(start), order(start + length));
     return forward_score - reverse_score;
+}
+
+nb::ndarray<nb::numpy, int64_t, nb::shape<-1>> delta_minimization_order(
+    const nb::ndarray<bool, nb::shape<-1, -1>, nb::device::cpu>& all_masks,
+    const int max_swap_size = 100,
+    const int num_passes = 2
+) {
+    size_t n = all_masks.shape(0);
+
+    int64_t* data = new int64_t[n];
+    for (size_t i = 0; i < n; i++) data[i] = static_cast<int64_t>(i);
+
+    nb::capsule owner(data, [](void* p) noexcept {
+        delete[] static_cast<int64_t*>(p);
+    });
+
+    int effective_max = std::min(max_swap_size, static_cast<int>(n));
+
+    for (int pass = 0; pass < num_passes; pass++) {
+        for (int length = 2; length < effective_max; length++) {
+            for (int i = 1; i < static_cast<int>(n) - length; i++) {
+                int forward = detail::row_delta(all_masks, data[i - 1], data[i])
+                            + detail::row_delta(all_masks, data[i + length - 1], data[i + length]);
+                int reverse = detail::row_delta(all_masks, data[i - 1], data[i + length - 1])
+                            + detail::row_delta(all_masks, data[i], data[i + length]);
+                if (forward > reverse) {
+                    for (int j = 0; j < length / 2; j++) {
+                        std::swap(data[i + j], data[i + length - j - 1]);
+                    }
+                }
+            }
+        }
+    }
+
+    size_t shape[1] = {n};
+    return nb::ndarray<nb::numpy, int64_t, nb::shape<-1>>(data, 1, shape, owner);
 }
 
 #endif // CLUSTERING_UTILS_H

--- a/shap/cutils/clustering_utils.h
+++ b/shap/cutils/clustering_utils.h
@@ -43,8 +43,7 @@ int pt_shuffle_rec(
     }
     int left  = static_cast<int>(partition_tree(i, 0)) - M;
     int right = static_cast<int>(partition_tree(i, 1)) - M;
-    std::bernoulli_distribution coin(0.5);
-    if (coin(rng)) {
+    if (std::bernoulli_distribution(0.5)(rng)) {
         pos = pt_shuffle_rec(left,  indexes, index_mask, partition_tree, M, pos, rng);
         pos = pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos, rng);
     } else {
@@ -136,15 +135,15 @@ nb::ndarray<nb::numpy, int64_t, nb::shape<-1>> delta_minimization_order(
 }
 
 int pt_shuffle_rec(
-	int i,
-	nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& indexes,
-	const nb::ndarray<bool, nb::shape<-1>, nb::device::cpu>& index_mask,
-	const nb::ndarray<double, nb::shape<-1,-1>, nb::device::cpu>& partition_tree,
-	int M,
-	int pos
+    int i,
+    nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& indexes,
+    const nb::ndarray<bool, nb::shape<-1>, nb::device::cpu>& index_mask,
+    const nb::ndarray<double, nb::shape<-1, -1>, nb::device::cpu>& partition_tree,
+    int M,
+    int pos
 ) {
-	thread_local std::mt19937 rng{std::random_device{}()};
-	return detail::pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos, rng);
+    thread_local std::mt19937 rng{std::random_device{}()};
+    return detail::pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos, rng);
 }
 
 #endif // CLUSTERING_UTILS_H

--- a/shap/cutils/clustering_utils.h
+++ b/shap/cutils/clustering_utils.h
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <algorithm>
+#include <random>
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 
@@ -22,6 +23,35 @@ inline int row_delta(
         score += m(row_a, k) ^ m(row_b, k);
     }
     return score;
+}
+
+int pt_shuffle_rec(
+    int i,
+    nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& indexes,
+    const nb::ndarray<bool, nb::shape<-1>, nb::device::cpu>& index_mask,
+    const nb::ndarray<double, nb::shape<-1, -1>, nb::device::cpu>& partition_tree,
+    int M,
+    int pos,
+    std::mt19937& rng
+) {
+    if (i < 0) {
+        if (index_mask(i + M)) {
+            indexes(pos) = i + M;
+            return pos + 1;
+        }
+        return pos;
+    }
+    int left  = static_cast<int>(partition_tree(i, 0)) - M;
+    int right = static_cast<int>(partition_tree(i, 1)) - M;
+    std::bernoulli_distribution coin(0.5);
+    if (coin(rng)) {
+        pos = pt_shuffle_rec(left,  indexes, index_mask, partition_tree, M, pos, rng);
+        pos = pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos, rng);
+    } else {
+        pos = pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos, rng);
+        pos = pt_shuffle_rec(left,  indexes, index_mask, partition_tree, M, pos, rng);
+    }
+    return pos;
 }
 
 } // namespace detail
@@ -103,6 +133,18 @@ nb::ndarray<nb::numpy, int64_t, nb::shape<-1>> delta_minimization_order(
 
     size_t shape[1] = {n};
     return nb::ndarray<nb::numpy, int64_t, nb::shape<-1>>(data, 1, shape, owner);
+}
+
+int pt_shuffle_rec(
+	int i,
+	nb::ndarray<int64_t, nb::shape<-1>, nb::device::cpu>& indexes,
+	const nb::ndarray<bool, nb::shape<-1>, nb::device::cpu>& index_mask,
+	const nb::ndarray<double, nb::shape<-1,-1>, nb::device::cpu>& partition_tree,
+	int M,
+	int pos
+) {
+	thread_local std::mt19937 rng{std::random_device{}()};
+	return detail::pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos, rng);
 }
 
 #endif // CLUSTERING_UTILS_H

--- a/shap/cutils/cutils.cpp
+++ b/shap/cutils/cutils.cpp
@@ -13,4 +13,5 @@ NB_MODULE(_cutils, m)
     m.def("compute_exp_val", &compute_exp_val, "nsamples_run"_a, "nsamples_added"_a, "D"_a, "N"_a, "weights"_a, "y"_a, "ey"_a, "Compute the expected value for the kernel explainer algorithm");
     m.def("reverse_window", &reverse_window, "order"_a, "start"_a, "length"_a, "Reverse a window of length elements in order starting at index start");
     m.def("mask_delta_score", &mask_delta_score, "m1"_a, "m2"_a, "Compute the Hamming distance between two boolean masks");
+    m.def("reverse_window_score_gain", &reverse_window_score_gain, "masks"_a, "order"_a, "start"_a, "length"_a, "Compute the score gain from reversing a window in the ordering");
 }

--- a/shap/cutils/cutils.cpp
+++ b/shap/cutils/cutils.cpp
@@ -14,6 +14,6 @@ NB_MODULE(_cutils, m)
     m.def("reverse_window", &reverse_window, "order"_a, "start"_a, "length"_a, "Reverse a window of length elements in order starting at index start");
     m.def("mask_delta_score", &mask_delta_score, "m1"_a, "m2"_a, "Compute the Hamming distance between two boolean masks");
     m.def("reverse_window_score_gain", &reverse_window_score_gain, "masks"_a, "order"_a, "start"_a, "length"_a, "Compute the score gain from reversing a window in the ordering");
-	m.def("delta_minimization_order", &delta_minimization_order, "all_masks"_a, "max_swap_size"_a = 100, "num_passes"_a = 2, "Compute the delta minimization order for a set of masks");
-	m.def("pt_shuffle_rec", &pt_shuffle_rec, "i"_a, "indexes"_a, "index_mask"_a, "partition_tree"_a, "M"_a, "pos"_a, "Recursively shuffle feature indices in tree order using a random coin flip at each internal node");
+    m.def("delta_minimization_order", &delta_minimization_order, "all_masks"_a, "max_swap_size"_a = 100, "num_passes"_a = 2, "Compute the delta minimization order for a set of masks");
+    m.def("pt_shuffle_rec", &pt_shuffle_rec, "i"_a, "indexes"_a, "index_mask"_a, "partition_tree"_a, "M"_a, "pos"_a, "Recursively shuffle feature indices in tree order using a random coin flip at each internal node");
 }

--- a/shap/cutils/cutils.cpp
+++ b/shap/cutils/cutils.cpp
@@ -15,4 +15,5 @@ NB_MODULE(_cutils, m)
     m.def("mask_delta_score", &mask_delta_score, "m1"_a, "m2"_a, "Compute the Hamming distance between two boolean masks");
     m.def("reverse_window_score_gain", &reverse_window_score_gain, "masks"_a, "order"_a, "start"_a, "length"_a, "Compute the score gain from reversing a window in the ordering");
 	m.def("delta_minimization_order", &delta_minimization_order, "all_masks"_a, "max_swap_size"_a = 100, "num_passes"_a = 2, "Compute the delta minimization order for a set of masks");
+	m.def("pt_shuffle_rec", &pt_shuffle_rec, "i"_a, "indexes"_a, "index_mask"_a, "partition_tree"_a, "M"_a, "pos"_a, "Recursively shuffle feature indices in tree order using a random coin flip at each internal node");
 }

--- a/shap/cutils/cutils.cpp
+++ b/shap/cutils/cutils.cpp
@@ -2,6 +2,7 @@
 #include <nanobind/nanobind.h>
 #include "grey_code_utils.h"
 #include "kernel_explainer_utils.h"
+#include "clustering_utils.h"
 
 namespace nb = nanobind;
 
@@ -10,4 +11,6 @@ NB_MODULE(_cutils, m)
     m.def("compute_grey_code_row_values", &compute_grey_code_row_values_1d, "row_values"_a, "mask"_a, "inds"_a, "outputs"_a, "shapley_coeff"_a, "extended_delta_indexes"_a, "noop_code"_a, "Compute the row values for the grey code algorithm in 1D");
     m.def("compute_grey_code_row_values", &compute_grey_code_row_values_2d, "row_values"_a, "mask"_a, "inds"_a, "outputs"_a, "shapley_coeff"_a, "extended_delta_indexes"_a, "noop_code"_a, "Compute the row values for the grey code algorithm in 2D");
     m.def("compute_exp_val", &compute_exp_val, "nsamples_run"_a, "nsamples_added"_a, "D"_a, "N"_a, "weights"_a, "y"_a, "ey"_a, "Compute the expected value for the kernel explainer algorithm");
+    m.def("reverse_window", &reverse_window, "order"_a, "start"_a, "length"_a, "Reverse a window of length elements in order starting at index start");
+    m.def("mask_delta_score", &mask_delta_score, "m1"_a, "m2"_a, "Compute the Hamming distance between two boolean masks");
 }

--- a/shap/cutils/cutils.cpp
+++ b/shap/cutils/cutils.cpp
@@ -14,4 +14,5 @@ NB_MODULE(_cutils, m)
     m.def("reverse_window", &reverse_window, "order"_a, "start"_a, "length"_a, "Reverse a window of length elements in order starting at index start");
     m.def("mask_delta_score", &mask_delta_score, "m1"_a, "m2"_a, "Compute the Hamming distance between two boolean masks");
     m.def("reverse_window_score_gain", &reverse_window_score_gain, "masks"_a, "order"_a, "start"_a, "length"_a, "Compute the score gain from reversing a window in the ordering");
+	m.def("delta_minimization_order", &delta_minimization_order, "all_masks"_a, "max_swap_size"_a = 100, "num_passes"_a = 2, "Compute the delta minimization order for a set of masks");
 }

--- a/shap/utils/__init__.py
+++ b/shap/utils/__init__.py
@@ -1,5 +1,5 @@
+from .._cutils import delta_minimization_order
 from ._clustering import (
-    delta_minimization_order,
     hclust,
     hclust_ordering,
     partition_tree,

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -10,8 +10,10 @@ import pandas as pd
 import scipy.cluster
 import scipy.spatial
 import sklearn
-from numba import njit
 
+from .._cutils import (
+    pt_shuffle_rec,
+)
 from ..utils._exceptions import DimensionError
 from ._show_progress import show_progress
 
@@ -43,80 +45,7 @@ def partition_tree_shuffle(
 
     """
     M = len(index_mask)
-    # switch = np.random.randn(M) < 0
-    _pt_shuffle_rec(partition_tree.shape[0] - 1, indexes, index_mask, partition_tree, M, 0)
-
-
-@njit
-def _pt_shuffle_rec(
-    i: int,
-    indexes: npt.NDArray[Any],
-    index_mask: npt.NDArray[np.bool_],
-    partition_tree: npt.NDArray[Any],
-    M: int,
-    pos: int,
-) -> int:  # type: ignore[misc]
-    if i < 0:
-        # see if we should include this index in the ordering
-        if index_mask[i + M]:
-            indexes[pos] = i + M
-            return pos + 1
-        else:
-            return pos
-    left = int(partition_tree[i, 0] - M)
-    right = int(partition_tree[i, 1] - M)
-    if np.random.randn() < 0:
-        pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
-        pos = _pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos)
-    else:
-        pos = _pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos)
-        pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
-    return pos
-
-
-@njit
-def delta_minimization_order(
-    all_masks: npt.NDArray[Any],
-    max_swap_size: int = 100,
-    num_passes: int = 2,
-) -> npt.NDArray[Any]:  # type: ignore[misc]
-    order = np.arange(len(all_masks))
-    for _ in range(num_passes):
-        for length in list(range(2, max_swap_size)):
-            for i in range(1, len(order) - length):
-                if _reverse_window_score_gain(all_masks, order, i, length) > 0:
-                    _reverse_window(order, i, length)
-    return order
-
-
-@njit
-def _reverse_window(order: npt.NDArray[Any], start: int, length: int) -> None:  # type: ignore[misc]
-    for i in range(length // 2):
-        tmp = order[start + i]
-        order[start + i] = order[start + length - i - 1]
-        order[start + length - i - 1] = tmp
-
-
-@njit
-def _reverse_window_score_gain(
-    masks: npt.NDArray[Any],
-    order: npt.NDArray[Any],
-    start: int,
-    length: int,
-) -> int:  # type: ignore[misc]
-    forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + _mask_delta_score(
-        masks[order[start + length - 1]], masks[order[start + length]]
-    )
-    reverse_score = _mask_delta_score(masks[order[start - 1]], masks[order[start + length - 1]]) + _mask_delta_score(
-        masks[order[start]], masks[order[start + length]]
-    )
-
-    return forward_score - reverse_score
-
-
-@njit
-def _mask_delta_score(m1: npt.NDArray[Any], m2: npt.NDArray[Any]) -> int:  # type: ignore[misc]
-    return (m1 ^ m2).sum()
+    pt_shuffle_rec(partition_tree.shape[0] - 1, indexes, index_mask, partition_tree, M, 0)
 
 
 def hclust_ordering(

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -1,7 +1,15 @@
 """Tests for the C++ utility functions in shap._cutils."""
 
 import numpy as np
-from shap._cutils import delta_minimization_order, mask_delta_score, reverse_window, reverse_window_score_gain
+import scipy.cluster.hierarchy
+
+from shap._cutils import (
+    delta_minimization_order,
+    mask_delta_score,
+    pt_shuffle_rec,
+    reverse_window,
+    reverse_window_score_gain,
+)
 
 # Tests for reverse_window
 
@@ -134,3 +142,73 @@ def test_delta_minimization_order_reorders():
     order = delta_minimization_order(masks)
     np.testing.assert_array_equal(sorted(order), [0, 1, 2, 3])
     assert _total_delta(masks, order) < _total_delta(masks, np.array([0, 1, 2, 3]))
+
+
+# Tests for pt_shuffle_rec
+
+
+def _subtree_leaves(node, pt, M):
+    """Recursively collect all leaf feature indices under a given internal node."""
+    if node < 0:
+        return {node + M}
+    left = int(pt[node, 0]) - M
+    right = int(pt[node, 1]) - M
+    return _subtree_leaves(left, pt, M) | _subtree_leaves(right, pt, M)
+
+
+def _build_tree(M):
+    """Build a small scipy complete-linkage tree for M features."""
+    np.random.seed(0)
+    X = np.random.randn(M, 3)
+    return scipy.cluster.hierarchy.complete(X).astype(np.float64)
+
+
+# full mask — pos equals M and all feature indices 0..M-1 are written exactly once
+def test_pt_shuffle_rec_full_mask():
+    M = 8
+    pt = _build_tree(M)
+    index_mask = np.ones(M, dtype=bool)
+    indexes = np.zeros(M, dtype=np.int64)
+    pos = pt_shuffle_rec(int(pt.shape[0] - 1), indexes, index_mask, pt, M, 0)
+    assert pos == M
+    np.testing.assert_array_equal(sorted(indexes[:pos]), list(range(M)))
+
+
+# partial mask — only masked features appear, count matches number of True entries
+def test_pt_shuffle_rec_partial_mask():
+    M = 8
+    pt = _build_tree(M)
+    index_mask = np.array([i % 2 == 0 for i in range(M)], dtype=bool)
+    indexes = np.zeros(M, dtype=np.int64)
+    pos = pt_shuffle_rec(int(pt.shape[0] - 1), indexes, index_mask, pt, M, 0)
+    assert pos == int(index_mask.sum())
+    np.testing.assert_array_equal(sorted(indexes[:pos]), sorted(np.where(index_mask)[0]))
+
+
+# contiguity — every internal node's leaves appear as a contiguous block in the output
+def test_pt_shuffle_rec_contiguity():
+    M = 8
+    pt = _build_tree(M)
+    index_mask = np.ones(M, dtype=bool)
+    indexes = np.zeros(M, dtype=np.int64)
+    pos = pt_shuffle_rec(int(pt.shape[0] - 1), indexes, index_mask, pt, M, 0)
+    result = indexes[:pos].tolist()
+    for node in range(pt.shape[0]):
+        leaves = _subtree_leaves(node, pt, M)
+        positions = [result.index(leaf) for leaf in leaves]
+        assert max(positions) - min(positions) + 1 == len(positions)
+
+
+# stability — contiguity holds across 20 random runs, ruling out flaky RNG behaviour
+def test_pt_shuffle_rec_contiguity_stable():
+    M = 8
+    pt = _build_tree(M)
+    index_mask = np.ones(M, dtype=bool)
+    for _ in range(20):
+        indexes = np.zeros(M, dtype=np.int64)
+        pos = pt_shuffle_rec(int(pt.shape[0] - 1), indexes, index_mask, pt, M, 0)
+        result = indexes[:pos].tolist()
+        for node in range(pt.shape[0]):
+            leaves = _subtree_leaves(node, pt, M)
+            positions = [result.index(leaf) for leaf in leaves]
+            assert max(positions) - min(positions) + 1 == len(positions)

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -1,7 +1,6 @@
 """Tests for the C++ utility functions in shap._cutils."""
 
 import numpy as np
-
 from shap._cutils import mask_delta_score, reverse_window
 
 # Tests for reverse_window

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -1,7 +1,8 @@
 """Tests for the C++ utility functions in shap._cutils."""
 
 import numpy as np
-from shap._cutils import mask_delta_score, reverse_window, reverse_window_score_gain
+
+from shap._cutils import delta_minimization_order, mask_delta_score, reverse_window, reverse_window_score_gain
 
 # Tests for reverse_window
 
@@ -103,3 +104,34 @@ def test_reverse_window_score_gain_length_one():
     masks = np.array([[1, 0], [0, 1], [1, 1]], dtype=bool)
     order = np.array([0, 1, 2], dtype=np.int64)
     assert reverse_window_score_gain(masks, order, 1, 1) == 0
+
+
+# Tests for delta_minimization_order
+
+
+def _total_delta(masks, order):
+    """Sum of adjacent Hamming distances for a given ordering."""
+    return sum(int((masks[order[i]] ^ masks[order[i + 1]]).sum()) for i in range(len(order) - 1))
+
+
+# single row — output must be [0]
+def test_delta_minimization_order_single_row():
+    masks = np.array([[1, 0]], dtype=bool)
+    order = delta_minimization_order(masks)
+    np.testing.assert_array_equal(order, [0])
+
+
+# all identical masks — any ordering is equally good, output must be a valid permutation
+def test_delta_minimization_order_identical_masks():
+    masks = np.array([[1, 0], [1, 0], [1, 0]], dtype=bool)
+    order = delta_minimization_order(masks)
+    np.testing.assert_array_equal(sorted(order), [0, 1, 2])
+
+
+# alternating pattern — identity ordering has total delta 6, optimal is 2
+# rows [1,0],[0,1],[1,0],[0,1]: grouping similar rows cuts crossings from 3 to 1
+def test_delta_minimization_order_reorders():
+    masks = np.array([[1, 0], [0, 1], [1, 0], [0, 1]], dtype=bool)
+    order = delta_minimization_order(masks)
+    np.testing.assert_array_equal(sorted(order), [0, 1, 2, 3])
+    assert _total_delta(masks, order) < _total_delta(masks, np.array([0, 1, 2, 3]))

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -1,0 +1,71 @@
+"""Tests for the C++ utility functions in shap._cutils."""
+
+import numpy as np
+
+from shap._cutils import mask_delta_score, reverse_window
+
+# Tests for reverse_window
+
+
+# reverses a window in the middle of the array, leaving surrounding elements untouched
+def test_reverse_window_basic():
+    order = np.array([0, 1, 2, 3, 4], dtype=np.int64)
+    reverse_window(order, 1, 3)
+    np.testing.assert_array_equal(order, [0, 3, 2, 1, 4])
+
+
+# reverses the entire array
+def test_reverse_window_full_array():
+    order = np.array([0, 1, 2, 3, 4], dtype=np.int64)
+    reverse_window(order, 0, 5)
+    np.testing.assert_array_equal(order, [4, 3, 2, 1, 0])
+
+
+# length=1 is a no-op, array must be unchanged
+def test_reverse_window_single_element():
+    order = np.array([0, 1, 2, 3], dtype=np.int64)
+    reverse_window(order, 2, 1)
+    np.testing.assert_array_equal(order, [0, 1, 2, 3])
+
+
+# length=0 is a no-op, array must be unchanged
+def test_reverse_window_empty():
+    order = np.array([0, 1, 2, 3], dtype=np.int64)
+    reverse_window(order, 1, 0)
+    np.testing.assert_array_equal(order, [0, 1, 2, 3])
+
+
+# window positioned at the tail of the array
+def test_reverse_window_at_end():
+    order = np.array([0, 1, 2, 3, 4], dtype=np.int64)
+    reverse_window(order, 2, 3)
+    np.testing.assert_array_equal(order, [0, 1, 4, 3, 2])
+
+
+# Tests for mask_delta_score
+
+
+# identical masks have zero Hamming distance
+def test_mask_delta_score_identical():
+    m = np.array([True, False, True, True], dtype=bool)
+    assert mask_delta_score(m, m) == 0
+
+
+# completely opposite masks have distance equal to array length
+def test_mask_delta_score_all_different():
+    m1 = np.array([True, True, False, False], dtype=bool)
+    m2 = np.array([False, False, True, True], dtype=bool)
+    assert mask_delta_score(m1, m2) == 4
+
+
+# partially overlapping masks return the count of differing positions
+def test_mask_delta_score_partial():
+    m1 = np.array([True, False, True, False], dtype=bool)
+    m2 = np.array([True, True, False, False], dtype=bool)
+    assert mask_delta_score(m1, m2) == 2
+
+
+# single-element arrays — one matching, one different
+def test_mask_delta_score_single_element():
+    assert mask_delta_score(np.array([True], dtype=bool), np.array([True], dtype=bool)) == 0
+    assert mask_delta_score(np.array([True], dtype=bool), np.array([False], dtype=bool)) == 1

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import scipy.cluster.hierarchy
-
 from shap._cutils import (
     delta_minimization_order,
     mask_delta_score,

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -1,7 +1,7 @@
 """Tests for the C++ utility functions in shap._cutils."""
 
 import numpy as np
-from shap._cutils import mask_delta_score, reverse_window
+from shap._cutils import mask_delta_score, reverse_window, reverse_window_score_gain
 
 # Tests for reverse_window
 
@@ -68,3 +68,38 @@ def test_mask_delta_score_partial():
 def test_mask_delta_score_single_element():
     assert mask_delta_score(np.array([True], dtype=bool), np.array([True], dtype=bool)) == 0
     assert mask_delta_score(np.array([True], dtype=bool), np.array([False], dtype=bool)) == 1
+
+
+# Tests for reverse_window_score_gain
+
+
+# reversing reduces total delta — gain is positive
+def test_reverse_window_score_gain_positive():
+    masks = np.array([[1, 0], [0, 1], [1, 0], [0, 1]], dtype=bool)
+    order = np.array([0, 1, 2, 3], dtype=np.int64)
+    # forward: delta(row0,row1) + delta(row2,row3) = 2 + 2 = 4
+    # reverse: delta(row0,row2) + delta(row1,row3) = 0 + 0 = 0
+    assert reverse_window_score_gain(masks, order, 1, 2) == 4
+
+
+# reversing increases total delta — gain is negative
+def test_reverse_window_score_gain_negative():
+    masks = np.array([[1, 0], [1, 0], [0, 1], [0, 1]], dtype=bool)
+    order = np.array([0, 1, 2, 3], dtype=np.int64)
+    # forward: delta(row0,row1) + delta(row2,row3) = 0 + 0 = 0
+    # reverse: delta(row0,row2) + delta(row1,row3) = 2 + 2 = 4
+    assert reverse_window_score_gain(masks, order, 1, 2) == -4
+
+
+# all identical masks — all deltas are zero, gain is always zero
+def test_reverse_window_score_gain_zero():
+    masks = np.array([[1, 0], [1, 0], [1, 0], [1, 0]], dtype=bool)
+    order = np.array([0, 1, 2, 3], dtype=np.int64)
+    assert reverse_window_score_gain(masks, order, 1, 2) == 0
+
+
+# length=1 window — forward and reverse expressions are identical, gain is always zero
+def test_reverse_window_score_gain_length_one():
+    masks = np.array([[1, 0], [0, 1], [1, 1]], dtype=bool)
+    order = np.array([0, 1, 2], dtype=np.int64)
+    assert reverse_window_score_gain(masks, order, 1, 1) == 0

--- a/tests/test_cutils.py
+++ b/tests/test_cutils.py
@@ -1,7 +1,6 @@
 """Tests for the C++ utility functions in shap._cutils."""
 
 import numpy as np
-
 from shap._cutils import delta_minimization_order, mask_delta_score, reverse_window, reverse_window_score_gain
 
 # Tests for reverse_window


### PR DESCRIPTION
Part of #4327 (Stage 2) — continuation of #4570, retargeted to master after Stage 1 merged.

## Summary

Migrates the full clustering stack from `shap/utils/_clustering.py` (numba `@njit`) to C++ via nanobind. Removes the numba dependency from `_clustering.py` entirely.

Functions ported:
- `_reverse_window` → `reverse_window`
- `_mask_delta_score` → `mask_delta_score`
- `_reverse_window_score_gain` → `reverse_window_score_gain`
- `delta_minimization_order` → `delta_minimization_order`
- `_pt_shuffle_rec` → `pt_shuffle_rec`

## Changes

- `shap/cutils/clustering_utils.h` — C++ implementations
- `shap/cutils/cutils.cpp` — nanobind registrations for all 5 functions
- `shap/utils/_clustering.py` — removed all `@njit` functions and `from numba import njit`; `partition_tree_shuffle` retained as a thin Python wrapper calling `pt_shuffle_rec`
- `shap/utils/__init__.py` — updated `delta_minimization_order` re-export to pull from `_cutils` instead of `_clustering`
- `shap/_cutils.pyi` — type stubs for all 5 new functions
- `tests/test_cutils.py` — 20 unit tests across all 5 functions

## Design decisions

**`detail::` namespace for internal helpers**
`detail::row_delta` and `detail::pt_shuffle_rec` are not bound to Python — they live in an internal namespace. `row_delta` exists because nanobind does not support row slicing (`masks[i]` on a 2D array), so per-row Hamming distance is computed via a `.view()` accessor loop. `pt_shuffle_rec` is separated so the recursive worker takes `std::mt19937&` by reference without exposing the RNG to Python.

**`.view()` for 2D array access**
All 2D array access uses `arr.view()(i, j)` rather than raw pointers with `nb::c_contig`. This is stride-safe and consistent with the existing `grey_code_utils.h` convention in the codebase.

**`bool` dtype for mask arrays**
Mask parameters are typed as `nb::ndarray<bool, ...>` matching the actual dtype used throughout the codebase (`npt.NDArray[np.bool_]`). Using `int64_t` for bool masks would be incorrect.

**`nb::capsule` for owned return arrays**
`delta_minimization_order` allocates a heap array and returns it as a numpy array. Ownership is transferred via `nb::capsule` with a custom deleter — the standard nanobind pattern for returning C++-allocated data without copying.

**Raw pointer in `delta_minimization_order` inner loop**
The inner loop of `delta_minimization_order` accesses `data[i]` directly on the owned `int64_t*` pointer rather than going through a nanobind accessor. This is safe because we own the allocation, and avoids accessor overhead in the hot path.

**`thread_local std::mt19937` for RNG**
One RNG instance per thread, seeded from `std::random_device`. Safe for multi-threaded use without a mutex. Matches numba's behaviour — numba's internal `@njit` RNG is also independent of `np.random.seed()`.

**`std::bernoulli_distribution(0.5)` for coin flip**
The Python implementation uses `np.random.randn() < 0` — a normal draw checked for sign — which is a 50/50 coin flip. `std::bernoulli_distribution(0.5)` is semantically identical but makes the intent explicit.

## Tests

20 unit tests in `tests/test_cutils.py` using `np.testing.assert_array_equal` as requested in #4570 review. Tests cover correctness, edge cases, and structural invariants. For `pt_shuffle_rec` specifically, exact output cannot be asserted (non-deterministic RNG) so tests verify set correctness, tree-contiguity, and contiguity stability across 20 runs.

Note: `_build_tree` in the test file calls `np.random.seed(0)` to produce a deterministic partition tree. This resets numpy's global random state but is acceptable here since the C++ RNG is independent of numpy state.

## AI Disclosure

Claude (Anthropic) was used during this PR as follows:

Advised: Explained nanobind type mapping, codebase conventions, and scipy linkage matrix format  
Assisted: Reviewed implementation for correctness and style consistency  
Autonomous: None — all code was written and verified by the contributor  

All lines in this PR are understood independently by the contributor.