### PR TITLE
TEST: added test coverage for shap/utils/_types.py

### DIFF
--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -1,0 +1,31 @@
+from typing import get_args
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as ssp
+
+from shap.utils import _types
+
+
+def test_arraylike_union_contains_supported_types():
+    expected = (np.ndarray, pd.DataFrame, pd.Series, list, ssp.spmatrix)
+    alias_value = _types._ArrayLike.__value__
+    assert get_args(alias_value) == expected
+
+
+def test_arrayt_typevar_constraints_match_arraylike():
+    expected = (np.ndarray, pd.DataFrame, pd.Series, ssp.spmatrix, list)
+    assert _types._ArrayT.__constraints__ == expected
+
+
+def test_arraylike_runtime_examples_match_declared_types():
+    array_like_types = get_args(_types._ArrayLike.__value__)
+    examples = [
+        np.array([1, 2, 3]),
+        pd.DataFrame({"a": [1, 2]}),
+        pd.Series([1, 2]),
+        [1, 2, 3],
+        ssp.csr_matrix(np.eye(2)),
+    ]
+
+    assert all(isinstance(example, array_like_types) for example in examples)


### PR DESCRIPTION
## Overview

Closes #3690

## Description of the changes proposed in this pull request:

- Added a new test file: [test_types.py]

- Added tests that verify:

_ArrayLike declares the expected supported array-like types
_ArrayT has the expected TypeVar constraints
Runtime examples match the declared supported types (NumPy, pandas, list, scipy sparse)



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
- [x] Coverage check for [_types.py]: 100% (7/7 statements)
