### PR TITLE
 MAINT: stabilize logit link function

### DIFF
--- a/shap/links.py
+++ b/shap/links.py
@@ -23,8 +23,12 @@ identity.inverse = _identity_inverse  # type: ignore[attr-defined]
 
 @numba.njit
 def logit(x: npt.NDArray[Any] | float) -> npt.NDArray[Any] | float:
-    """A logit link function useful for going from probability units to log-odds units."""
-    return np.log(x / (1 - x))
+    """A logit link function useful for going from probability units to log-odds units.
+
+    This uses ``log(x) - log1p(-x)`` for better numerical stability near 0 and 1.
+    Inputs exactly equal to 0 or 1 still map to ``-inf`` and ``inf`` respectively.
+    """
+    return np.log(x) - np.log1p(-x)
 
 
 @numba.njit

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -17,3 +17,9 @@ def test_logit_round_trips_finite_probabilities():
 
     assert np.all(np.isfinite(logits))
     assert np.allclose(logit.inverse(logits), values, rtol=1e-12, atol=0.0)
+
+
+def test_logit_supports_scalar_inputs():
+    value = 0.5
+    assert logit(value) == 0.0
+    assert logit.inverse(logit(value)) == value

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from shap.links import logit
+
+
+def test_logit_handles_probability_boundaries():
+    values = np.array([0.0, 1.0])
+    result = logit(values)
+
+    assert np.isneginf(result[0])
+    assert np.isposinf(result[1])
+
+
+def test_logit_round_trips_finite_probabilities():
+    values = np.array([1e-12, 1e-6, 0.1, 0.9, 1 - 1e-6, 1 - 1e-12])
+    logits = logit(values)
+
+    assert np.all(np.isfinite(logits))
+    assert np.allclose(logit.inverse(logits), values, rtol=1e-12, atol=0.0)


### PR DESCRIPTION
Closes #4775

  Description of the changes proposed in this pull request:

  - Update `shap.links.logit` to use `log(x) - log1p(-x)` for better numerical stability near 0 and 1.
  - Document that exact boundary inputs still map to `-inf` and `inf`.
  - Add regression tests for boundary values and finite round-trip behavior through `logit.inverse`.

  ## Checklist

  - [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
  - [x] Unit tests added (if fixing a bug or adding a new feature)