### PR TITLE
Fix inconsistent feature scaling in KerasWrap

### DIFF
--- a/shap/benchmark/models.py
+++ b/shap/benchmark/models.py
@@ -20,14 +20,15 @@ class KerasWrap:
         else:
             self.model.set_weights(self.init_weights)
         self.scaler.fit(X)
-        return self.model.fit(X, y, epochs=self.epochs, verbose=verbose)
+        X_scaled = self.scaler.transform(X)
+        return self.model.fit(X_scaled, y, epochs=self.epochs, verbose=verbose)
 
     def predict(self, X):
-        X = self.scaler.transform(X)
+        X_scaled = self.scaler.transform(X)
         if self.flatten_output:
-            return self.model.predict(X).flatten()
+            return self.model.predict(X_scaled).flatten()
         else:
-            return self.model.predict(X)
+            return self.model.predict(X_scaled)
 
 
 # This models are all tuned for the corrgroups60 dataset

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -770,3 +770,24 @@ def test_pytorch_multiple_inputs(torch_device, disconnected, activation):
         np.testing.assert_allclose(sums + e.expected_value, outputs, atol=1e-3),
         "Sum of SHAP values does not match difference!",
     )
+
+def test_tf_keras_simple_dense_path():
+    """Simple test to ensure keras utilities are exercised via DeepExplainer."""
+    tf = pytest.importorskip("tensorflow")
+    import numpy as np
+    import shap
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(4, activation="relu"),
+        tf.keras.layers.Dense(1)
+    ])
+
+    model.compile(optimizer="adam", loss="mse")
+
+    X = np.random.randn(10, 4).astype(np.float32)
+
+    explainer = shap.DeepExplainer(model, X[:5])
+    shap_values = explainer.shap_values(X[:2])
+
+    assert shap_values is not None

--- a/tests/explainers/test_deep.py
+++ b/tests/explainers/test_deep.py
@@ -771,17 +771,17 @@ def test_pytorch_multiple_inputs(torch_device, disconnected, activation):
         "Sum of SHAP values does not match difference!",
     )
 
+
 def test_tf_keras_simple_dense_path():
     """Simple test to ensure keras utilities are exercised via DeepExplainer."""
     tf = pytest.importorskip("tensorflow")
     import numpy as np
+
     import shap
 
-    model = tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(4, activation="relu"),
-        tf.keras.layers.Dense(1)
-    ])
+    model = tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(4, activation="relu"), tf.keras.layers.Dense(1)]
+    )
 
     model.compile(optimizer="adam", loss="mse")
 

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,0 +1,41 @@
+import pytest
+
+try:
+    import tensorflow as tf
+    from shap.utils._keras import clone_keras_layers, split_keras_model
+    TF_AVAILABLE = True
+except ImportError:
+    TF_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
+
+
+def create_simple_model():
+    return tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(8, activation="relu"),
+        tf.keras.layers.Dense(2)
+    ])
+
+
+def test_clone_keras_layers_basic():
+    model = create_simple_model()
+    new_model = clone_keras_layers(model, 0, len(model.layers) - 1)
+
+    assert new_model is not None
+    assert isinstance(new_model, tf.keras.Model)
+
+
+def test_split_keras_model_basic():
+    model = create_simple_model()
+    model1, model2 = split_keras_model(model, 1)
+
+    assert isinstance(model1, tf.keras.Model)
+    assert isinstance(model2, tf.keras.Model)
+
+
+def test_split_keras_model_invalid_layer():
+    model = create_simple_model()
+
+    with pytest.raises(Exception):
+        split_keras_model(model, 100)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -2,7 +2,9 @@ import pytest
 
 try:
     import tensorflow as tf
+
     from shap.utils._keras import clone_keras_layers, split_keras_model
+
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
@@ -11,11 +13,9 @@ pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not install
 
 
 def create_simple_model():
-    return tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(8, activation="relu"),
-        tf.keras.layers.Dense(2)
-    ])
+    return tf.keras.Sequential(
+        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(8, activation="relu"), tf.keras.layers.Dense(2)]
+    )
 
 
 def test_clone_keras_layers_basic():

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,76 +1,86 @@
-import pytest
 import numpy as np
+import pytest
 
 try:
     import tensorflow as tf
+
     from shap.utils._keras import clone_keras_layers, split_keras_model
+
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
 
 pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
 
+
 def create_simple_model():
     """Create a Keras model with known weights for reproducible testing."""
-    model = tf.keras.Sequential([
-        tf.keras.layers.Input(shape=(4,)),
-        tf.keras.layers.Dense(8, activation="relu", name="dense1"),
-        tf.keras.layers.Dense(2, name="output")
-    ])
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input(shape=(4,)),
+            tf.keras.layers.Dense(8, activation="relu", name="dense1"),
+            tf.keras.layers.Dense(2, name="output"),
+        ]
+    )
     model.build((None, 4))
     return model
+
 
 def test_clone_keras_layers_output_correctness():
     """Test that cloned layers produce correct output matching original."""
     model = create_simple_model()
     X = np.random.randn(5, 4).astype(np.float32)
-    
+
     # Get predictions from full model
     full_output = model.predict(X, verbose=0)
-    
+
     # Clone layers and test
     cloned = clone_keras_layers(model, 1, len(model.layers) - 1)
     cloned_output = cloned.predict(X, verbose=0)
-    
+
     # Outputs should be identical
     np.testing.assert_allclose(full_output, cloned_output, rtol=1e-5)
