### PR TITLE
Add DeprecationWarning to summary_legacy (#3156)

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -581,6 +581,12 @@ def summary_legacy(
 
     """
     # handle randomization machinery in conformance with SPEC 7
+    warnings.warn(
+        "summary_legacy is deprecated and will be removed in a future version. "
+        "Use shap.plots.beeswarm() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if rng is not None:
         rng = np.random.default_rng(rng)
     else:

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -582,8 +582,7 @@ def summary_legacy(
     """
     # handle randomization machinery in conformance with SPEC 7
     warnings.warn(
-        "summary_legacy is deprecated and will be removed in a future version. "
-        "Use shap.plots.beeswarm() instead.",
+        "summary_legacy is deprecated and will be removed in a future version. Use shap.plots.beeswarm() instead.",
         DeprecationWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
Adds a `DeprecationWarning` to `summary_legacy()` in `shap/plots/_beeswarm.py`.

Users calling `summary_legacy()` will now see:
> "summary_legacy is deprecated and will be removed in a future version. Use shap.plots.beeswarm() instead."

Part of #3156.