### PR TITLE
DEPR: Deprecate TreeGain explainer before removal

### DIFF
--- a/shap/explainers/other/_treegain.py
+++ b/shap/explainers/other/_treegain.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from .._explainer import Explainer
@@ -7,9 +9,19 @@ class TreeGain(Explainer):
     """Simply returns the global gain/gini feature importances for tree models.
 
     This is only for benchmark comparisons and is not meant to approximate SHAP values.
+
+    .. deprecated::
+        TreeGain is deprecated and will be removed in a future release.
+        It was only intended for benchmark comparisons and is not a SHAP-based explainer.
     """
 
     def __init__(self, model):
+        warnings.warn(
+            "TreeGain is deprecated and will be removed in a future release. "
+            "It was only intended for benchmark comparisons and is not a SHAP-based explainer.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if str(type(model)).endswith("sklearn.tree.tree.DecisionTreeRegressor'>"):
             pass
         elif str(type(model)).endswith("sklearn.tree.tree.DecisionTreeClassifier'>"):


### PR DESCRIPTION
## Overview
Follow-up to #4427, as requested by @CloseChoice.

## Changes
### `shap/explainers/other/_treegain.py`
- Added `warnings.warn(..., DeprecationWarning, stacklevel=2)` to `TreeGain.__init__()` 
- Updated docstring with `.. deprecated::` directive

### `tests/explainers/other/test_treegain.py`  
- Updated all 3 tests to use `pytest.warns(DeprecationWarning)` to assert the warning is properly raised on instantiation

## Why
The maintainer identified that `TreeGain` is only for benchmarking and not a SHAP-based explainer. This PR gracefully deprecates it so users get a clear warning before it is fully removed in a future release.

**AI Usage Disclosure:** I used an AI pair-programming assistant to help implement this. I reviewed, tested, and am accountable for all changes.

## Checklist
- [x] All pre-commit checks pass
- [x] 3/3 tests passing locally
- [x] Deprecation warning uses `stacklevel=2` (correct for class `__init__`)
