### PR TITLE
ENH: Add TreeEnsemble.from_trees, roundtrip tests across tree backends, and deprecations for smaller integrations

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,12 +8,11 @@ build:
   jobs:
     # cf. https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
     pre_create_environment:
-      - asdf plugin add uv
+      - asdf plugin add uv || true
       - asdf install uv latest
       - asdf global uv latest
     create_environment:
       - uv venv
-      - uv sync
     install:
       - uv pip install -r docs/requirements-docs.txt
     build:

--- a/notebooks/api_examples/explainers/TreeEnsemble.from_trees.ipynb
+++ b/notebooks/api_examples/explainers/TreeEnsemble.from_trees.ipynb
@@ -19,10 +19,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "38c46875",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/akshat/ESOC/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import warnings\n",
     "\n",
@@ -35,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "be13da1f",
    "metadata": {},
    "outputs": [],
@@ -81,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "2e7258d3",
    "metadata": {},
    "outputs": [],
@@ -94,10 +103,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "bf6e2ee8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 150 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=150 when initializing the masker.\n",
+      "Background dataset has 150 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=150 when initializing the masker.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sklearn DecisionTreeRegressor\n",
+      "  predictions match: True\n",
+      "  values shape: (5, 8)\n",
+      "  base shape: (5,)\n",
+      "  max |delta SHAP|: 0.0\n",
+      "\n",
+      "sklearn RandomForestClassifier\n",
+      "  predictions match: True\n",
+      "  values shape: (5, 4, 2)\n",
+      "  base shape: (5, 2)\n",
+      "  max |delta SHAP|: 0.0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# sklearn examples\n",
     "\n",
@@ -112,10 +150,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "f0098fee",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[LightGBM] [Info] Auto-choosing row-wise multi-threading, the overhead of testing was 0.000244 seconds.\n",
+      "You can set `force_row_wise=true` to remove the overhead.\n",
+      "And if memory is not enough, you can set `force_col_wise=true`.\n",
+      "[LightGBM] [Info] Total Bins 501\n",
+      "[LightGBM] [Info] Number of data points in the train set: 200, number of used features: 8\n",
+      "[LightGBM] [Info] Start training from score 2.025840\n",
+      "[LightGBM] [Warning] No further splits with positive gain, best gain: -inf\n",
+      "[LightGBM] [Warning] No further splits with positive gain, best gain: -inf\n",
+      "[LightGBM] [Warning] No further splits with positive gain, best gain: -inf\n",
+      "[LightGBM] [Warning] No further splits with positive gain, best gain: -inf\n",
+      "[LightGBM] [Warning] No further splits with positive gain, best gain: -inf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "/tmp/ipykernel_378917/1204607216.py:2: DeprecationWarning: Support for ngboost tree models is deprecated and will be removed in a future release. Please export the trees and use TreeEnsemble.from_trees instead.\n",
+      "  existing = TreeEnsemble(model, data=X, model_output=model_output)\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n",
+      "Background dataset has 200 samples but max_samples=100. Subsampling to 100 samples for SHAP value computation. To use all samples, set max_samples=200 when initializing the masker.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[iter 0] loss=1.5263 val_loss=0.0000 scale=1.0000 norm=1.0774\n",
+      "xgboost XGBRegressor\n",
+      "  predictions match: True\n",
+      "  values shape: (5, 8)\n",
+      "  base shape: (5,)\n",
+      "  max |delta SHAP|: 0.0\n",
+      "\n",
+      "lightgbm LGBMRegressor\n",
+      "  predictions match: True\n",
+      "  values shape: (5, 8)\n",
+      "  base shape: (5,)\n",
+      "  max |delta SHAP|: 0.0\n",
+      "\n",
+      "catboost CatBoostRegressor\n",
+      "  predictions match: True\n",
+      "  values shape: (5, 8)\n",
+      "  base shape: (5,)\n",
+      "  max |delta SHAP|: 0.0\n",
+      "\n",
+      "ngboost NGBRegressor\n",
+      "  predictions match: True\n",
+      "  values shape: (5, 8)\n",
+      "  base shape: (5,)\n",
+      "  max |delta SHAP|: 0.0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# optional backend examples (executed when package is installed)\n",
     "\n",
