### PR TITLE
MAINT: remove duplicate numpy test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,9 +91,6 @@ test = [
   'tensorflow; python_version < "3.14"',  # TODO: pending 3.14 support
   "sentencepiece",
   "opencv-python",
-  # Constraint to prevent the combination of tf<2.15 and numpy>=2.0.
-  # See GH #3707, #3768, 3922
-  "numpy>=2.0",
   "causalml>=0.15.5",
   "selenium",  # needed to test the javascript based plots
 ]


### PR DESCRIPTION
Closes #4754

  Description of the changes proposed in this pull request:

  - Remove the duplicate `numpy>=2.0` entry from the `test` extras in `pyproject.toml`.
  - Keep the core `numpy>=2` dependency unchanged.

  ## Checklist

  - [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
  - [ ] Unit tests added (if fixing a bug or adding a new feature)