### PR TITLE
Remove redundant X.shape in human__decision_treeFix remove xshape

### DIFF
--- a/shap/benchmark/models.py
+++ b/shap/benchmark/models.py
@@ -203,7 +203,6 @@ def human__decision_tree():
     N = 1000000
     M = 3
     X = np.zeros((N, M))
-    X.shape
     y = np.zeros(N)
     X[0, 0] = 1
     y[0] = 8


### PR DESCRIPTION
## Overview

Closes #4713

---

## Description

Removed a redundant `X.shape` statement from `human__decision_tree()` in `_models.py`.

This line had no effect and appeared to be leftover debug code.

---

## Notes

This is a small cleanup to improve code readability.
