### PR TITLE
ENH: Fix typos and update deprecated API in LinearExplainer correlation nootebook

### DIFF
--- a/notebooks/tabular_examples/linear_models/Math behind LinearExplainer with correlation feature perturbation.ipynb
+++ b/notebooks/tabular_examples/linear_models/Math behind LinearExplainer with correlation feature perturbation.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# Math behind LinearExplainer with correlation feature perturbation\n",
     "\n",
-    "When we use `LinearExplainer(model, prior, feature_perturbation=\"correlation_dependent\")` we do not use $E[f(x) \\mid do(X_S = x_S)]$ to measure the impact of a set $S$ of features, but rather use $E[f(x) \\mid X_S = x_s]$ under the assumption that the random variable $X$ (representing the input features) follows a multivariate guassian distribution. To compute SHAP values this way we need to compute conditional expectations under the multivariate guassian distribution for all subset of features. This would be a lot of matrix match for an exponential number of terms, and it hence intractable for models with more than just a few features.\n",
+    "When we use `LinearExplainer(model, maskers.Impute(data))` we do not use $E[f(x) \\mid do(X_S = x_S)]$ to measure the impact of a set $S$ of features, but rather use $E[f(x) \\mid X_S = x_s]$ under the assumption that the random variable $X$ (representing the input features) follows a multivariate Gaussian distribution. To compute SHAP values this way we need to compute conditional expectations under the multivariate Gaussian distribution for all subsets of features. This would be a lot of matrix math for an exponential number of terms, and is hence intractable for models with more than just a few features.\n",
     "\n",
-    "This document briefly outlines the math we have used to precompute all of the required linear algebra using a sampling procedure that can be done just once, and then applied to as many samples as we like. This drastically speed up the computation compared to a brute force approach. Note that all these calculations depend on the fact that we are explaining a linear model $f(x) = \\beta x$."
+    "This document briefly outlines the math we have used to precompute all of the required linear algebra using a sampling procedure that can be done just once, and then applied to as many samples as we like. This drastically speeds up the computation compared to a brute force approach. Note that all these calculations depend on the fact that we are explaining a linear model $f(x) = \\beta x$."
    ]
   },
   {
@@ -97,11 +97,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",


### PR DESCRIPTION
## Overview

Closes #3036 (partial - `tabular/linear_models/Math behind LinearExplainer with correlation feature perturbation.ipynb`)

Clean up the LinearExplainer correlation feature perturbation notebook:

- Replace the deprecated `feature_perturbation="correlation_dependent"` API reference with the current `maskers.Impute(data)` approach
- Fix typos in the prose ("guassian" -> "Gaussian", "matrix match" -> "matrix math", "all subset" -> "all subsets", "it hence" -> "is hence", "speed up" -> "speeds up")
- Drop hardcoded `kernelspec` from notebook metadata to match other notebooks in the repo

This is a markdown-only notebook (no code cells), so no unit tests are needed.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature) - N/A, documentation-only change.