### PR TITLE
ENH: convert relative imports to absolute within shap package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,7 @@ select = [
   "SIM101",  # flake8-simplify
   "FA",  # future annotations
   "TCH",  # Move type only imports to type-checking condition.
+  "TID252",  # flake8-tidy-imports: disallow relative imports within the package
   # D417  # undocumented parameter. FIXME: get this passing
 ]
 ignore = [

--- a/shap/actions/_optimizer.py
+++ b/shap/actions/_optimizer.py
@@ -4,7 +4,8 @@ import copy
 import queue
 import warnings
 
-from ..utils._exceptions import ConvergenceError, InvalidAction
+from shap.utils._exceptions import ConvergenceError, InvalidAction
+
 from ._action import Action
 
 

--- a/shap/benchmark/experiments.py
+++ b/shap/benchmark/experiments.py
@@ -8,7 +8,8 @@ import sys
 import time
 from multiprocessing import Pool
 
-from .. import __version__, datasets
+from shap import __version__, datasets
+
 from . import metrics, models
 
 try:

--- a/shap/benchmark/methods.py
+++ b/shap/benchmark/methods.py
@@ -1,7 +1,7 @@
 import numpy as np
 import sklearn
 
-from .. import (
+from shap import (
     DeepExplainer,
     GradientExplainer,
     KernelExplainer,
@@ -10,7 +10,8 @@ from .. import (
     TreeExplainer,
     kmeans,
 )
-from ..explainers import other
+from shap.explainers import other
+
 from .models import KerasWrap
 
 

--- a/shap/benchmark/metrics.py
+++ b/shap/benchmark/metrics.py
@@ -5,7 +5,8 @@ import time
 import numpy as np
 import sklearn
 
-from .. import __version__
+from shap import __version__
+
 from . import measures, methods
 
 try:

--- a/shap/benchmark/plots.py
+++ b/shap/benchmark/plots.py
@@ -6,8 +6,9 @@ import numpy as np
 import sklearn
 from matplotlib.colors import LinearSegmentedColormap
 
-from .. import __version__
-from ..plots import colors
+from shap import __version__
+from shap.plots import colors
+
 from . import methods, metrics, models
 from .experiments import run_experiments
 

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -3,7 +3,8 @@ from typing import Any, Literal
 import numpy as np
 import numpy.typing as npt
 
-from ..utils import MaskedModel, safe_isinstance
+from shap.utils import MaskedModel, safe_isinstance
+
 from ._explainer import Explainer
 
 

--- a/shap/explainers/_coalition.py
+++ b/shap/explainers/_coalition.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np  # numpy base
 import numpy.typing as npt
 
-from .. import links  # shap modules
-from ..explainers._explainer import Explainer
-from ..models import Model
-from ..utils import MaskedModel, make_masks, safe_isinstance
+from shap import links  # shap modules
+from shap.explainers._explainer import Explainer
+from shap.models import Model
+from shap.utils import MaskedModel, make_masks, safe_isinstance
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from ..._explanation import Explanation
-from .._explainer import Explainer
+from shap._explanation import Explanation
+from shap.explainers._explainer import Explainer
 
 
 class DeepExplainer(Explainer):

--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -3,7 +3,8 @@ import warnings
 import numpy as np
 from packaging import version
 
-from .._explainer import Explainer
+from shap.explainers._explainer import Explainer
+
 from .deep_utils import _check_additivity
 
 

--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -13,9 +13,10 @@ from tensorflow.python.ops import (
     gradients_impl as tf_gradients_impl,
 )
 
-from ...utils._exceptions import DimensionError
-from .._explainer import Explainer
-from ..tf_utils import _get_graph, _get_model_inputs, _get_model_output, _get_session
+from shap.explainers._explainer import Explainer
+from shap.explainers.tf_utils import _get_graph, _get_model_inputs, _get_model_output, _get_session
+from shap.utils._exceptions import DimensionError
+
 from .deep_utils import _check_additivity
 
 if not hasattr(tf_gradients_impl, "_IsBackpropagatable"):

--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -7,15 +7,11 @@ import numpy as np
 import numpy.typing as npt
 from numba import njit  # type: ignore[attr-defined]
 
-from .. import links
-from .._cutils import compute_grey_code_row_values
-from ..models import Model
-from ..utils import (
-    MaskedModel,
-    delta_minimization_order,
-    make_masks,
-    shapley_coefficients,
-)
+from shap import links
+from shap._cutils import compute_grey_code_row_values
+from shap.models import Model
+from shap.utils import MaskedModel, delta_minimization_order, make_masks, shapley_coefficients
+
 from ._explainer import Explainer
 
 log = logging.getLogger("shap")

--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -8,12 +8,12 @@ import numpy as np
 import pandas as pd
 import scipy.sparse
 
-from .. import explainers, links, maskers, models
-from .._explanation import Explanation
-from .._serializable import Deserializer, Serializable, Serializer
-from ..utils import safe_isinstance, show_progress
-from ..utils._exceptions import InvalidAlgorithmError
-from ..utils.transformers import is_transformers_lm
+from shap import explainers, links, maskers, models
+from shap._explanation import Explanation
+from shap._serializable import Deserializer, Serializable, Serializer
+from shap.utils import safe_isinstance, show_progress
+from shap.utils._exceptions import InvalidAlgorithmError
+from shap.utils.transformers import is_transformers_lm
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 
-from ..utils import assert_import, record_import_error
+from shap.utils import assert_import, record_import_error
+
 from ._tree import (
     TreeExplainer,
     _xgboost_cat_unsupported,
@@ -11,7 +12,7 @@ from ._tree import (
 )
 
 try:
-    from .. import _cext_gpu  # type: ignore
+    from shap import _cext_gpu  # type: ignore
 except ImportError as e:
     record_import_error("cext_gpu", "cuda extension was not built during install!", e)
 

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -6,14 +6,9 @@ import numpy.typing as npt
 import pandas as pd
 from packaging import version
 
-from .._explanation import Explanation
-from ..explainers._explainer import Explainer
-from ..explainers.tf_utils import (
-    _get_graph,
-    _get_model_inputs,
-    _get_model_output,
-    _get_session,
-)
+from shap._explanation import Explanation
+from shap.explainers._explainer import Explainer
+from shap.explainers.tf_utils import _get_graph, _get_model_inputs, _get_model_output, _get_session
 
 keras = None
 tf = None

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -18,11 +18,11 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from tqdm.auto import tqdm
 
-from .._cutils import compute_exp_val
-from .._explanation import Explanation
-from ..utils import safe_isinstance
-from ..utils._exceptions import DimensionError
-from ..utils._legacy import (
+from shap._cutils import compute_exp_val
+from shap._explanation import Explanation
+from shap.utils import safe_isinstance
+from shap.utils._exceptions import DimensionError
+from shap.utils._legacy import (
     DenseData,
     SparseData,
     convert_to_data,
@@ -33,6 +33,7 @@ from ..utils._legacy import (
     match_instance_to_data,
     match_model_to_data,
 )
+
 from ._explainer import Explainer
 
 log = logging.getLogger("shap")

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -8,12 +8,9 @@ import pandas as pd
 from scipy.sparse import issparse
 from tqdm.auto import tqdm
 
-from .. import links, maskers
-from ..utils._exceptions import (
-    DimensionError,
-    InvalidFeaturePerturbationError,
-    InvalidModelError,
-)
+from shap import links, maskers
+from shap.utils._exceptions import DimensionError, InvalidFeaturePerturbationError, InvalidModelError
+
 from ._explainer import Explainer
 
 

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -8,9 +8,10 @@ import numpy.typing as npt
 from numba import njit  # type: ignore[attr-defined]
 from tqdm.auto import tqdm
 
-from .. import Explanation, links
-from ..models import Model
-from ..utils import MaskedModel, OpChain, make_masks, safe_isinstance
+from shap import Explanation, links
+from shap.models import Model
+from shap.utils import MaskedModel, OpChain, make_masks, safe_isinstance
+
 from ._explainer import Explainer
 
 

--- a/shap/explainers/_permutation.py
+++ b/shap/explainers/_permutation.py
@@ -4,13 +4,14 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from .. import links
-from ..models import Model
-from ..utils import MaskedModel, partition_tree_shuffle
+from shap import links
+from shap.models import Model
+from shap.utils import MaskedModel, partition_tree_shuffle
+
 from ._explainer import Explainer
 
 if TYPE_CHECKING:
-    from .._explanation import Explanation
+    from shap._explanation import Explanation
 
 
 class PermutationExplainer(Explainer):

--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -5,9 +5,10 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-from .._explanation import Explanation
-from ..utils._exceptions import ExplainerError
-from ..utils._legacy import convert_to_instance, match_instance_to_data
+from shap._explanation import Explanation
+from shap.utils._exceptions import ExplainerError
+from shap.utils._legacy import convert_to_instance, match_instance_to_data
+
 from ._kernel import KernelExplainer
 
 log = logging.getLogger("shap")

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -15,23 +15,24 @@ import scipy.sparse
 import scipy.special
 from packaging import version
 
-from .. import maskers
-from .._explanation import Explanation
-from ..utils import assert_import, record_import_error, safe_isinstance
-from ..utils._exceptions import (
+from shap import maskers
+from shap._explanation import Explanation
+from shap.utils import assert_import, record_import_error, safe_isinstance
+from shap.utils._exceptions import (
     DimensionError,
     ExplainerError,
     InvalidFeaturePerturbationError,
     InvalidMaskerError,
     InvalidModelError,
 )
-from ..utils._legacy import DenseData
-from ..utils._warnings import ExperimentalWarning
+from shap.utils._legacy import DenseData
+from shap.utils._warnings import ExperimentalWarning
+
 from ._explainer import Explainer
 from .other._ubjson import decode_ubjson_buffer
 
 try:
-    from .. import _cext  # type: ignore
+    from shap import _cext  # type: ignore
 except ImportError as e:
     record_import_error("cext", "C extension was not built during install!", e)
 

--- a/shap/explainers/other/_coefficient.py
+++ b/shap/explainers/other/_coefficient.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .._explainer import Explainer
+from shap.explainers._explainer import Explainer
 
 
 class Coefficient(Explainer):

--- a/shap/explainers/other/_lime.py
+++ b/shap/explainers/other/_lime.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from .._explainer import Explainer
+from shap.explainers._explainer import Explainer
 
 try:
     import lime

--- a/shap/explainers/other/_random.py
+++ b/shap/explainers/other/_random.py
@@ -1,10 +1,9 @@
 import numpy as np
 
 from shap import links
+from shap.explainers._explainer import Explainer
 from shap.models import Model
 from shap.utils import MaskedModel
-
-from .._explainer import Explainer
 
 
 class Random(Explainer):

--- a/shap/explainers/other/_treegain.py
+++ b/shap/explainers/other/_treegain.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .._explainer import Explainer
+from shap.explainers._explainer import Explainer
 
 
 class TreeGain(Explainer):

--- a/shap/explainers/pytree.py
+++ b/shap/explainers/pytree.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 # import numba
-from ..utils._exceptions import ExplainerError
+from shap.utils._exceptions import ExplainerError
 
 # class TreeExplainer(Explainer):
 #     def __init__(self, model, **kwargs):

--- a/shap/maskers/_composite.py
+++ b/shap/maskers/_composite.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import types
 from typing import Any
 
-from ..utils._exceptions import InvalidMaskerError
+from shap.utils._exceptions import InvalidMaskerError
+
 from ._masker import Masker
 
 

--- a/shap/maskers/_fixed_composite.py
+++ b/shap/maskers/_fixed_composite.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from .._serializable import Deserializer, Serializer
+from shap._serializable import Deserializer, Serializer
+
 from ._masker import Masker
 
 

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -5,9 +5,10 @@ import numba.typed
 import numpy as np
 from numba import njit
 
-from .._serializable import Deserializer, Serializer
-from ..utils import assert_import, record_import_error, safe_isinstance
-from ..utils._exceptions import DimensionError
+from shap._serializable import Deserializer, Serializer
+from shap.utils import assert_import, record_import_error, safe_isinstance
+from shap.utils._exceptions import DimensionError
+
 from ._masker import Masker
 
 try:

--- a/shap/maskers/_masker.py
+++ b/shap/maskers/_masker.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 
-from .._serializable import Serializable
+from shap._serializable import Serializable
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/shap/maskers/_output_composite.py
+++ b/shap/maskers/_output_composite.py
@@ -1,4 +1,5 @@
-from .._serializable import Deserializer, Serializer
+from shap._serializable import Deserializer, Serializer
+
 from ._masker import Masker
 
 

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -4,10 +4,11 @@ import numpy as np
 import pandas as pd
 from numba import njit
 
-from .. import utils
-from .._serializable import Deserializer, Serializer
-from ..utils import MaskedModel
-from ..utils._exceptions import DimensionError, InvalidClusteringError
+from shap import utils
+from shap._serializable import Deserializer, Serializer
+from shap.utils import MaskedModel
+from shap.utils._exceptions import DimensionError, InvalidClusteringError
+
 from ._masker import Masker
 
 log = logging.getLogger("shap")

--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -3,13 +3,10 @@ import re
 
 import numpy as np
 
-from .._serializable import Deserializer, Serializer
-from ..utils import safe_isinstance
-from ..utils.transformers import (
-    SENTENCEPIECE_TOKENIZERS,
-    getattr_silent,
-    parse_prefix_suffix_for_tokenizer,
-)
+from shap._serializable import Deserializer, Serializer
+from shap.utils import safe_isinstance
+from shap.utils.transformers import SENTENCEPIECE_TOKENIZERS, getattr_silent, parse_prefix_suffix_for_tokenizer
+
 from ._masker import Masker
 
 

--- a/shap/models/_model.py
+++ b/shap/models/_model.py
@@ -5,8 +5,8 @@ from typing import Any, BinaryIO, Literal, overload
 import numpy as np
 import numpy.typing as npt
 
-from .._serializable import Deserializer, Serializable, Serializer
-from ..utils import safe_isinstance
+from shap._serializable import Deserializer, Serializable, Serializer
+from shap.utils import safe_isinstance
 
 
 class Model(Serializable):

--- a/shap/models/_teacher_forcing.py
+++ b/shap/models/_teacher_forcing.py
@@ -6,10 +6,11 @@ from typing import Any
 import numpy as np
 import scipy.special
 
-from .. import models
-from .._serializable import Deserializer, Serializer
-from ..utils import safe_isinstance
-from ..utils.transformers import getattr_silent, parse_prefix_suffix_for_tokenizer
+from shap import models
+from shap._serializable import Deserializer, Serializer
+from shap.utils import safe_isinstance
+from shap.utils.transformers import getattr_silent, parse_prefix_suffix_for_tokenizer
+
 from ._model import Model
 
 

--- a/shap/models/_text_generation.py
+++ b/shap/models/_text_generation.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import numpy as np
 
-from .._serializable import Deserializer, Serializer
-from ..utils import safe_isinstance
+from shap._serializable import Deserializer, Serializer
+from shap.utils import safe_isinstance
+
 from ._model import Model
 
 

--- a/shap/models/_topk_lm.py
+++ b/shap/models/_topk_lm.py
@@ -1,9 +1,10 @@
 import numpy as np
 import scipy.special
 
-from .._serializable import Deserializer, Serializer
-from ..utils import safe_isinstance
-from ..utils.transformers import getattr_silent
+from shap._serializable import Deserializer, Serializer
+from shap.utils import safe_isinstance
+from shap.utils.transformers import getattr_silent
+
 from ._model import Model
 
 

--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -6,15 +6,16 @@ import numpy as np
 import pandas as pd
 import scipy
 
-from .. import Cohorts, Explanation
-from ..utils import format_value, ordinal_str
-from ..utils._exceptions import DimensionError
+from shap import Cohorts, Explanation
+from shap.utils import format_value, ordinal_str
+from shap.utils._exceptions import DimensionError
+
 from ._labels import labels
 from ._style import get_style
 from ._utils import convert_ordering, dendrogram_coords, get_sort_order, merge_nodes, sort_inds
 
 if TYPE_CHECKING:
-    from .._explanation import OpHistoryItem
+    from shap._explanation import OpHistoryItem
 
 
 # TODO: improve the bar chart to look better like the waterfall plot with numbers inside the bars when they fit

--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -16,9 +16,10 @@ from matplotlib.figure import Figure
 from packaging import version
 from scipy.stats import gaussian_kde
 
-from .. import Explanation
-from ..utils import safe_isinstance
-from ..utils._exceptions import DimensionError
+from shap import Explanation
+from shap.utils import safe_isinstance
+from shap.utils._exceptions import DimensionError
+
 from . import colors
 from ._labels import labels
 from ._utils import (

--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -7,8 +7,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from ..utils import hclust_ordering
-from ..utils._legacy import LogitLink, convert_to_link
+from shap.utils import hclust_ordering
+from shap.utils._legacy import LogitLink, convert_to_link
+
 from . import colors
 from ._labels import labels
 

--- a/shap/plots/_embedding.py
+++ b/shap/plots/_embedding.py
@@ -1,7 +1,8 @@
 import matplotlib.pyplot as plt
 import sklearn
 
-from ..utils import convert_name
+from shap.utils import convert_name
+
 from . import colors
 from ._labels import labels
 

--- a/shap/plots/_force.py
+++ b/shap/plots/_force.py
@@ -20,10 +20,11 @@ try:
 except ImportError:
     have_ipython = False
 
-from ..plots._force_matplotlib import draw_additive_plot
-from ..utils import hclust_ordering
-from ..utils._exceptions import DimensionError
-from ..utils._legacy import Data, DenseData, Instance, Link, Model, convert_to_link
+from shap.plots._force_matplotlib import draw_additive_plot
+from shap.utils import hclust_ordering
+from shap.utils._exceptions import DimensionError
+from shap.utils._legacy import Data, DenseData, Instance, Link, Model, convert_to_link
+
 from ._labels import labels
 
 

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -1,8 +1,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .. import Explanation
-from ..utils import OpChain
+from shap import Explanation
+from shap.utils import OpChain
+
 from . import colors
 from ._labels import labels
 from ._utils import convert_ordering

--- a/shap/plots/_image.py
+++ b/shap/plots/_image.py
@@ -15,9 +15,10 @@ try:
 except ImportError:
     have_ipython = False
 
-from .._explanation import Explanation
-from ..utils import ordinal_str
-from ..utils._legacy import kmeans
+from shap._explanation import Explanation
+from shap.utils import ordinal_str
+from shap.utils._legacy import kmeans
+
 from . import colors
 
 if TYPE_CHECKING:

--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -4,9 +4,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from .. import Explanation
-from ..plots.colors import blue_rgb, light_blue_rgb, red_blue_transparent, red_rgb
-from ..utils import convert_name
+from shap import Explanation
+from shap.plots.colors import blue_rgb, light_blue_rgb, red_blue_transparent, red_rgb
+from shap.utils import convert_name
 
 
 def compute_bounds(xmin, xmax, xv):

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -10,10 +10,11 @@ import numpy as np
 import pandas as pd
 from matplotlib.markers import MarkerStyle
 
-from .._explanation import Explanation
-from ..utils import approximate_interactions, convert_name
-from ..utils._exceptions import DimensionError
-from ..utils._general import encode_array_if_needed
+from shap._explanation import Explanation
+from shap.utils import approximate_interactions, convert_name
+from shap.utils._exceptions import DimensionError
+from shap.utils._general import encode_array_if_needed
+
 from . import colors
 from ._labels import labels
 from ._utils import AxisLimitSpec, parse_axis_limit

--- a/shap/plots/_style.py
+++ b/shap/plots/_style.py
@@ -11,7 +11,8 @@ from typing import TypedDict, Unpack
 
 import numpy as np
 
-from ..utils._exceptions import InvalidStyleOptionError
+from shap.utils._exceptions import InvalidStyleOptionError
+
 from . import colors
 
 # Type hints, adapted from matplotlib.typing

--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .. import Explanation
-from ..utils import OpChain
+from shap import Explanation
+from shap.utils import OpChain
+
 from . import colors
 
 if TYPE_CHECKING:

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -9,7 +9,8 @@ import pandas as pd
 from packaging import version
 from scipy.stats import gaussian_kde
 
-from ..utils._exceptions import DimensionError
+from shap.utils._exceptions import DimensionError
+
 from . import colors
 from ._labels import labels
 

--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -3,8 +3,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from .. import Explanation
-from ..utils import format_value
+from shap import Explanation
+from shap.utils import format_value
+
 from ._labels import labels
 from ._style import get_style
 

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -12,7 +12,8 @@ import scipy.spatial
 import sklearn
 from numba import njit
 
-from ..utils._exceptions import DimensionError
+from shap.utils._exceptions import DimensionError
+
 from ._show_progress import show_progress
 
 if TYPE_CHECKING:

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.sparse
 from numba import njit
 
-from .. import links
+from shap import links
 
 
 class MaskedModel:


### PR DESCRIPTION
Closes #4683.

@CloseChoice @tylerjereddy 
## Summary

Converts every relative import inside the `shap` package to its fully-qualified absolute form, and enables the `TID252` ruff rule so the change stays in place.

## Changes

- **51 files in `shap/`** — `from .x import y` / `from ..x import y` → `from shap.x import y`. 199 imports updated in total.
- **`pyproject.toml`** — added `"TID252"` to `[tool.ruff.lint.select]` (flake8-tidy-imports: disallow relative imports).
- No logic changes, no public API changes.

## Method

Conversion was done mechanically:

```
ruff check --select TID252 --fix --unsafe-fixes shap/
ruff format shap/
ruff check --fix .   # isort re-ordering after the rewrite
```

Followed by `ast.parse` across every file to confirm syntax correctness. Relies on CI for semantic verification since the C extension needs CMake locally.

## Rationale

Matches the case made in the issue: imports now make the source package explicit at every call site, removing ambiguity about which `shap.x` is being referenced; aligns with pandas / scikit-learn conventions and PEP 8; and via the new `TID252` rule the test suite now exclusively exercises the installed package rather than an accidental in-tree shadow.

## Follow-up considerations

- The diff is large but purely mechanical — no manual edits. Happy to split by subpackage if reviewers prefer smaller slices for easier review, though `git blame` ergonomics are better with a single commit.
- `from shap.x import y` inside `shap/__init__.py` imports from itself; Python handles this fine (the module object exists before its attributes are populated), but flagging in case you want to use the in-package `from .x import y` form specifically at the top of `__init__.py`. Currently the autofix kept it as absolute there too.
