### PR TITLE
BUG: fix pytree compatibility with modern sklearn and xgboost

### DIFF
--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 # import numba
 from ..utils._exceptions import ExplainerError
+from ..utils._general import safe_isinstance
 
 # class TreeExplainer(Explainer):
 #     def __init__(self, model, **kwargs):
@@ -143,14 +144,28 @@ class TreeExplainer:
     def __init__(self, model, **kwargs):
         self.model_type = "internal"
 
-        if str(type(model)).endswith("sklearn.ensemble.forest.RandomForestRegressor'>"):
+        if safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.RandomForestRegressor",
+                "sklearn.ensemble._forest.RandomForestRegressor",
+                "sklearn.ensemble.forest.RandomForestRegressor",
+            ],
+        ):
             self.trees = [Tree(e.tree_) for e in model.estimators_]
-        elif str(type(model)).endswith("sklearn.ensemble.forest.RandomForestClassifier'>"):
+        elif safe_isinstance(
+            model,
+            [
+                "sklearn.ensemble.RandomForestClassifier",
+                "sklearn.ensemble._forest.RandomForestClassifier",
+                "sklearn.ensemble.forest.RandomForestClassifier",
+            ],
+        ):
             self.trees = [Tree(e.tree_, normalize=True) for e in model.estimators_]
-        elif str(type(model)).endswith("xgboost.core.Booster'>"):
+        elif safe_isinstance(model, "xgboost.core.Booster"):
             self.model_type = "xgboost"
             self.trees = model
-        elif str(type(model)).endswith("lightgbm.basic.Booster'>"):
+        elif safe_isinstance(model, "lightgbm.basic.Booster"):
             self.model_type = "lightgbm"
             self.trees = model
         else:
@@ -171,11 +186,14 @@ class TreeExplainer:
         if self.model_type == "xgboost":
             import xgboost
 
-            if not str(type(X)).endswith("xgboost.core.DMatrix'>"):
+            if not safe_isinstance(X, "xgboost.core.DMatrix"):
                 X = xgboost.DMatrix(X)
             if tree_limit == -1:
                 tree_limit = 0
-            return self.trees.predict(X, ntree_limit=tree_limit, pred_contribs=True)
+            try:
+                return self.trees.predict(X, iteration_range=(0, tree_limit), pred_contribs=True)
+            except TypeError:
+                return self.trees.predict(X, ntree_limit=tree_limit, pred_contribs=True)
         elif self.model_type == "lightgbm":
             return self.trees.predict(X, num_iteration=tree_limit, pred_contrib=True)
 
@@ -190,7 +208,7 @@ class TreeExplainer:
 
         # single instance
         if len(X.shape) == 1:
-            phi = np.zeros(X.shape[0] + 1, n_outputs)
+            phi = np.zeros((X.shape[0] + 1, n_outputs))
             x_missing = np.zeros(X.shape[0], dtype=bool)
             for t in self.trees:
                 self.tree_shap(t, X, x_missing, phi)
@@ -219,11 +237,14 @@ class TreeExplainer:
         if self.model_type == "xgboost":
             import xgboost
 
-            if not str(type(X)).endswith("xgboost.core.DMatrix'>"):
+            if not safe_isinstance(X, "xgboost.core.DMatrix"):
                 X = xgboost.DMatrix(X)
             if tree_limit == -1:
                 tree_limit = 0
-            return self.trees.predict(X, ntree_limit=tree_limit, pred_interactions=True)
+            try:
+                return self.trees.predict(X, iteration_range=(0, tree_limit), pred_interactions=True)
+            except TypeError:
+                return self.trees.predict(X, ntree_limit=tree_limit, pred_interactions=True)
         else:
             raise NotImplementedError("Interaction values not yet supported for model type: " + str(type(X)))
 

--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -5,6 +5,7 @@ module which uses a compiled C++ implementation.
 
 import numpy as np
 import pandas as pd
+from packaging.version import Version
 
 # import numba
 from ..utils._exceptions import ExplainerError
