### PR TITLE
Ensure consistent use of `show=False` in waterfall plot tests

### DIFF
--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -53,7 +53,7 @@ def test_waterfall_bounds(explainer):
     explanation = explainer(explainer.data)
     explanation._s.lower_bounds = explanation.values - 0.1
     explanation._s.upper_bounds = explanation.values + 0.1
-    shap.plots.waterfall(explanation[0])
+    shap.plots.waterfall(explanation[0], show=False)
     plt.tight_layout()
     return fig
 
@@ -77,7 +77,7 @@ def test_waterfall_custom_style(explainer):
     ):
         fig = plt.figure()
         explanation = explainer(explainer.data)
-        shap.plots.waterfall(explanation[0])
+        shap.plots.waterfall(explanation[0], show=False)
         plt.tight_layout()
     return fig
 


### PR DESCRIPTION
Closes #4771

Hi! I noticed that most of the waterfall plot tests already use `show=False` to avoid rendering plots during test execution, but a few tests were missing this.

In this PR, I’ve added `show=False` to those remaining cases to make the behavior consistent across the test suite.

This helps avoid unintended plot rendering, especially in headless or CI environments, and keeps the tests more predictable.

There are no functional changes, this only affects how tests are executed.