### PR TITLE
ENH: add ASV benchmarking infrastructure for nanobind migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ node_modules
 mpl-results
 # intermediate AI skill files
 .claude/disclosures/
+.asv/

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -8,8 +8,5 @@
     "install_command": ["python -mpip install --no-build-isolation {build_dir}"],
     "show_commit_url": "https://github.com/shap/shap/commit/",
     "pythons": ["3.12"],
-    "benchmark_dir": "benchmarks",
-    "results_dir": ".asv/results",
-    "html_dir": ".asv/html",
-    "build_cache_size": 2
+    "benchmark_dir": "benchmarks"
 }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,15 @@
+{
+    "version": 1,
+    "project": "shap",
+    "project_url": "https://github.com/shap/shap",
+    "repo": ".",
+    "branches": ["master"],
+    "environment_type": "virtualenv",
+    "install_command": ["python -mpip install --no-build-isolation {build_dir}"],
+    "show_commit_url": "https://github.com/shap/shap/commit/",
+    "pythons": ["3.12"],
+    "benchmark_dir": "benchmarks",
+    "results_dir": ".asv/results",
+    "html_dir": ".asv/html",
+    "build_cache_size": 2
+}

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -43,6 +43,13 @@ try:
 except ImportError:
     _HAS_DELTA_MINIMIZATION_ORDER = False
 
+try:
+    from shap._cutils import pt_shuffle_rec as _cpp_pt_shuffle_rec
+
+    _HAS_PT_SHUFFLE_REC = True
+except ImportError:
+    _HAS_PT_SHUFFLE_REC = False
+
 
 # --- Numba reference implementations ---
 
@@ -69,6 +76,25 @@ def _delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
                 if _reverse_window_score_gain(all_masks, order, i, length) > 0:
                     _reverse_window(order, i, length)
     return order
+
+
+@njit
+def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
+    if i < 0:
+        if index_mask[i + M]:
+            indexes[pos] = i + M
+            return pos + 1
+        else:
+            return pos
+    left = int(partition_tree[i, 0] - M)
+    right = int(partition_tree[i, 1] - M)
+    if np.random.randn() < 0:
+        pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
+        pos = _pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos)
+    else:
+        pos = _pt_shuffle_rec(right, indexes, index_mask, partition_tree, M, pos)
+        pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
+    return pos
 
 
 @njit
@@ -158,3 +184,49 @@ class BenchmarkDeltaMinimizationOrder:
     @skip_benchmark_if(not _HAS_DELTA_MINIMIZATION_ORDER)
     def time_cpp(self, n_features):
         _cpp_delta_minimization_order(self.masks)
+
+
+class BenchmarkPtShuffleRec:
+    params = [4, 8, 13]
+    param_names = ["n_features"]
+
+    def setup(self, n_features):
+        from scipy.cluster.hierarchy import ward
+        from scipy.spatial.distance import pdist
+
+        rng = np.random.default_rng(0)
+        data = rng.random((n_features, n_features))
+        self.partition_tree = ward(pdist(data)).astype(np.float64)
+        self.M = n_features
+        self.index_mask = np.ones(n_features, dtype=bool)
+        self.indexes = np.zeros(n_features, dtype=np.int64)
+        # force JIT compilation
+        _pt_shuffle_rec(
+            self.partition_tree.shape[0] - 1,
+            self.indexes.copy(),
+            self.index_mask,
+            self.partition_tree,
+            self.M,
+            0,
+        )
+
+    def time_numba(self, n_features):
+        _pt_shuffle_rec(
+            self.partition_tree.shape[0] - 1,
+            self.indexes.copy(),
+            self.index_mask,
+            self.partition_tree,
+            self.M,
+            0,
+        )
+
+    @skip_benchmark_if(not _HAS_PT_SHUFFLE_REC)
+    def time_cpp(self, n_features):
+        _cpp_pt_shuffle_rec(
+            self.partition_tree.shape[0] - 1,
+            self.indexes.copy(),
+            self.index_mask,
+            self.partition_tree,
+            self.M,
+            0,
+        )

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -213,8 +213,7 @@ class BenchmarkPtShuffleRec:
         self.M = n_features
         self.index_mask = np.ones(n_features, dtype=bool)
         self.indexes = np.zeros(n_features, dtype=np.int64)