@@ -141,6 +142,12 @@ from ..utils._general import safe_isinstance
 class TreeExplainer:
     """A pure Python (slow) implementation of Tree SHAP."""
 
+    @staticmethod
+    def _xgboost_supports_iteration_range():
+        import xgboost
+
+        return Version(xgboost.__version__) >= Version("1.4.0")
+
     def __init__(self, model, **kwargs):
         self.model_type = "internal"
 
@@ -190,10 +197,9 @@ class TreeExplainer:
                 X = xgboost.DMatrix(X)
             if tree_limit == -1:
                 tree_limit = 0
-            try:
+            if self._xgboost_supports_iteration_range():
                 return self.trees.predict(X, iteration_range=(0, tree_limit), pred_contribs=True)
-            except TypeError:
-                return self.trees.predict(X, ntree_limit=tree_limit, pred_contribs=True)
+            return self.trees.predict(X, ntree_limit=tree_limit, pred_contribs=True)
         elif self.model_type == "lightgbm":
             return self.trees.predict(X, num_iteration=tree_limit, pred_contrib=True)
 
@@ -241,10 +247,9 @@ class TreeExplainer:
                 X = xgboost.DMatrix(X)
             if tree_limit == -1:
                 tree_limit = 0
-            try:
+            if self._xgboost_supports_iteration_range():
                 return self.trees.predict(X, iteration_range=(0, tree_limit), pred_interactions=True)
-            except TypeError:
-                return self.trees.predict(X, ntree_limit=tree_limit, pred_interactions=True)
+            return self.trees.predict(X, ntree_limit=tree_limit, pred_interactions=True)
         else:
             raise NotImplementedError("Interaction values not yet supported for model type: " + str(type(X)))
 

--- a/tests/explainers/test_pytree.py
+++ b/tests/explainers/test_pytree.py
@@ -30,6 +30,7 @@ def test_pytree_supports_modern_random_forest():
 def test_pytree_uses_iteration_range_for_xgboost(monkeypatch):
     xgboost = types.ModuleType("xgboost")
     xgboost_core = types.ModuleType("xgboost.core")
+    xgboost.__version__ = "3.0.0"
 
     class DMatrix:
         def __init__(self, data):
@@ -68,5 +69,51 @@ def test_pytree_uses_iteration_range_for_xgboost(monkeypatch):
     assert len(booster.calls) == 2
     assert booster.calls[0][1]["iteration_range"] == (0, 5)
     assert booster.calls[1][1]["iteration_range"] == (0, 6)
+    assert isinstance(booster.calls[0][0], DMatrix)
+    assert isinstance(booster.calls[1][0], DMatrix)
+
+
+def test_pytree_falls_back_to_ntree_limit_for_old_xgboost(monkeypatch):
+    xgboost = types.ModuleType("xgboost")
+    xgboost_core = types.ModuleType("xgboost.core")
+    xgboost.__version__ = "1.3.3"
+
+    class DMatrix:
+        def __init__(self, data):
+            self.data = np.asarray(data)
+
+    class Booster:
+        def __init__(self):
+            self.calls = []
+
+        def predict(self, data, **kwargs):
+            self.calls.append((data, kwargs))
+            assert "iteration_range" not in kwargs
+            assert "ntree_limit" in kwargs
+            if kwargs.get("pred_contribs"):
+                return np.ones((data.data.shape[0], data.data.shape[1] + 1))
+            if kwargs.get("pred_interactions"):
+                n_features = data.data.shape[1] + 1
+                return np.ones((data.data.shape[0], n_features, n_features))
+            raise AssertionError("Unexpected predict call")
+
+    xgboost.DMatrix = DMatrix
+    xgboost_core.Booster = Booster
+    xgboost.core = xgboost_core
+
+    monkeypatch.setitem(sys.modules, "xgboost", xgboost)
+    monkeypatch.setitem(sys.modules, "xgboost.core", xgboost_core)
+
+    booster = Booster()
+    explainer = PyTreeExplainer(booster)
+
+    contribs = explainer.shap_values([[1.0, 2.0, 3.0]], tree_limit=5)
+    interactions = explainer.shap_interaction_values([[1.0, 2.0, 3.0]], tree_limit=6)
+
+    assert contribs.shape == (1, 4)
+    assert interactions.shape == (1, 4, 4)
+    assert len(booster.calls) == 2
+    assert booster.calls[0][1]["ntree_limit"] == 5
+    assert booster.calls[1][1]["ntree_limit"] == 6
     assert isinstance(booster.calls[0][0], DMatrix)
     assert isinstance(booster.calls[1][0], DMatrix)

