### PR TITLE
fix(TreeExplainer): warn on ignored link and linearize_link params

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -142,7 +142,6 @@ class TreeExplainer(Explainer):
         feature_perturbation: Literal["auto", "interventional", "tree_path_dependent"] = "auto",
         feature_names: list[str] | None = None,
         approximate: Any = DEPRECATED_APPROX,
-        # FIXME: The `link` and `linearize_link` arguments are ignored. GH #3513
         link: Any = None,
         linearize_link: Any = None,
     ) -> None:
@@ -217,6 +216,17 @@ class TreeExplainer(Explainer):
             Deprecated, will be deprecated in v0.47.0 and removed in version v0.49.0.
             Please use the ``approximate`` argument in the :meth:`.shap_values` or ``__call__`` methods instead.
 
+        link : None
+            .. deprecated::
+               The ``link`` parameter is not supported by ``TreeExplainer`` and has never had any
+               effect. It will be removed in a future release. To explain probability outputs use
+               ``model_output="probability"`` instead.
+
+        linearize_link : None
+            .. deprecated::
+               The ``linearize_link`` parameter is not supported by ``TreeExplainer`` and has never
+               had any effect. It will be removed in a future release.
+
         References
         ----------
         .. [1] Janzing, Dominik, Lenon Minorics, and Patrick Blöbaum.
@@ -229,6 +239,21 @@ class TreeExplainer(Explainer):
                 "The approximate argument has been deprecated in version v0.47.0 and will be removed in version v0.48.0. "
                 "Please use the approximate argument in the shap_values or the __call__ method instead.",
                 DeprecationWarning,
+            )
+        if link is not None:
+            warnings.warn(
+                "The `link` parameter is not supported by TreeExplainer and has never had any effect. "
+                "It will be removed in a future release. "
+                "To explain probability outputs, use model_output='probability' instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        if linearize_link is not None:
+            warnings.warn(
+                "The `linearize_link` parameter is not supported by TreeExplainer and has never had any effect. "
+                "It will be removed in a future release.",
+                FutureWarning,
+                stacklevel=2,
             )
         if feature_names is not None:
             self.data_feature_names = feature_names

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -4,6 +4,7 @@ import itertools
 import math
 import pickle
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -3004,3 +3005,31 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+
+def test_tree_explainer_link_warns():
+
+    X, y = sklearn.datasets.make_classification(n_samples=100, n_features=5, random_state=0)
+    model = RandomForestClassifier(n_estimators=10, random_state=0).fit(X, y)
+
+    with pytest.warns(FutureWarning, match="link.*parameter is not supported by TreeExplainer"):
+        shap.TreeExplainer(model, link="logit")
+
+
+def test_tree_explainer_linearize_link_warns():
+
+    X, y = sklearn.datasets.make_classification(n_samples=100, n_features=5, random_state=0)
+    model = RandomForestClassifier(n_estimators=10, random_state=0).fit(X, y)
+
+    with pytest.warns(FutureWarning, match="linearize_link.*parameter is not supported by TreeExplainer"):
+        shap.TreeExplainer(model, linearize_link=True)
+
+
+def test_tree_explainer_no_link_no_warning():
+    """Passing neither link= nor linearize_link= must not emit any FutureWarning."""
+    X, y = sklearn.datasets.make_classification(n_samples=100, n_features=5, random_state=0)
+    model = RandomForestClassifier(n_estimators=10, random_state=0).fit(X, y)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        shap.TreeExplainer(model)


### PR DESCRIPTION
## Overview

Closes #3513 

## Description of the changes proposed in this pull request:

  - `link=` and `linearize_link=` were silently ignored by `TreeExplainer`, producing wrong SHAP attributions with no diagnostic message 
  - Now raises `FutureWarning` when either is passed as non-`None`, pointing users to `model_output='probability'` as the correct alternative.
  - Adds 3 regression tests covering both warning cases and the no-warning baseline.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
