### PR TITLE
ENH: add abs_correlation metric to shap.utils.hclust

### DIFF
--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -243,13 +243,19 @@ def hclust(
         Defines the method to calculate the distance between clusters. Must be
         one of "single", "complete" or "average".
     metric: str
-        Scipy distance metric or "xgboost_distances_r2".
+        Scipy distance metric, ``"abs_correlation"``, or ``"xgboost_distances_r2"``.
 
         * If ``xgboost_distances_r2``, estimate redundancy distances between
           features X with respect to target variable y using
           :func:`shap.utils.xgboost_distances_r2`.
+        * If ``abs_correlation``, use absolute-correlation distance
+          ``1 - |corr(u, v)|``, which clusters perfectly anti-correlated
+          features together. The standard ``"correlation"`` metric treats
+          perfectly anti-correlated features as maximally distant, which is
+          usually not what you want when the goal is to group redundant
+          features.
         * Otherwise, calculate distances between features using the given
-          distance metric.
+          scipy distance metric.
         * If ``auto`` (default), use ``xgboost_distances_r2`` if target variable
           is provided, or else ``cosine`` distance metric.
     random_state: int or np.random.RandomState
@@ -302,7 +308,15 @@ def hclust(
         bg_no_nan: npt.NDArray[Any] = X_arr.copy()
         for i in range(bg_no_nan.shape[1]):
             np.nan_to_num(bg_no_nan[:, i], nan=np.nanmean(bg_no_nan[:, i]), copy=False)
-        dist = scipy.spatial.distance.pdist(bg_no_nan.T + np.random.randn(*bg_no_nan.T.shape) * 1e-8, metric=metric)
+        X_jittered: npt.NDArray[Any] = bg_no_nan.T + np.random.randn(*bg_no_nan.T.shape) * 1e-8
+        if metric == "abs_correlation":
+            # pdist's "correlation" returns 1 - corr, so corr = 1 - d_corr and
+            # 1 - |corr| = 1 - |1 - d_corr|. Folding this way keeps perfectly
+            # anti-correlated features at distance 0.
+            corr_dist: npt.NDArray[Any] = scipy.spatial.distance.pdist(X_jittered, metric="correlation")
+            dist = 1 - np.abs(1 - corr_dist)
+        else:
+            dist = scipy.spatial.distance.pdist(X_jittered, metric=metric)
 
     # build linkage
     if linkage == "single":

--- a/tests/utils/test_clustering.py
+++ b/tests/utils/test_clustering.py
@@ -40,3 +40,49 @@ def test_hclust_errors_on_unknown_linkages():
     X = np.column_stack((np.arange(1, 10), np.arange(100, 1000, step=100)))
     with pytest.raises(ValueError, match=r"Unknown linkage type:"):
         hclust(X, linkage="random-string", random_state=0)  # type: ignore
+
+
+def test_hclust_abs_correlation_groups_anti_correlated_features():
+    """Regression test for https://github.com/shap/shap/issues/4134.
+
+    With ``metric="abs_correlation"``, a perfectly anti-correlated pair of
+    features clusters at near-zero distance — the same as a perfectly
+    correlated pair — because knowing one determines the other. The standard
+    ``"correlation"`` metric treats them as maximally distant (d = 2.0).
+    """
+    rs = np.random.RandomState(0)
+    n = 200
+    base = rs.randn(n)
+    # Features 0, 1, 2 are all mutually (anti-)correlated with magnitude ~1:
+    #   0 and 1 are (near) perfectly correlated,
+    #   2 is perfectly anti-correlated to 0 and 1.
+    # Feature 3 is independent noise.
+    X = np.column_stack([base, base + rs.randn(n) * 1e-6, -base, rs.randn(n)])
+
+    np.random.seed(0)
+    clustered_abs = hclust(X, metric="abs_correlation")
+    np.random.seed(0)
+    clustered_corr = hclust(X, metric="correlation")
+
+    # Column 2 of the linkage matrix is the cluster merge distance.
+    # Under abs_correlation, features {0, 1, 2} form a tight cluster: both
+    # of the first two merges should happen at distance ~0.
+    first_two_abs = clustered_abs[:2, 2]
+    assert np.all(first_two_abs < 0.05), (
+        f"abs_correlation: expected the first two merges at distance ~0 "
+        f"(three mutually (anti-)correlated features should cluster tightly). "
+        f"Got {first_two_abs}."
+    )
+
+    # Under plain correlation, only feature 1 merges tightly with feature 0;
+    # feature 2 sits at distance ~2 and cannot merge until far later.
+    first_two_corr = clustered_corr[:2, 2]
+    assert first_two_corr[0] < 0.05, (
+        f"correlation: first merge should be at distance ~0 (features 0, 1 "
+        f"are near-identical). Got {first_two_corr[0]}."
+    )
+    assert first_two_corr[1] > 0.5, (
+        f"correlation: second merge should be far — the anti-correlated feature "
+        f"is treated as maximally distant. Got {first_two_corr[1]}. If this fails, "
+        f"the premise of the abs_correlation test is undermined."
+    )


### PR DESCRIPTION
Closes #4134.

## Context

`shap.utils.hclust` currently passes its `metric` arg straight to `scipy.spatial.distance.pdist`. scipy's `"correlation"` metric is `1 - corr`, so perfectly anti-correlated features (corr = -1) get distance 2.0 — maximally far. That's usually the opposite of the intent when clustering to identify **redundant** features: an anti-correlated pair is just as redundant as a correlated one (knowing one determines the other).

## Change

Add `"abs_correlation"` as an accepted value for the `metric` argument. It computes scipy's correlation distance, then folds:

```
d_abs = 1 - |1 - d_corr|   # equivalent to 1 - |corr|
```

so:

| corr | d_correlation | d_abs_correlation |
|---|---|---|
| +1 | 0 | 0 |
| -1 | 2 | 0 |
|  0 | 1 | 1 |

Also refactored the jittered-matrix creation out of the `pdist` call so the new and existing branches share one random perturbation instead of drawing twice.

## Tests

`test_hclust_abs_correlation_groups_anti_correlated_features` in `tests/utils/test_clustering.py`:

- builds four features: two near-identical, one perfectly anti-correlated to those, one independent noise
- asserts that under `abs_correlation` the first two merges both have distance ≈ 0 (all three (anti-)correlated features cluster tightly)
- verifies the premise by confirming plain `correlation` merges the near-identical pair but leaves the anti-correlated feature at large distance

Verified the distance math numerically before writing the test:
```
correlation:      [0.0,  2.0, 0.94, 2.0, 0.94, 0.94]
abs_correlation:  [0.0,  0.0, 0.94, 0.0, 0.94, 0.94]
```

## Local verification

- `ruff check` + `ruff format --check` clean.
- Full pytest not run locally (C extension requires CMake); relying on CI.
