### PR TITLE
FIX: don't pass fontsize kwarg to Axes.set_yticks in shap.plots.bar

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -274,7 +274,10 @@ def bar(
         )
 
     # draw the yticks (the 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks)
-    ax.set_yticks(list(y_pos) + list(y_pos + 1e-8), yticklabels + [t.split("=")[-1] for t in yticklabels], fontsize=13)
+    # NB: fontsize is applied separately via tick_params because set_yticks only
+    # accepts text-property kwargs on matplotlib >= 3.5 (see shap/shap#3673).
+    ax.set_yticks(list(y_pos) + list(y_pos + 1e-8), yticklabels + [t.split("=")[-1] for t in yticklabels])
+    ax.tick_params(axis="y", labelsize=13)
 
     xlen = ax.get_xlim()[1] - ax.get_xlim()[0]
     # xticks = ax.get_xticks()

--- a/tests/plots/test_bar.py
+++ b/tests/plots/test_bar.py
@@ -1,5 +1,8 @@
 """This file contains tests for the bar plot."""
 
+from unittest.mock import patch
+
+import matplotlib.axes
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -24,6 +27,34 @@ def test_input_shap_values_type(unsupported_inputs):
     )
     with pytest.raises(TypeError, match=emsg):
         shap.plots.bar(unsupported_inputs, show=False)
+
+
+def test_bar_does_not_pass_text_props_to_set_yticks(explainer):
+    """Regression test for https://github.com/shap/shap/issues/3673.
+
+    matplotlib < 3.5.0 does not accept text-property kwargs (e.g. ``fontsize``)
+    on ``Axes.set_yticks`` / ``set_ticks``. shap.plots.bar previously passed
+    ``fontsize=13`` directly, causing a TypeError on older matplotlib. This
+    test captures the actual kwargs handed to ``set_yticks`` and asserts no
+    text-property kwargs leak through.
+    """
+    shap_values = explainer(explainer.data)
+
+    captured_kwargs = []
+    real_set_yticks = matplotlib.axes.Axes.set_yticks
+
+    def capturing_set_yticks(self, *args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return real_set_yticks(self, *args, **kwargs)
+
+    with patch.object(matplotlib.axes.Axes, "set_yticks", capturing_set_yticks):
+        shap.plots.bar(shap_values, show=False)
+
+    text_props = {"fontsize", "color", "rotation", "size", "weight", "family", "fontfamily", "fontweight"}
+    offending = sorted({k for call in captured_kwargs for k in call} & text_props)
+    assert not offending, (
+        f"shap.plots.bar passed text-property kwargs to Axes.set_yticks, which breaks matplotlib < 3.5.0: {offending}"
+    )
 
 
 def test_input_shap_values_type_2():


### PR DESCRIPTION
## Summary

Closes #3673.
@CloseChoice @tylerjereddy 
`shap.plots.bar` fails with a `TypeError` on matplotlib < 3.5.0 because `Axes.set_ticks` / `set_yticks` didn't accept text-property kwargs before that version. matplotlib 3.5.0 (Nov 2021) added the `**kwargs` passthrough, which is why the bug only surfaces on older environments.

`matplotlib` has no minimum version pinned in `pyproject.toml` so users on old versions still hit this.

Split the font-size argument out into a separate `tick_params(axis="y", labelsize=13)` call. Zero behavioural change on matplotlib ≥ 3.5, fixes users on older matplotlib.

## Alternative considered

Pin `matplotlib >= 3.5.0` in `pyproject.toml`. mpl 3.5 is ~4 years old and well within the SPEC 0 drop-support window, so that's a reasonable follow-up — but it's a policy decision that affects more than this bug, so I kept this PR minimal. Happy to open a separate issue if maintainers want to bump the minimum.

## Tests

Added `test_bar_does_not_pass_text_props_to_set_yticks` in `tests/plots/test_bar.py`. It patches `matplotlib.axes.Axes.set_yticks` to capture the actual kwargs passed, runs `shap.plots.bar`, and asserts none of `{fontsize, color, rotation, size, weight, family, fontfamily, fontweight}` leaked through. This catches any future regression that re-introduces text props to `set_yticks` — even if the test environment has modern matplotlib.

## Local verification

- `ruff check` and `ruff format --check` clean on changed files.
- Full pytest not run locally (the C extension requires CMake which I don't have set up); relying on CI.
