### PR TITLE
TEST: add coverage for shap/plots/_scatter.py helpers and branches

### DIFF
--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -3,6 +3,10 @@ import numpy as np
 import pytest
 
 import shap
+from shap.plots._scatter import dependence_legacy
+from shap.plots._scatter import _plot_histogram
+from shap.plots._scatter import _suggest_buffered_limits
+from shap.plots._scatter import _suggest_x_jitter
 
 
 @pytest.mark.mpl_image_compare
@@ -62,6 +66,130 @@ def test_scatter_custom(explainer):
     )
     plt.tight_layout()
     return plt.gcf()
+
+
+def test_scatter_rejects_non_explanation_input():
+    with pytest.raises(TypeError, match="The shap_values parameter must be a shap\\.Explanation object!"):
+        shap.plots.scatter(np.array([1.0, 2.0, 3.0]), show=False)
+
+
+def test_scatter_multi_column_with_ax_raises_value_error():
+    explanation = shap.Explanation(
+        values=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        data=np.array([[10.0, 20.0], [30.0, 40.0]]),
+        feature_names=["feature_a", "feature_b"],
+    )
+    _, ax = plt.subplots()
+
+    with pytest.raises(ValueError, match="The ax parameter is not supported when plotting multiple features"):
+        shap.plots.scatter(explanation, ax=ax, show=False)
+
+
+def test_scatter_single_column_show_false_returns_passed_axes():
+    explanation = shap.Explanation(
+        values=np.array([1.0, 2.0, 3.0]),
+        data=np.array([10.0, 20.0, 30.0]),
+        feature_names="feature_a",
+    )
+    _, ax = plt.subplots()
+
+    returned_ax = shap.plots.scatter(explanation, ax=ax, show=False)
+
+    assert returned_ax is ax
+
+
+def test_scatter_sets_xticklabels_from_string_display_data():
+    explanation = shap.Explanation(
+        values=np.array([0.1, 0.2, 0.3]),
+        data=np.array([0.0, 1.0, 2.0]),
+        display_data=np.array(["low", "med", "high"]),
+        feature_names="feature_a",
+    )
+
+    ax = shap.plots.scatter(explanation, show=False)
+
+    assert sorted(tick.get_text() for tick in ax.get_xticklabels()) == sorted(["low", "med", "high"])
+
+
+def test_suggest_buffered_limits_adds_five_percent_buffer():
+    assert _suggest_buffered_limits(None, None, np.array([0.0, 10.0])) == (-0.5, 10.5)
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (np.array([1, 1, 1]), 0.0),
+        (np.array([1, 2, 1, 2]), 0),
+        (np.tile(np.array([1, 2]), 25), 0.1),
+        (np.tile(np.array([1, 2]), 250), 0.2),
+    ],
+)
+def test_suggest_x_jitter_branches(values, expected):
+    assert _suggest_x_jitter(values) == expected
+
+
+def test_plot_histogram_uses_discrete_bins_and_updates_xlim():
+    xv = np.tile(np.arange(5), 20)
+    fig, ax = plt.subplots()
+    axes_before = len(fig.axes)
+
+    _plot_histogram(ax, xv, xv)
+
+    assert len(fig.axes) == axes_before + 1
+    assert ax.get_xlim() == (-0.5, 4.5)
+
+
+def test_dependence_legacy_rejects_list_shap_values():
+    with pytest.raises(TypeError, match="list not an array"):
+        dependence_legacy(ind=0, shap_values=[np.array([0.1]), np.array([0.2])], features=np.array([[1.0], [2.0]]), show=False)
+
+
+def test_dependence_legacy_sets_symmetric_ylim_when_only_ymax_given():
+    _, ax = plt.subplots()
+
+    dependence_legacy(
+        ind=0,
+        shap_values=np.array([[0.1], [0.2]]),
+        features=np.array([[1.0], [2.0]]),
+        ax=ax,
+        ymin=None,
+        ymax=2,
+        show=False,
+    )
+
+    assert ax.get_ylim() == (-2.0, 2.0)
+
+
+def test_suggest_x_jitter_handles_tiny_diffs():
+    values = np.tile(np.array([1.0, 1.0 + 1e-10]), 250)
+
+    assert _suggest_x_jitter(values) == 0.2
+
+
+def test_scatter_uses_display_data_for_xticklabels():
+    explanation = shap.Explanation(
+        values=np.array([0.1, 0.2, 0.3]),
+        data=np.array([0.0, 1.0, 2.0]),
+        display_data=np.array(["low", "med", "high"]),
+        feature_names="feature_a",
+    )
+
+    ax = shap.plots.scatter(explanation, show=False)
+
+    assert sorted(ax.get_xticks().tolist()) == [0.0, 1.0, 2.0]
+    assert sorted(tick.get_text() for tick in ax.get_xticklabels()) == sorted(["low", "med", "high"])
+
+
+def test_scatter_auto_jitter_triggers_helper():
+    values = np.tile(np.array([0.1, 0.2]), 250)
+    data = np.tile(np.array([1.0, 2.0]), 250)
+    explanation = shap.Explanation(values=values, data=data, feature_names="feature_a")
+
+    ax = shap.plots.scatter(explanation, show=False)
+    x_positions = ax.collections[0].get_offsets()[:, 0]
+
+    assert isinstance(ax, plt.Axes)
+    assert np.any(np.abs(x_positions - np.round(x_positions)) > 1e-12)
 
 
 @pytest.fixture()

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -3,10 +3,7 @@ import numpy as np
 import pytest
 
 import shap
-from shap.plots._scatter import dependence_legacy
-from shap.plots._scatter import _plot_histogram
-from shap.plots._scatter import _suggest_buffered_limits
-from shap.plots._scatter import _suggest_x_jitter
+from shap.plots._scatter import _plot_histogram, _suggest_buffered_limits, _suggest_x_jitter, dependence_legacy
 
 
 @pytest.mark.mpl_image_compare
@@ -141,7 +138,9 @@ def test_plot_histogram_uses_discrete_bins_and_updates_xlim():
 
 def test_dependence_legacy_rejects_list_shap_values():
     with pytest.raises(TypeError, match="list not an array"):
-        dependence_legacy(ind=0, shap_values=[np.array([0.1]), np.array([0.2])], features=np.array([[1.0], [2.0]]), show=False)
+        dependence_legacy(
+            ind=0, shap_values=[np.array([0.1]), np.array([0.2])], features=np.array([[1.0], [2.0]]), show=False
+        )
 
 
 def test_dependence_legacy_sets_symmetric_ylim_when_only_ymax_given():


### PR DESCRIPTION
Works towards #3690.

shap/plots/_scatter.py was at 21%. After these tests, 
`coverage run -m pytest tests/plots/test_scatter.py` reports 58%.

Tests added:
- TypeError on non-Explanation input
- ValueError when ax is passed with multiple features
- show=False returning the passed axes
- string display_data producing correct xticks and xticklabels
- _suggest_buffered_limits 5% buffer
- _suggest_x_jitter across all branches including the tiny-diff 
  except path
- _plot_histogram discrete-bin branch
- dependence_legacy list TypeError and symmetric ylim
- scatter auto jitter path

A few assertions use sorted() because scatter shuffles internally 
with np.random.shuffle.



## Checklist
- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)