### PR TITLE
Add tests for shap.utils.image to improve coverage

### DIFF
--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,7 +1,9 @@
-import numpy as np
-import shap.utils.image as img
-import tempfile
 import os
+import tempfile
+
+import numpy as np
+
+import shap.utils.image as img
 
 
 def test_resize_image_behavior():
@@ -12,19 +14,18 @@ def test_resize_image_behavior():
 
     try:
         import cv2
+
         cv2.imwrite(path, dummy)
 
         result = img.resize_image(path, (5, 5))
 
-        
         assert isinstance(result, tuple)
 
         resized = result[0]
 
-        
         assert isinstance(resized, np.ndarray)
         assert resized.ndim == 3
-        assert resized.shape[2] == 3   # RGB channels
+        assert resized.shape[2] == 3  # RGB channels
 
     finally:
         os.remove(path)

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,0 +1,37 @@
+import numpy as np
+import shap.utils.image as img
+import tempfile
+import os
+
+
+def test_resize_image_behavior():
+    dummy = np.ones((10, 10, 3), dtype=np.uint8) * 255
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        path = tmp.name
+
+    try:
+        import cv2
+        cv2.imwrite(path, dummy)
+
+        result = img.resize_image(path, (5, 5))
+
+        
+        assert isinstance(result, tuple)
+
+        resized = result[0]
+
+        
+        assert isinstance(resized, np.ndarray)
+        assert resized.ndim == 3
+        assert resized.shape[2] == 3   # RGB channels
+
+    finally:
+        os.remove(path)
+
+
+def test_resize_image_invalid_path():
+    import pytest
+
+    with pytest.raises(Exception):
+        img.resize_image("invalid_path.png", (5, 5))


### PR DESCRIPTION
##Overview

Closes #3690

This PR adds unit tests for `shap.utils.image` to improve test coverage.

## Changes

- Added tests for `resize_image` behavior
- Verified return type and structure of output
- Added test for invalid image path handling
- Used `tempfile` for safe file creation and cleanup

## Notes

- No changes to existing functionality
- Only test cases have been added

## Checklist

- [x] All pre-commit checks pass
- [x] Unit tests added