### PR TITLE
ENH: add rcParams-backed plot style options

### DIFF
--- a/shap/plots/__init__.py
+++ b/shap/plots/__init__.py
@@ -17,6 +17,7 @@ from ._image import image, image_to_text
 from ._monitoring import monitoring
 from ._partial_dependence import partial_dependence
 from ._scatter import scatter
+from ._style import get_style, load_default_style, load_matplotlib_style, set_style, style_context
 from ._text import text
 from ._violin import violin
 from ._waterfall import waterfall
@@ -36,6 +37,11 @@ __all__ = [
     "monitoring",
     "partial_dependence",
     "scatter",
+    "get_style",
+    "load_default_style",
+    "load_matplotlib_style",
+    "set_style",
+    "style_context",
     "text",
     "violin",
     "waterfall",

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -274,7 +274,11 @@ def bar(
         )
 
     # draw the yticks (the 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks)
-    ax.set_yticks(list(y_pos) + list(y_pos + 1e-8), yticklabels + [t.split("=")[-1] for t in yticklabels], fontsize=13)
+    ax.set_yticks(
+        list(y_pos) + list(y_pos + 1e-8),
+        yticklabels + [t.split("=")[-1] for t in yticklabels],
+        fontsize=style.label_size,
+    )
 
     xlen = ax.get_xlim()[1] - ax.get_xlim()[0]
     # xticks = ax.get_xticks()
@@ -294,7 +298,7 @@ def bar(
                     horizontalalignment="right",
                     verticalalignment="center",
                     color=style.primary_color_negative,
-                    fontsize=12,
+                    fontsize=style.font_size,
                 )
             else:
                 ax.text(
@@ -304,12 +308,12 @@ def bar(
                     horizontalalignment="left",
                     verticalalignment="center",
                     color=style.primary_color_positive,
-                    fontsize=12,
+                    fontsize=style.font_size,
                 )
 
     # put horizontal lines for each feature row
     for i in range(num_features):
-        ax.axhline(i + 1, color="#888888", lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(i + 1, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
 
     if features is not None:
         features = list(features)
@@ -328,7 +332,7 @@ def bar(
     ax.spines["top"].set_visible(False)
     if negative_values_present:
         ax.spines["left"].set_visible(False)
-    ax.tick_params("x", labelsize=11)
+    ax.tick_params("x", labelsize=style.tick_label_size)
 
     xmin, xmax = ax.get_xlim()
     ymin, ymax = ax.get_ylim()
@@ -340,12 +344,12 @@ def bar(
         ax.set_xlim(xmin, xmax + x_buffer)
 
     # if features is None:
-    #     plt.xlabel(labels["GLOBAL_VALUE"], fontsize=13)
+    #     plt.xlabel(labels["GLOBAL_VALUE"], fontsize=style.label_size)
     # else:
-    ax.set_xlabel(xlabel, fontsize=13)
+    ax.set_xlabel(xlabel, fontsize=style.label_size)
 
     if len(values) > 1:
-        ax.legend(fontsize=12)
+        ax.legend(fontsize=style.font_size)
 
     # color the y tick labels that have the feature values as gray
     # (these fall behind the black ones with just the feature name)
@@ -369,8 +373,8 @@ def bar(
             "Clustering cutoff = " + format_value(clustering_cutoff, "%0.02f"),
             horizontalalignment="left",
             verticalalignment="center",
-            color="#999999",
-            fontsize=12,
+            color=style.tick_labels_color,
+            fontsize=style.font_size,
             rotation=-90,
         )
         line = ax.axvline(ct_line_pos, color="#dddddd", dashes=(1, 1))
@@ -384,7 +388,11 @@ def bar(
             if np.array(xline).max() <= clustering_cutoff:
                 # only draw if we are not going past the bottom of the plot
                 if yline.max() < max_display:
-                    lines = ax.plot(xv * 0.1 * (xmax - xmin) + xmax, max_display - np.array(yline), color="#999999")
+                    lines = ax.plot(
+                        xv * 0.1 * (xmax - xmin) + xmax,
+                        max_display - np.array(yline),
+                        color=style.tick_labels_color,
+                    )
                     for line in lines:
                         line.set_clip_on(False)
 
@@ -432,7 +440,7 @@ def bar_legacy(shap_values, features=None, feature_names=None, max_display=None,
             for i in range(len(y_pos))
         ],
     )
-    plt.yticks(y_pos, fontsize=13)
+    plt.yticks(y_pos, fontsize=style.label_size)
     if features is not None:
         features = list(features)
 

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -21,6 +21,7 @@ from ..utils import safe_isinstance
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels
+from ._style import get_style
 from ._utils import (
     convert_color,
     convert_ordering,
@@ -106,6 +107,7 @@ def beeswarm(
     See `beeswarm plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/beeswarm.html>`_.
 
     """
+    style = get_style()
     if not isinstance(shap_values, Explanation):
         emsg = "The beeswarm plot requires an `Explanation` object as the `shap_values` argument."
         raise TypeError(emsg)
@@ -372,11 +374,11 @@ def beeswarm(
         fig.set_size_inches(plot_size[0], plot_size[1])
     elif plot_size is not None:
         fig.set_size_inches(8, min(len(feature_order), max_display) * plot_size + 1.5)
-    ax.axvline(x=0, color="#999999", zorder=-1)
+    ax.axvline(x=0, color=style.vlines_color, linewidth=style.line_width, zorder=-1)
 
     # make the beeswarm dots
     for pos, i in enumerate(reversed(feature_inds)):
-        ax.axhline(y=pos, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(y=pos, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
         shaps = values[:, i]
         fvalues = None if features is None else features[:, i]
         f_inds = np.arange(len(shaps))
@@ -480,8 +482,8 @@ def beeswarm(
         m.set_array([0, 1])
         cb = fig.colorbar(m, ax=ax, ticks=[0, 1], aspect=80)
         cb.set_ticklabels([labels["FEATURE_VALUE_LOW"], labels["FEATURE_VALUE_HIGH"]])
-        cb.set_label(color_bar_label, size=12, labelpad=0)
-        cb.ax.tick_params(labelsize=11, length=0)
+        cb.set_label(color_bar_label, size=style.font_size, labelpad=0)
+        cb.ax.tick_params(labelsize=style.tick_label_size, length=0)
         cb.set_alpha(1)
         cb.outline.set_visible(False)  # type: ignore
     #         bbox = cb.ax.get_window_extent().transformed(plt.gcf().dpi_scale_trans.inverted())
@@ -494,11 +496,11 @@ def beeswarm(
     ax.spines["top"].set_visible(False)
     ax.spines["left"].set_visible(False)
     ax.tick_params(color=axis_color, labelcolor=axis_color)
-    ax.set_yticks(range(len(feature_inds)), list(reversed(yticklabels)), fontsize=13)
-    ax.tick_params("y", length=20, width=0.5, which="major")
-    ax.tick_params("x", labelsize=11)
+    ax.set_yticks(range(len(feature_inds)), list(reversed(yticklabels)), fontsize=style.label_size)
+    ax.tick_params("y", length=20, width=style.line_width, which="major")
+    ax.tick_params("x", labelsize=style.tick_label_size)
     ax.set_ylim(-1, len(feature_inds))
-    ax.set_xlabel(labels["VALUE"], fontsize=13)
+    ax.set_xlabel(labels["VALUE"], fontsize=style.label_size)
     if show:
         plt.show()
     else:
@@ -580,6 +582,7 @@ def summary_legacy(
         passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
     """
+    style = get_style()
     # handle randomization machinery in conformance with SPEC 7
     if rng is not None:
         rng = np.random.default_rng(rng)
@@ -781,11 +784,11 @@ def summary_legacy(
         plt.gcf().set_size_inches(plot_size[0], plot_size[1])
     elif plot_size is not None:
         plt.gcf().set_size_inches(8, len(feature_order) * plot_size + 1.5)
-    plt.axvline(x=0, color="#999999", zorder=-1)
+    plt.axvline(x=0, color=style.vlines_color, linewidth=style.line_width, zorder=-1)
 
     if plot_type == "dot":
         for pos, i in enumerate(feature_order):
-            plt.axhline(y=pos, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
+            plt.axhline(y=pos, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
             shaps = shap_values[:, i]
             values = None if features is None else features[:, i]
             inds = np.arange(len(shaps))
@@ -886,7 +889,7 @@ def summary_legacy(
 
     elif plot_type == "violin":
         for pos in range(len(feature_order)):
-            plt.axhline(y=pos, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
+            plt.axhline(y=pos, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
 
         if features is not None:
             global_low = np.nanpercentile(shap_values[:, : len(feature_names)].flatten(), 1)
@@ -1071,7 +1074,7 @@ def summary_legacy(
         y_pos = np.arange(len(feature_inds))
         global_shap_values = np.abs(shap_values).mean(0)
         plt.barh(y_pos, global_shap_values[feature_inds], 0.7, align="center", color=color)
-        plt.yticks(y_pos, fontsize=13)
+        plt.yticks(y_pos, fontsize=style.label_size)
         plt.gca().set_yticklabels([feature_names[i] for i in feature_inds])
 
     elif multi_class and plot_type == "bar":
@@ -1107,9 +1110,9 @@ def summary_legacy(
                 y_pos, global_shap_values[feature_inds], 0.7, left=left_pos, align="center", color=color(i), label=label
             )
             left_pos += global_shap_values[feature_inds]
-        plt.yticks(y_pos, fontsize=13)
+        plt.yticks(y_pos, fontsize=style.label_size)
         plt.gca().set_yticklabels([feature_names[i] for i in feature_inds])
-        plt.legend(frameon=False, fontsize=12)
+        plt.legend(frameon=False, fontsize=style.font_size)
 
     # draw the color bar
     if (
@@ -1124,8 +1127,8 @@ def summary_legacy(
         m.set_array([0, 1])
         cb = plt.colorbar(m, ax=plt.gca(), ticks=[0, 1], aspect=80)
         cb.set_ticklabels([labels["FEATURE_VALUE_LOW"], labels["FEATURE_VALUE_HIGH"]])
-        cb.set_label(color_bar_label, size=12, labelpad=0)
-        cb.ax.tick_params(labelsize=11, length=0)
+        cb.set_label(color_bar_label, size=style.font_size, labelpad=0)
+        cb.ax.tick_params(labelsize=style.tick_label_size, length=0)
         cb.set_alpha(1)
         cb.outline.set_visible(False)  # type: ignore
     #         bbox = cb.ax.get_window_extent().transformed(plt.gcf().dpi_scale_trans.inverted())
@@ -1138,15 +1141,15 @@ def summary_legacy(
     plt.gca().spines["top"].set_visible(False)
     plt.gca().spines["left"].set_visible(False)
     plt.gca().tick_params(color=axis_color, labelcolor=axis_color)
-    plt.yticks(range(len(feature_order)), [feature_names[i] for i in feature_order], fontsize=13)
+    plt.yticks(range(len(feature_order)), [feature_names[i] for i in feature_order], fontsize=style.label_size)
     if plot_type != "bar":
-        plt.gca().tick_params("y", length=20, width=0.5, which="major")
-    plt.gca().tick_params("x", labelsize=11)
+        plt.gca().tick_params("y", length=20, width=style.line_width, which="major")
+    plt.gca().tick_params("x", labelsize=style.tick_label_size)
     plt.ylim(-1, len(feature_order))
     if plot_type == "bar":
-        plt.xlabel(labels["GLOBAL_VALUE"], fontsize=13)
+        plt.xlabel(labels["GLOBAL_VALUE"], fontsize=style.label_size)
     else:
-        plt.xlabel(labels["VALUE"], fontsize=13)
+        plt.xlabel(labels["VALUE"], fontsize=style.label_size)
     plt.tight_layout()
     if show:
         plt.show()

--- a/shap/plots/_benchmark.py
+++ b/shap/plots/_benchmark.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import colors
+from ._style import get_style
 
 xlabel_names = {
     "remove absolute": "Fraction removed",
@@ -18,6 +19,7 @@ xlabel_names = {
 
 def benchmark(benchmark, show=True):
     """Plot a BenchmarkResult or list of such results."""
+    style = get_style()
     if hasattr(benchmark, "__iter__"):
         benchmark = list(benchmark)
 
@@ -63,14 +65,14 @@ def benchmark(benchmark, show=True):
                 )
                 # plt.fill_between(b.curve_x, b.curve_y - b.curve_y_std, b.curve_y + b.curve_y_std, color=method_color[b.method], alpha=0.2)
                 ax = plt.gca()
-            ax.set_xlabel(xlabel_names[metric_name], fontsize=13)
-            ax.set_ylabel("Model output", fontsize=13)
+            ax.set_xlabel(xlabel_names[metric_name], fontsize=style.label_size)
+            ax.set_ylabel("Model output", fontsize=style.label_size)
             ax.xaxis.set_ticks_position("bottom")
             ax.yaxis.set_ticks_position("left")
             ax.spines["right"].set_visible(False)
             ax.spines["top"].set_visible(False)
             plt.title(metric_name.capitalize())
-            plt.legend(fontsize=11)
+            plt.legend(fontsize=style.tick_label_size)
             if show:
                 plt.show()
 
@@ -98,15 +100,15 @@ def benchmark(benchmark, show=True):
             # )
             ax = plt.gca()
             ax.set_yticks(np.arange(len(methods)))
-            ax.set_yticklabels([b.method for b in benchmark], rotation=0, fontsize=11)
-            ax.set_xlabel(xlabel_names[metric_name], fontsize=13)
-            # ax.set_ylabel("Model output", fontsize=13)
+            ax.set_yticklabels([b.method for b in benchmark], rotation=0, fontsize=style.tick_label_size)
+            ax.set_xlabel(xlabel_names[metric_name], fontsize=style.label_size)
+            # ax.set_ylabel("Model output", fontsize=style.label_size)
             ax.xaxis.set_ticks_position("bottom")
             ax.yaxis.set_ticks_position("left")
             ax.spines["right"].set_visible(False)
             ax.spines["top"].set_visible(False)
             plt.title(metric_name.capitalize())
-            # plt.legend(fontsize=11)
+            # plt.legend(fontsize=style.tick_label_size)
             plt.gca().invert_yaxis()
             if show:
                 plt.show()
@@ -180,12 +182,14 @@ def benchmark(benchmark, show=True):
 
             ax = plt.gca()
             ax.set_yticks([1 - i / (len(methods) - 1) for i in range(len(methods))])
-            ax.set_yticklabels(methods, rotation=0, fontsize=11)
+            ax.set_yticklabels(methods, rotation=0, fontsize=style.tick_label_size)
 
             ax.set_xticks(np.arange(len(metrics) + 1))
             # from matplotlib import rcParams
             # rcParams['text.latex.preamble'] = [r'\boldmath']
-            ax.set_xticklabels([""] + [m.capitalize() for m in metrics], rotation=45, ha="left", fontsize=11)
+            ax.set_xticklabels(
+                [""] + [m.capitalize() for m in metrics], rotation=45, ha="left", fontsize=style.tick_label_size
+            )
 
             ax.xaxis.tick_top()
             plt.grid(which="major", axis="x", linestyle="--")
@@ -223,12 +227,12 @@ def benchmark(benchmark, show=True):
             label=benchmark.method + f" ({benchmark.value:0.3})",
         )
         ax = plt.gca()
-        ax.set_xlabel(xlabel_names[benchmark.metric], fontsize=13)
-        ax.set_ylabel("Model output", fontsize=13)
+        ax.set_xlabel(xlabel_names[benchmark.metric], fontsize=style.label_size)
+        ax.set_ylabel("Model output", fontsize=style.label_size)
         ax.xaxis.set_ticks_position("bottom")
         ax.yaxis.set_ticks_position("left")
         ax.spines["right"].set_visible(False)
         ax.spines["top"].set_visible(False)
-        plt.legend(fontsize=11)
+        plt.legend(fontsize=style.tick_label_size)
         if show:
             plt.show()

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -11,6 +11,7 @@ from ..utils import hclust_ordering
 from ..utils._legacy import LogitLink, convert_to_link
 from . import colors
 from ._labels import labels
+from ._style import get_style
 
 
 def __change_shap_base_value(base_value, new_base_value, shap_values) -> np.ndarray:
@@ -53,17 +54,18 @@ def __decision_plot_matplotlib(
     legend_location,
 ):
     """Matplotlib rendering for decision_plot()"""
+    style = get_style()
     # image size
     row_height = 0.4
     if auto_size_plot:
         plt.gcf().set_size_inches(8, feature_display_count * row_height + 1.5)
 
     # draw vertical line indicating center
-    plt.axvline(x=base_value, color="#999999", zorder=-1)
+    plt.axvline(x=base_value, color=style.vlines_color, linewidth=style.line_width, zorder=-1)
 
     # draw horizontal dashed lines for each feature contribution
     for i in range(1, feature_display_count):
-        plt.axhline(y=i, color=y_demarc_color, lw=0.5, dashes=(1, 5), zorder=-1)
+        plt.axhline(y=i, color=y_demarc_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
 
     # initialize highlighting
     linestyle = np.array("-", dtype=object)
@@ -130,9 +132,9 @@ def __decision_plot_matplotlib(
     ax.spines["left"].set_visible(False)
     ax.tick_params(color=axis_color, labelcolor=axis_color, labeltop=True)
     plt.yticks(np.arange(feature_display_count) + 0.5, feature_names, fontsize=fontsize)
-    ax.tick_params("x", labelsize=11)
+    ax.tick_params("x", labelsize=style.tick_label_size)
     plt.ylim(0, feature_display_count)
-    plt.xlabel(labels["MODEL_OUTPUT"], fontsize=13)
+    plt.xlabel(labels["MODEL_OUTPUT"], fontsize=style.label_size)
 
     # draw the color bar - must come after axes styling
     if color_bar:
@@ -144,7 +146,7 @@ def __decision_plot_matplotlib(
         ax_cb = ax.inset_axes((xlim[0], feature_display_count, xlim[1] - xlim[0], 0.25), transform=ax.transData)
         cb = plt.colorbar(m, ticks=[0, 1], orientation="horizontal", cax=ax_cb)
         cb.set_ticklabels([])
-        cb.ax.tick_params(labelsize=11, length=0)
+        cb.ax.tick_params(labelsize=style.tick_label_size, length=0)
         cb.set_alpha(alpha)
         cb.outline.set_visible(False)  # type: ignore
 

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -4,6 +4,7 @@ import sklearn
 from ..utils import convert_name
 from . import colors
 from ._labels import labels
+from ._style import get_style
 
 
 def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, show=True):
@@ -34,6 +35,7 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
         show density of the data points when using a large dataset.
 
     """
+    style = get_style()
     if feature_names is None:
         feature_names = [labels["FEATURE"] % str(i) for i in range(shap_values.shape[1])]
 
@@ -58,7 +60,7 @@ def embedding(ind, shap_values, feature_names=None, method="pca", alpha=1.0, sho
     plt.axis("off")
     # plt.title(feature_names[ind])
     cb = plt.colorbar()
-    cb.set_label("SHAP value for\n" + fname, size=13)
+    cb.set_label("SHAP value for\n" + fname, size=style.label_size)
     cb.outline.set_visible(False)  # type: ignore
 
     plt.gcf().set_size_inches(7.5, 5)

--- a/shap/plots/_force_matplotlib.py
+++ b/shap/plots/_force_matplotlib.py
@@ -6,6 +6,8 @@ from matplotlib.font_manager import FontProperties
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
 
+from ._style import get_style
+
 
 def draw_bars(out_value, features, feature_type, width_separators, width_bar):
     """Draw the bars and separators."""
@@ -79,6 +81,7 @@ def draw_bars(out_value, features, feature_type, width_separators, width_bar):
 def draw_labels(
     fig, ax, out_value, features, feature_type, offset_text, total_effect=0, min_perc=0.05, text_rotation=0
 ):
+    style = get_style()
     start_text = out_value
     pre_val = out_value
 
@@ -126,7 +129,7 @@ def draw_labels(
             start_text - sign * offset_text,
             -0.15,
             text,
-            fontsize=12,
+            fontsize=style.font_size,
             color=colors[0],
             horizontalalignment=alignment,
             va=va_alignment,
@@ -272,6 +275,7 @@ def format_data(data):
 
 
 def draw_output_element(out_name, out_value, ax):
+    style = get_style()
     # Add output value
     x, y = np.array([[out_value, out_value], [0, 0.24]])
     line = lines.Line2D(x, y, lw=2.0, color="#F2F2F2")
@@ -282,32 +286,54 @@ def draw_output_element(out_name, out_value, ax):
     font = font0.copy()
     font.set_weight("bold")
     text_out_val = plt.text(
-        out_value, 0.25, f"{out_value:.2f}", fontproperties=font, fontsize=14, horizontalalignment="center"
+        out_value,
+        0.25,
+        f"{out_value:.2f}",
+        fontproperties=font,
+        fontsize=style.label_size,
+        horizontalalignment="center",
     )
     text_out_val.set_bbox(dict(facecolor="white", edgecolor="white"))
 
-    text_out_val = plt.text(out_value, 0.33, out_name, fontsize=12, alpha=0.5, horizontalalignment="center")
+    text_out_val = plt.text(
+        out_value, 0.33, out_name, fontsize=style.font_size, alpha=0.5, horizontalalignment="center"
+    )
     text_out_val.set_bbox(dict(facecolor="white", edgecolor="white"))
 
 
 def draw_base_element(base_value, ax):
+    style = get_style()
     x, y = np.array([[base_value, base_value], [0.13, 0.25]])
     line = lines.Line2D(x, y, lw=2.0, color="#F2F2F2")
     line.set_clip_on(False)
     ax.add_line(line)
 
-    text_out_val = plt.text(base_value, 0.33, "base value", fontsize=12, alpha=0.5, horizontalalignment="center")
+    text_out_val = plt.text(
+        base_value, 0.33, "base value", fontsize=style.font_size, alpha=0.5, horizontalalignment="center"
+    )
     text_out_val.set_bbox(dict(facecolor="white", edgecolor="white"))
 
 
 def draw_higher_lower_element(out_value, offset_text):
-    plt.text(out_value - offset_text, 0.405, "higher", fontsize=13, color="#FF0D57", horizontalalignment="right")
+    style = get_style()
+    plt.text(
+        out_value - offset_text,
+        0.405,
+        "higher",
+        fontsize=style.label_size,
+        color="#FF0D57",
+        horizontalalignment="right",
+    )
 
-    plt.text(out_value + offset_text, 0.405, "lower", fontsize=13, color="#1E88E5", horizontalalignment="left")
+    plt.text(
+        out_value + offset_text, 0.405, "lower", fontsize=style.label_size, color="#1E88E5", horizontalalignment="left"
+    )
 
-    plt.text(out_value, 0.4, r"$\leftarrow$", fontsize=13, color="#1E88E5", horizontalalignment="center")
+    plt.text(out_value, 0.4, r"$\leftarrow$", fontsize=style.label_size, color="#1E88E5", horizontalalignment="center")
 
-    plt.text(out_value, 0.425, r"$\rightarrow$", fontsize=13, color="#FF0D57", horizontalalignment="center")
+    plt.text(
+        out_value, 0.425, r"$\rightarrow$", fontsize=style.label_size, color="#FF0D57", horizontalalignment="center"
+    )
 
 
 def update_axis_limits(ax, total_pos, pos_features, total_neg, neg_features, base_value, out_value):

--- a/shap/plots/_group_difference.py
+++ b/shap/plots/_group_difference.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from . import colors
+from ._style import get_style
 
 
 def group_difference(
@@ -34,6 +35,7 @@ def group_difference(
         A list of feature names.
 
     """
+    style = get_style()
     # Compute confidence bounds for the group difference value
     vs = []
     gmean = group_mask.mean()
@@ -70,23 +72,23 @@ def group_difference(
         figsize = (6.4, 0.2 + 0.9 * len(inds))
         _, ax = plt.subplots(figsize=figsize)
     ticks = range(len(inds) - 1, -1, -1)
-    ax.axvline(0, color="#999999", linewidth=0.5)
+    ax.axvline(0, color=style.vlines_color, linewidth=style.line_width)
     ax.barh(ticks, diff[inds], color=colors.blue_rgb, capsize=3, xerr=np.abs(xerr[:, inds]))
 
     for i in range(len(inds)):
-        ax.axhline(y=i, color="#cccccc", lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(y=i, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
 
     ax.xaxis.set_ticks_position("bottom")
     ax.yaxis.set_ticks_position("none")
     ax.set_yticks(ticks)
-    ax.set_yticklabels([feature_names[i] for i in inds], fontsize=13)
+    ax.set_yticklabels([feature_names[i] for i in inds], fontsize=style.label_size)
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
     ax.spines["left"].set_visible(False)
-    ax.tick_params(labelsize=11)
+    ax.tick_params(labelsize=style.tick_label_size)
     if xlabel is None:
         xlabel = "Group SHAP value difference"
-    ax.set_xlabel(xlabel, fontsize=13)
+    ax.set_xlabel(xlabel, fontsize=style.label_size)
     ax.set_xlim(xmin, xmax)
     if show:
         plt.show()

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -5,6 +5,7 @@ from .. import Explanation
 from ..utils import OpChain
 from . import colors
 from ._labels import labels
+from ._style import get_style
 from ._utils import convert_ordering
 
 
@@ -70,6 +71,7 @@ def heatmap(
     See `heatmap plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/heatmap.html>`_.
 
     """
+    style = get_style()
     # sort the SHAP values matrix by rows and columns
     values = shap_values.values
     if issubclass(type(feature_values), OpChain):
@@ -143,7 +145,7 @@ def heatmap(
     ax.yaxis.set_ticks(
         [-1.5, *heatmap_yticks_pos],
         [r"$f(x)$", *heatmap_yticks_labels],
-        fontsize=13,
+        fontsize=style.label_size,
     )
     # remove the y-tick line for the f(x) label
     ax.yaxis.get_ticklines()[0].set_visible(False)
@@ -152,7 +154,7 @@ def heatmap(
     ax.set_xlabel(xlabel)
 
     # plot the f(x) line chart above the heat map
-    ax.axhline(-1.5, color="#aaaaaa", linestyle="--", linewidth=0.5)
+    ax.axhline(-1.5, color=style.hlines_color, linestyle="--", linewidth=style.line_width)
     fx = values.T.sum(0)
     ax.plot(
         -fx / np.abs(fx).max() - 1.5,
@@ -185,8 +187,8 @@ def heatmap(
         fraction=0.01,
         pad=0.10,  # padding between the cb and the main axes
     )
-    cb.set_label(labels["VALUE"], size=12, labelpad=-10)
-    cb.ax.tick_params(labelsize=11, length=0)
+    cb.set_label(labels["VALUE"], size=style.font_size, labelpad=-10)
+    cb.ax.tick_params(labelsize=style.tick_label_size, length=0)
     cb.set_alpha(1)
     cb.outline.set_visible(False)  # type: ignore
     # bbox = cb.ax.get_window_extent().transformed(plt.gcf().dpi_scale_trans.inverted())

--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -5,6 +5,7 @@ import scipy.stats
 
 from . import colors
 from ._labels import labels
+from ._style import get_style
 
 
 def truncate_text(text, max_len):
@@ -38,6 +39,7 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
         Names of the features (length # features)
 
     """
+    style = get_style()
     if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
@@ -67,7 +69,7 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     plt.scatter(xs, ys, s=10, c=features[:, ind], cmap=colors.red_blue)
 
     plt.xlabel("Sample index")
-    plt.ylabel(truncate_text(feature_names[ind], 30) + "\nSHAP value", size=13)
+    plt.ylabel(truncate_text(feature_names[ind], 30) + "\nSHAP value", size=style.label_size)
     plt.gca().xaxis.set_ticks_position("bottom")
     plt.gca().yaxis.set_ticks_position("left")
     plt.gca().spines["right"].set_visible(False)
@@ -76,6 +78,6 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     cb.outline.set_visible(False)  # type: ignore
     bbox = cb.ax.get_window_extent().transformed(plt.gcf().dpi_scale_trans.inverted())
     cb.ax.set_aspect((bbox.height - 0.7) * 20)
-    cb.set_label(truncate_text(feature_names[ind], 30), size=13)
+    cb.set_label(truncate_text(feature_names[ind], 30), size=style.label_size)
     if show:
         plt.show()

--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -7,6 +7,7 @@ import pandas as pd
 from .. import Explanation
 from ..plots.colors import blue_rgb, light_blue_rgb, red_blue_transparent, red_rgb
 from ..utils import convert_name
+from ._style import get_style
 
 
 def compute_bounds(xmin, xmax, xv):
@@ -50,6 +51,7 @@ def partial_dependence(
     show=True,
 ):
     """A basic partial dependence plot function."""
+    style = get_style()
     if isinstance(data, Explanation):
         features = data.data
         shap_values = data
@@ -124,18 +126,18 @@ def partial_dependence(
         ax1.plot(xs, vals, color=blue_rgb, linewidth=pd_linewidth, alpha=pd_opacity)
 
         ax2.set_ylim(0, features.shape[0])  # ax2.get_ylim()[0], ax2.get_ylim()[1] * 4)
-        ax1.set_xlabel(feature_names[ind], fontsize=13)
+        ax1.set_xlabel(feature_names[ind], fontsize=style.label_size)
         if ylabel is None:
             if not ice:
                 ylabel = "E[f(x) | " + str(feature_names[ind]) + "]"
             else:
                 ylabel = "f(x) | " + str(feature_names[ind])
-        ax1.set_ylabel(ylabel, fontsize=13)
+        ax1.set_ylabel(ylabel, fontsize=style.label_size)
         ax1.xaxis.set_ticks_position("bottom")
         ax1.yaxis.set_ticks_position("left")
         ax1.spines["right"].set_visible(False)
         ax1.spines["top"].set_visible(False)
-        ax1.tick_params(labelsize=11)
+        ax1.tick_params(labelsize=style.tick_label_size)
 
         ax2.xaxis.set_ticks_position("bottom")
         ax2.yaxis.set_ticks_position("left")
@@ -153,8 +155,8 @@ def partial_dependence(
             ax3.set_xticklabels(["E[" + str(feature_names[ind]) + "]"])
             ax3.spines["right"].set_visible(False)
             ax3.spines["top"].set_visible(False)
-            ax3.tick_params(length=0, labelsize=11)
-            ax1.axvline(mval, color="#999999", zorder=-1, linestyle="--", linewidth=1)
+            ax3.tick_params(length=0, labelsize=style.tick_label_size)
+            ax1.axvline(mval, color=style.vlines_color, zorder=-1, linestyle="--", linewidth=style.line_width)
 
         if model_expected_value is not False or shap_values is not None:
             if model_expected_value is True:
@@ -171,8 +173,10 @@ def partial_dependence(
             ax4.set_yticklabels(["E[f(x)]"])
             ax4.spines["right"].set_visible(False)
             ax4.spines["top"].set_visible(False)
-            ax4.tick_params(length=0, labelsize=11)
-            ax1.axhline(model_expected_value, color="#999999", zorder=-1, linestyle="--", linewidth=1)
+            ax4.tick_params(length=0, labelsize=style.tick_label_size)
+            ax1.axhline(
+                model_expected_value, color=style.hlines_color, zorder=-1, linestyle="--", linewidth=style.line_width
+            )
 
         if shap_values is not None:
             # vals = shap_values.values[:, ind]
@@ -246,9 +250,11 @@ def partial_dependence(
 
         ax.plot_surface(x0, x1, vals, cmap=red_blue_transparent)
 
-        ax.set_xlabel(feature_names[ind0], fontsize=13)
-        ax.set_ylabel(feature_names[ind1], fontsize=13)
-        ax.set_zlabel("E[f(x) | " + str(feature_names[ind0]) + ", " + str(feature_names[ind1]) + "]", fontsize=13)
+        ax.set_xlabel(feature_names[ind0], fontsize=style.label_size)
+        ax.set_ylabel(feature_names[ind1], fontsize=style.label_size)
+        ax.set_zlabel(
+            "E[f(x) | " + str(feature_names[ind0]) + ", " + str(feature_names[ind1]) + "]", fontsize=style.label_size
+        )
 
         if show:
             plt.show()

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -16,6 +16,7 @@ from ..utils._exceptions import DimensionError
 from ..utils._general import encode_array_if_needed
 from . import colors
 from ._labels import labels
+from ._style import get_style
 from ._utils import AxisLimitSpec, parse_axis_limit
 
 
@@ -128,6 +129,7 @@ def scatter(
     See `scatter plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/scatter.html>`_.
 
     """
+    style = get_style()
     if not isinstance(shap_values, Explanation):
         raise TypeError("The shap_values parameter must be a shap.Explanation object!")
 
@@ -329,7 +331,7 @@ def scatter(
             vmax = chigh
         else:
             vmin = vmax = None
-        ax.axhline(0, color="#888888", lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(0, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
         p = ax.scatter(
             xv[xv_notnan],
             s[xv_notnan],
@@ -360,8 +362,8 @@ def scatter(
 
         # Type narrowing for mypy
         assert isinstance(interaction_index, (int, np.integer)), f"Unexpected {type(interaction_index)=}"
-        cb.set_label(feature_names[interaction_index], size=13)
-        cb.ax.tick_params(labelsize=11)
+        cb.set_label(feature_names[interaction_index], size=style.label_size)
+        cb.ax.tick_params(labelsize=style.tick_label_size)
         if categorical_interaction:
             cb.ax.tick_params(length=0)
         cb.set_alpha(1)
@@ -406,20 +408,20 @@ def scatter(
     plt.sca(ax)
 
     # make the plot more readable
-    ax.set_xlabel(name, color=axis_color, fontsize=13)
-    ax.set_ylabel(labels["VALUE_FOR"] % name, color=axis_color, fontsize=13)
+    ax.set_xlabel(name, color=axis_color, fontsize=style.label_size)
+    ax.set_ylabel(labels["VALUE_FOR"] % name, color=axis_color, fontsize=style.label_size)
     if title is not None:
-        ax.set_title(title, color=axis_color, fontsize=13)
+        ax.set_title(title, color=axis_color, fontsize=style.label_size)
     ax.xaxis.set_ticks_position("bottom")
     ax.yaxis.set_ticks_position("left")
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    ax.tick_params(color=axis_color, labelcolor=axis_color, labelsize=11)
+    ax.tick_params(color=axis_color, labelcolor=axis_color, labelsize=style.tick_label_size)
     for spine in ax.spines.values():
         spine.set_edgecolor(axis_color)
     if isinstance(xd[0], str):
         ax.set_xticks([name_map[n] for n in xnames])
-        ax.set_xticklabels(xnames, fontdict=dict(rotation="vertical", fontsize=11))
+        ax.set_xticklabels(xnames, fontdict=dict(rotation="vertical", fontsize=style.tick_label_size))
     if show:
         with warnings.catch_warnings():  # ignore expected matplotlib warnings
             warnings.simplefilter("ignore", RuntimeWarning)
@@ -596,6 +598,7 @@ def dependence_legacy(
         Represents the upper bound of the plot's y-axis.
 
     """
+    style = get_style()
     if cmap is None:
         cmap = colors.red_blue
 
@@ -786,8 +789,8 @@ def dependence_legacy(
         else:
             cb = plt.colorbar(p, ax=ax, aspect=80)
 
-        cb.set_label(feature_names[interaction_index], size=13)
-        cb.ax.tick_params(labelsize=11)
+        cb.set_label(feature_names[interaction_index], size=style.label_size)
+        cb.ax.tick_params(labelsize=style.tick_label_size)
         if categorical_interaction:
             cb.ax.tick_params(length=0)
         cb.set_alpha(1)
@@ -830,8 +833,8 @@ def dependence_legacy(
     ax.set_xlim(xlim)
 
     # make the plot more readable
-    ax.set_xlabel(name, color=axis_color, fontsize=13)
-    ax.set_ylabel(labels["VALUE_FOR"] % name, color=axis_color, fontsize=13)
+    ax.set_xlabel(name, color=axis_color, fontsize=style.label_size)
+    ax.set_ylabel(labels["VALUE_FOR"] % name, color=axis_color, fontsize=style.label_size)
 
     if (ymin is not None) or (ymax is not None):
         if ymin is None:
@@ -842,17 +845,17 @@ def dependence_legacy(
         ax.set_ylim(ymin, ymax)
 
     if title is not None:
-        ax.set_title(title, color=axis_color, fontsize=13)
+        ax.set_title(title, color=axis_color, fontsize=style.label_size)
     ax.xaxis.set_ticks_position("bottom")
     ax.yaxis.set_ticks_position("left")
     ax.spines["right"].set_visible(False)
     ax.spines["top"].set_visible(False)
-    ax.tick_params(color=axis_color, labelcolor=axis_color, labelsize=11)
+    ax.tick_params(color=axis_color, labelcolor=axis_color, labelsize=style.tick_label_size)
     for spine in ax.spines.values():
         spine.set_edgecolor(axis_color)
     if isinstance(xd[0], str):
         ax.set_xticks([name_map[n] for n in xnames])
-        ax.set_xticklabels(xnames, fontdict=dict(rotation="vertical", fontsize=11))
+        ax.set_xticklabels(xnames, fontdict=dict(rotation="vertical", fontsize=style.tick_label_size))
     if show:
         with warnings.catch_warnings():  # ignore expected matplotlib warnings
             warnings.simplefilter("ignore", RuntimeWarning)

--- a/shap/plots/_style.py
+++ b/shap/plots/_style.py
@@ -29,6 +29,9 @@ type RGBAColorType = (
 )
 type ColorType = RGBColorType | RGBAColorType | np.ndarray
 
+# Matches matplotlib's accepted fontsize values (number or named size string)
+FontSizeType = int | float | str
+
 
 # TODO: Use dataclass(kw_only=True) when we drop Python 3.9
 @dataclasses.dataclass(frozen=True)
@@ -43,6 +46,11 @@ class StyleConfig:
     vlines_color: ColorType
     text_color: ColorType
     tick_labels_color: ColorType
+    # Typography and line properties
+    font_size: FontSizeType  # inline annotation text and colorbar labels
+    label_size: FontSizeType  # axis labels and feature names
+    tick_label_size: FontSizeType  # axis tick labels
+    line_width: float  # thin separator and grid lines
 
     def asdict(self):
         return dataclasses.asdict(self)
@@ -62,6 +70,10 @@ class StyleOptions(TypedDict, total=False):
     vlines_color: ColorType
     text_color: ColorType
     tick_labels_color: ColorType
+    font_size: FontSizeType
+    label_size: FontSizeType
+    tick_label_size: FontSizeType
+    line_width: float
 
 
 _shap_defaults = StyleConfig(
@@ -73,6 +85,10 @@ _shap_defaults = StyleConfig(
     vlines_color="#bbbbbb",
     text_color="white",
     tick_labels_color="#999999",
+    font_size=12,
+    label_size=13,
+    tick_label_size=11,
+    line_width=0.5,
 )
 
 
@@ -80,6 +96,40 @@ def load_default_style() -> StyleConfig:
     """Load the default style configuration."""
     # In future, this could allow reading from a persistent config file, like matplotlib rcParams.
     return _shap_defaults
+
+
+def load_matplotlib_style(style: str | None = None) -> StyleConfig:
+    """Load style configuration from the active matplotlib rcParams or a matplotlib style sheet."""
+    import matplotlib.pyplot as plt
+
+    if style is not None:
+        with plt.style.context(style):
+            return _style_from_rc_params()
+    return _style_from_rc_params()
+
+
+def _style_from_rc_params() -> StyleConfig:
+    import matplotlib.pyplot as plt
+
+    rc_params = plt.rcParams
+    prop_cycle = rc_params["axes.prop_cycle"].by_key().get("color", [])
+    primary_color_positive = prop_cycle[0] if len(prop_cycle) > 0 else _shap_defaults.primary_color_positive
+    primary_color_negative = prop_cycle[1] if len(prop_cycle) > 1 else _shap_defaults.primary_color_negative
+
+    return StyleConfig(
+        primary_color_positive=primary_color_positive,
+        primary_color_negative=primary_color_negative,
+        secondary_color_positive=primary_color_positive,
+        secondary_color_negative=primary_color_negative,
+        hlines_color=rc_params["grid.color"],
+        vlines_color=rc_params["axes.edgecolor"],
+        text_color=rc_params["text.color"],
+        tick_labels_color=rc_params["xtick.color"],
+        font_size=rc_params["font.size"],
+        label_size=rc_params["axes.labelsize"],
+        tick_label_size=rc_params["xtick.labelsize"],
+        line_width=rc_params["grid.linewidth"],
+    )
 
 
 # Singleton instance that determines the current style.
@@ -93,12 +143,23 @@ def get_style() -> StyleConfig:
     return _STYLE
 
 
-def set_style(_style: StyleConfig | None = None, /, **options: Unpack[StyleOptions]) -> None:
+def set_style(_style: StyleConfig | str | None = None, /, **options: Unpack[StyleOptions]) -> None:
     """Set options in the currently active global style configuration.
 
-    Pass keyword arguments to set individual options, or pass a StyleConfig dataclass to replace all options.
+    Pass keyword arguments to set individual options, pass a StyleConfig dataclass
+    to replace all options, or pass ``"shap"``/``"matplotlib"`` to load a base style.
     """
     if _style is not None:
+        if isinstance(_style, str):
+            if _style == "shap":
+                _style = load_default_style()
+            elif _style == "matplotlib":
+                _style = load_matplotlib_style()
+            else:
+                try:
+                    _style = load_matplotlib_style(_style)
+                except OSError as exc:
+                    raise InvalidStyleOptionError(f"Invalid style config option: {_style}") from exc
         # Unpack the dataclass; any keyword arguments take precendence.
         options = _style.asdict() | options
     global _STYLE
@@ -106,7 +167,7 @@ def set_style(_style: StyleConfig | None = None, /, **options: Unpack[StyleOptio
 
 
 @contextmanager
-def style_context(**options: Unpack[StyleOptions]):
+def style_context(_style: StyleConfig | str | None = None, /, **options: Unpack[StyleOptions]):
     """Context manager to temporarily change style options.
 
     NOTE: This is experimental and subject to change!
@@ -119,9 +180,11 @@ def style_context(**options: Unpack[StyleOptions]):
             shap.plots.waterfall(...)
     """
     old_style = get_style()
-    set_style(**options)
-    yield
-    set_style(**old_style.asdict())
+    set_style(_style, **options)
+    try:
+        yield
+    finally:
+        set_style(old_style)
 
 
 def _apply_options(style: StyleConfig, changes: StyleOptions) -> StyleConfig:

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -12,6 +12,7 @@ from scipy.stats import gaussian_kde
 from ..utils._exceptions import DimensionError
 from . import colors
 from ._labels import labels
+from ._style import get_style
 
 # TODO: simplify this when we drop support for matplotlib 3.9
 if version.parse(matplotlib.__version__) >= version.parse("3.10"):
@@ -41,9 +42,9 @@ def violin(
     class_inds=None,
     color_bar_label=labels["FEATURE_VALUE"],
     cmap=colors.red_blue,
-    color_bar_label_size=12,
-    color_bar_tick_size=11,
-    axhline_lw=0.5,
+    color_bar_label_size=None,
+    color_bar_tick_size=None,
+    axhline_lw=None,
     use_log_scale=False,
 ):
     """Create a SHAP violin plot, colored by feature values when they are provided.
@@ -103,6 +104,13 @@ def violin(
     See `violin plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/violin.html>`_.
 
     """
+    style = get_style()
+    if color_bar_label_size is None:
+        color_bar_label_size = style.font_size
+    if color_bar_tick_size is None:
+        color_bar_tick_size = style.tick_label_size
+    if axhline_lw is None:
+        axhline_lw = style.line_width
     if title is not None:
         warnings.warn("The `title` argument is unused and will be removed in a future release.", DeprecationWarning)
     # support passing an explanation object
@@ -184,11 +192,11 @@ def violin(
         plt.gcf().set_size_inches(plot_size[0], plot_size[1])
     elif plot_size is not None:
         plt.gcf().set_size_inches(8, len(feature_order) * plot_size + 1.5)
-    plt.axvline(x=0, color="#999999", zorder=-1)
+    plt.axvline(x=0, color=style.vlines_color, linewidth=style.line_width, zorder=-1)
 
     if plot_type == "violin":
         for pos in range(len(feature_order)):
-            plt.axhline(y=pos, color="#cccccc", lw=axhline_lw, dashes=(1, 5), zorder=-1)
+            plt.axhline(y=pos, color=style.hlines_color, lw=axhline_lw, dashes=(1, 5), zorder=-1)
 
         if features is not None:
             global_low = np.nanpercentile(shap_values[:, : len(feature_names)].flatten(), 1)
@@ -378,11 +386,11 @@ def violin(
     plt.gca().spines["top"].set_visible(False)
     plt.gca().spines["left"].set_visible(False)
     plt.gca().tick_params(color=axis_color, labelcolor=axis_color)
-    plt.yticks(range(len(feature_order)), [feature_names[i] for i in feature_order], fontsize=13)
-    plt.gca().tick_params("y", length=20, width=0.5, which="major")
-    plt.gca().tick_params("x", labelsize=11)
+    plt.yticks(range(len(feature_order)), [feature_names[i] for i in feature_order], fontsize=style.label_size)
+    plt.gca().tick_params("y", length=20, width=style.line_width, which="major")
+    plt.gca().tick_params("x", labelsize=style.tick_label_size)
     plt.ylim(-1, len(feature_order))
-    plt.xlabel(labels["VALUE"], fontsize=13)
+    plt.xlabel(labels["VALUE"], fontsize=style.label_size)
 
     if show:
         plt.show()

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -132,7 +132,7 @@ def waterfall(shap_values, max_display=10, show=True):
                 [rng[i] - 1 - 0.4, rng[i] + 0.4],
                 color=style.vlines_color,
                 linestyle="--",
-                linewidth=0.5,
+                linewidth=style.line_width,
                 zorder=-1,
             )
         if features is None:
@@ -225,7 +225,7 @@ def waterfall(shap_values, max_display=10, show=True):
             horizontalalignment="center",
             verticalalignment="center",
             color=style.text_color,
-            fontsize=12,
+            fontsize=style.font_size,
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
@@ -241,7 +241,7 @@ def waterfall(shap_values, max_display=10, show=True):
                 horizontalalignment="left",
                 verticalalignment="center",
                 color=style.primary_color_positive,
-                fontsize=12,
+                fontsize=style.font_size,
             )
 
     # draw the negative arrows
@@ -274,7 +274,7 @@ def waterfall(shap_values, max_display=10, show=True):
             horizontalalignment="center",
             verticalalignment="center",
             color=style.text_color,
-            fontsize=12,
+            fontsize=style.font_size,
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
@@ -290,22 +290,32 @@ def waterfall(shap_values, max_display=10, show=True):
                 horizontalalignment="right",
                 verticalalignment="center",
                 color=style.primary_color_negative,
-                fontsize=12,
+                fontsize=style.font_size,
             )
 
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
     # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     ytick_pos = list(range(num_features)) + list(np.arange(num_features) + 1e-8)
-    plt.yticks(ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
+    plt.yticks(
+        ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=style.label_size
+    )
 
     # put horizontal lines for each feature row
     for i in range(num_features):
-        plt.axhline(i, color=style.hlines_color, lw=0.5, dashes=(1, 5), zorder=-1)
+        plt.axhline(i, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
 
     # mark the prior expected value and the model prediction
-    plt.axvline(base_values, 0, 1 / num_features, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    plt.axvline(
+        base_values,
+        0,
+        1 / num_features,
+        color=style.vlines_color,
+        linestyle="--",
+        linewidth=style.line_width,
+        zorder=-1,
+    )
     fx = base_values + values.sum()
-    plt.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    plt.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=style.line_width, zorder=-1)
 
     # clean up the main axis
     plt.gca().xaxis.set_ticks_position("bottom")
@@ -313,8 +323,8 @@ def waterfall(shap_values, max_display=10, show=True):
     plt.gca().spines["right"].set_visible(False)
     plt.gca().spines["top"].set_visible(False)
     plt.gca().spines["left"].set_visible(False)
-    ax.tick_params(labelsize=13)
-    # plt.xlabel("\nModel output", fontsize=12)
+    ax.tick_params(labelsize=style.label_size)
+    # plt.xlabel("\nModel output", fontsize=style.font_size)
 
     # draw the E[f(X)] tick mark
     xmin, xmax = ax.get_xlim()
@@ -324,7 +334,9 @@ def waterfall(shap_values, max_display=10, show=True):
         [base_values, base_values + min(1e-8, xmax * 1e-10)]
     )  # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     # However, for very small values, 1e-8 is disruptively large, so xmax * 1e-10 is used instead
-    ax2.set_xticklabels(["\n$E[f(X)]$", "\n$ = " + format_value(base_values, "%0.03f") + "$"], fontsize=12, ha="left")
+    ax2.set_xticklabels(
+        ["\n$E[f(X)]$", "\n$ = " + format_value(base_values, "%0.03f") + "$"], fontsize=style.font_size, ha="left"
+    )
     ax2.spines["right"].set_visible(False)
     ax2.spines["top"].set_visible(False)
     ax2.spines["left"].set_visible(False)
@@ -336,7 +348,7 @@ def waterfall(shap_values, max_display=10, show=True):
         [base_values + values.sum(), base_values + values.sum() + min(1e-8, xmax * 1e-10)]
     )  # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     # However, for very small values, 1e-8 is disruptively large, so xmax * 1e-10 is used instead
-    ax3.set_xticklabels(["$f(x)$", "$ = " + format_value(fx, "%0.03f") + "$"], fontsize=12, ha="left")
+    ax3.set_xticklabels(["$f(x)$", "$ = " + format_value(fx, "%0.03f") + "$"], fontsize=style.font_size, ha="left")
     tick_labels = ax3.xaxis.get_majorticklabels()
     tick_labels[0].set_transform(
         tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-10 / 72.0, 0, fig.dpi_scale_trans)
@@ -497,7 +509,12 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             neg_lefts.append(loc)
         if num_individual != num_features or i + 4 < num_individual:
             plt.plot(
-                [loc, loc], [rng[i] - 1 - 0.4, rng[i] + 0.4], color="#bbbbbb", linestyle="--", linewidth=0.5, zorder=-1
+                [loc, loc],
+                [rng[i] - 1 - 0.4, rng[i] + 0.4],
+                color=style.vlines_color,
+                linestyle="--",
+                linewidth=style.line_width,
+                zorder=-1,
             )
         if features is None:
             yticklabels[rng[i]] = feature_names[order[i]]
@@ -584,7 +601,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             horizontalalignment="center",
             verticalalignment="center",
             color=style.text_color,
-            fontsize=12,
+            fontsize=style.font_size,
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
@@ -600,7 +617,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
                 horizontalalignment="left",
                 verticalalignment="center",
                 color=style.primary_color_positive,
-                fontsize=12,
+                fontsize=style.font_size,
             )
 
     # draw the negative arrows
@@ -633,7 +650,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             horizontalalignment="center",
             verticalalignment="center",
             color=style.text_color,
-            fontsize=12,
+            fontsize=style.font_size,
         )
         text_bbox = txt_obj.get_window_extent(renderer=renderer)
         arrow_bbox = arrow_obj.get_window_extent(renderer=renderer)
@@ -649,24 +666,32 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
                 horizontalalignment="right",
                 verticalalignment="center",
                 color=style.primary_color_negative,
-                fontsize=12,
+                fontsize=style.font_size,
             )
 
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
     plt.yticks(
         list(range(num_features)) * 2,
         yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]],
-        fontsize=13,
+        fontsize=style.label_size,
     )
 
     # put horizontal lines for each feature row
     for i in range(num_features):
-        plt.axhline(i, color=style.hlines_color, lw=0.5, dashes=(1, 5), zorder=-1)
+        plt.axhline(i, color=style.hlines_color, lw=style.line_width, dashes=(1, 5), zorder=-1)
 
     # mark the prior expected value and the model prediction
-    plt.axvline(expected_value, 0, 1 / num_features, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    plt.axvline(
+        expected_value,
+        0,
+        1 / num_features,
+        color=style.vlines_color,
+        linestyle="--",
+        linewidth=style.line_width,
+        zorder=-1,
+    )
     fx = expected_value + shap_values.sum()
-    plt.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    plt.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=style.line_width, zorder=-1)
 
     # clean up the main axis
     plt.gca().xaxis.set_ticks_position("bottom")
@@ -674,8 +699,8 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     plt.gca().spines["right"].set_visible(False)
     plt.gca().spines["top"].set_visible(False)
     plt.gca().spines["left"].set_visible(False)
-    ax.tick_params(labelsize=13)
-    # plt.xlabel("\nModel output", fontsize=12)
+    ax.tick_params(labelsize=style.label_size)
+    # plt.xlabel("\nModel output", fontsize=style.font_size)
 
     # draw the E[f(X)] tick mark
     xmin, xmax = ax.get_xlim()
@@ -685,7 +710,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
         [expected_value, expected_value + 1e-8]
     )  # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     ax2.set_xticklabels(
-        ["\n$E[f(X)]$", "\n$ = " + format_value(expected_value, "%0.03f") + "$"], fontsize=12, ha="left"
+        ["\n$E[f(X)]$", "\n$ = " + format_value(expected_value, "%0.03f") + "$"], fontsize=style.font_size, ha="left"
     )
     ax2.spines["right"].set_visible(False)
     ax2.spines["top"].set_visible(False)
@@ -701,7 +726,7 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             expected_value + shap_values.sum() + 1e-8,
         ]
     )
-    ax3.set_xticklabels(["$f(x)$", "$ = " + format_value(fx, "%0.03f") + "$"], fontsize=12, ha="left")
+    ax3.set_xticklabels(["$f(x)$", "$ = " + format_value(fx, "%0.03f") + "$"], fontsize=style.font_size, ha="left")
     tick_labels = ax3.xaxis.get_majorticklabels()
     tick_labels[0].set_transform(
         tick_labels[0].get_transform() + matplotlib.transforms.ScaledTranslation(-10 / 72.0, 0, fig.dpi_scale_trans)

--- a/tests/plots/test_style.py
+++ b/tests/plots/test_style.py
@@ -3,7 +3,9 @@ from typing import get_type_hints
 
 import numpy as np
 import pytest
+from matplotlib import pyplot as plt
 
+import shap
 from shap.plots import _style
 from shap.plots._style import get_style
 from shap.utils._exceptions import InvalidStyleOptionError
@@ -17,11 +19,40 @@ def test_default_style():
     assert configs_are_equal(get_style(), default_stype)
 
 
+def test_style_helpers_are_available_from_plots_namespace():
+    assert shap.plots.get_style is _style.get_style
+    assert shap.plots.set_style is _style.set_style
+    assert shap.plots.style_context is _style.style_context
+
+
 def test_set_style():
     prev_style = get_style()
     _style.set_style(text_color="green")
     assert get_style().text_color == "green"
     assert not configs_are_equal(get_style(), prev_style)
+
+
+def test_set_style_shap_alias():
+    _style.set_style(text_color="green")
+    _style.set_style("shap")
+    assert configs_are_equal(get_style(), _style.load_default_style())
+
+
+def test_set_style_matplotlib_alias():
+    with plt.rc_context({"font.size": 17, "axes.labelsize": 19, "xtick.labelsize": 7, "grid.linewidth": 2.5}):
+        _style.set_style("matplotlib", text_color="green")
+
+    current_style = get_style()
+    assert current_style.font_size == 17
+    assert current_style.label_size == 19
+    assert current_style.tick_label_size == 7
+    assert current_style.line_width == 2.5
+    assert current_style.text_color == "green"
+
+
+def test_set_style_matplotlib_style_sheet():
+    _style.set_style("ggplot")
+    assert configs_are_equal(get_style(), _style.load_matplotlib_style("ggplot"))
 
 
 def test_style_context():
@@ -31,9 +62,22 @@ def test_style_context():
     assert get_style().text_color == original_text_color
 
 
+def test_style_context_with_matplotlib_alias():
+    original_style = get_style()
+    with plt.rc_context({"font.size": 17}):
+        with _style.style_context("matplotlib"):
+            assert get_style().font_size == 17
+    assert configs_are_equal(get_style(), original_style)
+
+
 def test_set_style_raises_on_invalid_options():
     with pytest.raises(InvalidStyleOptionError, match="Invalid style config option"):
         _style.set_style(foo="bar")  # type: ignore
+
+
+def test_set_style_raises_on_invalid_style_alias():
+    with pytest.raises(InvalidStyleOptionError, match="Invalid style config option"):
+        _style.set_style("foo")  # type: ignore
 
 
 def test_style_context_raises_on_invalid_options():


### PR DESCRIPTION
## Summary
- extend SHAP plot style config with font sizes, tick label size, and line width
- add rcParams-backed style loading via set_style("matplotlib") and matplotlib style sheet names
- apply style settings across matplotlib-based plots and export style helpers from shap.plots

## Tests
- .venv/bin/ruff check shap/plots/__init__.py shap/plots/_style.py shap/plots/_embedding.py shap/plots/_monitoring.py shap/plots/_force_matplotlib.py shap/plots/_violin.py shap/plots/_scatter.py shap/plots/_beeswarm.py shap/plots/_benchmark.py shap/plots/_decision.py shap/plots/_group_difference.py shap/plots/_heatmap.py shap/plots/_partial_dependence.py shap/plots/_bar.py shap/plots/_waterfall.py tests/plots/test_style.py
- .venv/bin/python -m pytest tests/plots/test_style.py
- .venv/bin/python -m pytest tests/plots/test_waterfall.py::test_waterfall_custom_style

Closes #1430