### PR TITLE
BUG: handle single-row heatmap explanations

### DIFF
--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -83,7 +83,10 @@ def heatmap(
     elif not hasattr(feature_order, "__len__"):
         raise Exception(f"Unsupported feature_order: {str(feature_order)}!")
     xlabel = "Instances"
-    instance_order = convert_ordering(instance_order, shap_values)
+    if values.shape[0] < 2:
+        instance_order = np.arange(values.shape[0])
+    else:
+        instance_order = convert_ordering(instance_order, shap_values)
     # if issubclass(type(instance_order), OpChain):
     #     #xlabel += " " + instance_order.summary_string("SHAP values")
     #     instance_order = instance_order.apply(Explanation(values))

--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -31,8 +31,9 @@ def heatmap(
     Parameters
     ----------
     shap_values : shap.Explanation
-        A multi-row :class:`.Explanation` object that we want to visualize in a
-        cluster ordering.
+        A :class:`.Explanation` object that we want to visualize in a cluster
+        ordering. Single-row explanations are supported, but they are shown
+        without clustering.
 
     instance_order : OpChain or numpy.ndarray
         A function that returns a sort ordering given a matrix of SHAP values and an axis, or
@@ -83,7 +84,7 @@ def heatmap(
     elif not hasattr(feature_order, "__len__"):
         raise Exception(f"Unsupported feature_order: {str(feature_order)}!")
     xlabel = "Instances"
-    if values.shape[0] < 2:
+    if values.shape[0] == 1:
         instance_order = np.arange(values.shape[0])
     else:
         instance_order = convert_ordering(instance_order, shap_values)

--- a/tests/plots/test_heatmap.py
+++ b/tests/plots/test_heatmap.py
@@ -25,3 +25,18 @@ def test_heatmap_feature_order(explainer):
     )
     plt.tight_layout()
     return fig
+
+
+def test_heatmap_single_row_explanation():
+    """Heatmap should handle a single-row Explanation without clustering failures."""
+    ex = shap.Explanation(
+        values=np.array([[1.0, -2.0, 3.0]]),
+        base_values=np.array([0.0]),
+        data=np.array([[10.0, 20.0, 30.0]]),
+        feature_names=["a", "b", "c"],
+    )
+
+    ax = shap.plots.heatmap(ex, show=False)
+    plt.tight_layout()
+
+    assert ax is not None


### PR DESCRIPTION
Closes #4783

  Description of the changes proposed in this pull request:

  - Make `shap.plots.heatmap()` handle single-row `Explanation` objects without crashing in the default clustering path.
  - Skip clustering for the single-row case by using a trivial instance order.
  - Add a regression test covering a single-row explanation with `feature_names` present.

  ## Checklist

  - [x] All [pre-commit checks](https://pre-commit.com/) pass.
  - [x] Unit tests added (if fixing a bug or adding a new feature)