### PR TITLE
TST+DOCS: add coverage and docstrings for shap.utils._exceptions

### DIFF
--- a/shap/utils/_exceptions.py
+++ b/shap/utils/_exceptions.py
@@ -1,44 +1,99 @@
+"""Custom exception classes raised by shap.
+
+These are kept as a small, dependency-free module so any shap subpackage
+can import them without pulling in heavy runtime dependencies. User code
+can catch the public base-class shape — ``ValueError`` or ``Exception`` —
+or catch a specific shap subclass for finer-grained handling.
+"""
+
+
 class DimensionError(Exception):
-    """Used for instances where dimensions are either
-    not supported or cause errors.
+    """Raised when an array argument has an unsupported shape or rank.
+
+    Typically raised by explainers and plotting functions when the shape
+    of ``values``, ``data``, or a clustering matrix doesn't line up with
+    what the caller expects.
     """
 
     pass
 
 
 class InvalidAction(Exception):
+    """Raised when an :class:`shap.actions.Action` configuration is invalid."""
+
     pass
 
 
 class ConvergenceError(Exception):
+    """Raised when an iterative estimator (e.g. an explainer optimisation loop) fails to converge."""
+
     pass
 
 
 class InvalidMaskerError(ValueError):
+    """Raised when a masker passed to an explainer is unsupported or mis-configured.
+
+    Subclasses ``ValueError`` so generic ``except ValueError`` handlers
+    still catch it.
+    """
+
     pass
 
 
 class ExplainerError(Exception):
-    """Generic errors related to Explainers"""
+    """Generic runtime error from an Explainer's internals."""
 
     pass
 
 
 class InvalidAlgorithmError(ValueError):
+    """Raised when an unknown or unsupported ``algorithm`` string is passed to :class:`shap.Explainer`.
+
+    Subclasses ``ValueError`` so generic ``except ValueError`` handlers
+    still catch it.
+    """
+
     pass
 
 
 class InvalidFeaturePerturbationError(ValueError):
+    """Raised when an unknown ``feature_perturbation`` option is passed to an explainer.
+
+    Subclasses ``ValueError`` so generic ``except ValueError`` handlers
+    still catch it.
+    """
+
     pass
 
 
 class InvalidModelError(ValueError):
+    """Raised when the model passed to an explainer is not of a supported type.
+
+    Subclasses ``ValueError`` so generic ``except ValueError`` handlers
+    still catch it.
+    """
+
     pass
 
 
 class InvalidClusteringError(ValueError):
+    """Raised when a clustering / partition tree argument is malformed.
+
+    For example, when a linkage matrix has the wrong shape, or when
+    feature indices in a partition tree are out of range.
+
+    Subclasses ``ValueError`` so generic ``except ValueError`` handlers
+    still catch it.
+    """
+
     pass
 
 
 class InvalidStyleOptionError(ValueError):
+    """Raised when a plot style option is unknown or of the wrong type.
+
+    See :mod:`shap.plots._style`. Subclasses ``ValueError`` so generic
+    ``except ValueError`` handlers still catch it.
+    """
+
     pass

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -1,0 +1,60 @@
+"""Tests for shap.utils._exceptions.
+
+The module defines a handful of narrow exception classes that shap
+subpackages raise. These tests pin the public shape — class names,
+inheritance relationships, message pass-through, raise/catch behaviour —
+so an unintended rename or reparent is caught at CI time.
+
+Partial coverage of shap/shap#3690 (test coverage meta-issue).
+"""
+
+import pytest
+
+from shap.utils import _exceptions
+
+# (class, expected base class)
+_SHAP_EXCEPTIONS: list[tuple[type[BaseException], type[BaseException]]] = [
+    (_exceptions.DimensionError, Exception),
+    (_exceptions.InvalidAction, Exception),
+    (_exceptions.ConvergenceError, Exception),
+    (_exceptions.ExplainerError, Exception),
+    (_exceptions.InvalidMaskerError, ValueError),
+    (_exceptions.InvalidAlgorithmError, ValueError),
+    (_exceptions.InvalidFeaturePerturbationError, ValueError),
+    (_exceptions.InvalidModelError, ValueError),
+    (_exceptions.InvalidClusteringError, ValueError),
+    (_exceptions.InvalidStyleOptionError, ValueError),
+]
+
+
+@pytest.mark.parametrize("exc_cls,expected_base", _SHAP_EXCEPTIONS)
+def test_exception_inheritance(exc_cls, expected_base):
+    """Each shap exception subclasses the documented base.
+
+    The ValueError-subclassed ones matter in particular: downstream user
+    code frequently catches ``ValueError`` broadly, so dropping that base
+    (e.g. repointing to ``Exception``) would silently break that code.
+    """
+    assert issubclass(exc_cls, expected_base)
+    # ValueError also subclasses Exception, which subclasses BaseException.
+    assert issubclass(exc_cls, Exception)
+
+
+@pytest.mark.parametrize("exc_cls,_", _SHAP_EXCEPTIONS)
+def test_exception_preserves_message(exc_cls, _):
+    """str(exc) returns the message passed at construction time."""
+    msg = f"sentinel message for {exc_cls.__name__}"
+    with pytest.raises(exc_cls, match=msg):
+        raise exc_cls(msg)
+
+
+@pytest.mark.parametrize("exc_cls,expected_base", _SHAP_EXCEPTIONS)
+def test_exception_caught_by_base(exc_cls, expected_base):
+    """A shap exception is caught by its documented public base class.
+
+    This is the guarantee that lets user code keep using
+    ``except ValueError`` / ``except Exception`` without knowing about
+    shap's internal hierarchy.
+    """
+    with pytest.raises(expected_base):
+        raise exc_cls("should propagate to the base handler")


### PR DESCRIPTION
## Summary

`shap/utils/_exceptions.py` defines ten narrow exception classes used across shap subpackages. Most had no docstring, and none had any test coverage, so a rename or accidental reparent would slip past CI silently. That matters in particular for the `ValueError`-subclassed ones (`InvalidMaskerError`, `InvalidAlgorithmError`, `InvalidFeaturePerturbationError`, `InvalidModelError`, `InvalidClusteringError`, `InvalidStyleOptionError`) — downstream user code often catches `ValueError` broadly, and dropping that base would silently break those handlers.

## Changes

- **`shap/utils/_exceptions.py`** — module docstring + class docstrings for every exception. Each `ValueError`-subclassed exception now says so explicitly so callers know generic `except ValueError` handlers will catch it.
- **`tests/utils/test_exceptions.py`** — new file. Three parameterised tests over all ten classes:
  1. Inheritance pinned to the documented base class.
  2. `str(exc)` preserves the message passed at construction.
  3. Each exception is caught by its documented public base class (the guarantee that makes generic `except ValueError` handlers work).

No runtime behaviour changes.

## Issue relation

Partial coverage of #3690 (test coverage meta-issue). Not claiming to close it — it's a meta.

## Verification

- `ruff check` + `ruff format --check` clean.
- Tested the assertion logic in isolation (bypassing the full `import shap` which needs CMake locally) against all ten classes — every case passes.
