### PR TITLE
ENH: ship a PEP 561 py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ wheel.packages = [
 ]
 
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["shap/_version.py"]
+sdist.include = ["shap/_version.py", "shap/py.typed"]
 sdist.exclude = ["docs/", "notebooks/"]
 
 # Protect the configuration against future changes in scikit-build-core


### PR DESCRIPTION
Closes #3860 (pending maintainer greenlight — see discussion on issue).

## Context

shap has a mature internal typing posture:

- `[tool.mypy]` configured in `pyproject.toml`
- type hints landed across `shap.models`, `shap.plots.scatter`, `shap.datasets` and the wider production surface (#3753, #3811, #3812, #3815, #4217)
- `typing-extensions` was cleaned up when confirmed unused (#4629)

Without a PEP 561 `py.typed` marker, downstream users running mypy get none of that — every `shap.*` symbol is treated as `Any`.

## Changes

1. Added empty `shap/py.typed` marker
2. Added `"shap/py.typed"` to `sdist.include` in `pyproject.toml` so the marker ships in both wheels and sdists under scikit-build-core's packaging rules

No code changes, no runtime behaviour changes. Strictly additive for downstream type-checker users; invisible to everyone else.

## Verification

Build artifacts need verifying by a maintainer (I don't have CMake set up locally to run `python -m build`). Expected: `unzip -l dist/shap-*.whl | grep py.typed` should show the file.

## Re maintainer hesitation in the original issue

The library-adoption landscape has shifted since Sept 2024 — numpy and xgboost ship it, many others (matplotlib, pandas) now do too. shap's typing work is already exercised via mypy in CI, so exposing it is lower-risk than shipping experimental stubs like the scipy-stubs case.

Happy to hold this open pending any maintainer consultation you'd like to run per @CloseChoice's earlier question in the issue thread.
