### PR TITLE
TST: increase test coverage for shap/plots/_waterfall.py

### DIFF
--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -118,3 +118,102 @@ def test_waterfall_plot_for_data_with_number_columns():
     explainer = shap.Explainer(f, med)
     shap_values = explainer(X)
     shap.plots.waterfall(shap_values[0], show=False)
+
+
+def _make_explanation(n_features=5, seed=0):
+    """Helper to build a simple Explanation object for waterfall tests."""
+    rng = np.random.default_rng(seed)
+    values = rng.standard_normal(n_features)
+    data = rng.standard_normal(n_features)
+    feature_names = [f"feature_{i}" for i in range(n_features)]
+    return shap.Explanation(
+        values=values,
+        base_values=0.5,
+        data=data,
+        feature_names=feature_names,
+    )
+
+
+def test_waterfall_max_display_triggers_grouping():
+    """When max_display < n_features, remaining features are grouped into one bar."""
+    exp = _make_explanation(n_features=10)
+    shap.plots.waterfall(exp, max_display=4, show=False)
+    plt.close()
+
+
+def test_waterfall_no_feature_names():
+    """Fallback feature names (Feature 0, Feature 1, ...) are used when feature_names is None."""
+    exp = shap.Explanation(
+        values=np.array([0.3, -0.2, 0.1]),
+        base_values=0.0,
+        data=np.array([1.0, 2.0, 3.0]),
+        feature_names=None,
+    )
+    shap.plots.waterfall(exp, show=False)
+    plt.close()
+
+
+def test_waterfall_features_none():
+    """waterfall works when data is None (only feature names are shown)."""
+    exp = shap.Explanation(
+        values=np.array([0.4, -0.1, 0.2]),
+        base_values=0.0,
+        data=None,
+        feature_names=["a", "b", "c"],
+    )
+    shap.plots.waterfall(exp, show=False)
+    plt.close()
+
+
+def test_waterfall_pandas_series_features():
+    """Features passed as a pandas Series should be unwrapped correctly."""
+    features = pd.Series([1.5, 2.5, 3.5], index=["x", "y", "z"])
+    exp = shap.Explanation(
+        values=np.array([0.3, -0.2, 0.1]),
+        base_values=0.0,
+        data=features,
+    )
+    shap.plots.waterfall(exp, show=False)
+    plt.close()
+
+
+def test_waterfall_legacy_multi_output_expected_value_raises():
+    """waterfall_legacy raises when expected_value is an array (multi-output)."""
+    shap_values = np.array([0.1, -0.2, 0.3])
+    with pytest.raises(Exception, match="scalar expected_value"):
+        shap.plots._waterfall.waterfall_legacy(np.array([0.5, 0.6]), shap_values, show=False)
+
+
+def test_waterfall_legacy_2d_shap_values_raises():
+    """waterfall_legacy raises when shap_values is 2D."""
+    shap_values = np.array([[0.1, -0.2, 0.3], [0.4, 0.5, -0.1]])
+    with pytest.raises(Exception, match="single explanation"):
+        shap.plots._waterfall.waterfall_legacy(0.5, shap_values, show=False)
+
+
+def test_waterfall_legacy_no_feature_names():
+    """waterfall_legacy uses default feature names when feature_names is None."""
+    shap_values = np.array([0.3, -0.1, 0.2])
+    shap.plots._waterfall.waterfall_legacy(
+        0.5, shap_values, features=np.array([1.0, 2.0, 3.0]), feature_names=None, show=False
+    )
+    plt.close()
+
+
+def test_waterfall_legacy_max_display_triggers_grouping():
+    """waterfall_legacy groups remaining features when max_display < n_features."""
+    shap_values = np.random.default_rng(0).standard_normal(10)
+    features = np.random.default_rng(1).standard_normal(10)
+    feature_names = [f"f{i}" for i in range(10)]
+    shap.plots._waterfall.waterfall_legacy(
+        0.5, shap_values, features=features, feature_names=feature_names, max_display=4, show=False
+    )
+    plt.close()
+
+
+def test_waterfall_legacy_pandas_series_features():
+    """waterfall_legacy unwraps pandas Series features correctly."""
+    shap_values = np.array([0.3, -0.2, 0.1])
+    features = pd.Series([1.5, 2.5, 3.5], index=["x", "y", "z"])
+    shap.plots._waterfall.waterfall_legacy(0.5, shap_values, features=features, show=False)
+    plt.close()


### PR DESCRIPTION
Related to #3690

## Summary
Adds 9 new tests for `shap/plots/_waterfall.py` to increase coverage of previously untested code paths:

- `max_display` parameter triggering grouped features display
- Fallback feature names when `feature_names=None`
- `data=None` path (only feature names shown)
- pandas `Series` features unwrapping
- `waterfall_legacy` error cases (multi-output expected_value, 2D shap_values)
- `waterfall_legacy` with `feature_names=None` fallback
- `waterfall_legacy` with `max_display` grouping
- `waterfall_legacy` with pandas `Series` features

Applying to ESoC 2026 for the shap project. Happy to iterate based on maintainer feedback!