### PR TITLE
ENH: Add ax parameter to shap.plots.waterfall() for consistency

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -13,7 +13,7 @@ from ._style import get_style
 # plot that is associated with that feature get overlaid on the plot...it would quickly allow users to answer
 # why a feature is pushing down or up. Perhaps the best way to do this would be with an ICE plot hanging off
 # of the bar...
-def waterfall(shap_values, max_display=10, show=True):
+def waterfall(shap_values, max_display=10, show=True, ax=None):
     """Plots an explanation of a single prediction as a waterfall plot.
 
     The SHAP value of a feature represents the impact of the evidence provided by that feature on the model's
@@ -37,6 +37,15 @@ def waterfall(shap_values, max_display=10, show=True):
         Whether :external+mpl:func:`matplotlib.pyplot.show()` is called before returning.
         Setting this to ``False`` allows the plot to be customized further after it
         has been created, returning the current axis via plt.gca().
+
+    ax : matplotlib.axes.Axes
+        Axes object to draw the plot onto, otherwise uses the current Axes.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        Returns the :external+mpl:class:`~matplotlib.axes.Axes` object with the plot drawn onto it. Only
+        returned if ``show=False``.
 
     Examples
     --------
@@ -99,8 +108,11 @@ def waterfall(shap_values, max_display=10, show=True):
     loc = base_values + values.sum()
     yticklabels = ["" for _ in range(num_features + 1)]
 
-    # size the plot based on how many features we are plotting
-    plt.gcf().set_size_inches(8, num_features * row_height + 1.5)
+    # set up axes — only resize the figure when we create the axes ourselves
+    if ax is None:
+        ax = plt.gca()
+        plt.gcf().set_size_inches(8, num_features * row_height + 1.5)
+    fig = ax.get_figure()
 
     # see how many individual (vs. grouped at the end) features we are plotting
     if num_features == len(values):
@@ -127,7 +139,7 @@ def waterfall(shap_values, max_display=10, show=True):
                 neg_high.append(upper_bounds[order[i]])
             neg_lefts.append(loc)
         if num_individual != num_features or i + 4 < num_individual:
-            plt.plot(
+            ax.plot(
                 [loc, loc],
                 [rng[i] - 1 - 0.4, rng[i] + 0.4],
                 color=style.vlines_color,
@@ -168,7 +180,7 @@ def waterfall(shap_values, max_display=10, show=True):
 
     # draw invisible bars just for sizing the axes
     label_padding = np.array([0.1 * dataw if w < 1 else 0 for w in pos_widths])
-    plt.barh(
+    ax.barh(
         pos_inds,
         np.array(pos_widths) + label_padding + 0.02 * dataw,
         left=np.array(pos_lefts) - 0.01 * dataw,
@@ -176,7 +188,7 @@ def waterfall(shap_values, max_display=10, show=True):
         alpha=0,
     )
     label_padding = np.array([-0.1 * dataw if -w < 1 else 0 for w in neg_widths])
-    plt.barh(
+    ax.barh(
         neg_inds,
         np.array(neg_widths) + label_padding - 0.02 * dataw,
         left=np.array(neg_lefts) + 0.01 * dataw,
@@ -187,9 +199,7 @@ def waterfall(shap_values, max_display=10, show=True):
     # define variable we need for plotting the arrows
     head_length = 0.08
     bar_width = 0.8
-    xlen = plt.xlim()[1] - plt.xlim()[0]
-    fig = plt.gcf()
-    ax = plt.gca()
+    xlen = ax.get_xlim()[1] - ax.get_xlim()[0]
     bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     width = bbox.width
     bbox_to_xscale = xlen / width
@@ -199,7 +209,7 @@ def waterfall(shap_values, max_display=10, show=True):
     # draw the positive arrows
     for i in range(len(pos_inds)):
         dist = pos_widths[i]
-        arrow_obj = plt.arrow(
+        arrow_obj = ax.arrow(
             pos_lefts[i],
             pos_inds[i],
             dist - hl_scaled,
@@ -211,14 +221,14 @@ def waterfall(shap_values, max_display=10, show=True):
         )
 
         if pos_low is not None and i < len(pos_low):
-            plt.errorbar(
+            ax.errorbar(
                 pos_lefts[i] + pos_widths[i],
                 pos_inds[i],
                 xerr=np.array([[pos_widths[i] - pos_low[i]], [pos_high[i] - pos_widths[i]]]),
                 ecolor=style.secondary_color_positive,
             )
 
-        txt_obj = plt.text(
+        txt_obj = ax.text(
             pos_lefts[i] + 0.5 * dist,
             pos_inds[i],
             format_value(pos_widths[i], "%+0.02f"),
@@ -234,7 +244,7 @@ def waterfall(shap_values, max_display=10, show=True):
         if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
 
-            txt_obj = plt.text(
+            txt_obj = ax.text(
                 pos_lefts[i] + (5 / 72) * bbox_to_xscale + dist,
                 pos_inds[i],
                 format_value(pos_widths[i], "%+0.02f"),
@@ -248,7 +258,7 @@ def waterfall(shap_values, max_display=10, show=True):
     for i in range(len(neg_inds)):
         dist = neg_widths[i]
 
-        arrow_obj = plt.arrow(
+        arrow_obj = ax.arrow(
             neg_lefts[i],
             neg_inds[i],
             -(-dist - hl_scaled),
@@ -260,14 +270,14 @@ def waterfall(shap_values, max_display=10, show=True):
         )
 
         if neg_low is not None and i < len(neg_low):
-            plt.errorbar(
+            ax.errorbar(
                 neg_lefts[i] + neg_widths[i],
                 neg_inds[i],
                 xerr=np.array([[neg_widths[i] - neg_low[i]], [neg_high[i] - neg_widths[i]]]),
                 ecolor=style.secondary_color_negative,
             )
 
-        txt_obj = plt.text(
+        txt_obj = ax.text(
             neg_lefts[i] + 0.5 * dist,
             neg_inds[i],
             format_value(neg_widths[i], "%+0.02f"),
@@ -283,7 +293,7 @@ def waterfall(shap_values, max_display=10, show=True):
         if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
 
-            txt_obj = plt.text(
+            txt_obj = ax.text(
                 neg_lefts[i] - (5 / 72) * bbox_to_xscale + dist,
                 neg_inds[i],
                 format_value(neg_widths[i], "%+0.02f"),
@@ -296,23 +306,23 @@ def waterfall(shap_values, max_display=10, show=True):
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
     # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     ytick_pos = list(range(num_features)) + list(np.arange(num_features) + 1e-8)
-    plt.yticks(ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
+    ax.set_yticks(ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
 
     # put horizontal lines for each feature row
     for i in range(num_features):
-        plt.axhline(i, color=style.hlines_color, lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(i, color=style.hlines_color, lw=0.5, dashes=(1, 5), zorder=-1)
 
     # mark the prior expected value and the model prediction
-    plt.axvline(base_values, 0, 1 / num_features, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    ax.axvline(base_values, 0, 1 / num_features, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
     fx = base_values + values.sum()
-    plt.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    ax.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
 
     # clean up the main axis
-    plt.gca().xaxis.set_ticks_position("bottom")
-    plt.gca().yaxis.set_ticks_position("none")
-    plt.gca().spines["right"].set_visible(False)
-    plt.gca().spines["top"].set_visible(False)
-    plt.gca().spines["left"].set_visible(False)
+    ax.xaxis.set_ticks_position("bottom")
+    ax.yaxis.set_ticks_position("none")
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
+    ax.spines["left"].set_visible(False)
     ax.tick_params(labelsize=13)
     # plt.xlabel("\nModel output", fontsize=12)
 
@@ -370,7 +380,7 @@ def waterfall(shap_values, max_display=10, show=True):
     if show:
         plt.show()
     else:
-        return plt.gca()
+        return ax
 
 
 def waterfall_legacy(expected_value, shap_values=None, features=None, feature_names=None, max_display=10, show=True):

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -9,6 +9,17 @@ import shap
 from shap.plots import _style
 
 
+def test_waterfall_ax_parameter(explainer):
+    """Test that passing ax draws the waterfall onto the given axes."""
+    fig, axes = plt.subplots(1, 2)
+    explanation = explainer(explainer.data)
+    returned = shap.plots.waterfall(explanation[0], show=False, ax=axes[0])
+    assert returned is axes[0]
+    # The second subplot must be untouched (no waterfall content)
+    assert len(axes[1].patches) == 0
+    plt.close(fig)
+
+
 def test_waterfall_input_is_explanation():
     """Checks an error is raised if a non-Explanation object is passed as input."""
     with pytest.raises(


### PR DESCRIPTION
## Overview

Fixes #4670

`shap.plots.waterfall()` lacked an `ax` parameter, making it impossible to embed a waterfall plot in a subplot grid. Every other primary SHAP plot (`bar`, `beeswarm`, `scatter`, `heatmap`, `decision`, `group_difference`) already accepts `ax`.

Added `ax=None` following the same pattern as `shap/plots/_bar.py`: when `ax=None` the function falls back to `plt.gca()` and resizes the figure as before; when an `Axes` is passed the plot is drawn onto it without touching the figure size. Return value when `show=False` is now the `Axes` object.

`waterfall_legacy()` is not changed.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)