### PR TITLE
ENH: dispatch to KernelExplainer from Explainer when algorithm="kernel"

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -39,7 +39,9 @@ class Explainer(Serializable):
         model: Any,
         masker: Any = None,
         link: Callable[..., Any] = links.identity,
-        algorithm: Literal["auto", "permutation", "partition", "tree", "linear", "deep", "exact", "additive"] = "auto",
+        algorithm: Literal[
+            "auto", "permutation", "partition", "tree", "linear", "deep", "exact", "additive", "kernel"
+        ] = "auto",
         output_names: list[str] | None = None,
         feature_names: list[str] | list[list[str]] | None = None,
         linearize_link: bool = True,
@@ -74,7 +76,7 @@ class Explainer(Serializable):
             units. For more details on how link functions work see any overview of link functions for generalized
             linear models.
 
-        algorithm : "auto", "permutation", "partition", "tree", or "linear"
+        algorithm : "auto", "permutation", "partition", "tree", "linear", "deep", "exact", "additive", or "kernel"
             The algorithm used to estimate the Shapley values. There are many different algorithms that
             can be used to estimate the Shapley values (and the related value for constrained games), each
             of these algorithms have various tradeoffs and are preferable in different situations. By
@@ -297,6 +299,18 @@ class Explainer(Serializable):
                     link=self.link,
                     feature_names=self.feature_names,  # type: ignore[arg-type]
                     linearize_link=linearize_link,
+                    **kwargs,
+                )
+            elif algorithm == "kernel":
+                # KernelExplainer has a narrower signature (model, data, ...)
+                # and does not take a linearize_link kwarg. GH #3996.
+                self.__class__ = explainers.KernelExplainer
+                explainers.KernelExplainer.__init__(  # type: ignore[call-arg]
+                    self,  # type: ignore[arg-type]
+                    self.model,
+                    self.masker,
+                    link=self.link,
+                    feature_names=self.feature_names,  # type: ignore[arg-type]
                     **kwargs,
                 )
             else:

--- a/tests/explainers/test_explainer.py
+++ b/tests/explainers/test_explainer.py
@@ -26,6 +26,40 @@ def test_explainer_to_permutationexplainer():
         _ = explainer(X_test)
 
 
+def test_explainer_algorithm_kernel():
+    """Checks that Explainer dispatches to KernelExplainer when ``algorithm='kernel'`` is set.
+
+    GH #3996.
+    """
+    X_train, _, y_train, _ = sklearn.model_selection.train_test_split(
+        *shap.datasets.adult(), test_size=0.1, random_state=0
+    )
+    lr = sklearn.linear_model.LogisticRegression(solver="liblinear")
+    lr.fit(X_train, y_train)
+
+    # KernelExplainer warns about background sets > 100 rows; keep the sample
+    # small so the test stays fast and quiet.
+    explainer = shap.Explainer(lr.predict_proba, masker=X_train.iloc[:50], algorithm="kernel")
+    assert isinstance(explainer, shap.KernelExplainer)
+
+
+def test_explainer_rejects_unknown_algorithm():
+    """Unknown algorithm strings should raise InvalidAlgorithmError.
+
+    Guards the else-branch of the dispatch against silent fallthrough.
+    """
+    from shap.utils._exceptions import InvalidAlgorithmError
+
+    X_train, _, y_train, _ = sklearn.model_selection.train_test_split(
+        *shap.datasets.adult(), test_size=0.1, random_state=0
+    )
+    lr = sklearn.linear_model.LogisticRegression(solver="liblinear")
+    lr.fit(X_train, y_train)
+
+    with pytest.raises(InvalidAlgorithmError, match="Unknown algorithm"):
+        shap.Explainer(lr.predict_proba, masker=X_train.iloc[:20], algorithm="not-a-real-algorithm")  # type: ignore[arg-type]
+
+
 def test_wrapping_for_text_to_text_teacher_forcing_model():
     """This tests using the Explainer class to auto wrap a masker in a text to text scenario."""
     pytest.importorskip("torch")


### PR DESCRIPTION
Closes #3996.

## Problem

`shap.Explainer(..., algorithm="kernel")` currently falls through to the else-branch of the dispatch and raises `InvalidAlgorithmError`. Users who want KernelSHAP have to instantiate `shap.KernelExplainer` directly instead of going through the unified `Explainer` entry point. The issue author asked for consistency with the way `permutation`, `tree`, `linear`, etc. are already dispatched.

## Change

- Added `elif algorithm == "kernel":` to the dispatch in `shap/explainers/_explainer.py`, constructing `shap.KernelExplainer`.
- `KernelExplainer.__init__` has a narrower signature (takes `model, data` rather than `model, masker`, and does not accept `linearize_link`) so the call site is tailored to its surface. All other kwargs flow through unchanged.
- Extended the `algorithm` `Literal` type hint and the docstring to include `"kernel"`.

## Tests

- `test_explainer_algorithm_kernel` — constructs `shap.Explainer(..., algorithm="kernel")` and asserts the resulting object `isinstance shap.KernelExplainer`.
- `test_explainer_rejects_unknown_algorithm` — ensures unknown algorithm strings still raise `InvalidAlgorithmError`. This branch was uncovered before and regressions would be silent.

## Scope kept small

I noticed `"sampling"` (`SamplingExplainer`) is also missing from the dispatch. That's a natural follow-up but out of scope here so this PR stays focused.

## Note to issue author

@stephenpardy — I saw you checked the "interested in making a PR" box on the issue 14 months ago. If you have a WIP branch, happy to defer. Otherwise this is my attempt.