@@ -173,8 +276,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/api_examples/explainers/TreeEnsemble.from_trees.ipynb
+++ b/notebooks/api_examples/explainers/TreeEnsemble.from_trees.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f1549d47",
+   "metadata": {},
+   "source": [
+    "# TreeEnsemble.from_trees\n",
+    "\n",
+    "This notebook shows how to build a `TreeEnsemble` from pre-extracted trees and explain it with `TreeExplainer`.\n",
+    "\n",
+    "The same roundtrip conversion works for currently supported tree model families.\n",
+    "\n",
+    "Each example uses this pattern:\n",
+    "1. Fit a model and let SHAP parse it into a `TreeEnsemble`.\n",
+    "2. Rebuild a new ensemble with `TreeEnsemble.from_trees(existing.trees, ...)`.\n",
+    "3. Explain data with the rebuilt ensemble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38c46875",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.tree import DecisionTreeRegressor\n",
+    "\n",
+    "import shap\n",
+    "from shap.explainers._tree import TreeEnsemble"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be13da1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rebuild_with_from_trees(model, X, model_output=\"raw\"):\n",
+    "    existing = TreeEnsemble(model, data=X, model_output=model_output)\n",
+    "    rebuilt = TreeEnsemble.from_trees(\n",
+    "        existing.trees,\n",
+    "        base_offset=existing.base_offset,\n",
+    "        model_output=existing.model_output,\n",
+    "        objective=existing.objective,\n",
+    "        tree_output=existing.tree_output,\n",
+    "        internal_dtype=existing.internal_dtype,\n",
+    "        input_dtype=existing.input_dtype,\n",
+    "        data=None,\n",
+    "        data_missing=None,\n",
+    "        fully_defined_weighting=existing.fully_defined_weighting,\n",
+    "        tree_limit=existing.tree_limit,\n",
+    "        num_stacked_models=existing.num_stacked_models,\n",
+    "        cat_feature_indices=existing.cat_feature_indices,\n",
+    "        model_type=\"internal\",\n",
+    "    )\n",
+    "    return existing, rebuilt\n",
+    "\n",
+    "\n",
+    "def show_example(name, model, X, model_output=\"raw\", perturbation=\"interventional\"):\n",
+    "    existing, rebuilt = rebuild_with_from_trees(model, X, model_output=model_output)\n",
+    "    sample = X.iloc[:5] if hasattr(X, \"iloc\") else X[:5]\n",
+    "    kwargs = {}\n",
+    "    if perturbation == \"interventional\":\n",
+    "        kwargs = {\"data\": X, \"feature_perturbation\": \"interventional\"}\n",
+    "    else:\n",
+    "        kwargs = {\"feature_perturbation\": \"tree_path_dependent\"}\n",
+    "    e1 = shap.TreeExplainer(existing, **kwargs)(sample)\n",
+    "    e2 = shap.TreeExplainer(rebuilt, **kwargs)(sample)\n",
+    "    print(name)\n",
+    "    print(\"  predictions match:\", bool((existing.predict(sample) == rebuilt.predict(sample)).all()))\n",
+    "    print(\"  values shape:\", e2.values.shape)\n",
+    "    print(\"  base shape:\", e2.base_values.shape)\n",
+    "    print(\"  max |delta SHAP|:\", float(abs(e1.values - e2.values).max()))\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e7258d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X, y = shap.datasets.california(n_points=200)\n",
+    "X_clf, y_clf = shap.datasets.iris()\n",
+    "y_clf = y_clf.copy()\n",
+    "y_clf[y_clf == 2] = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf6e2ee8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sklearn examples\n",
+    "\n",
+    "tree_model = DecisionTreeRegressor(max_depth=3, random_state=0)\n",
+    "tree_model.fit(X, y)\n",
+    "show_example(\"sklearn DecisionTreeRegressor\", tree_model, X)\n",
+    "\n",
+    "forest = RandomForestClassifier(n_estimators=5, random_state=0)\n",
+    "forest.fit(X_clf, y_clf)\n",
+    "show_example(\"sklearn RandomForestClassifier\", forest, X_clf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0098fee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# optional backend examples (executed when package is installed)\n",
+    "\n",
+    "optional_examples = []\n",
+    "\n",
+    "try:\n",
+    "    import xgboost\n",
+    "\n",
+    "    xgb = xgboost.XGBRegressor(n_estimators=5, max_depth=3, learning_rate=0.1, random_state=0)\n",
+    "    xgb.fit(X, y)\n",
+    "    optional_examples.append((\"xgboost XGBRegressor\", xgb, X, \"raw\", \"interventional\"))\n",
+    "except Exception as exc:\n",
+    "    warnings.warn(f\"Skipping xgboost example: {exc}\")\n",
+    "\n",
+    "try:\n",
+    "    import lightgbm\n",
+    "\n",
+    "    lgbm = lightgbm.LGBMRegressor(n_estimators=5, random_state=0)\n",
+    "    lgbm.fit(X, y)\n",
+    "    optional_examples.append((\"lightgbm LGBMRegressor\", lgbm, X, \"raw\", \"interventional\"))\n",
+    "except Exception as exc:\n",
+    "    warnings.warn(f\"Skipping lightgbm example: {exc}\")\n",
+    "\n",
+    "try:\n",
+    "    import catboost\n",
+    "\n",
+    "    cb = catboost.CatBoostRegressor(iterations=5, depth=3, verbose=False, random_seed=0)\n",
+    "    cb.fit(X, y)\n",
+    "    optional_examples.append((\"catboost CatBoostRegressor\", cb, X, \"raw\", \"interventional\"))\n",
+    "except Exception as exc:\n",
+    "    warnings.warn(f\"Skipping catboost example: {exc}\")\n",
+    "\n",
+    "try:\n",
+    "    import ngboost\n",
+    "\n",
+    "    ngb = ngboost.NGBRegressor(n_estimators=5, col_sample=1.0)\n",
+    "    ngb.fit(X, y)\n",
+    "    optional_examples.append((\"ngboost NGBRegressor\", ngb, X, 0, \"interventional\"))\n",
+    "except Exception as exc:\n",
+    "    warnings.warn(f\"Skipping ngboost example: {exc}\")\n",
+    "\n",
+    "for name, model, data, output, perturbation in optional_examples:\n",
+    "    show_example(name, model, data, model_output=output, perturbation=perturbation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89f147fe",
+   "metadata": {},
+   "source": [
+    "## Deprecation note\n",
+    "\n",
+    "For smaller legacy integrations (for example gpboost, ngboost, and skopt), SHAP now emits deprecation warnings and recommends exporting trees and using `TreeEnsemble.from_trees` directly."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -977,7 +977,7 @@ class TreeEnsemble:
         num_stacked_models: int = 1,
         cat_feature_indices: npt.NDArray[Any] | None = None,
         model_type: str = "internal",
-    ) -> "TreeEnsemble":
+    ) -> TreeEnsemble:
         """Build a TreeEnsemble from pre-extracted trees.
 
         The trees may be provided either as native sklearn tree objects or as
@@ -988,7 +988,10 @@ class TreeEnsemble:
 
         ensemble = cls.__new__(cls)
         ensemble.model_type = model_type
-        ensemble.trees = [tree if isinstance(tree, SingleTree) else SingleTree(tree, data=data, data_missing=data_missing) for tree in trees]
+        ensemble.trees = [
+            tree if isinstance(tree, SingleTree) else SingleTree(tree, data=data, data_missing=data_missing)
+            for tree in trees
+        ]
         ensemble.base_offset = base_offset
         ensemble.model_output = model_output
         ensemble.objective = objective
@@ -1088,7 +1091,9 @@ class TreeEnsemble:
                 "causalml.inference.tree.CausalRandomForestRegressor",
             ],
         ):
-            if not safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor"]):
+            if not safe_isinstance(
+                model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor"]
+            ):
                 warnings.warn(
                     "Support for econml and causalml tree models is deprecated and will be removed in a future release. "
                     "Please export the trees and use TreeEnsemble.from_trees instead.",
@@ -1135,7 +1140,9 @@ class TreeEnsemble:
                 "skopt.learning.forest.ExtraTreesRegressor",
             ],
         ):
-            if safe_isinstance(model, ["skopt.learning.forest.RandomForestRegressor", "skopt.learning.forest.ExtraTreesRegressor"]):
+            if safe_isinstance(
+                model, ["skopt.learning.forest.RandomForestRegressor", "skopt.learning.forest.ExtraTreesRegressor"]
+            ):
                 warnings.warn(
                     "Support for scikit-optimize tree models is deprecated and will be removed in a future release. "
                     "Please export the trees and use TreeEnsemble.from_trees instead.",
@@ -1160,7 +1167,9 @@ class TreeEnsemble:
                 "causalml.inference.tree.causal.causaltree.CausalTreeRegressor",
             ],
         ):
-            if not safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor"]):
+            if not safe_isinstance(
+                model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor"]
+            ):
                 warnings.warn(
                     "Support for econml and causalml tree models is deprecated and will be removed in a future release. "
                     "Please export the trees and use TreeEnsemble.from_trees instead.",

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -284,8 +284,13 @@ class TreeExplainer(Explainer):
         self.data_missing = None if self.data is None else pd.isna(self.data)
         self.feature_perturbation = feature_perturbation
         self.expected_value = None
-        self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
-        self.model_output = model_output
+        if isinstance(model, TreeEnsemble):
+            self.model = model
+            if model_output is not None:
+                self.model.model_output = model_output
+        else:
+            self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
+        self.model_output = self.model.model_output
         # self.model_output = self.model.model_output # this allows the TreeEnsemble to translate model outputs types by how it loads the model
 
         # check for unsupported combinations of feature_perturbation and model_outputs
@@ -910,6 +915,9 @@ class TreeExplainer(Explainer):
         if not isinstance(masker, (maskers.Independent)) and masker is not None:
             return False
 
+        if isinstance(model, TreeEnsemble):
+            return True
+
         try:
             TreeEnsemble(model)
         except Exception:
@@ -950,6 +958,54 @@ class TreeEnsemble:
     max_depth: int
     _xgboost_n_outputs: int
     _xgb_dmatrix_props: dict[str, Any]
+
+    @classmethod
+    def from_trees(
+        cls,
+        trees: list[Any],
+        *,
+        base_offset: Any = 0,
+        model_output: str | None = "raw",
+        objective: str | None = None,
+        tree_output: str | None = None,
+        internal_dtype: type[np.floating[Any]] | None = None,
+        input_dtype: type[np.floating[Any]] | None = None,
+        data: npt.NDArray[Any] | None = None,
+        data_missing: npt.NDArray[np.bool_] | None = None,
+        fully_defined_weighting: bool = True,
+        tree_limit: int | None = None,
+        num_stacked_models: int = 1,
+        cat_feature_indices: npt.NDArray[Any] | None = None,
+        model_type: str = "internal",
+    ) -> "TreeEnsemble":
+        """Build a TreeEnsemble from pre-extracted trees.
+
+        The trees may be provided either as native sklearn tree objects or as
+        already normalized SingleTree instances.
+        """
+        if len(trees) == 0:
+            raise ValueError("TreeEnsemble.from_trees requires at least one tree.")
+
+        ensemble = cls.__new__(cls)
+        ensemble.model_type = model_type
+        ensemble.trees = [tree if isinstance(tree, SingleTree) else SingleTree(tree, data=data, data_missing=data_missing) for tree in trees]
+        ensemble.base_offset = base_offset
+        ensemble.model_output = model_output
+        ensemble.objective = objective
+        ensemble.tree_output = tree_output
+        ensemble.internal_dtype = internal_dtype or ensemble.trees[0].values.dtype.type
+        ensemble.input_dtype = input_dtype or np.float32
+        ensemble.data = data
+        ensemble.data_missing = data_missing
+        ensemble.fully_defined_weighting = fully_defined_weighting
+        ensemble.tree_limit = tree_limit
+        ensemble.num_stacked_models = num_stacked_models
+        ensemble.cat_feature_indices = cat_feature_indices
+        ensemble.original_model = None
+        ensemble._xgboost_n_outputs = 1
+        ensemble._xgb_dmatrix_props = {}
+        ensemble._finalize_tree_ensemble()
+        return ensemble
 
     def __init__(
         self,
@@ -1032,6 +1088,13 @@ class TreeEnsemble:
                 "causalml.inference.tree.CausalRandomForestRegressor",
             ],
         ):
+            if not safe_isinstance(model, ["sklearn.ensemble.RandomForestRegressor", "sklearn.ensemble.forest.RandomForestRegressor"]):
+                warnings.warn(
+                    "Support for econml and causalml tree models is deprecated and will be removed in a future release. "
+                    "Please export the trees and use TreeEnsemble.from_trees instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -1072,6 +1135,13 @@ class TreeEnsemble:
                 "skopt.learning.forest.ExtraTreesRegressor",
             ],
         ):
+            if safe_isinstance(model, ["skopt.learning.forest.RandomForestRegressor", "skopt.learning.forest.ExtraTreesRegressor"]):
+                warnings.warn(
+                    "Support for scikit-optimize tree models is deprecated and will be removed in a future release. "
+                    "Please export the trees and use TreeEnsemble.from_trees instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -1090,6 +1160,13 @@ class TreeEnsemble:
                 "causalml.inference.tree.causal.causaltree.CausalTreeRegressor",
             ],
         ):
+            if not safe_isinstance(model, ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor"]):
+                warnings.warn(
+                    "Support for econml and causalml tree models is deprecated and will be removed in a future release. "
+                    "Please export the trees and use TreeEnsemble.from_trees instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             self.internal_dtype = model.tree_.value.dtype.type
             self.input_dtype = np.float32
             self.trees = [SingleTree(model.tree_, data=data, data_missing=data_missing)]
@@ -1372,6 +1449,12 @@ class TreeEnsemble:
 
         elif safe_isinstance(model, "gpboost.basic.Booster"):
             assert_import("gpboost")
+            warnings.warn(
+                "Support for gpboost tree models is deprecated and will be removed in a future release. "
+                "Please export the trees and use TreeEnsemble.from_trees instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.model_type = "gpboost"
             self.original_model = model
             tree_info = self.original_model.dump_model()["tree_info"]
@@ -1453,6 +1536,12 @@ class TreeEnsemble:
             self.original_model = model
             self.cat_feature_indices = model.get_cat_feature_indices()
         elif safe_isinstance(model, "imblearn.ensemble._forest.BalancedRandomForestClassifier"):
+            warnings.warn(
+                "Support for imbalanced-learn tree models is deprecated and will be removed in a future release. "
+                "Please export the trees and use TreeEnsemble.from_trees instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.input_dtype = np.float32
             scaling = 1.0 / len(model.estimators_)  # output is average of trees
             self.trees = [
@@ -1469,6 +1558,12 @@ class TreeEnsemble:
                 "ngboost.api.NGBClassifier",
             ],
         ):
+            warnings.warn(
+                "Support for ngboost tree models is deprecated and will be removed in a future release. "
+                "Please export the trees and use TreeEnsemble.from_trees instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             assert model.base_models, "The NGBoost model has empty `base_models`! Have you called `model.fit`?"
             if self.model_output == "raw":
                 param_idx = 0  # default to the first parameter of the output distribution
@@ -1513,59 +1608,66 @@ class TreeEnsemble:
         else:
             raise InvalidModelError("Model type not yet supported by TreeExplainer: " + str(type(model)))
 
-        # build a dense numpy version of all the tree objects
-        if self.trees is not None and self.trees:
-            max_nodes = np.max([len(t.values) for t in self.trees])
-            assert len(np.unique([t.values.shape[1] for t in self.trees])) == 1, (
-                "All trees in the ensemble must have the same output dimension!"
-            )
-            num_trees = len(self.trees)
-            # important to be -1 in unused sections!! This way we can tell which entries are valid.
-            self.children_left = -np.ones((num_trees, max_nodes), dtype=np.int32)
-            self.children_right = -np.ones((num_trees, max_nodes), dtype=np.int32)
-            self.children_default = -np.ones((num_trees, max_nodes), dtype=np.int32)
-            self.features = -np.ones((num_trees, max_nodes), dtype=np.int32)
+        self._finalize_tree_ensemble()
 
-            self.thresholds = np.zeros((num_trees, max_nodes), dtype=self.internal_dtype)
-            self.threshold_types = np.zeros((num_trees, max_nodes), dtype=np.int32)
-            self.values = np.zeros((num_trees, max_nodes, self.num_outputs), dtype=self.internal_dtype)
-            self.node_sample_weight = np.zeros((num_trees, max_nodes), dtype=self.internal_dtype)
+    def _finalize_tree_ensemble(self) -> None:
+        if self.trees is None:
+            return
+        if len(self.trees) == 0:
+            raise ValueError("TreeEnsemble requires at least one tree.")
 
-            for i in range(num_trees):
-                self.children_left[i, : len(self.trees[i].children_left)] = self.trees[i].children_left
-                self.children_right[i, : len(self.trees[i].children_right)] = self.trees[i].children_right
-                self.children_default[i, : len(self.trees[i].children_default)] = self.trees[i].children_default
-                self.features[i, : len(self.trees[i].features)] = self.trees[i].features
-                self.thresholds[i, : len(self.trees[i].thresholds)] = self.trees[i].thresholds
-                self.threshold_types[i, : len(self.trees[i].threshold_types)] = self.trees[i].threshold_types
+        max_nodes = np.max([len(t.values) for t in self.trees])
+        if len(np.unique([t.values.shape[1] for t in self.trees])) != 1:
+            raise ValueError("All trees in the ensemble must have the same output dimension!")
 
-                # XGBoost supports boosting forest, which is not compatible with the
-                # current assumption here that the number of stacked models represents
-                # the number of outputs.
-                if self.model_type == "xgboost":
-                    n_stacks = self.num_outputs
-                else:
-                    n_stacks = self.num_stacked_models
+        num_trees = len(self.trees)
+        # important to be -1 in unused sections!! This way we can tell which entries are valid.
+        self.children_left = -np.ones((num_trees, max_nodes), dtype=np.int32)
+        self.children_right = -np.ones((num_trees, max_nodes), dtype=np.int32)
+        self.children_default = -np.ones((num_trees, max_nodes), dtype=np.int32)
+        self.features = -np.ones((num_trees, max_nodes), dtype=np.int32)
 
-                if n_stacks > 1:
-                    stack_pos = i % n_stacks
-                    self.values[i, : len(self.trees[i].values[:, 0]), stack_pos] = self.trees[i].values[:, 0]
-                else:
-                    self.values[i, : len(self.trees[i].values)] = self.trees[i].values
-                self.node_sample_weight[i, : len(self.trees[i].node_sample_weight)] = self.trees[i].node_sample_weight
+        self.thresholds = np.zeros((num_trees, max_nodes), dtype=self.internal_dtype)
+        self.threshold_types = np.zeros((num_trees, max_nodes), dtype=np.int32)
+        self.values = np.zeros((num_trees, max_nodes, self.num_outputs), dtype=self.internal_dtype)
+        self.node_sample_weight = np.zeros((num_trees, max_nodes), dtype=self.internal_dtype)
 
-                # ensure that the passed background dataset lands in every leaf
-                if np.min(self.trees[i].node_sample_weight) <= 0:
-                    self.fully_defined_weighting = False
+        for i in range(num_trees):
+            self.children_left[i, : len(self.trees[i].children_left)] = self.trees[i].children_left
+            self.children_right[i, : len(self.trees[i].children_right)] = self.trees[i].children_right
+            self.children_default[i, : len(self.trees[i].children_default)] = self.trees[i].children_default
+            self.features[i, : len(self.trees[i].features)] = self.trees[i].features
+            self.thresholds[i, : len(self.trees[i].thresholds)] = self.trees[i].thresholds
+            self.threshold_types[i, : len(self.trees[i].threshold_types)] = self.trees[i].threshold_types
 
-            self.num_nodes = np.array([len(t.values) for t in self.trees], dtype=np.int32)
-            self.max_depth = np.max([t.max_depth for t in self.trees])
+            # XGBoost supports boosting forest, which is not compatible with the
+            # current assumption here that the number of stacked models represents
+            # the number of outputs.
+            if self.model_type == "xgboost":
+                n_stacks = self.num_outputs
+            else:
+                n_stacks = self.num_stacked_models
 
-            # make sure the base offset is a 1D array
-            if not hasattr(self.base_offset, "__len__") or len(self.base_offset) == 0:
-                self.base_offset = (np.ones(self.num_outputs) * self.base_offset).astype(self.internal_dtype)
-            self.base_offset = self.base_offset.flatten()
-            assert len(self.base_offset) == self.num_outputs
+            if n_stacks > 1:
+                stack_pos = i % n_stacks
+                self.values[i, : len(self.trees[i].values[:, 0]), stack_pos] = self.trees[i].values[:, 0]
+            else:
+                self.values[i, : len(self.trees[i].values)] = self.trees[i].values
+            self.node_sample_weight[i, : len(self.trees[i].node_sample_weight)] = self.trees[i].node_sample_weight
+
+            # ensure that the passed background dataset lands in every leaf
+            if np.min(self.trees[i].node_sample_weight) <= 0:
+                self.fully_defined_weighting = False
+
+        self.num_nodes = np.array([len(t.values) for t in self.trees], dtype=np.int32)
+        self.max_depth = np.max([t.max_depth for t in self.trees])
+
+        # make sure the base offset is a 1D array
+        if not hasattr(self.base_offset, "__len__") or len(self.base_offset) == 0:
+            self.base_offset = (np.ones(self.num_outputs) * self.base_offset).astype(self.internal_dtype)
+        self.base_offset = np.asarray(self.base_offset, dtype=self.internal_dtype).flatten()
+        if len(self.base_offset) != self.num_outputs:
+            raise ValueError("base_offset must have one value per model output.")
 
     def _set_xgboost_model_attributes(
         self,

--- a/tests/explainers/test_tree_from_trees.py
+++ b/tests/explainers/test_tree_from_trees.py
@@ -1,10 +1,11 @@
 """Tests for TreeEnsemble.from_trees."""
 
+import sys
+
 import numpy as np
 import pandas as pd
 import pytest
 import sklearn
-import sys
 from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor, RandomForestClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
@@ -114,7 +115,9 @@ def test_from_trees_roundtrip_supported_sklearn_models():
         sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
         existing_explanation = shap.TreeExplainer(existing, data=X, feature_perturbation="interventional")(sample)
         rebuilt_explanation = shap.TreeExplainer(rebuilt, data=X, feature_perturbation="interventional")(sample)
-        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        np.testing.assert_allclose(
+            existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6
+        )
         _assert_explanation_additivity(existing_explanation, existing.predict(sample), err_msg=case_name)
         _assert_explanation_additivity(rebuilt_explanation, rebuilt.predict(sample), err_msg=case_name)
 
@@ -139,7 +142,9 @@ def test_from_trees_roundtrip_isolation_forest_models():
         sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
         existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
         rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
-        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        np.testing.assert_allclose(
+            existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6
+        )
         np.testing.assert_allclose(
             existing_explanation.base_values,
             rebuilt_explanation.base_values,
@@ -202,7 +207,9 @@ def test_from_trees_roundtrip_optional_models():
         sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
         existing_explanation = shap.TreeExplainer(existing, data=X, feature_perturbation="interventional")(sample)
         rebuilt_explanation = shap.TreeExplainer(rebuilt, data=X, feature_perturbation="interventional")(sample)
-        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        np.testing.assert_allclose(
+            existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6
+        )
         _assert_explanation_additivity(existing_explanation, existing.predict(sample), err_msg=case_name)
         _assert_explanation_additivity(rebuilt_explanation, rebuilt.predict(sample), err_msg=case_name)
 
@@ -238,7 +245,11 @@ def test_from_trees_roundtrip_smaller_tree_libraries():
     cases.append(
         (
             "lightgbm_booster",
-            lightgbm.train(params={"objective": "regression", "learning_rate": 0.1, "verbose": -1}, train_set=lgb_train, num_boost_round=5),
+            lightgbm.train(
+                params={"objective": "regression", "learning_rate": 0.1, "verbose": -1},
+                train_set=lgb_train,
+                num_boost_round=5,
+            ),
             X,
             None,
             "raw",
@@ -288,12 +299,16 @@ def test_from_trees_roundtrip_smaller_tree_libraries():
     )
 
     for case_name, model, X_case, data_missing, model_output in cases:
-        existing, rebuilt = _roundtrip_tree_ensemble(model, X_case, data_missing=data_missing, model_output=model_output)
+        existing, rebuilt = _roundtrip_tree_ensemble(
+            model, X_case, data_missing=data_missing, model_output=model_output
+        )
         np.testing.assert_allclose(existing.predict(X_case), rebuilt.predict(X_case), err_msg=case_name)
         sample = X_case.iloc[:10] if isinstance(X_case, pd.DataFrame) else X_case[:10]
         existing_explanation = shap.TreeExplainer(existing, data=X_case, feature_perturbation="interventional")(sample)
         rebuilt_explanation = shap.TreeExplainer(rebuilt, data=X_case, feature_perturbation="interventional")(sample)
-        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        np.testing.assert_allclose(
+            existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6
+        )
         _assert_explanation_additivity(existing_explanation, existing.predict(sample), err_msg=case_name)
         _assert_explanation_additivity(rebuilt_explanation, rebuilt.predict(sample), err_msg=case_name)
 
@@ -315,7 +330,9 @@ def test_from_trees_roundtrip_gpboost():
     existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
     rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
     np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg="gpboost", atol=1e-6)
-    np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg="gpboost", atol=1e-6)
+    np.testing.assert_allclose(
+        existing_explanation.base_values, rebuilt_explanation.base_values, err_msg="gpboost", atol=1e-6
+    )
 
 
 def test_from_trees_roundtrip_pyod_iforest():
@@ -333,8 +350,12 @@ def test_from_trees_roundtrip_pyod_iforest():
     sample = X[:10]
     existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
     rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
-    np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg="pyod_iforest", atol=1e-6)
-    np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg="pyod_iforest", atol=1e-6)
+    np.testing.assert_allclose(
+        existing_explanation.values, rebuilt_explanation.values, err_msg="pyod_iforest", atol=1e-6
+    )
+    np.testing.assert_allclose(
+        existing_explanation.base_values, rebuilt_explanation.base_values, err_msg="pyod_iforest", atol=1e-6
+    )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fails due to OOM errors, see #4021")
@@ -342,7 +363,9 @@ def test_from_trees_roundtrip_pyspark(configure_pyspark_python):
     pyspark = pytest.importorskip("pyspark")
     pytest.importorskip("pyspark.ml")
     try:
-        spark = pyspark.sql.SparkSession.builder.config(conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
+        spark = pyspark.sql.SparkSession.builder.config(
+            conf=pyspark.SparkConf().set("spark.master", "local[*]")
+        ).getOrCreate()
     except Exception:
         pytest.skip("Could not create pyspark context")
 
@@ -377,16 +400,21 @@ def test_from_trees_roundtrip_pyspark(configure_pyspark_python):
         existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
         rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
         np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=str(type(model)))
-        np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg=str(type(model)))
+        np.testing.assert_allclose(
+            existing_explanation.base_values, rebuilt_explanation.base_values, err_msg=str(type(model))
+        )
 
     regressors = [
         pyspark.ml.regression.GBTRegressor(labelCol="sepal_length", featuresCol="features"),
         pyspark.ml.regression.RandomForestRegressor(labelCol="sepal_length", featuresCol="features"),
         pyspark.ml.regression.DecisionTreeRegressor(labelCol="sepal_length", featuresCol="features"),
     ]
-    iris_reg = spark.createDataFrame(pd.DataFrame(data=np.c_[iris_sk["data"], iris_sk["target"]], columns=iris_sk["feature_names"] + ["target"])[
-        :100
-    ], col).drop("type")
+    iris_reg = spark.createDataFrame(
+        pd.DataFrame(data=np.c_[iris_sk["data"], iris_sk["target"]], columns=iris_sk["feature_names"] + ["target"])[
+            :100
+        ],
+        col,
+    ).drop("type")
     iris_reg = pyspark.ml.feature.VectorAssembler(inputCols=col[1:-1], outputCol="features").transform(iris_reg)
     X_reg = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop("sepal length (cm)", axis=1)[:100]
     for regressor in regressors:
@@ -398,6 +426,8 @@ def test_from_trees_roundtrip_pyspark(configure_pyspark_python):
         existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
         rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
         np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=str(type(model)))
-        np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg=str(type(model)))
+        np.testing.assert_allclose(
+            existing_explanation.base_values, rebuilt_explanation.base_values, err_msg=str(type(model))
+        )
 
     spark.stop()

--- a/tests/explainers/test_tree_from_trees.py
+++ b/tests/explainers/test_tree_from_trees.py
@@ -1,0 +1,403 @@
+"""Tests for TreeEnsemble.from_trees."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import sklearn
+import sys
+from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor, RandomForestClassifier
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+import shap
+from shap.explainers._tree import TreeEnsemble
+
+
+def _assert_explanation_additivity(explanation, predictions, err_msg, atol=1e-5):
+    summed = explanation.values.sum(1) + explanation.base_values
+    pred = np.asarray(predictions)
+    if summed.ndim == 1 and pred.ndim > 1 and pred.shape[1] == 1:
+        pred = pred[:, 0]
+    np.testing.assert_allclose(summed, pred, err_msg=err_msg, atol=atol)
+
+
+def _roundtrip_tree_ensemble(model, X, data_missing=None, model_output="raw"):
+    existing = TreeEnsemble(model, data=X, data_missing=data_missing, model_output=model_output)
+    rebuilt = TreeEnsemble.from_trees(
+        existing.trees,
+        base_offset=existing.base_offset,
+        model_output=existing.model_output,
+        objective=existing.objective,
+        tree_output=existing.tree_output,
+        internal_dtype=existing.internal_dtype,
+        input_dtype=existing.input_dtype,
+        data=None,
+        data_missing=data_missing,
+        fully_defined_weighting=existing.fully_defined_weighting,
+        tree_limit=existing.tree_limit,
+        num_stacked_models=existing.num_stacked_models,
+        cat_feature_indices=existing.cat_feature_indices,
+        model_type="internal",
+    )
+    return existing, rebuilt
+
+
+@pytest.fixture
+def configure_pyspark_python(monkeypatch):
+    monkeypatch.setenv("PYSPARK_PYTHON", sys.executable)
+    monkeypatch.setenv("PYSPARK_DRIVER_PYTHON", sys.executable)
+
+
+def test_from_trees_accepts_sklearn_tree_structure():
+    X, y = shap.datasets.california(n_points=200)
+    model = DecisionTreeRegressor(max_depth=3, random_state=0)
+    model.fit(X, y)
+
+    existing = TreeEnsemble(model, data=X, data_missing=None, model_output="raw")
+    rebuilt = TreeEnsemble.from_trees(
+        [model.tree_],
+        base_offset=existing.base_offset,
+        model_output=existing.model_output,
+        objective=existing.objective,
+        tree_output=existing.tree_output,
+        internal_dtype=existing.internal_dtype,
+        input_dtype=existing.input_dtype,
+        data=None,
+        data_missing=None,
+        fully_defined_weighting=existing.fully_defined_weighting,
+        model_type="internal",
+    )
+
+    np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X))
+
+    existing_explanation = shap.TreeExplainer(existing)(X[:10])
+    rebuilt_explanation = shap.TreeExplainer(rebuilt)(X[:10])
+    np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values)
+    np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values)
+
+    auto_explainer = shap.Explainer(rebuilt, masker=X)
+    assert isinstance(auto_explainer, shap.TreeExplainer)
+
+
+def test_from_trees_roundtrip_supported_sklearn_models():
+    cases = []
+
+    X_reg, y_reg = shap.datasets.california(n_points=200)
+    regressor_models = [
+        DecisionTreeRegressor(max_depth=3, random_state=0),
+        sklearn.ensemble.RandomForestRegressor(n_estimators=5, random_state=0),
+        sklearn.ensemble.ExtraTreesRegressor(n_estimators=5, random_state=0),
+        GradientBoostingRegressor(n_estimators=5, random_state=0),
+        sklearn.ensemble.HistGradientBoostingRegressor(max_depth=3, random_state=0),
+    ]
+    for model in regressor_models:
+        model.fit(X_reg, y_reg)
+        cases.append((type(model).__name__, model, X_reg, None, "raw"))
+
+    X_clf, y_clf = shap.datasets.iris()
+    y_clf = y_clf.copy()
+    y_clf[y_clf == 2] = 1
+    classifier_models = [
+        DecisionTreeClassifier(max_depth=3, random_state=0),
+        RandomForestClassifier(n_estimators=5, random_state=0),
+        sklearn.ensemble.ExtraTreesClassifier(n_estimators=5, random_state=0),
+        GradientBoostingClassifier(n_estimators=5, random_state=0),
+        sklearn.ensemble.HistGradientBoostingClassifier(max_depth=3, random_state=0),
+    ]
+    for model in classifier_models:
+        model.fit(X_clf, y_clf)
+        cases.append((type(model).__name__, model, X_clf, None, "raw"))
+
+    for case_name, model, X, data_missing, model_output in cases:
+        existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=data_missing, model_output=model_output)
+        np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg=case_name)
+
+        sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
+        existing_explanation = shap.TreeExplainer(existing, data=X, feature_perturbation="interventional")(sample)
+        rebuilt_explanation = shap.TreeExplainer(rebuilt, data=X, feature_perturbation="interventional")(sample)
+        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        _assert_explanation_additivity(existing_explanation, existing.predict(sample), err_msg=case_name)
+        _assert_explanation_additivity(rebuilt_explanation, rebuilt.predict(sample), err_msg=case_name)
+
+
+def test_from_trees_roundtrip_isolation_forest_models():
+    X, _ = shap.datasets.california(n_points=200)
+    cases = [
+        (
+            "IsolationForest",
+            sklearn.ensemble.IsolationForest(max_features=1.0, random_state=0).fit(X),
+        ),
+        (
+            "IsolationForest_subsampled_features",
+            sklearn.ensemble.IsolationForest(max_features=0.75, random_state=0).fit(X),
+        ),
+    ]
+
+    for case_name, model in cases:
+        existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=None, model_output="raw")
+        np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg=case_name)
+
+        sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
+        existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
+        rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
+        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        np.testing.assert_allclose(
+            existing_explanation.base_values,
+            rebuilt_explanation.base_values,
+            err_msg=case_name,
+            atol=1e-6,
+        )
+
+
+def test_from_trees_roundtrip_optional_models():
+    xgboost = pytest.importorskip("xgboost")
+    ngboost = pytest.importorskip("ngboost")
+
+    X_reg, y_reg = shap.datasets.california(n_points=200)
+    X_clf, y_clf = shap.datasets.iris()
+    y_clf = y_clf.copy()
+    y_clf[y_clf == 2] = 1
+
+    dtrain = xgboost.DMatrix(X_reg, label=y_reg)
+    booster = xgboost.train(
+        params={"objective": "reg:squarederror", "max_depth": 3, "eta": 0.1},
+        dtrain=dtrain,
+        num_boost_round=5,
+    )
+
+    cases = [
+        (
+            "XGBRegressor",
+            xgboost.XGBRegressor(n_estimators=5, max_depth=3, learning_rate=0.1, random_state=0).fit(X_reg, y_reg),
+            X_reg,
+            None,
+            "raw",
+        ),
+        (
+            "XGBClassifier",
+            xgboost.XGBClassifier(n_estimators=5, max_depth=3, learning_rate=0.1, random_state=0).fit(X_clf, y_clf),
+            X_clf,
+            None,
+            "raw",
+        ),
+        (
+            "XGBooster",
+            booster,
+            X_reg,
+            None,
+            "raw",
+        ),
+        (
+            "NGBRegressor",
+            ngboost.NGBRegressor(n_estimators=5, col_sample=1.0).fit(X_reg, y_reg),
+            X_reg,
+            None,
+            0,
+        ),
+    ]
+
+    for case_name, model, X, data_missing, model_output in cases:
+        existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=data_missing, model_output=model_output)
+        np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg=case_name)
+
+        sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
+        existing_explanation = shap.TreeExplainer(existing, data=X, feature_perturbation="interventional")(sample)
+        rebuilt_explanation = shap.TreeExplainer(rebuilt, data=X, feature_perturbation="interventional")(sample)
+        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        _assert_explanation_additivity(existing_explanation, existing.predict(sample), err_msg=case_name)
+        _assert_explanation_additivity(rebuilt_explanation, rebuilt.predict(sample), err_msg=case_name)
+
+
+def test_from_trees_roundtrip_smaller_tree_libraries():
+    X, y = shap.datasets.california(n_points=200)
+    X_clf, y_clf = shap.datasets.iris()
+    y_clf = y_clf.copy()
+    y_clf[y_clf == 2] = 1
+
+    cases = []
+
+    lightgbm = pytest.importorskip("lightgbm")
+    cases.append(
+        (
+            "lightgbm_regressor",
+            lightgbm.LGBMRegressor(n_estimators=5, random_state=0).fit(X, y),
+            X,
+            None,
+            "raw",
+        )
+    )
+    cases.append(
+        (
+            "lightgbm_classifier",
+            lightgbm.LGBMClassifier(n_estimators=5, random_state=0).fit(X_clf, y_clf),
+            X_clf,
+            None,
+            "raw",
+        )
+    )
+    lgb_train = lightgbm.Dataset(X, y)
+    cases.append(
+        (
+            "lightgbm_booster",
+            lightgbm.train(params={"objective": "regression", "learning_rate": 0.1, "verbose": -1}, train_set=lgb_train, num_boost_round=5),
+            X,
+            None,
+            "raw",
+        )
+    )
+
+    catboost = pytest.importorskip("catboost")
+    cases.append(
+        (
+            "catboost_regressor",
+            catboost.CatBoostRegressor(iterations=5, depth=3, verbose=False, random_seed=0).fit(X, y),
+            X,
+            None,
+            "raw",
+        )
+    )
+    cases.append(
+        (
+            "catboost_classifier",
+            catboost.CatBoostClassifier(iterations=5, depth=3, verbose=False, random_seed=0).fit(X_clf, y_clf),
+            X_clf,
+            None,
+            "raw",
+        )
+    )
+
+    skopt = pytest.importorskip("skopt")
+    cases.append(
+        (
+            "skopt_random_forest_regressor",
+            skopt.learning.forest.RandomForestRegressor(n_estimators=5, random_state=0).fit(X, y),
+            X,
+            None,
+            "raw",
+        )
+    )
+
+    imblearn = pytest.importorskip("imblearn")
+    cases.append(
+        (
+            "imbalanced_learn_balanced_random_forest",
+            imblearn.ensemble.BalancedRandomForestClassifier(n_estimators=5, random_state=0).fit(X_clf, y_clf),
+            X_clf,
+            None,
+            "raw",
+        )
+    )
+
+    for case_name, model, X_case, data_missing, model_output in cases:
+        existing, rebuilt = _roundtrip_tree_ensemble(model, X_case, data_missing=data_missing, model_output=model_output)
+        np.testing.assert_allclose(existing.predict(X_case), rebuilt.predict(X_case), err_msg=case_name)
+        sample = X_case.iloc[:10] if isinstance(X_case, pd.DataFrame) else X_case[:10]
+        existing_explanation = shap.TreeExplainer(existing, data=X_case, feature_perturbation="interventional")(sample)
+        rebuilt_explanation = shap.TreeExplainer(rebuilt, data=X_case, feature_perturbation="interventional")(sample)
+        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=case_name, atol=1e-6)
+        _assert_explanation_additivity(existing_explanation, existing.predict(sample), err_msg=case_name)
+        _assert_explanation_additivity(rebuilt_explanation, rebuilt.predict(sample), err_msg=case_name)
+
+
+def test_from_trees_roundtrip_gpboost():
+    gpboost = pytest.importorskip("gpboost")
+    X, y = shap.datasets.california(n_points=200)
+    data_train = gpboost.Dataset(X, y)
+    model = gpboost.train(
+        params={"objective": "regression_l2", "learning_rate": 0.1, "verbose": 0},
+        train_set=data_train,
+        num_boost_round=5,
+    )
+
+    existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=None, model_output="raw")
+    np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg="gpboost")
+
+    sample = X.iloc[:10] if isinstance(X, pd.DataFrame) else X[:10]
+    existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
+    rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
+    np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg="gpboost", atol=1e-6)
+    np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg="gpboost", atol=1e-6)
+
+
+def test_from_trees_roundtrip_pyod_iforest():
+    pytest.importorskip("pyod.models.iforest")
+    from pyod.models.iforest import IForest
+
+    X, _ = shap.datasets.california(n_points=200)
+    X = sklearn.utils.check_array(X)
+    model = IForest(max_features=0.75)
+    model.fit(X)
+
+    existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=None, model_output="raw")
+    np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg="pyod_iforest")
+
+    sample = X[:10]
+    existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
+    rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
+    np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg="pyod_iforest", atol=1e-6)
+    np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg="pyod_iforest", atol=1e-6)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fails due to OOM errors, see #4021")
+def test_from_trees_roundtrip_pyspark(configure_pyspark_python):
+    pyspark = pytest.importorskip("pyspark")
+    pytest.importorskip("pyspark.ml")
+    try:
+        spark = pyspark.sql.SparkSession.builder.config(conf=pyspark.SparkConf().set("spark.master", "local[*]")).getOrCreate()
+    except Exception:
+        pytest.skip("Could not create pyspark context")
+
+    iris_sk = sklearn.datasets.load_iris()
+    iris = pd.DataFrame(data=np.c_[iris_sk["data"], iris_sk["target"]], columns=iris_sk["feature_names"] + ["target"])[
+        :100
+    ]
+    col = ["sepal_length", "sepal_width", "petal_length", "petal_width", "type"]
+    iris = spark.createDataFrame(iris, col)
+    iris = pyspark.ml.feature.VectorAssembler(inputCols=col[:-1], outputCol="features").transform(iris)
+    iris = pyspark.ml.feature.StringIndexer(inputCol="type", outputCol="label").fit(iris).transform(iris)
+
+    classifiers = [
+        pyspark.ml.classification.GBTClassifier(labelCol="label", featuresCol="features"),
+        pyspark.ml.classification.RandomForestClassifier(labelCol="label", featuresCol="features"),
+        pyspark.ml.classification.DecisionTreeClassifier(labelCol="label", featuresCol="features"),
+    ]
+    X = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names)[:100]
+    for classifier in classifiers:
+        model = classifier.fit(iris)
+        existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=None, model_output="raw")
+        predictions = (
+            model.transform(iris)
+            .select("rawPrediction")
+            .rdd.map(lambda x: [float(y) for y in x["rawPrediction"]])
+            .toDF(["class0", "class1"])
+            .toPandas()
+        )
+        np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg=str(type(model)))
+
+        sample = X.iloc[:10]
+        existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
+        rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
+        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=str(type(model)))
+        np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg=str(type(model)))
+
+    regressors = [
+        pyspark.ml.regression.GBTRegressor(labelCol="sepal_length", featuresCol="features"),
+        pyspark.ml.regression.RandomForestRegressor(labelCol="sepal_length", featuresCol="features"),
+        pyspark.ml.regression.DecisionTreeRegressor(labelCol="sepal_length", featuresCol="features"),
+    ]
+    iris_reg = spark.createDataFrame(pd.DataFrame(data=np.c_[iris_sk["data"], iris_sk["target"]], columns=iris_sk["feature_names"] + ["target"])[
+        :100
+    ], col).drop("type")
+    iris_reg = pyspark.ml.feature.VectorAssembler(inputCols=col[1:-1], outputCol="features").transform(iris_reg)
+    X_reg = pd.DataFrame(data=iris_sk.data, columns=iris_sk.feature_names).drop("sepal length (cm)", axis=1)[:100]
+    for regressor in regressors:
+        model = regressor.fit(iris_reg)
+        existing, rebuilt = _roundtrip_tree_ensemble(model, X_reg, data_missing=None, model_output="raw")
+        np.testing.assert_allclose(existing.predict(X_reg), rebuilt.predict(X_reg), err_msg=str(type(model)))
+
+        sample = X_reg.iloc[:10]
+        existing_explanation = shap.TreeExplainer(existing, feature_perturbation="tree_path_dependent")(sample)
+        rebuilt_explanation = shap.TreeExplainer(rebuilt, feature_perturbation="tree_path_dependent")(sample)
+        np.testing.assert_allclose(existing_explanation.values, rebuilt_explanation.values, err_msg=str(type(model)))
+        np.testing.assert_allclose(existing_explanation.base_values, rebuilt_explanation.base_values, err_msg=str(type(model)))
+
+    spark.stop()

