### PR TITLE
fix: use svals instead of total_values in ExplanationError return (#4616)

### DIFF
--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -189,5 +189,4 @@ class ExplanationError:
         # FIX: average per-row first, then average across rows
         # correctly computes E_row [ E_mask [ error² ] ] instead of using only the last row
         row_means = [np.mean(s) for s in svals]
-        return BenchmarkResult("explanation error", name,
-                               value=np.sqrt(np.mean(row_means)))
+        return BenchmarkResult("explanation error", name, value=np.sqrt(np.mean(row_means)))

--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -188,4 +188,5 @@ class ExplanationError:
         # reset the random seed so we don't mess up the caller
         np.random.seed(old_seed)
 
-        return BenchmarkResult("explanation error", name, value=np.sqrt(np.sum(total_values) / len(total_values)))
+        # FIX: use svals (all rows) instead of total_values (last row only)
+        return BenchmarkResult("explanation error", name, value=np.sqrt(np.mean(svals)))

--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -183,10 +183,11 @@ class ExplanationError:
         if pbar is not None:
             pbar.close()
 
-        svals = np.array(svals)
-
         # reset the random seed so we don't mess up the caller
         np.random.seed(old_seed)
 
-        # FIX: use svals (all rows) instead of total_values (last row only)
-        return BenchmarkResult("explanation error", name, value=np.sqrt(np.mean(svals)))
+        # FIX: average per-row first, then average across rows
+        # correctly computes E_row [ E_mask [ error² ] ] instead of using only the last row
+        row_means = [np.mean(s) for s in svals]
+        return BenchmarkResult("explanation error", name,
+                               value=np.sqrt(np.mean(row_means)))


### PR DESCRIPTION
Fixes #4616

## Problem
`ExplanationError.__call__` collects per-row results into `svals` across 
all rows, but the final return statement incorrectly used `total_values` 
which only holds the last row's values after the loop ends.

## Fix
Changed the return statement to correctly compute `E_row [ E_mask [ error² ] ]`
by averaging per-row first, then averaging across rows:

- Before: `np.sqrt(np.sum(total_values) / len(total_values))`
- After: `row_means = [np.mean(s) for s in svals]` then `np.sqrt(np.mean(row_means))`

## Testing
Manually verified with a multi-row input that the result now correctly 
aggregates across all rows instead of using only the last one.