+
 
 def test_split_keras_model_composition():
     """Test that split models recombine correctly: model2(model1(X)) = model(X)."""
     model = create_simple_model()
     X = np.random.randn(5, 4).astype(np.float32)
-    
+
     # Original prediction
     original_output = model.predict(X, verbose=0)
-    
+
     # Split model at layer 1
     model1, model2 = split_keras_model(model, 1)
-    
+
     # Pass through both parts
     intermediate = model1.predict(X, verbose=0)
     recombined_output = model2.predict(intermediate, verbose=0)
-    
+
     # Should match original
     np.testing.assert_allclose(original_output, recombined_output, rtol=1e-5)
+
 
 def test_split_keras_model_with_layer_name():
     """Test split_keras_model using layer name instead of index."""
     model = create_simple_model()
     model1, model2 = split_keras_model(model, "dense1")
-    
+
     assert isinstance(model1, tf.keras.Model)
     assert isinstance(model2, tf.keras.Model)
     assert len(model1.layers) > 0
     assert len(model2.layers) > 0
+
 
 def test_clone_keras_layers_with_layer_object():
     """Test clone_keras_layers with layer objects instead of indices."""
     model = create_simple_model()
     layer1 = model.layers[1]
     layer2 = model.layers[-1]
-    
+
     cloned = clone_keras_layers(model, layer1, layer2)
     assert isinstance(cloned, tf.keras.Model)
+
 
 def test_split_keras_model_invalid_layer():
     """Test error handling for invalid layer index."""

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -1,41 +1,79 @@
 import pytest
+import numpy as np
 
 try:
     import tensorflow as tf
-
     from shap.utils._keras import clone_keras_layers, split_keras_model
-
     TF_AVAILABLE = True
 except ImportError:
     TF_AVAILABLE = False
 
 pytestmark = pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not installed")
 
-
 def create_simple_model():
-    return tf.keras.Sequential(
-        [tf.keras.layers.Input(shape=(4,)), tf.keras.layers.Dense(8, activation="relu"), tf.keras.layers.Dense(2)]
-    )
+    """Create a Keras model with known weights for reproducible testing."""
+    model = tf.keras.Sequential([
+        tf.keras.layers.Input(shape=(4,)),
+        tf.keras.layers.Dense(8, activation="relu", name="dense1"),
+        tf.keras.layers.Dense(2, name="output")
+    ])
+    model.build((None, 4))
+    return model
 
-
-def test_clone_keras_layers_basic():
+def test_clone_keras_layers_output_correctness():
+    """Test that cloned layers produce correct output matching original."""
     model = create_simple_model()
-    new_model = clone_keras_layers(model, 0, len(model.layers) - 1)
+    X = np.random.randn(5, 4).astype(np.float32)
+    
+    # Get predictions from full model
+    full_output = model.predict(X, verbose=0)
+    
+    # Clone layers and test
+    cloned = clone_keras_layers(model, 1, len(model.layers) - 1)
+    cloned_output = cloned.predict(X, verbose=0)
+    
+    # Outputs should be identical
+    np.testing.assert_allclose(full_output, cloned_output, rtol=1e-5)
 
-    assert new_model is not None
-    assert isinstance(new_model, tf.keras.Model)
-
-
-def test_split_keras_model_basic():
+def test_split_keras_model_composition():
+    """Test that split models recombine correctly: model2(model1(X)) = model(X)."""
     model = create_simple_model()
+    X = np.random.randn(5, 4).astype(np.float32)
+    
+    # Original prediction
+    original_output = model.predict(X, verbose=0)
+    
+    # Split model at layer 1
     model1, model2 = split_keras_model(model, 1)
+    
+    # Pass through both parts
+    intermediate = model1.predict(X, verbose=0)
+    recombined_output = model2.predict(intermediate, verbose=0)
+    
+    # Should match original
+    np.testing.assert_allclose(original_output, recombined_output, rtol=1e-5)
 
+def test_split_keras_model_with_layer_name():
+    """Test split_keras_model using layer name instead of index."""
+    model = create_simple_model()
+    model1, model2 = split_keras_model(model, "dense1")
+    
     assert isinstance(model1, tf.keras.Model)
     assert isinstance(model2, tf.keras.Model)
+    assert len(model1.layers) > 0
+    assert len(model2.layers) > 0
 
+def test_clone_keras_layers_with_layer_object():
+    """Test clone_keras_layers with layer objects instead of indices."""
+    model = create_simple_model()
+    layer1 = model.layers[1]
+    layer2 = model.layers[-1]
+    
+    cloned = clone_keras_layers(model, layer1, layer2)
+    assert isinstance(cloned, tf.keras.Model)
 
 def test_split_keras_model_invalid_layer():
+    """Test error handling for invalid layer index."""
     model = create_simple_model()
-
     with pytest.raises(Exception):
         split_keras_model(model, 100)

--- a/tests/utils/test_keras.py
+++ b/tests/utils/test_keras.py
@@ -3,7 +3,6 @@ import pytest
 
 try:
     import tensorflow as tf
-
     from shap.utils._keras import clone_keras_layers, split_keras_model
 
     TF_AVAILABLE = True


### PR DESCRIPTION
## Overview

Closes #4704

While reviewing `KerasWrap`, I noticed that feature scaling was applied during prediction but not during training.

---

## Description of the changes

* Applied `StandardScaler.transform()` in the `fit()` method
* Ensures consistent preprocessing between training and prediction

Previously, the model was trained on unscaled data but received scaled inputs during prediction, which could lead to inconsistent behavior.

---

## Notes

This is a small change that keeps training and inference aligned.
