### PR TITLE
test: increase coverage for shap/plots/_embedding.py from 19% to 94%

### DIFF
--- a/tests/plots/test_embedding.py
+++ b/tests/plots/test_embedding.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from shap.plots._embedding import embedding
+
+
+@pytest.fixture(autouse=True)
+def close_plots():
+    yield
+    plt.close("all")
+
+
+def test_embedding_pca_basic():
+    shap_values = np.random.randn(20, 5)
+    embedding(0, shap_values, show=False)
+
+
+def test_embedding_with_feature_names():
+    shap_values = np.random.randn(20, 5)
+    feature_names = ["f1", "f2", "f3", "f4", "f5"]
+    embedding(0, shap_values, feature_names=feature_names, show=False)
+
+
+def test_embedding_sum():
+    shap_values = np.random.randn(20, 5)
+    embedding("sum()", shap_values, show=False)
+
+
+def test_embedding_custom_array():
+    shap_values = np.random.randn(20, 5)
+    custom_embedding = np.random.randn(20, 2)
+    embedding(0, shap_values, method=custom_embedding, show=False)
+
+
+def test_embedding_alpha():
+    shap_values = np.random.randn(20, 5)
+    embedding(0, shap_values, alpha=0.5, show=False)

--- a/tests/plots/test_embedding.py
+++ b/tests/plots/test_embedding.py
@@ -1,8 +1,10 @@
+import matplotlib
 import numpy as np
 import pytest
-import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+
 from shap.plots._embedding import embedding
 
 


### PR DESCRIPTION
## Overview

Closes #3690

This PR increases test coverage for `shap/plots/_embedding.py` from 19% to 94% by adding a dedicated test file `tests/plots/test_embedding.py`.

Tests added cover:
- PCA-based embedding (default method)
- Custom feature names
- sum() as ind argument
- Custom 2D array as embedding method
- Custom alpha transparency

## Checklist

- [x] All pre-commit checks pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)