### PR TITLE
fix: ExplanationError aggregates across all rows instead of last row only (#4616)

### DIFF
--- a/shap/benchmark/_explanation_error.py
+++ b/shap/benchmark/_explanation_error.py
@@ -174,7 +174,10 @@ class ExplanationError:
 
             if pbar is None and time.time() - start_time > 5:
                 pbar = tqdm(
-                    total=len(self.model_args[0]), disable=silent, leave=False, desc=f"ExplanationError for {name}"
+                    total=len(self.model_args[0]),
+                    disable=silent,
+                    leave=False,
+                    desc=f"ExplanationError for {name}",
                 )
                 pbar.update(i + 1)
             if pbar is not None:
@@ -183,9 +186,9 @@ class ExplanationError:
         if pbar is not None:
             pbar.close()
 
-        svals = np.array(svals)
-
         # reset the random seed so we don't mess up the caller
         np.random.seed(old_seed)
 
-        return BenchmarkResult("explanation error", name, value=np.sqrt(np.sum(total_values) / len(total_values)))
+        per_row_mse = np.array([np.mean(row_values) for row_values in svals])
+
+        return BenchmarkResult("explanation error", name, value=np.sqrt(np.mean(per_row_mse)))

--- a/tests/benchmark/test_explanation_error.py
+++ b/tests/benchmark/test_explanation_error.py
@@ -43,6 +43,5 @@ def test_aggregates_all_rows_not_just_last():
     result_last = benchmark_last(attributions[-1:], "test", silent=True)
 
     assert result.value > result_last.value + 1e-8, (
-        "ExplanationError should aggregate across all rows, "
-        "not just use the last row"
+        "ExplanationError should aggregate across all rows, not just use the last row"
     )

--- a/tests/benchmark/test_explanation_error.py
+++ b/tests/benchmark/test_explanation_error.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from shap.benchmark import ExplanationError
+from shap.maskers import Independent
+
+
+def make_benchmark(x, num_permutations=2):
+    masker = Independent(np.zeros((1, x.shape[1])))
+
+    def model(v):
+        return v.sum(axis=1)
+
+    return ExplanationError(
+        masker,
+        model,
+        x,
+        num_permutations=num_permutations,
+        seed=0,
+    )
+
+
+def test_aggregates_all_rows_not_just_last():
+    x = np.array(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+        ]
+    )
+
+    attributions = np.array(
+        [
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [5.0, 6.0],
+        ]
+    )
+
+    benchmark = make_benchmark(x)
+    result = benchmark(attributions, "test", silent=True)
+
+    benchmark_last = make_benchmark(x[-1:])
+    result_last = benchmark_last(attributions[-1:], "test", silent=True)
+
+    assert result.value > result_last.value + 1e-8, (
+        "ExplanationError should aggregate across all rows, "
+        "not just use the last row"
+    )


### PR DESCRIPTION
## Summary

Fixes #4616

`ExplanationError.__call__` was silently returning incorrect results for 
multi-row inputs. The loop collected per-row results into `svals` correctly, 
but the final return statement used `total_values` — which after the loop 
holds only the last row's values. All preceding rows were ignored.

## Root Cause

```python
for i, args in enumerate(zip(*self.model_args)):
    # ...
    total_values /= self.num_permutations
    svals.append(total_values)  # stores each row

svals = np.array(svals)  # converts but never used

# ✗ BUG: total_values is only the last row after the loop ends
return BenchmarkResult("explanation error", name,
                       value=np.sqrt(np.sum(total_values) / len(total_values)))
```

## Fix

- Removed the unused `svals = np.array(svals)` conversion line
- Compute per-row MSE by averaging over mask steps within each row
- Average per-row MSEs across all rows, then take square root

```python
per_row_mse = np.array([np.mean(row_vals) for row_vals in svals])

return BenchmarkResult(
    "explanation error",
    name,
    value=np.sqrt(np.mean(per_row_mse)),
)
```

The list comprehension is intentional over `np.mean(svals, axis=1)` because 
`svals` is a ragged list — rows with different feature sizes produce different 
numbers of mask steps (e.g. variable-length text inputs). Converting to a 
NumPy array would produce a dtype=object array where axis-based operations 
are unreliable. The list comprehension handles both uniform and ragged cases 
correctly.


## Testing

Added `tests/benchmark/test_explanation_error.py`:

- Sets up a 3-row input where the first two rows have deliberately wrong 
  attributions (high error) and the last row has correct attributions 
  (near-zero error)
- Compares the multi-row result against a single last-row benchmark
- If the bug is present, both return near-zero (last row dominates) and the 
  assertion fails
- If fixed, the multi-row result is larger due to errors in rows 0 and 1

## Checklist

- [x] Bug reproduced on master
- [x] Fix applied and verified
- [x] Regression test added
- [x] `pre-commit run --all-files` passes
- [x] `black` formatting applied to both changed files