### PR TITLE
MAINT: increase test coverage for SamplingExplainer from 39% to 97%

### DIFF
--- a/tests/explainers/test_sampling.py
+++ b/tests/explainers/test_sampling.py
@@ -52,3 +52,93 @@ def test_front_page_model_agnostic():
     # use Kernel SHAP to explain test set predictions
     explainer = shap.SamplingExplainer(svm.predict_proba, X_train, nsamples=100)
     explainer.shap_values(X_test)
+
+
+def test_non_identity_link_raises():
+    """Lines 59-60: ValueError when non-identity link is used."""
+    with pytest.raises(ValueError, match="identity link"):
+        shap.SamplingExplainer(
+            lambda x: np.zeros(x.shape[0]),
+            np.ones((2, 4)),
+            link="logit",
+        )
+
+
+def test_call_with_dataframe():
+    """Lines 69-70: __call__ with pandas DataFrame input."""
+    explainer = shap.SamplingExplainer(
+        lambda x: np.zeros(x.shape[0]),
+        np.ones((2, 4)),
+        nsamples=100,
+    )
+    X_df = pd.DataFrame(np.ones((1, 4)), columns=["a", "b", "c", "d"])
+    result = explainer(X_df, nsamples=100)
+    assert result.feature_names == ["a", "b", "c", "d"]
+    assert np.sum(np.abs(result.values)) < 1e-8
+
+
+def test_call_multioutput():
+    """Line 76: __call__ when shap_values returns a list (multi-output)."""
+    # SamplingExplainer returns a list when model has multiple outputs
+    # and shap_values is called internally — force this by using
+    # a model that returns a 2-column output so KernelExplainer
+    # produces a list
+    background = np.ones((5, 4))
+
+    def multi_output(x):
+        out = np.zeros((x.shape[0], 2))
+        return out
+
+    explainer = shap.SamplingExplainer(
+        multi_output,
+        background,
+        nsamples=100,
+    )
+    result = explainer(np.ones((1, 4)), nsamples=100)
+    # result.values should have shape (1, 4, 2) for 2 outputs
+    assert result.values.ndim == 3
+
+
+def test_single_varying_feature():
+    """Lines 120-124: M==1 path — exactly one feature varies."""
+    np.random.seed(42)
+    # background is all zeros
+    background = np.zeros((5, 3))
+    explainer = shap.SamplingExplainer(
+        lambda x: x[:, 0],  # only feature 0 matters
+        background,
+    )
+    # only feature 0 differs from background (zeros)
+    instance = np.array([[1.0, 0.0, 0.0]])
+    result = explainer.explain(instance, nsamples=100)
+    # all effect should be on feature 0
+    assert result.shape == (3,)
+    assert abs(result[0]) > abs(result[1])
+
+
+def test_nsamples_remainder_distribution():
+    """Line 143: remainder loop when round1_samples % (M*2) > 0."""
+    np.random.seed(42)
+    background = np.random.randn(10, 3)
+    explainer = shap.SamplingExplainer(
+        lambda x: x[:, 0] + x[:, 1] + x[:, 2],
+        background,
+    )
+    instance = np.random.randn(1, 3)
+    # nsamples=101 causes remainder: 101 % (3*2) = 5, so loop runs
+    result = explainer.explain(instance, nsamples=101)
+    assert result.shape == (3,)
+
+
+def test_phi_var_zero_spread():
+    """Line 156: phi_var += 1 when phi_var.sum() == 0 (null model, large nsamples)."""
+    np.random.seed(42)
+    background = np.random.randn(10, 3)
+    explainer = shap.SamplingExplainer(
+        lambda x: np.zeros(x.shape[0]),  # null model — all phi_var will be 0
+        background,
+    )
+    instance = np.random.randn(1, 3)
+    # large nsamples triggers round2 where phi_var.sum()==0 check happens
+    result = explainer.explain(instance, nsamples=3000)
+    assert result.shape == (3,)


### PR DESCRIPTION
Contributes to #3690

## Overview
This PR adds 6 new tests for `shap/explainers/_sampling.py`, increasing coverage from 39% to 97%.

## Changes
Only `tests/explainers/test_sampling.py` is modified — no source code is changed.

## New tests added
- `test_non_identity_link_raises` —  covers the ValueError raised when a non-identity link is passed to SamplingExplainer.__init__
- `test_call_with_dataframe` —  covers  __call__ when X is a pandas DataFrame, verifying feature_names are preserved
- `test_call_multioutput` —  covers  __call__ with a multi-output model returning shape (1, 4, 2)
- `test_single_varying_feature` —  covers the M==1 branch in explain() where exactly one feature differs from background
- `test_nsamples_remainder_distribution` —  covers the remainder loop in round1 sample allocation when round1_samples %(M*2) > 0
- `test_phi_var_zero_spread` —  covers the phi_var += 1 fallback in round2 when a null model produces zero variance

## Findings
Line 75 (`if isinstance(v, list)`) appears to be unreachable — shap_values() now always returns a numpy array, never a list. This may be dead code worth removing in a follow-up.

Lines 89-90 (ExplainerError for feature groups) and 100 (keep_index=True path) remain uncovered as they require constructing internal SHAP data structures that are not part of the public API. These are left for a follow-up.

## Checklist
- [x] All pre-commit checks pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)

## AI usage
Used Claude as an assistant for debugging a coverage tooling issue (pytest-cov + numpy 2.x incompatibility on Windows) and for understanding the inheritance chain between SamplingExplainer and KernelExplainer. All tests were written, understood, and verified by me line by line. I can explain every test and the code path it covers.