--- a/tests/explainers/test_tree_from_trees.py
+++ b/tests/explainers/test_tree_from_trees.py
@@ -387,13 +387,6 @@ def test_from_trees_roundtrip_pyspark(configure_pyspark_python):
     for classifier in classifiers:
         model = classifier.fit(iris)
         existing, rebuilt = _roundtrip_tree_ensemble(model, X, data_missing=None, model_output="raw")
-        predictions = (
-            model.transform(iris)
-            .select("rawPrediction")
-            .rdd.map(lambda x: [float(y) for y in x["rawPrediction"]])
-            .toDF(["class0", "class1"])
-            .toPandas()
-        )
         np.testing.assert_allclose(existing.predict(X), rebuilt.predict(X), err_msg=str(type(model)))
 
         sample = X.iloc[:10]


### PR DESCRIPTION
## Summary
This PR introduces `TreeEnsemble.from_trees` as a generic ingestion path for pre-extracted trees, expands validation through a dedicated roundtrip test suite, adds a notebook demonstrating usage, and emits deprecation warnings for selected smaller/maintenance-heavy tree integrations.

## Why
Direct support for many small tree libraries has become costly and brittle. `from_trees` provides a scalable path where integrations can export tree structures and rely on SHAP’s core tree machinery without requiring SHAP-side bespoke parsers for every new library.

