### PR TITLE
FIX (Calculation): rsub silently returns incorrect values due to wrong operand order

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -491,7 +491,7 @@ class Explanation(metaclass=MetaExplanation):
         return self._apply_binary_operator(other, operator.sub, "__sub__")
 
     def __rsub__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:  # type: ignore[misc]
-        # other - self; __sub__ and __rsub__ were identical before — subtraction is not commutative so operands must be swapped
+        # other - self; __sub__ and __rsub__ were identical before and subtraction is not commutative so operands must be swapped
         return self._apply_binary_operator(other, lambda a, b: b - a, "__rsub__")
 
     def __mul__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -487,10 +487,12 @@ class Explanation(metaclass=MetaExplanation):
         return self._apply_binary_operator(other, operator.add, "__add__")
 
     def __sub__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:
+        # self - other
         return self._apply_binary_operator(other, operator.sub, "__sub__")
 
     def __rsub__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:  # type: ignore[misc]
-        return self._apply_binary_operator(other, operator.sub, "__sub__")
+        # other - self; __sub__ and __rsub__ were identical before — subtraction is not commutative so operands must be swapped
+        return self._apply_binary_operator(other, lambda a, b: b - a, "__rsub__")
 
     def __mul__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:
         return self._apply_binary_operator(other, operator.mul, "__mul__")


### PR DESCRIPTION
## Overview

Closes #4709

While computing residuals to measure how far each feature's SHAP contribution deviates from a reference value, I noticed that `value - explanation` returns the same result as `explanation - value`, which is wrong. The root cause is that `__rsub__` was identical to `__sub__`, so `value - explanation` always silently computed `explanation - value` instead.

**Screenshot (bug confirmed):**

<img width="704" height="388" alt="image" src="https://github.com/user-attachments/assets/5d833e60-6c39-4750-9c3b-50f41543c7fa" />

---
Fixed by swapping the operands in `__rsub__` so it correctly computes `other - self`. Also added short comments on both methods to make the operand order explicit.

## Checklist

- [x] All pre-commit checks pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)