### PR TITLE
Remove unused sklearn import in _models.py

### DIFF
--- a/shap/benchmark/models.py
+++ b/shap/benchmark/models.py
@@ -1,5 +1,4 @@
 import numpy as np
-import sklearn
 import sklearn.ensemble
 from sklearn.preprocessing import StandardScaler
 


### PR DESCRIPTION
## Overview

Closes #4706

---

## Description

Removed an unused import of `sklearn` from `_models.py`.

The file already imports specific submodules (e.g., `sklearn.ensemble`), so the top-level import was redundant.

---

## Notes

This is a small cleanup to improve code clarity.
