### PR TITLE
Fix API section headings capitalization

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,7 +20,7 @@ Explanation
 
 .. _explainers_api:
 
-explainers
+Explainers
 ----------
 *See also:* :ref:`Explainer API Examples <explainers_examples>`.
 
@@ -49,7 +49,7 @@ explainers
 
 .. _plots_api:
 
-plots
+Plots
 -----
 *See also:* :ref:`Plot API Examples <plots_examples>`.
 
@@ -76,7 +76,7 @@ plots
 
 .. _maskers_api:
 
-maskers
+Maskers
 -------
 *See also:* :ref:`Masker API Examples <maskers_examples>`.
 
@@ -97,7 +97,7 @@ maskers
 
 .. _models_api:
 
-models
+Models
 ------
 .. autosummary::
     :toctree: generated/
@@ -111,7 +111,7 @@ models
 
 .. _utils_api:
 
-utils
+Utils
 -----
 .. autosummary::
     :toctree: generated/
@@ -134,7 +134,7 @@ utils
 
 .. _datasets_api:
 
-datasets
+Datasets
 --------
 .. autosummary::
     :toctree: generated/

--- a/docs/api_examples.rst
+++ b/docs/api_examples.rst
@@ -47,7 +47,7 @@ Models
 ======
 .. Examples for members of :ref:`shap.models <models_api>`.
 
-Overview of model-related classes available in SHAP.
+Work in progress.
 
 .. TODO: Uncomment this toctree once we have at least one example to share
     .. toctree::

--- a/docs/api_examples.rst
+++ b/docs/api_examples.rst
@@ -4,8 +4,7 @@
 
 API Examples
 ----------------
-
-These examples parallel the namespace structure of SHAP. Each object or function in SHAP has a
+These examples follow the namespace structure of SHAP. Each object or function in SHAP has a
 corresponding example notebook here that demonstrates its API usage. The source notebooks
 are `available on GitHub <https://github.com/shap/shap/tree/master/notebooks/api_examples>`_.
 
@@ -18,7 +17,7 @@ are `available on GitHub <https://github.com/shap/shap/tree/master/notebooks/api
 
 .. _explainers_examples:
 
-explainers
+Explainers
 ==========
 *See also:* :ref:`Explainer API Reference <explainers_api>`.
 
@@ -31,7 +30,7 @@ explainers
 
 .. _maskers_examples:
 
-maskers
+Maskers
 =======
 *See also:* :ref:`Masker API Reference <maskers_api>`.
 
@@ -44,11 +43,11 @@ maskers
 
 .. _models_examples:
 
-models
+Models
 ======
 .. Examples for members of :ref:`shap.models <models_api>`.
 
-Work in progress.
+Overview of model-related classes available in SHAP.
 
 .. TODO: Uncomment this toctree once we have at least one example to share
     .. toctree::
@@ -60,7 +59,7 @@ Work in progress.
 
 .. _plots_examples:
 
-plots
+Plots
 =====
 *See also:* :ref:`Plot API Reference <plots_api>`.
 


### PR DESCRIPTION
## Overview

Updated API section headings to use consistent capitalization for better readability.