-        # force JIT compilation
-        _pt_shuffle_rec(
+        _pt_shuffle_rec(  # force JIT compilation
             self.partition_tree.shape[0] - 1,
             self.indexes.copy(),
             self.index_mask,

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -1,0 +1,52 @@
+"""Benchmarks for clustering utility functions.
+
+Numba reference implementations are copied from shap/utils/_clustering.py
+for migration validation. They will be removed once numba is fully eliminated.
+
+Input sizes are anchored to real SHAP datasets:
+  n_features=4  — iris (4 features)
+  n_features=8  — california housing (8 features)
+  n_features=13 — adult (13 features)
+
+n_masks is derived as 2**n_features to reflect the exact explainer mask matrix size.
+"""
+
+import numpy as np
+from asv_runner.benchmarks.mark import skip_benchmark_if
+from numba import njit
+
+try:
+    from shap._cutils import mask_delta_score as _cpp_mask_delta_score
+
+    _HAS_MASK_DELTA_SCORE = True
+except ImportError:
+    _HAS_MASK_DELTA_SCORE = False
+
+
+# --- Numba reference implementations ---
+
+
+@njit
+def _mask_delta_score(m1, m2):
+    return (m1 ^ m2).sum()
+
+
+# --- Benchmarks ---
+
+
+class BenchmarkMaskDeltaScore:
+    params = [4, 8, 13]
+    param_names = ["n_features"]
+
+    def setup(self, n_features):
+        rng = np.random.default_rng(0)
+        self.m1 = rng.integers(0, 2, n_features).astype(bool)
+        self.m2 = rng.integers(0, 2, n_features).astype(bool)
+        _mask_delta_score(self.m1, self.m2)  # force JIT compilation
+
+    def time_numba(self, n_features):
+        _mask_delta_score(self.m1, self.m2)
+
+    @skip_benchmark_if(not _HAS_MASK_DELTA_SCORE)
+    def time_cpp(self, n_features):
+        _cpp_mask_delta_score(self.m1, self.m2)

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -13,7 +13,19 @@ n_masks is derived as 2**n_features to reflect the exact explainer mask matrix s
 
 import numpy as np
 from asv_runner.benchmarks.mark import skip_benchmark_if
-from numba import njit
+from scipy.cluster.hierarchy import ward
+from scipy.spatial.distance import pdist
+
+try:
+    from numba import njit
+
+    _HAS_NUMBA = True
+except ImportError:
+    _HAS_NUMBA = False
+
+    def njit(fn):
+        return fn
+
 
 try:
     from shap._cutils import mask_delta_score as _cpp_mask_delta_score
@@ -68,6 +80,17 @@ def _reverse_window(order, start, length):
 
 
 @njit
+def _reverse_window_score_gain(masks, order, start, length):
+    forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + _mask_delta_score(
+        masks[order[start + length - 1]], masks[order[start + length]]
+    )
+    reverse_score = _mask_delta_score(masks[order[start - 1]], masks[order[start + length - 1]]) + _mask_delta_score(
+        masks[order[start]], masks[order[start + length]]
+    )
+    return forward_score - reverse_score
+
+
+@njit
 def _delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
     order = np.arange(len(all_masks))
     for _ in range(num_passes):
@@ -97,17 +120,6 @@ def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
     return pos
 
 
-@njit
-def _reverse_window_score_gain(masks, order, start, length):
-    forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + _mask_delta_score(
-        masks[order[start + length - 1]], masks[order[start + length]]
-    )
-    reverse_score = _mask_delta_score(masks[order[start - 1]], masks[order[start + length - 1]]) + _mask_delta_score(
-        masks[order[start]], masks[order[start + length]]
-    )
-    return forward_score - reverse_score
-
-
 # --- Benchmarks ---
 
 
@@ -121,6 +133,7 @@ class BenchmarkMaskDeltaScore:
         self.m2 = rng.integers(0, 2, n_features).astype(bool)
         _mask_delta_score(self.m1, self.m2)  # force JIT compilation
 
+    @skip_benchmark_if(not _HAS_NUMBA)
     def time_numba(self, n_features):
         _mask_delta_score(self.m1, self.m2)
 
@@ -140,6 +153,7 @@ class BenchmarkReverseWindow:
         self.length = n_masks // 2
         _reverse_window(self.order.copy(), 1, self.length)  # force JIT compilation
 
+    @skip_benchmark_if(not _HAS_NUMBA)
     def time_numba(self, n_features):
         _reverse_window(self.order.copy(), 1, self.length)
 
@@ -160,6 +174,7 @@ class BenchmarkReverseWindowScoreGain:
         self.length = n_masks // 2
         _reverse_window_score_gain(self.masks, self.order, 1, self.length)  # force JIT
 
+    @skip_benchmark_if(not _HAS_NUMBA)
     def time_numba(self, n_features):
         _reverse_window_score_gain(self.masks, self.order, 1, self.length)
 
@@ -178,6 +193,7 @@ class BenchmarkDeltaMinimizationOrder:
         self.masks = rng.integers(0, 2, (n_masks, n_features)).astype(bool)
         _delta_minimization_order(self.masks)  # force JIT compilation
 
+    @skip_benchmark_if(not _HAS_NUMBA)
     def time_numba(self, n_features):
         _delta_minimization_order(self.masks)
 
@@ -191,9 +207,6 @@ class BenchmarkPtShuffleRec:
     param_names = ["n_features"]
 
     def setup(self, n_features):
-        from scipy.cluster.hierarchy import ward
-        from scipy.spatial.distance import pdist
-
         rng = np.random.default_rng(0)
         data = rng.random((n_features, n_features))
         self.partition_tree = ward(pdist(data)).astype(np.float64)
@@ -210,6 +223,7 @@ class BenchmarkPtShuffleRec:
             0,
         )
 
+    @skip_benchmark_if(not _HAS_NUMBA)
     def time_numba(self, n_features):
         _pt_shuffle_rec(
             self.partition_tree.shape[0] - 1,

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -22,6 +22,13 @@ try:
 except ImportError:
     _HAS_MASK_DELTA_SCORE = False
 
+try:
+    from shap._cutils import reverse_window as _cpp_reverse_window
+
+    _HAS_REVERSE_WINDOW = True
+except ImportError:
+    _HAS_REVERSE_WINDOW = False
+
 
 # --- Numba reference implementations ---
 
@@ -29,6 +36,14 @@ except ImportError:
 @njit
 def _mask_delta_score(m1, m2):
     return (m1 ^ m2).sum()
+
+
+@njit
+def _reverse_window(order, start, length):
+    for i in range(length // 2):
+        tmp = order[start + i]
+        order[start + i] = order[start + length - i - 1]
+        order[start + length - i - 1] = tmp
 
 
 # --- Benchmarks ---
@@ -50,3 +65,22 @@ class BenchmarkMaskDeltaScore:
     @skip_benchmark_if(not _HAS_MASK_DELTA_SCORE)
     def time_cpp(self, n_features):
         _cpp_mask_delta_score(self.m1, self.m2)
+
+
+class BenchmarkReverseWindow:
+    params = [4, 8, 13]
+    param_names = ["n_features"]
+
+    def setup(self, n_features):
+        n_masks = 2**n_features
+        rng = np.random.default_rng(0)
+        self.order = rng.permutation(n_masks).astype(np.int64)
+        self.length = n_masks // 2
+        _reverse_window(self.order.copy(), 1, self.length)  # force JIT compilation
+
+    def time_numba(self, n_features):
+        _reverse_window(self.order.copy(), 1, self.length)
+
+    @skip_benchmark_if(not _HAS_REVERSE_WINDOW)
+    def time_cpp(self, n_features):
+        _cpp_reverse_window(self.order.copy(), 1, self.length)

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -36,6 +36,13 @@ try:
 except ImportError:
     _HAS_REVERSE_WINDOW_SCORE_GAIN = False
 
+try:
+    from shap._cutils import delta_minimization_order as _cpp_delta_minimization_order
+
+    _HAS_DELTA_MINIMIZATION_ORDER = True
+except ImportError:
+    _HAS_DELTA_MINIMIZATION_ORDER = False
+
 
 # --- Numba reference implementations ---
 
@@ -51,6 +58,17 @@ def _reverse_window(order, start, length):
         tmp = order[start + i]
         order[start + i] = order[start + length - i - 1]
         order[start + length - i - 1] = tmp
+
+
+@njit
+def _delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
+    order = np.arange(len(all_masks))
+    for _ in range(num_passes):
+        for length in range(2, max_swap_size):
+            for i in range(1, len(order) - length):
+                if _reverse_window_score_gain(all_masks, order, i, length) > 0:
+                    _reverse_window(order, i, length)
+    return order
 
 
 @njit
@@ -122,3 +140,21 @@ class BenchmarkReverseWindowScoreGain:
     @skip_benchmark_if(not _HAS_REVERSE_WINDOW_SCORE_GAIN)
     def time_cpp(self, n_features):
         _cpp_reverse_window_score_gain(self.masks, self.order, 1, self.length)
+
+
+class BenchmarkDeltaMinimizationOrder:
+    params = [4, 8, 13]
+    param_names = ["n_features"]
+
+    def setup(self, n_features):
+        n_masks = 2**n_features
+        rng = np.random.default_rng(0)
+        self.masks = rng.integers(0, 2, (n_masks, n_features)).astype(bool)
+        _delta_minimization_order(self.masks)  # force JIT compilation
+
+    def time_numba(self, n_features):
+        _delta_minimization_order(self.masks)
+
+    @skip_benchmark_if(not _HAS_DELTA_MINIMIZATION_ORDER)
+    def time_cpp(self, n_features):
+        _cpp_delta_minimization_order(self.masks)

--- a/benchmarks/benchmarks_clustering.py
+++ b/benchmarks/benchmarks_clustering.py
@@ -29,6 +29,13 @@ try:
 except ImportError:
     _HAS_REVERSE_WINDOW = False
 
+try:
+    from shap._cutils import reverse_window_score_gain as _cpp_reverse_window_score_gain
+
+    _HAS_REVERSE_WINDOW_SCORE_GAIN = True
+except ImportError:
+    _HAS_REVERSE_WINDOW_SCORE_GAIN = False
+
 
 # --- Numba reference implementations ---
 
@@ -44,6 +51,17 @@ def _reverse_window(order, start, length):
         tmp = order[start + i]
         order[start + i] = order[start + length - i - 1]
         order[start + length - i - 1] = tmp
+
+
+@njit
+def _reverse_window_score_gain(masks, order, start, length):
+    forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + _mask_delta_score(
+        masks[order[start + length - 1]], masks[order[start + length]]
+    )
+    reverse_score = _mask_delta_score(masks[order[start - 1]], masks[order[start + length - 1]]) + _mask_delta_score(
+        masks[order[start]], masks[order[start + length]]
+    )
+    return forward_score - reverse_score
 
 
 # --- Benchmarks ---
@@ -84,3 +102,23 @@ class BenchmarkReverseWindow:
     @skip_benchmark_if(not _HAS_REVERSE_WINDOW)
     def time_cpp(self, n_features):
         _cpp_reverse_window(self.order.copy(), 1, self.length)
+
+
+class BenchmarkReverseWindowScoreGain:
+    params = [4, 8, 13]
+    param_names = ["n_features"]
+
+    def setup(self, n_features):
+        n_masks = 2**n_features
+        rng = np.random.default_rng(0)
+        self.masks = rng.integers(0, 2, (n_masks, n_features)).astype(bool)
+        self.order = rng.permutation(n_masks).astype(np.int64)
+        self.length = n_masks // 2
+        _reverse_window_score_gain(self.masks, self.order, 1, self.length)  # force JIT
+
+    def time_numba(self, n_features):
+        _reverse_window_score_gain(self.masks, self.order, 1, self.length)
+
+    @skip_benchmark_if(not _HAS_REVERSE_WINDOW_SCORE_GAIN)
+    def time_cpp(self, n_features):
+        _cpp_reverse_window_score_gain(self.masks, self.order, 1, self.length)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ nbtest = [
 
 [dependency-groups]
 core = ["pytest", "pytest-mpl", "pytest-cov", "mypy", "pre-commit"]
+benchmark = ["asv"]
 test = [
   "pytest",
   "pytest-mpl",


### PR DESCRIPTION
Part of #4327 (Stage 2) — performance monitoring infrastructure for the nanobind migration.

## What this PR does

Sets up [ASV (Airspeed Velocity)](https://asv.readthedocs.io/en/stable/) benchmarking infrastructure and adds the first benchmark file covering the 5 clustering functions being ported in #4654.

Following the discussion in #4570, both @CloseChoice and @daidahao identified ASV as a blocker before merging further nanobind migrations — see [this comment](https://github.com/shap/shap/pull/4570#issuecomment-4254720468) and the Stage 2 priority note in #4327. This PR delivers that infrastructure.

The benchmark structure mirrors the full migration scope from #4327, with one benchmark file per source file. This PR establishes the pattern; subsequent porting PRs add their corresponding benchmark class.

| Benchmark file | Source `.py` file | C++ header | Functions |
|---|---|---|---|
| `benchmarks_clustering.py` ✅ | `utils/_clustering.py` | `clustering_utils.h` ✅ | 5 — this PR |
| `benchmarks_exact.py` | `explainers/_exact.py` | `grey_code_utils.h` ✅ (partial) | 2 |
| `benchmarks_partition.py` | `explainers/_partition.py` | `partition_utils.h` (new) | 1 |
| `benchmarks_tabular.py` | `maskers/_tabular.py` | `tabular_utils.h` (new) | 2 |
| `benchmarks_masked_model.py` | `utils/_masked_model.py` | `masked_model_utils.h` (new) | 4 |
| `benchmarks_image.py` | `maskers/_image.py` | `image_utils.h` (new) | 1 |

**Files added/changed:**
- `asv.conf.json` — ASV project config (`--no-build-isolation` required for scikit-build-core)
- `benchmarks/__init__.py` — marks directory as benchmark package
- `benchmarks/benchmarks_clustering.py` — benchmarks for all 5 clustering functions
- `pyproject.toml` — adds `benchmark = ["asv"]` to `[dependency-groups]`
- `.gitignore` — excludes `.asv/` build artifacts

## Benchmark design

### One class per function

The alternative — one class per file with all functions benchmarked together — was rejected because the functions in `_clustering.py` have structurally different inputs that cannot share a `setup()`:

- `mask_delta_score` takes two 1D bool vectors of length `n_features`
- `reverse_window` takes a 1D int64 array of length `n_masks = 2**n_features`
- `reverse_window_score_gain` takes a 2D bool matrix `(n_masks, n_features)` plus an index array
- `delta_minimization_order` takes the same 2D matrix but runs a full 2-opt pass over it
- `pt_shuffle_rec` takes a partition tree built from scipy linkage

A shared `setup()` would have to allocate all of these simultaneously and pass the right subset to each method — fragile, hard to read, and wrong for functions like `delta_minimization_order` whose input size grows as `2**n_features` not `n_features`. One class per function keeps each `setup()` minimal and correct.

```
benchmarks/
└── benchmarks_clustering.py
    ├── BenchmarkMaskDeltaScore
    ├── BenchmarkReverseWindow
    ├── BenchmarkReverseWindowScoreGain
    ├── BenchmarkDeltaMinimizationOrder
    └── BenchmarkPtShuffleRec
```

As more `@njit` functions are ported from other source files (`_masked_model.py`, `_tabular.py`, etc.), each source file gets its own benchmark file following the same pattern.

### Input sizes anchored to real SHAP datasets

- `n_features=4` — iris
- `n_features=8` — california housing
- `n_features=13` — adult

`n_masks = 2**n_features` to reflect the exact explainer mask matrix size.

### Numba reference implementations copied inline

The `@njit` functions are copied verbatim from `shap/utils/_clustering.py` as `time_numba` baselines. This serves two purposes:

1. Like-for-like steady-state comparison excluding JIT warmup overhead (numba's warmup costs 200–500ms per function and would dominate any cold-start measurement).
2. When the source file has its `@njit` functions removed as part of the migration, the benchmark retains a numba baseline to compare against.

These copies will be deleted once numba is fully eliminated from the codebase.

### JIT warmup in `setup()`

ASV calls `setup()` once before timing begins, then calls the benchmark method repeatedly. We exploit this by calling each `@njit` function once inside `setup()` — this triggers numba's JIT compilation before the timer starts. Without this, the first timed call would include 200–500ms of compilation overhead, making numba look catastrophically slow against C++ and invalidating all steady-state comparisons.

```python
def setup(self, n_features):
    rng = np.random.default_rng(0)
    self.masks = rng.integers(0, 2, (2**n_features, n_features)).astype(bool)
    _delta_minimization_order(self.masks)  # force JIT compilation

def time_numba(self, n_features):
    _delta_minimization_order(self.masks)  # already compiled — measures steady-state only
```

### Degradation via `skip_benchmark_if`

Both `time_numba` and `time_cpp` are guarded independently using [`@skip_benchmark_if`](https://asv.readthedocs.io/en/stable/benchmarks.html#skipping-benchmarks) from `asv_runner.benchmarks.mark`. This is the correct skip pattern for ASV 0.6.x — the older approach of raising `NotImplementedError` inside the benchmark body still runs `setup()` and wastes time; `@skip_benchmark_if` is evaluated at collection time and skips the method entirely.

numba and each C++ function are imported under separate `_HAS_*` flags so a missing dependency skips only the affected method without touching any other benchmark.

```python
try:
    from numba import njit
    _HAS_NUMBA = True
except ImportError:
    _HAS_NUMBA = False
    def njit(fn):
        return fn

try:
    from shap._cutils import mask_delta_score as _cpp_mask_delta_score
    _HAS_MASK_DELTA_SCORE = True
except ImportError:
    _HAS_MASK_DELTA_SCORE = False

class BenchmarkMaskDeltaScore:
    @skip_benchmark_if(not _HAS_NUMBA)
    def time_numba(self, n_features): ...

    @skip_benchmark_if(not _HAS_MASK_DELTA_SCORE)
    def time_cpp(self, n_features): ...
```

**Note:** on `master`, all `time_cpp` methods currently show as SKIPPED because the C++ implementations live in unmerged #4654. This is intentional — the infrastructure is safe to merge independently.

## How to run

```bash
# All benchmarks in a file
asv run --python=same -b benchmarks_clustering

# All methods in one class
asv run --python=same -b BenchmarkDeltaMinimizationOrder

# Specific method
asv run --python=same -b BenchmarkDeltaMinimizationOrder.time_cpp
```

## Results (measured against #4654)

| Function | n=4 | n=8 | n=13 | Verdict |
|---|---|---|---|---|
| `mask_delta_score` | C++ 472ns / numba 438ns | C++ 486ns / numba 436ns | C++ 503ns / numba 444ns | numba ~7% — ns-scale, negligible |
| `reverse_window` | C++ 622ns / numba 581ns | C++ 786ns / numba 706ns | C++ 4.87μs / numba 3.32μs | numba faster; gap grows with array size |
| `reverse_window_score_gain` | C++ 536ns / numba 590ns | C++ 555ns / numba 563ns | C++ 559ns / numba 568ns | C++ ~9% at n=4, tied at n≥8 |
| `delta_minimization_order` | C++ 4.02μs / numba 43.6μs | C++ 989μs / numba 3.89ms | C++ 56.3ms / numba 173ms | **C++ ~11x / 3.9x / 3.1x faster** |
| `pt_shuffle_rec` | C++ 1.06μs / numba 1.04μs | C++ 1.16μs / numba 1.24μs | C++ 1.27μs / numba 1.52μs | C++ wins n≥8, tied at n=4 |

`delta_minimization_order` is the hot path — called once per `Explainer` invocation and dominates clustering time. C++ wins by 3–11x depending on feature count. `reverse_window` is the one function where numba consistently wins; LLVM auto-vectorises the tight in-place loop over large arrays in a way our plain C++ for-loop does not. This is expected and acceptable — `reverse_window` is called inside `delta_minimization_order`, and the overall function is still 3–11x faster in C++.

## AI Disclosure

Claude (Anthropic) was used during this PR as follows:

- **Advised:** Explained ASV configuration and benchmarking methodology
- **Assisted:** Reviewed implementation for correctness and style consistency
- **Autonomous:** None — all code was written and verified by the contributor

All lines in this PR are understood independently by the contributor.