--- a/tests/explainers/test_pytree.py
+++ b/tests/explainers/test_pytree.py
@@ -1,0 +1,72 @@
+import sys
+import types
+
+import numpy as np
+import sklearn.ensemble
+
+from shap.explainers.pytree import TreeExplainer as PyTreeExplainer
+
+
+def test_pytree_supports_modern_random_forest():
+    X = np.array(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0, 4.0],
+            [2.0, 3.0, 4.0, 5.0],
+            [3.0, 4.0, 5.0, 6.0],
+        ]
+    )
+    y = np.array([0.5, 1.5, 2.5, 3.5])
+
+    model = sklearn.ensemble.RandomForestRegressor(n_estimators=4, random_state=0)
+    model.fit(X, y)
+
+    explainer = PyTreeExplainer(model)
+    shap_values = explainer.shap_values(X[0])
+
+    assert shap_values.shape == (X.shape[1] + 1,)
+
+
+def test_pytree_uses_iteration_range_for_xgboost(monkeypatch):
+    xgboost = types.ModuleType("xgboost")
+    xgboost_core = types.ModuleType("xgboost.core")
+
+    class DMatrix:
+        def __init__(self, data):
+            self.data = np.asarray(data)
+
+    class Booster:
+        def __init__(self):
+            self.calls = []
+
+        def predict(self, data, **kwargs):
+            self.calls.append((data, kwargs))
+            assert "ntree_limit" not in kwargs
+            assert "iteration_range" in kwargs
+            if kwargs.get("pred_contribs"):
+                return np.ones((data.data.shape[0], data.data.shape[1] + 1))
+            if kwargs.get("pred_interactions"):
+                n_features = data.data.shape[1] + 1
+                return np.ones((data.data.shape[0], n_features, n_features))
+            raise AssertionError("Unexpected predict call")
+
+    xgboost.DMatrix = DMatrix
+    xgboost_core.Booster = Booster
+    xgboost.core = xgboost_core
+
+    monkeypatch.setitem(sys.modules, "xgboost", xgboost)
+    monkeypatch.setitem(sys.modules, "xgboost.core", xgboost_core)
+
+    booster = Booster()
+    explainer = PyTreeExplainer(booster)
+
+    contribs = explainer.shap_values([[1.0, 2.0, 3.0]], tree_limit=5)
+    interactions = explainer.shap_interaction_values([[1.0, 2.0, 3.0]], tree_limit=6)
+
+    assert contribs.shape == (1, 4)
+    assert interactions.shape == (1, 4, 4)
+    assert len(booster.calls) == 2
+    assert booster.calls[0][1]["iteration_range"] == (0, 5)
+    assert booster.calls[1][1]["iteration_range"] == (0, 6)
+    assert isinstance(booster.calls[0][0], DMatrix)
+    assert isinstance(booster.calls[1][0], DMatrix)


### PR DESCRIPTION
 Closes #4486

  Description of the changes proposed in this pull request:

  - Update `shap.explainers.pytree.TreeExplainer` to use `safe_isinstance` for model detection instead of brittle
  string-based type checks.
  - Add compatibility for modern `scikit-learn` module paths for `RandomForestRegressor` and `RandomForestClassifier`.
  - Update XGBoost prediction calls to prefer `iteration_range` and fall back to `ntree_limit` for older versions.
  - Fix the single-instance `np.zeros(...)` allocation bug uncovered while adding the regression test.
  - Add regression tests covering modern scikit-learn support and the XGBoost prediction path.

  ## Checklist

  - [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
  - [x] Unit tests added (if fixing a bug or adding a new feature)