### PR TITLE
fix(warnings): add stacklevel=2 to all warnings.warn() calls

### DIFF
--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -11,7 +11,9 @@ from ._action import Action
 class ActionOptimizer:
     def __init__(self, model, actions: list[Action | list[Action]]):
         self.model = model
-        warnings.warn("Note that ActionOptimizer is still in an alpha state and is subject to API changes.")
+        warnings.warn(
+            "Note that ActionOptimizer is still in an alpha state and is subject to API changes.", stacklevel=2
+        )
         # actions go into mutually exclusive groups
         self.action_groups: list[list[Action]] = []
         for group in actions:

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -22,7 +22,7 @@ def remove_retrain(
     to get the change in model performance when a specified fraction of the most important features
     are withheld.
     """
-    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!")
+    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!", stacklevel=2)
 
     # see if we match the last cached call
     global _remove_cache
@@ -175,7 +175,7 @@ def batch_remove_retrain(
     and then retrains the model once, instead of retraining the model for every test sample like
     the holdout metric.
     """
-    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!")
+    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!", stacklevel=2)
 
     X_train, X_test = to_array(X_train, X_test)
 
@@ -221,7 +221,7 @@ def keep_retrain(
     to get the change in model performance when a specified fraction of the most important features
     are retained.
     """
-    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!")
+    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!", stacklevel=2)
 
     # see if we match the last cached call
     global _keep_cache
@@ -373,7 +373,7 @@ def batch_keep_retrain(
     and then retrains the model once, instead of retraining the model for every test sample like
     the keep metric.
     """
-    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!")
+    warnings.warn("The retrain based measures can incorrectly evaluate models in some cases!", stacklevel=2)
 
     X_train, X_test = to_array(X_train, X_test)
 

--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -12,7 +12,7 @@ class PyTorchDeep(Explainer):
         import torch
 
         if version.parse(torch.__version__) < version.parse("0.4"):
-            warnings.warn("Your PyTorch version is older than 0.4 and not supported.")
+            warnings.warn("Your PyTorch version is older than 0.4 and not supported.", stacklevel=2)
 
         # check if we have multiple inputs
         self.multi_input = False
@@ -252,7 +252,7 @@ def deeplift_grad(module, grad_input, grad_output):
         if op_handler[module_type].__name__ not in ["passthrough", "linear_1d"]:
             return op_handler[module_type](module, grad_input, grad_output)
     else:
-        warnings.warn(f"unrecognized nn.Module: {module_type}")
+        warnings.warn(f"unrecognized nn.Module: {module_type}", stacklevel=2)
         return grad_input
 
 

--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -88,11 +88,12 @@ class TFDeep(Explainer):
 
         """
         if version.parse(tf.__version__) < version.parse("1.4.0"):
-            warnings.warn("Your TensorFlow version is older than 1.4.0 and not supported.")
+            warnings.warn("Your TensorFlow version is older than 1.4.0 and not supported.", stacklevel=2)
 
         if version.parse(tf.__version__) >= version.parse("2.4.0"):
             warnings.warn(
-                "Your TensorFlow version is newer than 2.4.0 and so graph support has been removed in eager mode and some static graphs may not be supported. See PR #1483 for discussion."
+                "Your TensorFlow version is newer than 2.4.0 and so graph support has been removed in eager mode and some static graphs may not be supported. See PR #1483 for discussion.",
+                stacklevel=2,
             )
 
         # determine the model inputs and outputs
@@ -151,7 +152,8 @@ class TFDeep(Explainer):
         else:
             if self.data[0].shape[0] > 5000:
                 warnings.warn(
-                    "You have provided over 5k background samples! For better performance consider using smaller random sample."
+                    "You have provided over 5k background samples! For better performance consider using smaller random sample.",
+                    stacklevel=2,
                 )
             if not tf.executing_eagerly():
                 self.expected_value = self.run(self.model_output, self.model_inputs, self.data).mean(0)
@@ -184,7 +186,7 @@ class TFDeep(Explainer):
     def _get_model_output(self, model):
         if len(model.layers[-1]._inbound_nodes) == 0:
             if len(model.outputs) > 1:
-                warnings.warn("Only one model output supported.")
+                warnings.warn("Only one model output supported.", stacklevel=2)
             return model.outputs[0]
         else:
             return model.layers[-1].output

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -207,13 +207,13 @@ class _TFGradient(Explainer):
             import tensorflow as tf
 
             if version.parse(tf.__version__) < version.parse("1.4.0"):  # type: ignore[attr-defined]
-                warnings.warn("Your TensorFlow version is older than 1.4.0 and not supported.")
+                warnings.warn("Your TensorFlow version is older than 1.4.0 and not supported.", stacklevel=2)
         if keras is None:
             try:
                 from tensorflow import keras
 
                 if version.parse(keras.__version__) < version.parse("2.1.0"):  # type: ignore[attr-defined]
-                    warnings.warn("Your Keras version is older than 2.1.0 and not supported.")
+                    warnings.warn("Your Keras version is older than 2.1.0 and not supported.", stacklevel=2)
             except Exception:
                 pass
         if tf.executing_eagerly():  # type: ignore[attr-defined]
@@ -485,7 +485,7 @@ class _PyTorchGradient(Explainer):
         import torch
 
         if version.parse(torch.__version__) < version.parse("0.4"):
-            warnings.warn("Your PyTorch version is older than 0.4 and not supported.")
+            warnings.warn("Your PyTorch version is older than 0.4 and not supported.", stacklevel=2)
 
         # check if we have multiple inputs
         self.multi_input = False

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -699,7 +699,9 @@ class KernelExplainer(Explainer):
         nonzero_inds = np.arange(self.M)
         log.debug(f"{fraction_evaluated = }")
         if self.l1_reg == "auto":
-            warnings.warn("l1_reg='auto' is deprecated and will be removed in a future version.", DeprecationWarning)
+            warnings.warn(
+                "l1_reg='auto' is deprecated and will be removed in a future version.", DeprecationWarning, stacklevel=2
+            )
         if (self.l1_reg not in ["auto", False, 0]) or (fraction_evaluated < 0.2 and self.l1_reg == "auto"):
             w_aug = np.hstack((self.kernelWeights * (self.M - s), self.kernelWeights * s))
             log.info(f"{np.sum(w_aug) = }")
@@ -767,7 +769,8 @@ class KernelExplainer(Explainer):
                 "To avoid this situation and get a regular matrix do one of the following:\n"
                 "1) turn up the number of samples,\n"
                 "2) turn up the L1 regularization with num_features(N) where N is less than the number of samples,\n"
-                "3) group features together to reduce the number of inputs that need to be explained."
+                "3) group features together to reduce the number of inputs that need to be explained.",
+                stacklevel=2,
             )
             # XWX = np.linalg.pinv(X.T @ WX)
             # w = np.dot(XWX, np.dot(np.transpose(WX), y))

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -120,7 +120,7 @@ class LinearExplainer(Explainer):
                 "The feature_perturbation option is now deprecated in favor of using the appropriate "
                 "masker (maskers.Independent, maskers.Partition or maskers.Impute)."
             )
-            warnings.warn(wmsg, FutureWarning)
+            warnings.warn(wmsg, FutureWarning, stacklevel=2)
         else:
             feature_perturbation = "interventional"
 
@@ -241,7 +241,9 @@ class LinearExplainer(Explainer):
             self.x_transform = x_transform
         elif self.feature_perturbation == "interventional":
             if nsamples != 1000:
-                warnings.warn("Setting nsamples has no effect when feature_perturbation = 'interventional'!")
+                warnings.warn(
+                    "Setting nsamples has no effect when feature_perturbation = 'interventional'!", stacklevel=2
+                )
         else:
             raise InvalidFeaturePerturbationError(
                 "Unknown type of feature_perturbation provided: " + self.feature_perturbation

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -84,10 +84,13 @@ def _safe_check_tree_instance_experimental(tree_instance: Any) -> None:
                 f"The {library} support is verified for the following versions: {experimental.get(library)}. "
                 f"As experimental functionality, this integration may be removed or significantly changed in future releases without following semantic versioning. Use in production systems at your own risk.",
                 ExperimentalWarning,
+                stacklevel=2,
             )
     else:
         warnings.warn(
-            f"Unable to check experimental integration status for {tree_instance} object", ExperimentalWarning
+            f"Unable to check experimental integration status for {tree_instance} object",
+            ExperimentalWarning,
+            stacklevel=2,
         )
 
 
@@ -229,6 +232,7 @@ class TreeExplainer(Explainer):
                 "The approximate argument has been deprecated in version v0.47.0 and will be removed in version v0.48.0. "
                 "Please use the approximate argument in the shap_values or the __call__ method instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
         if feature_names is not None:
             self.data_feature_names = feature_names
@@ -265,6 +269,7 @@ class TreeExplainer(Explainer):
                     "will raise an error. Please provide a background dataset to continue using the interventional "
                     "approach or set feature_perturbation='auto' to automatically switch approaches.",
                     FutureWarning,
+                    stacklevel=2,
                 )
                 feature_perturbation = "tree_path_dependent"
         elif feature_perturbation != "tree_path_dependent":
@@ -278,7 +283,7 @@ class TreeExplainer(Explainer):
                 f"Passing {self.data.shape[0]} background samples may lead to slow runtimes. Consider "
                 "using shap.sample(data, 100) to create a smaller background data set."
             )
-            warnings.warn(wmsg)
+            warnings.warn(wmsg, stacklevel=2)
 
         _safe_check_tree_instance_experimental(model)
 
@@ -426,7 +431,7 @@ class TreeExplainer(Explainer):
                     "update your xgboost to >=1.7.0 or explicitly set `Explanation.data = X`, where "
                     "`X` is a numpy or scipy array."
                 )
-                warnings.warn(wmsg)
+                warnings.warn(wmsg, stacklevel=2)
                 X_data = None
             else:
                 X_data = X.get_data()
@@ -498,7 +503,8 @@ class TreeExplainer(Explainer):
                 "check_additivity requires us to run predictions which is not supported with "
                 "spark, "
                 "ignoring."
-                " Set check_additivity=False to remove this warning"
+                " Set check_additivity=False to remove this warning",
+                stacklevel=2,
             )
             check_additivity = False
 
@@ -618,7 +624,8 @@ class TreeExplainer(Explainer):
                 ):
                     if not from_call:
                         warnings.warn(
-                            "LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray"
+                            "LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray",
+                            stacklevel=2,
                         )
                 if phi.shape[1] != X.shape[1] + 1:
                     try:
@@ -1474,7 +1481,8 @@ class TreeEnsemble:
             if self.model_output == "raw":
                 param_idx = 0  # default to the first parameter of the output distribution
                 warnings.warn(
-                    'Translating model_output="raw" to model_output=0 for the 0-th parameter in the distribution. Use model_output=0 directly to avoid this warning.'
+                    'Translating model_output="raw" to model_output=0 for the 0-th parameter in the distribution. Use model_output=0 directly to avoid this warning.',
+                    stacklevel=2,
                 )
             elif isinstance(self.model_output, int):
                 param_idx = self.model_output

--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -98,7 +98,7 @@ def _get_model_output(model):
     ):
         if len(model.layers[-1]._inbound_nodes) == 0:
             if len(model.outputs) > 1:
-                warnings.warn("Only one model output supported.")
+                warnings.warn("Only one model output supported.", stacklevel=2)
             return model.outputs[0]
         else:
             return model.layers[-1].output

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -401,6 +401,7 @@ def bar_legacy(shap_values, features=None, feature_names=None, max_display=None,
         "\nFor more information on using the new API, see:\n"
         "https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/migrating-to-new-api.html",
         DeprecationWarning,
+        stacklevel=2,
     )
     style = get_style()
     # unwrap pandas series

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -1032,7 +1032,8 @@ def summary_legacy(
                 if shaps.shape[0] == 1:
                     warnings.warn(
                         f"Not enough data in bin #{i} for feature {feature_names[ind]}, so it'll be ignored."
-                        " Try increasing the number of records to plot."
+                        " Try increasing the number of records to plot.",
+                        stacklevel=2,
                     )
                     # to ignore it, just set it to the previous y-values (so the area between them will be zero). Not ys is already 0, so there's
                     # nothing to do if i == 0

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -208,7 +208,9 @@ def force(
             raise NotImplementedError("matplotlib = True is not yet supported for force plots with multiple samples!")
 
         if shap_values.shape[0] > 3000:
-            warnings.warn("shap.plots.force is slow for many thousands of rows, try subsampling your data.")
+            warnings.warn(
+                "shap.plots.force is slow for many thousands of rows, try subsampling your data.", stacklevel=2
+            )
 
         exps = []
         for k in range(shap_values.shape[0]):

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -768,6 +768,7 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
         "This function is not used within the shap library and will therefore be removed in an upcoming release. "
         "If you rely on this function, please open an issue: https://github.com/shap/shap/issues.",
         FutureWarning,
+        stacklevel=2,
     )
     M = len(tokens)
     if len(shap_values) != M:

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -104,7 +104,9 @@ def violin(
 
     """
     if title is not None:
-        warnings.warn("The `title` argument is unused and will be removed in a future release.", DeprecationWarning)
+        warnings.warn(
+            "The `title` argument is unused and will be removed in a future release.", DeprecationWarning, stacklevel=2
+        )
     # support passing an explanation object
     if str(type(shap_values)).endswith("Explanation'>"):
         shap_exp = shap_values
@@ -321,7 +323,8 @@ def violin(
                 if shaps.shape[0] == 1:
                     warnings.warn(
                         f"Not enough data in bin #{i} for feature {feature_names[ind]}, so it'll be ignored."
-                        " Try increasing the number of records to plot."
+                        " Try increasing the number of records to plot.",
+                        stacklevel=2,
                     )
                     # to ignore it, just set it to the previous y-values (so the area between them will be zero). Not ys is already 0, so there's
                     # nothing to do if i == 0

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -195,7 +195,8 @@ def xgboost_distances_r2(
             warnings.warn(
                 f"No/low signal found from feature {i} (this is typically caused by constant or "
                 "near-constant features)! Cluster distances can't be computed for it (so setting "
-                "all redundancy distances to 1)."
+                "all redundancy distances to 1).",
+                stacklevel=2,
             )
             r2: float = 0
 
@@ -297,7 +298,8 @@ def hclust(
         if y is not None:
             warnings.warn(
                 "Ignoring the y argument passed to shap.utils.hclust since the given clustering metric is "
-                "not based on label fitting!"
+                "not based on label fitting!",
+                stacklevel=2,
             )
         bg_no_nan: npt.NDArray[Any] = X_arr.copy()
         for i in range(bg_no_nan.shape[1]):

--- a/tests/test_warnings_stacklevel.py
+++ b/tests/test_warnings_stacklevel.py
@@ -1,0 +1,134 @@
+"""Tests to verify that warnings.warn() calls use stacklevel=2 so warnings
+point to the user's calling code rather than internal SHAP files."""
+
+import warnings
+
+import numpy as np
+import pytest
+import sklearn.linear_model
+
+
+def _this_file() -> str:
+    return __file__
+
+
+def test_bar_legacy_warning_stacklevel():
+    """bar_legacy() should emit a DeprecationWarning pointing at the caller."""
+    from shap.plots._bar import bar_legacy
+
+    rs = np.random.RandomState(42)
+    shap_values = rs.randn(4)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        bar_legacy(shap_values, show=False)  # caller line
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep_warnings, "Expected a DeprecationWarning from bar_legacy"
+    assert dep_warnings[0].filename == _this_file(), (
+        f"Warning should point to test file, not {dep_warnings[0].filename}"
+    )
+
+
+def test_violin_title_deprecation_warning_stacklevel():
+    """violin() title argument should emit a DeprecationWarning pointing at the caller."""
+    import shap
+
+    rs = np.random.RandomState(42)
+    shap_values = rs.randn(20, 5)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        shap.plots.violin(shap_values, title="some title", show=False)  # caller line
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep_warnings, "Expected a DeprecationWarning for unused title argument"
+    assert dep_warnings[0].filename == _this_file(), (
+        f"Warning should point to test file, not {dep_warnings[0].filename}"
+    )
+
+
+def test_linear_feature_perturbation_deprecation_stacklevel():
+    """LinearExplainer with feature_perturbation should emit FutureWarning at caller."""
+    import shap
+
+    rs = np.random.RandomState(42)
+    X = rs.randn(20, 5)
+    y = rs.randn(20)
+    model = sklearn.linear_model.Ridge()
+    model.fit(X, y)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        shap.LinearExplainer(model, X, feature_perturbation="interventional")  # caller line
+
+    future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+    assert future_warnings, "Expected a FutureWarning for feature_perturbation deprecation"
+    assert future_warnings[0].filename == _this_file(), (
+        f"Warning should point to test file, not {future_warnings[0].filename}"
+    )
+
+
+def test_hclust_ignores_y_warning_stacklevel():
+    """hclust() should emit a warning pointing at the caller when y is ignored."""
+    from shap.utils import hclust
+
+    rs = np.random.RandomState(42)
+    X = rs.randn(20, 5)
+    y = rs.randn(20)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        hclust(X, y=y, metric="cosine")  # caller line; non-label-fit metric causes y to be ignored
+
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert user_warnings, "Expected a UserWarning about ignoring y in hclust"
+    assert user_warnings[0].filename == _this_file(), (
+        f"Warning should point to test file, not {user_warnings[0].filename}"
+    )
+
+
+def test_tree_approximate_deprecation_stacklevel():
+    """TreeExplainer with approximate arg should emit DeprecationWarning at caller."""
+    pytest.importorskip("sklearn")
+    from sklearn.ensemble import RandomForestClassifier
+
+    import shap
+
+    rs = np.random.RandomState(42)
+    X = rs.randn(100, 4)
+    y = (X[:, 0] > 0).astype(int)
+    model = RandomForestClassifier(n_estimators=5, random_state=0).fit(X, y)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        shap.TreeExplainer(model, approximate=False)  # caller line
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep_warnings, "Expected a DeprecationWarning for the approximate argument"
+    assert dep_warnings[0].filename == _this_file(), (
+        f"Warning should point to test file, not {dep_warnings[0].filename}"
+    )
+
+
+def test_tree_feature_perturbation_futurewarning_stacklevel():
+    """TreeExplainer with interventional perturbation but no data should warn at caller."""
+    pytest.importorskip("sklearn")
+    from sklearn.ensemble import RandomForestClassifier
+
+    import shap
+
+    rs = np.random.RandomState(42)
+    X = rs.randn(100, 4)
+    y = (X[:, 0] > 0).astype(int)
+    model = RandomForestClassifier(n_estimators=5, random_state=0).fit(X, y)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        shap.TreeExplainer(model, feature_perturbation="interventional")  # caller line
+
+    future_warnings = [w for w in caught if issubclass(w.category, FutureWarning)]
+    assert future_warnings, "Expected a FutureWarning for interventional without data"
+    assert future_warnings[0].filename == _this_file(), (
+        f"Warning should point to test file, not {future_warnings[0].filename}"
+    )


### PR DESCRIPTION
## Overview

Closes #4700 

### Description of the changes proposed in this pull request:

35 warnings.warn() calls across the codebase were missing the stacklevel=2 argument. This caused all warnings to point to internal SHAP files instead of the caller's code.

  ### Changes

  - Added stacklevel=2 to all 35 warnings.warn() calls in:
    - shap/benchmark/measures.py (4)
    - shap/utils/_clustering.py (2)
    - shap/actions/_optimizer.py (1)
    - shap/explainers/_gradient.py (3)
    - shap/explainers/_deep/deep_pytorch.py (2)
    - shap/explainers/_deep/deep_tf.py (4)
    - shap/explainers/tf_utils.py (1)
    - shap/explainers/_linear.py (2)
    - shap/explainers/_kernel.py (2)
    - shap/explainers/_tree.py (10)
    - shap/plots/_violin.py (2)
    - shap/plots/_text.py (1)
    - shap/plots/_force.py (1)
    - shap/plots/_beeswarm.py (1)
    - shap/plots/_bar.py (1)
  - Added tests/test_warnings_stacklevel.py with 6 tests that assert warning filename points to the test file (caller), not SHAP internals.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
