### PR TITLE
FIX: preserve categorical dtypes in shap.plots.partial_dependence

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -56,11 +56,18 @@ def partial_dependence(
     else:
         features = data
 
-    # convert from DataFrames if we got any
+    # convert from DataFrames if we got any. Keep a reference to the
+    # original DataFrame so we can reconstruct with the same per-column
+    # dtypes — see GH #3670: rebuilding via ``pd.DataFrame(arr, columns=...)``
+    # drops categorical dtypes, which causes XGBoost (and other frameworks
+    # that care about column types) to reject the prediction input when
+    # ``enable_categorical=True``.
     use_dataframe = False
+    features_df: pd.DataFrame | None = None
     if isinstance(features, pd.DataFrame):
         if feature_names is None:
             feature_names = features.columns
+        features_df = features
         features = features.values
         use_dataframe = True
 
@@ -81,7 +88,11 @@ def partial_dependence(
             for i in range(npoints):
                 features_tmp[:, ind] = xs[i]
                 if use_dataframe:
-                    ice_vals[i, :] = model(pd.DataFrame(features_tmp, columns=feature_names))
+                    # Preserve dtypes of non-target columns (GH #3670).
+                    assert features_df is not None
+                    df = features_df.copy()
+                    df.iloc[:, ind] = xs[i]
+                    ice_vals[i, :] = model(df)
                 else:
                     ice_vals[i, :] = model(features_tmp)
             # if linewidth is None:
@@ -94,7 +105,10 @@ def partial_dependence(
         for i in range(npoints):
             features_tmp[:, ind] = xs[i]
             if use_dataframe:
-                vals[i] = model(pd.DataFrame(features_tmp, columns=feature_names)).mean()
+                assert features_df is not None
+                df = features_df.copy()
+                df.iloc[:, ind] = xs[i]
+                vals[i] = model(df).mean()
             else:
                 vals[i] = model(features_tmp).mean()
 
@@ -159,7 +173,10 @@ def partial_dependence(
         if model_expected_value is not False or shap_values is not None:
             if model_expected_value is True:
                 if use_dataframe:
-                    model_expected_value = model(pd.DataFrame(features, columns=feature_names)).mean()
+                    # Use the original DataFrame directly; rebuilding from
+                    # ``features`` would drop categorical dtypes (GH #3670).
+                    assert features_df is not None
+                    model_expected_value = model(features_df).mean()
                 else:
                     model_expected_value = model(features).mean()
             else:

--- a/tests/plots/test_partial_dependence.py
+++ b/tests/plots/test_partial_dependence.py
@@ -1,0 +1,66 @@
+"""Tests for shap.plots._partial_dependence."""
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend for CI
+
+import numpy as np
+import pandas as pd
+
+import shap
+
+
+def test_partial_dependence_preserves_categorical_dtypes():
+    """Regression test for https://github.com/shap/shap/issues/3670.
+
+    ``shap.plots.partial_dependence`` previously reconstructed temporary
+    DataFrames as ``pd.DataFrame(arr, columns=...)``, which silently
+    promotes ``category`` columns to ``object`` dtype. That breaks any
+    model (notably XGBoost with ``enable_categorical=True``) that
+    validates column dtypes on the prediction call.
+
+    This test uses a stub predict function that asserts the DataFrame it
+    receives still has categorical dtypes where the original input did.
+    """
+    rs = np.random.RandomState(0)
+    n = 50
+    df = pd.DataFrame(
+        {
+            "numeric": rs.randn(n).astype("float64"),
+            "cat_small": pd.Categorical(rs.choice(["a", "b", "c"], size=n)),
+            "cat_bool": pd.Categorical(rs.choice([True, False], size=n)),
+        }
+    )
+
+    expected_dtypes = df.dtypes.to_dict()
+
+    seen_frames: list[pd.DataFrame] = []
+
+    def model(frame):
+        # The plot function is expected to hand us a DataFrame (because
+        # we passed one in). If it downgrades to ndarray the cast below
+        # will raise before we get to the dtype check.
+        assert isinstance(frame, pd.DataFrame), (
+            f"partial_dependence should keep the DataFrame input type; got {type(frame)}"
+        )
+        seen_frames.append(frame)
+        for col, expected in expected_dtypes.items():
+            if col == "numeric":
+                continue  # this is the column being varied
+            assert frame[col].dtype == expected, (
+                f"column {col!r} dtype changed from {expected} to {frame[col].dtype} (GH #3670)"
+            )
+        return np.full(len(frame), 0.5)
+
+    # hist=False avoids a matplotlib histogram path that isn't relevant here.
+    shap.plots.partial_dependence(
+        "numeric",
+        model,
+        df,
+        ice=False,
+        hist=False,
+        show=False,
+    )
+
+    # Sanity: the model was actually called (otherwise the test proves nothing).
+    assert seen_frames, "model callable was never invoked"


### PR DESCRIPTION
Closes #3670.

## Problem

When `shap.plots.partial_dependence` receives a pandas DataFrame, it captures `features = features.values` and then reconstructs a new DataFrame via `pd.DataFrame(features_tmp, columns=feature_names)` on every evaluation inside the ICE / PD loops. That round-trip silently promotes categorical (and boolean-categorical) columns to object dtype:

```python
>>> df.dtypes
numeric      float64
cat         category
cat_bool    category

>>> pd.DataFrame(df.values, columns=df.columns).dtypes
numeric     object
cat            str
cat_bool    object
```

XGBoost with `enable_categorical=True` then rejects the prediction input:

```
ValueError: DataFrame.dtypes for data must be int, float, bool or
category. When categorical type is supplied, The experimental DMatrix
parameter `enable_categorical` must be set to `True`.
```

The same lossy reconstruction also happens in the `model_expected_value=True` branch.

## Fix

Keep a reference to the original DataFrame when the caller passes one in. For each evaluation, copy the original and assign the scan value directly via `df.iloc[:, ind] = xs[i]`. Non-target columns retain their original dtypes, so models that validate column types on predict continue to work.

Scope is the 1D PDP path plus the `model_expected_value=True` branch — both sites had the same pattern. The 2D path is unchanged (it was already using the ndarray all the way down and doesn't go through a model callable).

## Test

New `tests/plots/test_partial_dependence.py` with a stub predict callable that:
- asserts it receives a `DataFrame` (not an ndarray)
- asserts all non-target columns still have their original `category` dtype
- asserts it actually got invoked (so the test isn't vacuous)

Avoids the XGBoost dependency by using a type-checking stub — the bug is about dtype preservation, not about any specific model framework.

## Local verification

- `ruff check` and `ruff format --check` clean on both changed files.
- Confirmed the old vs new behaviour numerically in an isolated Python session before writing the test.
- Full pytest not run locally (C extension needs CMake); relying on CI.
