### PR TITLE
 feat(plots): add ax parameter to shap.plots.waterfall

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -13,7 +13,7 @@ from ._style import get_style
 # plot that is associated with that feature get overlaid on the plot...it would quickly allow users to answer
 # why a feature is pushing down or up. Perhaps the best way to do this would be with an ICE plot hanging off
 # of the bar...
-def waterfall(shap_values, max_display=10, show=True):
+def waterfall(shap_values, max_display=10, show=True, ax=None):
     """Plots an explanation of a single prediction as a waterfall plot.
 
     The SHAP value of a feature represents the impact of the evidence provided by that feature on the model's
@@ -37,6 +37,11 @@ def waterfall(shap_values, max_display=10, show=True):
         Whether :external+mpl:func:`matplotlib.pyplot.show()` is called before returning.
         Setting this to ``False`` allows the plot to be customized further after it
         has been created, returning the current axis via plt.gca().
+
+    ax : matplotlib.axes.Axes or None
+        Axes object to draw the plot onto. If ``None`` (default), the current axes are
+        used, and the figure is resized to fit the number of features. Pass an explicit
+        ``Axes`` to embed the waterfall plot in a subplot grid.
 
     Examples
     --------
@@ -99,8 +104,12 @@ def waterfall(shap_values, max_display=10, show=True):
     loc = base_values + values.sum()
     yticklabels = ["" for _ in range(num_features + 1)]
 
-    # size the plot based on how many features we are plotting
-    plt.gcf().set_size_inches(8, num_features * row_height + 1.5)
+    # resolve axes
+    if ax is None:
+        ax = plt.gca()
+        ax.figure.set_size_inches(8, num_features * row_height + 1.5)
+
+    fig = ax.figure
 
     # see how many individual (vs. grouped at the end) features we are plotting
     if num_features == len(values):
@@ -127,7 +136,7 @@ def waterfall(shap_values, max_display=10, show=True):
                 neg_high.append(upper_bounds[order[i]])
             neg_lefts.append(loc)
         if num_individual != num_features or i + 4 < num_individual:
-            plt.plot(
+            ax.plot(
                 [loc, loc],
                 [rng[i] - 1 - 0.4, rng[i] + 0.4],
                 color=style.vlines_color,
@@ -168,7 +177,7 @@ def waterfall(shap_values, max_display=10, show=True):
 
     # draw invisible bars just for sizing the axes
     label_padding = np.array([0.1 * dataw if w < 1 else 0 for w in pos_widths])
-    plt.barh(
+    ax.barh(
         pos_inds,
         np.array(pos_widths) + label_padding + 0.02 * dataw,
         left=np.array(pos_lefts) - 0.01 * dataw,
@@ -176,7 +185,7 @@ def waterfall(shap_values, max_display=10, show=True):
         alpha=0,
     )
     label_padding = np.array([-0.1 * dataw if -w < 1 else 0 for w in neg_widths])
-    plt.barh(
+    ax.barh(
         neg_inds,
         np.array(neg_widths) + label_padding - 0.02 * dataw,
         left=np.array(neg_lefts) + 0.01 * dataw,
@@ -187,9 +196,7 @@ def waterfall(shap_values, max_display=10, show=True):
     # define variable we need for plotting the arrows
     head_length = 0.08
     bar_width = 0.8
-    xlen = plt.xlim()[1] - plt.xlim()[0]
-    fig = plt.gcf()
-    ax = plt.gca()
+    xlen = ax.get_xlim()[1] - ax.get_xlim()[0]
     bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     width = bbox.width
     bbox_to_xscale = xlen / width
@@ -199,7 +206,7 @@ def waterfall(shap_values, max_display=10, show=True):
     # draw the positive arrows
     for i in range(len(pos_inds)):
         dist = pos_widths[i]
-        arrow_obj = plt.arrow(
+        arrow_obj = ax.arrow(
             pos_lefts[i],
             pos_inds[i],
             dist - hl_scaled,
@@ -211,14 +218,14 @@ def waterfall(shap_values, max_display=10, show=True):
         )
 
         if pos_low is not None and i < len(pos_low):
-            plt.errorbar(
+            ax.errorbar(
                 pos_lefts[i] + pos_widths[i],
                 pos_inds[i],
                 xerr=np.array([[pos_widths[i] - pos_low[i]], [pos_high[i] - pos_widths[i]]]),
                 ecolor=style.secondary_color_positive,
             )
 
-        txt_obj = plt.text(
+        txt_obj = ax.text(
             pos_lefts[i] + 0.5 * dist,
             pos_inds[i],
             format_value(pos_widths[i], "%+0.02f"),
@@ -234,7 +241,7 @@ def waterfall(shap_values, max_display=10, show=True):
         if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
 
-            txt_obj = plt.text(
+            txt_obj = ax.text(
                 pos_lefts[i] + (5 / 72) * bbox_to_xscale + dist,
                 pos_inds[i],
                 format_value(pos_widths[i], "%+0.02f"),
@@ -248,7 +255,7 @@ def waterfall(shap_values, max_display=10, show=True):
     for i in range(len(neg_inds)):
         dist = neg_widths[i]
 
-        arrow_obj = plt.arrow(
+        arrow_obj = ax.arrow(
             neg_lefts[i],
             neg_inds[i],
             -(-dist - hl_scaled),
@@ -260,14 +267,14 @@ def waterfall(shap_values, max_display=10, show=True):
         )
 
         if neg_low is not None and i < len(neg_low):
-            plt.errorbar(
+            ax.errorbar(
                 neg_lefts[i] + neg_widths[i],
                 neg_inds[i],
                 xerr=np.array([[neg_widths[i] - neg_low[i]], [neg_high[i] - neg_widths[i]]]),
                 ecolor=style.secondary_color_negative,
             )
 
-        txt_obj = plt.text(
+        txt_obj = ax.text(
             neg_lefts[i] + 0.5 * dist,
             neg_inds[i],
             format_value(neg_widths[i], "%+0.02f"),
@@ -283,7 +290,7 @@ def waterfall(shap_values, max_display=10, show=True):
         if text_bbox.width > arrow_bbox.width:
             txt_obj.remove()
 
-            txt_obj = plt.text(
+            txt_obj = ax.text(
                 neg_lefts[i] - (5 / 72) * bbox_to_xscale + dist,
                 neg_inds[i],
                 format_value(neg_widths[i], "%+0.02f"),
@@ -296,25 +303,26 @@ def waterfall(shap_values, max_display=10, show=True):
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
     # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
     ytick_pos = list(range(num_features)) + list(np.arange(num_features) + 1e-8)
-    plt.yticks(ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
+    ax.set_yticks(ytick_pos)
+    ax.set_yticklabels(yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
 
     # put horizontal lines for each feature row
     for i in range(num_features):
-        plt.axhline(i, color=style.hlines_color, lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(i, color=style.hlines_color, lw=0.5, dashes=(1, 5), zorder=-1)
 
     # mark the prior expected value and the model prediction
-    plt.axvline(base_values, 0, 1 / num_features, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    ax.axvline(base_values, 0, 1 / num_features, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
     fx = base_values + values.sum()
-    plt.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
+    ax.axvline(fx, 0, 1, color=style.vlines_color, linestyle="--", linewidth=0.5, zorder=-1)
 
     # clean up the main axis
-    plt.gca().xaxis.set_ticks_position("bottom")
-    plt.gca().yaxis.set_ticks_position("none")
-    plt.gca().spines["right"].set_visible(False)
-    plt.gca().spines["top"].set_visible(False)
-    plt.gca().spines["left"].set_visible(False)
+    ax.xaxis.set_ticks_position("bottom")
+    ax.yaxis.set_ticks_position("none")
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
+    ax.spines["left"].set_visible(False)
     ax.tick_params(labelsize=13)
-    # plt.xlabel("\nModel output", fontsize=12)
+    # ax.set_xlabel("\nModel output", fontsize=12)
 
     # draw the E[f(X)] tick mark
     xmin, xmax = ax.get_xlim()
@@ -370,7 +378,7 @@ def waterfall(shap_values, max_display=10, show=True):
     if show:
         plt.show()
     else:
-        return plt.gca()
+        return ax
 
 
 def waterfall_legacy(expected_value, shap_values=None, features=None, feature_names=None, max_display=10, show=True):

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -93,6 +93,21 @@ def test_waterfall_plot_for_decision_tree_explanation():
     shap.plots.waterfall(explanation[0], show=False)
 
 
+def test_waterfall_ax_parameter(explainer):
+    """Test that waterfall accepts an explicit ax and draws into it without resizing the figure."""
+    explanation = explainer(explainer.data)
+    fig, axes = plt.subplots(1, 2, figsize=(16, 5))
+    returned_ax = shap.plots.waterfall(explanation[0], ax=axes[0], show=False)
+    shap.plots.waterfall(explanation[1], ax=axes[1], show=False)
+    # the returned axes should be the one we passed in
+    assert returned_ax is axes[0]
+    # the figure should not have been resized from the original (16, 5)
+    size = fig.get_size_inches()
+    assert size[0] == pytest.approx(16.0)
+    assert size[1] == pytest.approx(5.0)
+    plt.close(fig)
+
+
 def test_waterfall_plot_for_data_with_number_columns():
     # GH 4150
     model = KNeighborsClassifier()


### PR DESCRIPTION
## Overview

Closes #4697 

### Description of the changes proposed in this pull request:

Adds ax=None to shap.plots.waterfall, matching the interface already offered by bar, beeswarm, scatter, heatmap, and violin.
Changes:
  - shap/plots/_waterfall.py: Added ax=None parameter. When ax is None (default), behaviour is identical to before — plt.gca() is used and the figure is auto-sized. When an Axes is passed, the plot renders into it and the figure is not resized. All internal plt.xxx() calls replaced with ax.xxx() / fig.xxx() equivalents. Return value changed from plt.gca() to ax (still the same object in the default case, now guaranteed to be the passed-in axes).
  - tests/plots/test_waterfall.py: Added test_waterfall_ax_parameter which creates a 1×2 subplot grid, draws two waterfall plots into each cell, asserts the returned axes is the one passed in, and asserts figure size was not altered.
- Backward compatibility: Fully backward-compatible — ax=None default preserves all existing behaviour.




## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
