### PR TITLE
ENH: Refactor image_to_text to use matplotlib instead of HTML/JS

### DIFF
--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -1,22 +1,11 @@
 from __future__ import annotations
 
-import json
-import random
-import string
 from typing import TYPE_CHECKING, Literal, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-try:
-    from IPython.display import HTML, display
-
-    have_ipython = True
-except ImportError:
-    have_ipython = False
-
 from .._explanation import Explanation
-from ..utils import ordinal_str
 from ..utils._legacy import kmeans
 from . import colors
 
@@ -198,400 +187,107 @@ def image(
         plt.show()
 
 
-def image_to_text(shap_values):
-    """Plots SHAP values for image inputs with test outputs.
+def image_to_text(
+    shap_values: Explanation,
+    max_display: int = 10,
+    cmap: str | Colormap | None = colors.red_transparent_blue,
+    vmax: float | None = None,
+    show: bool = True,
+):
+    """Plots SHAP values for image inputs with text outputs.
 
     Parameters
     ----------
-    shap_values : [numpy.array]
-        List of arrays of SHAP values. Each array has the shap (# width x height x channels x num output tokens). One array
-        for each sample
+    shap_values : Explanation
+        An Explanation object with values of shape
+        (height, width, channels, num_tokens) for a single instance or
+        (num_instances, height, width, channels, num_tokens) for a batch.
+
+    max_display : int
+        Maximum number of output tokens to show.
+
+    cmap: str or matplotlib.colors.Colormap
+        Colormap to use when plotting the SHAP values.
+
+    vmax: float or None
+        Sets the colormap scale for SHAP values from ``-vmax`` to ``+vmax``.
+
+    show : bool
+        Whether :external+mpl:func:`matplotlib.pyplot.show()` is called before returning.
+        Setting this to ``False`` allows the plot
+        to be customized further after it has been created.
 
     """
-    if not have_ipython:  # pragma: no cover
-        msg = "IPython is required for this function but is not installed. Fix this with `pip install ipython`."
-        raise ImportError(msg)
+    if not isinstance(shap_values, Explanation):
+        raise TypeError("image_to_text requires an Explanation object as input.")
 
+    # handle batched input
     if len(shap_values.values.shape) == 5:
         for i in range(shap_values.values.shape[0]):
-            display(HTML(f"<br/><b>{ordinal_str(i)} instance:</b><br/>"))
-            image_to_text(shap_values[i])
-
+            image_to_text(shap_values[i], max_display=max_display, cmap=cmap, vmax=vmax, show=show)
         return
 
-    uuid = "".join(random.choices(string.ascii_lowercase, k=20))
-
-    # creating input html tokens
-
-    model_output = shap_values.output_names
-
-    output_text_html = ""
-
-    for i in range(model_output.shape[0]):
-        output_text_html += (
-            "<div style='display:inline; text-align:center;'>"
-            f"<div id='{uuid}_output_flat_value_label_{i}'"
-            "style='display:none;color: #999; padding-top: 0px; font-size:12px;'>"
-            "</div>"
-            f"<div id='{uuid}_output_flat_token_{i}'"
-            "style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'"
-            f'onmouseover="onMouseHoverFlat_{uuid}(this.id)" '
-            f'onmouseout="onMouseOutFlat_{uuid}(this.id)" '
-            f'onclick="onMouseClickFlat_{uuid}(this.id)" '
-            ">"
-            + model_output[i]
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace(" ##", "")
-            .replace("▁", "")
-            .replace("Ġ", "")
-            + " </div>"
-            + "</div>"
-        )
-
-    # computing gray scale images
     image_data = shap_values.data
-    image_height = image_data.shape[0]
-    image_width = image_data.shape[1]
+    values = shap_values.values
+    output_names = shap_values.output_names
+    num_tokens = min(max_display, values.shape[-1])
 
-    # computing gray scale image
-    image_data_gray_scale = np.ones((image_height, image_width, 4)) * 255 * 0.5
-    image_data_gray_scale[:, :, 0] = np.mean(image_data, axis=2).astype(int)
-    image_data_gray_scale[:, :, 1] = image_data_gray_scale[:, :, 0]
-    image_data_gray_scale[:, :, 2] = image_data_gray_scale[:, :, 0]
+    # get a grayscale version of the image
+    if len(image_data.shape) == 3 and image_data.shape[2] == 3:
+        image_gray = 0.2989 * image_data[:, :, 0] + 0.5870 * image_data[:, :, 1] + 0.1140 * image_data[:, :, 2]
+    elif len(image_data.shape) == 3:
+        image_gray = image_data.mean(axis=2)
+    else:
+        image_gray = image_data
 
-    # computing shap color values for every pixel and for every output token
+    # sum shap values across color channels
+    if len(values.shape) == 4:
+        sv_per_token = values.sum(axis=2)
+    else:
+        sv_per_token = values
 
-    shap_values_color_maps = shap_values.values[:, :, 0, :]
-    max_val = np.nanpercentile(np.abs(shap_values.values), 99.9)
+    max_val = np.nanpercentile(np.abs(sv_per_token[:, :, :num_tokens]), 99.9) if vmax is None else vmax
 
-    shap_values_color_dict = {}
+    ncols = num_tokens + 1
+    fig_size = np.array([3 * ncols, 3.0])
+    if fig_size[0] > 20:
+        fig_size *= 20 / fig_size[0]
 
-    for index in range(model_output.shape[0]):
-        shap_values_color_dict[f"{uuid}_output_flat_token_{index}"] = (
-            (colors.red_transparent_blue(0.5 + 0.5 * shap_values_color_maps[:, :, index] / max_val) * 255)
-            .astype(int)
-            .tolist()
+    fig, axes = plt.subplots(nrows=1, ncols=ncols, figsize=fig_size, squeeze=False)
+
+    # show original image
+    if len(image_data.shape) == 3 and image_data.shape[2] == 3:
+        axes[0, 0].imshow(image_data.astype(np.uint8) if image_data.max() > 1 else image_data)
+    else:
+        axes[0, 0].imshow(image_gray, cmap=plt.get_cmap("gray"))
+    axes[0, 0].set_title("Input Image", fontsize=10)
+    axes[0, 0].axis("off")
+
+    # plot per-token shap heatmaps
+    im = None
+    for i in range(num_tokens):
+        ax = axes[0, i + 1]
+        sv = sv_per_token[:, :, i]
+        ax.imshow(
+            image_gray,
+            cmap=plt.get_cmap("gray"),
+            alpha=0.15,
+            extent=(-1, sv.shape[1], sv.shape[0], -1),
         )
+        im = ax.imshow(sv, cmap=cmap, vmin=-max_val, vmax=max_val)
+        token_label = str(output_names[i]).replace("▁", "").replace("Ġ", "").replace(" ##", "")
+        ax.set_title(token_label, fontsize=9)
+        ax.axis("off")
 
-    # converting to json to be read in javascript
-
-    image_data_json = json.dumps(shap_values.data.astype(int).tolist())
-    shap_values_color_dict_json = json.dumps(shap_values_color_dict)
-    image_data_gray_scale_json = json.dumps(image_data_gray_scale.astype(int).tolist())
-
-    image_viz_html = f"""
-
-        <div id="{uuid}_image_viz" class="{uuid}_image_viz_content">
-          <div id="{uuid}_image_viz_header" style="padding:15px;margin:5px;font-family:sans-serif;font-weight:bold;">
-            <div style="display:inline">
-              <span style="font-size: 20px;"> Input/Output - Heatmap </span>
-            </div>
-          </div>
-          <div id="{uuid}_image_viz_content" style="display:flex;">
-            <div id="{uuid}_image_viz_input_container" style="padding:15px;border-style:solid;margin:5px;flex:2;">
-              <div id="{uuid}_image_viz_input_header" style="margin:5px;font-weight:bold;font-family:sans-serif;margin-bottom:10px">
-                Input Image
-              </div>
-              <div id="{uuid}_image_viz_input_content" style="margin:5px;font-family:sans-serif;">
-                  <canvas id="{uuid}_image_canvas" style="cursor:grab;width:100%;max-height:500px;"></canvas>
-                  <br>
-                  <br>
-                  <div id="{uuid}_tools">
-                      <div id="{uuid}_zoom">
-                        <span style="font-size:12px;margin-right:15px;"> Zoom </span>
-                        <button id="{uuid}_minus_button" class="zoom-button" onclick="{uuid}_zoom(-1)" style="background-color: #555555;color: white; border:none;font-size:15px;">-</button>
-                        <button id="{uuid}_plus_button" class="zoom-button" onclick="{uuid}_zoom(1)" style="background-color: #555555;color: white; border:none;font-size:15px;">+</button>
-                        <button id="{uuid}_reset_button" class="zoom-button" onclick="{uuid}_reset()" style="background-color: #555555;color: white; border:none;font-size:15px;"> Reset </button>
-                      </div>
-                      <br>
-                      <div id="{uuid}_opacity" style="display:none">
-                      <span style="font-size:12px;margin-right:15px;"> Shap-Overlay Opacity </span>
-                      <input type="range" min="1" max="100" value="35" style="width:100px" oninput="{uuid}_set_opacity(this.value)">
-                      </div>
-                  </div>
-              </div>
-            </div>
-            <div id="{uuid}_image_viz_output_container" style="padding:15px;border-style:solid;margin:5px;flex:1;">
-              <div id="{uuid}_image_viz_output_header" style="margin:5px;font-weight:bold;font-family:sans-serif;margin-bottom:10px">
-                Output Text
-              </div>
-              <div id="{uuid}_image_viz_output_content" style="margin:5px;font-family:sans-serif;">
-                  {output_text_html}
-              </div>
-            </div>
-          </div>
-        </div>
-
-    """
-
-    image_viz_script = f"""
-        <script>
-
-            var {uuid}_heatmap_flat_state = null;
-            var {uuid}_opacity = 0.35
-
-            function onMouseHoverFlat_{uuid}(id) {{
-                if ({uuid}_heatmap_flat_state === null) {{
-                    document.getElementById(id).style.backgroundColor  = "grey";
-                    {uuid}_update_image_and_overlay(id);
-                }}
-            }}
-
-            function onMouseOutFlat_{uuid}(id) {{
-                if ({uuid}_heatmap_flat_state === null) {{
-                    document.getElementById(id).style.backgroundColor  = "transparent";
-                    {uuid}_update_image_and_overlay(null);
-                }}
-            }}
-
-            function onMouseClickFlat_{uuid}(id) {{
-                if ({uuid}_heatmap_flat_state === null) {{
-                    document.getElementById(id).style.backgroundColor  = "grey";
-                    document.getElementById('{uuid}_opacity').style.display  = "block";
-                    {uuid}_update_image_and_overlay(id);
-                    {uuid}_heatmap_flat_state = id;
-                }}
-                else {{
-                    if ({uuid}_heatmap_flat_state === id) {{
-                        document.getElementById(id).style.backgroundColor  = "transparent";
-                        document.getElementById('{uuid}_opacity').style.display  = "none";
-                        {uuid}_update_image_and_overlay(null);
-                        {uuid}_heatmap_flat_state = null;
-                    }}
-                    else {{
-                        document.getElementById({uuid}_heatmap_flat_state).style.backgroundColor  = "transparent";
-                        document.getElementById(id).style.backgroundColor  = "grey";
-                        {uuid}_update_image_and_overlay(id)
-                        {uuid}_heatmap_flat_state = id
-                    }}
-                }}
-            }}
-
-            const {uuid}_image_data_matrix = {image_data_json};
-            const {uuid}_image_data_gray_scale = {image_data_gray_scale_json};
-            const {uuid}_image_height = {image_height};
-            const {uuid}_image_width = {image_width};
-            const {uuid}_shap_values_color_dict = {shap_values_color_dict_json};
-
-            {uuid}_canvas = document.getElementById('{uuid}_image_canvas');
-            {uuid}_context = {uuid}_canvas.getContext('2d');
-
-            var {uuid}_imageData = {uuid}_convert_image_matrix_to_data({uuid}_image_data_matrix, {image_height}, {image_width}, {uuid}_context);
-            var {uuid}_currImagData = {uuid}_imageData;
-
-
-            {uuid}_trackTransforms({uuid}_context);
-            initial_scale_factor = Math.min({uuid}_canvas.height/{uuid}_image_height,{uuid}_canvas.width/{uuid}_image_width);
-            {uuid}_context.scale(initial_scale_factor, initial_scale_factor);
-
-            function {uuid}_update_image_and_overlay(selected_id) {{
-                if (selected_id == null) {{
-                    {uuid}_currImagData = {uuid}_imageData;
-                    {uuid}_redraw();
-                }}
-                else {{
-                    {uuid}_currImagData = {uuid}_blend_image_shap_map({uuid}_image_data_gray_scale, {uuid}_shap_values_color_dict[selected_id], {image_height}, {image_width}, {uuid}_opacity, {uuid}_context);
-                    {uuid}_redraw();
-                }}
-            }}
-
-            function {uuid}_set_opacity(value) {{
-                {uuid}_opacity = value/100;
-
-                if ({uuid}_heatmap_flat_state !== null ) {{
-                    {uuid}_currImagData = {uuid}_blend_image_shap_map({uuid}_image_data_gray_scale, {uuid}_shap_values_color_dict[{uuid}_heatmap_flat_state], {image_height}, {image_width}, {uuid}_opacity, {uuid}_context);
-                    {uuid}_redraw();
-                }}
-            }}
-
-            function {uuid}_redraw() {{
-
-                // Clear the entire canvas
-                var p1 = {uuid}_context.transformedPoint(0, 0);
-                var p2 = {uuid}_context.transformedPoint({uuid}_canvas.width, {uuid}_canvas.height);
-                {uuid}_context.clearRect(p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
-
-                {uuid}_context.save();
-                {uuid}_context.setTransform(1, 0, 0, 1, 0, 0);
-                {uuid}_context.clearRect(0, 0, {uuid}_canvas.width, {uuid}_canvas.height);
-                {uuid}_context.restore();
-
-                createImageBitmap({uuid}_currImagData, {{ premultiplyAlpha: 'premultiply' }}).then(function(imgBitmap) {{
-                    {uuid}_context.drawImage(imgBitmap, 0, 0);
-                }});
-            }}
-            {uuid}_redraw();
-            {uuid}_context.save();
-
-            var lastX = {uuid}_canvas.width / 2,
-                lastY = {uuid}_canvas.height / 2;
-
-            var dragStart, dragged;
-
-            {uuid}_canvas.addEventListener('mousedown', function(evt) {{
-                document.body.style.mozUserSelect = document.body.style.webkitUserSelect = document.body.style.userSelect = 'none';
-                lastX = evt.offsetX || (evt.pageX - {uuid}_canvas.offsetLeft);
-                lastY = evt.offsetY || (evt.pageY - {uuid}_canvas.offsetTop);
-                dragStart = {uuid}_context.transformedPoint(lastX, lastY);
-                dragged = false;
-                document.getElementById('{uuid}_image_canvas').style.cursor = 'grabbing';
-            }}, false);
-
-            {uuid}_canvas.addEventListener('mousemove', function(evt) {{
-                lastX = evt.offsetX || (evt.pageX - {uuid}_canvas.offsetLeft);
-                lastY = evt.offsetY || (evt.pageY - {uuid}_canvas.offsetTop);
-                dragged = true;
-                if (dragStart) {{
-                    var pt = {uuid}_context.transformedPoint(lastX, lastY);
-                    {uuid}_context.translate(pt.x - dragStart.x, pt.y - dragStart.y);
-                    {uuid}_redraw();
-                }}
-            }}, false);
-
-            {uuid}_canvas.addEventListener('mouseup', function(evt) {{
-                dragStart = null;
-                document.getElementById('{uuid}_image_canvas').style.cursor = 'grab';
-            }}, false);
-
-            var scaleFactor = 1.1;
-
-            var {uuid}_zoom = function(clicks) {{
-                var pt = {uuid}_context.transformedPoint(lastX, lastY);
-                {uuid}_context.translate(pt.x, pt.y);
-                var factor = Math.pow(scaleFactor, clicks);
-                {uuid}_context.scale(factor, factor);
-                {uuid}_context.translate(-pt.x, -pt.y);
-                {uuid}_redraw();
-            }}
-
-            var {uuid}_reset = function(clicks) {{
-                {uuid}_context.restore();
-                {uuid}_redraw();
-                {uuid}_context.save();
-            }}
-
-            var handleScroll = function(evt) {{
-                var delta = evt.wheelDelta ? evt.wheelDelta / 40 : evt.detail ? -evt.detail : 0;
-                if (delta) {uuid}_zoom(delta);
-                return evt.preventDefault() && false;
-            }}
-
-            {uuid}_canvas.addEventListener('DOMMouseScroll', handleScroll, false);
-            {uuid}_canvas.addEventListener('mousewheel', handleScroll, false);
-
-
-
-            function {uuid}_trackTransforms(ctx) {{
-                var svg = document.createElementNS("http://www.w3.org/2000/svg", 'svg');
-                var xform = svg.createSVGMatrix();
-                ctx.getTransform = function() {{
-                    return xform;
-                }}
-
-                var savedTransforms = [];
-                var save = ctx.save;
-                ctx.save = function() {{
-                    savedTransforms.push(xform.translate(0, 0));
-                    return save.call(ctx);
-                }}
-
-                var restore = ctx.restore;
-                ctx.restore = function() {{
-                    xform = savedTransforms.pop();
-                    return restore.call(ctx);
-                }}
-
-                var scale = ctx.scale;
-                ctx.scale = function(sx, sy) {{
-                    xform = xform.scaleNonUniform(sx, sy);
-                    return scale.call(ctx, sx, sy);
-                }}
-
-                var rotate = ctx.rotate;
-                ctx.rotate = function(radians) {{
-                    xform = xform.rotate(radians * 180 / Math.PI);
-                    return rotate.call(ctx, radians);
-                }}
-
-                var translate = ctx.translate;
-                ctx.translate = function(dx, dy) {{
-                    xform = xform.translate(dx, dy);
-                    return translate.call(ctx, dx, dy);
-                }}
-
-                var transform = ctx.transform;
-                ctx.transform = function(a, b, c, d, e, f) {{
-                    var m2 = svg.createSVGMatrix();
-                    m2.a = a;
-                    m2.b = b;
-                    m2.c = c;
-                    m2.d = d;
-                    m2.e = e;
-                    m2.f = f;
-                    xform = xform.multiply(m2);
-                    return transform.call(ctx, a, b, c, d, e, f);
-                }}
-
-                var setTransform = ctx.setTransform;
-                ctx.setTransform = function(a, b, c, d, e, f) {{
-                    xform.a = a;
-                    xform.b = b;
-                    xform.c = c;
-                    xform.d = d;
-                    xform.e = e;
-                    xform.f = f;
-                    return setTransform.call(ctx, a, b, c, d, e, f);
-                }}
-
-                var pt = svg.createSVGPoint();
-                ctx.transformedPoint = function(x, y) {{
-                    pt.x = x;
-                    pt.y = y;
-                    return pt.matrixTransform(xform.inverse());
-                }}
-            }}
-
-
-            function {uuid}_convert_image_matrix_to_data(image_data_matrix, image_height, image_width, context) {{
-
-                var imageData = context.createImageData(image_height, image_width);
-
-                for(var row_index = 0; row_index < image_height; row_index++) {{
-                    for(var col_index = 0; col_index < image_width; col_index++) {{
-
-                        index = (row_index * image_width + col_index) * 4;
-
-                        imageData.data[index + 0] = image_data_matrix[row_index][col_index][0];
-                        imageData.data[index + 1] = image_data_matrix[row_index][col_index][1];
-                        imageData.data[index + 2] = image_data_matrix[row_index][col_index][2];
-                        imageData.data[index + 3] = 255;
-                    }}
-                }}
-
-                return imageData;
-            }}
-
-            function {uuid}_blend_image_shap_map(image_data_matrix, shap_color_map, image_height, image_width, alpha, context) {{
-                var blendedImageData = context.createImageData(image_height, image_width);
-
-                for(var row_index = 0; row_index < image_height; row_index++) {{
-
-                    for(var col_index = 0; col_index < image_width; col_index++) {{
-
-                        index = (row_index * image_width + col_index) * 4;
-
-                        blendedImageData.data[index + 0] = image_data_matrix[row_index][col_index][0] * alpha + (shap_color_map[row_index][col_index][0]) * ( 1 - alpha);
-                        blendedImageData.data[index + 1] = image_data_matrix[row_index][col_index][1] * alpha + (shap_color_map[row_index][col_index][1]) * ( 1 - alpha);
-                        blendedImageData.data[index + 2] = image_data_matrix[row_index][col_index][2] * alpha + (shap_color_map[row_index][col_index][2]) * ( 1 - alpha);
-                        blendedImageData.data[index + 3] = image_data_matrix[row_index][col_index][3] * alpha + (shap_color_map[row_index][col_index][3]) * ( 1 - alpha);
-                    }}
-                }}
-
-                return blendedImageData;
-            }}
-
-        </script>
-    """
-
-    display(HTML(image_viz_html + image_viz_script))
+    fig.tight_layout()
+    if im is not None:
+        cb = fig.colorbar(
+            im,
+            ax=np.ravel(axes).tolist(),
+            label="SHAP value",
+            orientation="horizontal",
+            aspect=fig_size[0] / 0.2,
+        )
+        cb.outline.set_visible(False)  # type: ignore
+    if show:
+        plt.show()

--- a/tests/plots/test_image.py
+++ b/tests/plots/test_image.py
@@ -105,23 +105,55 @@ def test_random_multi_image():
 
 
 def test_image_to_text_single():
-    """Just make sure the image_to_text function doesn't crash."""
+    """Just make sure image_to_text doesn't crash."""
+    test_data = np.ones((50, 50, 3)) * 50
+    test_values = np.random.rand(50, 50, 3, 4)
+    test_output_names = np.array(["token_" + str(i) for i in range(4)])
 
-    class MockImageExplanation:
-        """Fake explanation object."""
+    shap_values_test = shap.Explanation(
+        values=test_values,
+        data=test_data,
+        output_names=test_output_names,
+    )
+    shap.plots.image_to_text(shap_values_test, show=False)
+    plt.close("all")
 
-        def __init__(self, data, values, output_names):
-            self.data = data
-            self.values = values
-            self.output_names = output_names
 
-    test_image_height = 500
-    test_image_width = 500
-    test_word_length = 4
+def test_image_to_text_max_display():
+    """Check that max_display limits the number of token subplots."""
+    test_data = np.ones((20, 20, 3)) * 50
+    test_values = np.random.rand(20, 20, 3, 8)
+    test_output_names = np.array(["tok_" + str(i) for i in range(8)])
 
-    test_data = np.ones((test_image_height, test_image_width, 3)) * 50
-    test_values = np.random.rand(test_image_height, test_image_width, 3, test_word_length)
-    test_output_names = np.array([str(i) for i in range(test_word_length)])
+    shap_values_test = shap.Explanation(
+        values=test_values,
+        data=test_data,
+        output_names=test_output_names,
+    )
+    shap.plots.image_to_text(shap_values_test, max_display=3, show=False)
+    fig = plt.gcf()
+    axes = fig.get_axes()
+    # 1 input image + 3 token heatmaps + 1 colorbar
+    assert len(axes) >= 4
+    plt.close("all")
 
-    shap_values_test = MockImageExplanation(test_data, test_values, test_output_names)
-    shap.plots.image_to_text(shap_values_test)
+
+def test_image_to_text_requires_explanation():
+    """image_to_text should raise TypeError for non-Explanation input."""
+    with pytest.raises(TypeError, match="Explanation"):
+        shap.plots.image_to_text(np.random.randn(20, 20, 3, 4))
+
+
+def test_image_to_text_grayscale():
+    """Just make sure image_to_text works with a single-channel image."""
+    test_data = np.ones((20, 20, 1)) * 128
+    test_values = np.random.rand(20, 20, 1, 3)
+    test_output_names = np.array(["w" + str(i) for i in range(3)])
+
+    shap_values_test = shap.Explanation(
+        values=test_values,
+        data=test_data,
+        output_names=test_output_names,
+    )
+    shap.plots.image_to_text(shap_values_test, show=False)
+    plt.close("all")


### PR DESCRIPTION

## Overview

Closes #3802

Replaced the `image_to_text` implementation that used inline HTML/JavaScript with a matplotlib version, matching the style of the existing `image()` plot. Added `show`, `max_display`, `cmap`, and `vmax` parameters. Removed the IPython dependency from this module. Updated tests to use real `shap.Explanation` objects.




## Checklist

- [X] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [X] Unit tests added (if fixing a bug or adding a new feature)