## What Changed

### Core Implementation
- Added `TreeEnsemble.from_trees` constructor  
- Added/centralized finalization logic for dense tree arrays and validation  
- Enabled `TreeExplainer` to accept a prebuilt `TreeEnsemble` directly  
- Updated `TreeExplainer` support checks so auto-routing recognizes `TreeEnsemble` inputs  

### Deprecation Warnings
Added deprecation warnings guiding users to export trees and call `TreeEnsemble.from_trees` for selected smaller integrations, including:
- ngboost  
- gpboost  
- imbalanced-learn BRF  
- scikit-optimize tree regressors  
- econml / causalml tree paths  

### Tests
Added a dedicated `from_trees` test module with roundtrip checks across:
- sklearn tree families  
- optional backends (e.g., xgboost, ngboost)  
- smaller library backends (e.g., lightgbm, catboost, skopt, imbalanced-learn)  
- gpboost  
- pyod isolation forest path  
- pyspark path (skip-safe when Spark context cannot be created)  

Assertions validate:
- prediction parity  
- SHAP parity/additivity under appropriate perturbation modes  

### Notebook
Added an API example notebook demonstrating:
- sklearn examples  
- optional backend examples when installed  
- recommended `from_trees` roundtrip workflow  

## Validation

### Targeted Suite
- `tests/explainers/test_tree_from_trees.py`

### Broader Suite
- `tests/explainers/test_tree.py`  
- `tests/explainers/test_tree_from_trees.py`  

### Latest Run Summary (local environment)
- 120 passed  
- 3 skipped  
- 1 deselected  

Skips were related to pyspark-context environment limitations.

## Backward Compatibility
- No removal of existing integrations in this PR  
- Existing paths remain available, with deprecation warnings for selected integrations  

Closes #4694 