### PR TITLE
FIX: Correct variance of the mean calculation in SamplingExplainer

### DIFF
--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -179,7 +179,7 @@ class SamplingExplainer(KernelExplainer):
 
             # convert from the variance of the differences to the variance of the mean (phi)
             for i, ind in enumerate(self.varyingInds):
-                phi_var[ind, :] /= np.sqrt(nsamples_each1[i] + nsamples_each2[i])
+                phi_var[ind, :] /= nsamples_each1[i] + nsamples_each2[i]
 
             # correct the sum of the SHAP values to equal the output of the model using a linear
             # regression model with priors of the coefficients equal to the estimated variances for each


### PR DESCRIPTION


## Description

Closes #4767.

I was looking into the internals of [SamplingExplainer](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_sampling.py:15:0-226:42) and found a mathematical error in how it estimates the variance of the sample mean. 

Around line 182 in [_sampling.py](cci:7://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_sampling.py:0:0-0:0), the sample variance (`phi_var`) is divided by `np.sqrt(N)` (where N is the number of samples). Because this is calculating the variance of the mean (and the code comment also explicitly states this), the correct statistical formula requires dividing the sample variance by exactly $N$, not $\sqrt{N}$ (dividing by $\sqrt{N}$ would only make sense if we were computing the standard error from the standard deviation, not variance from variance).

This is actually pretty important because this `phi_var` serves as the prior in the ridge regression model that enforces additivity. Because it was dividing by $\sqrt{N}$, it severely overestimated the variance. This caused the ridge regression to over-penalize features with naturally higher variance and distribute the Sherman-Morrison additivity adjustments incorrectly.

## Changes
- Removed `np.sqrt` from the variance calculation so `phi_var` scales by `N` correctly.

All the tests in `test_sampling.py` pass without any issues on my end!
