### PR TITLE
_tree: reduce time complexity for queue pop operation from O(n) to O(1).

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -6,8 +6,8 @@ import json
 import os
 import time
 import warnings
-from typing import Any, Literal
 from collections import deque
+from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -7,6 +7,7 @@ import os
 import time
 import warnings
 from typing import Any, Literal
+from collections import deque
 
 import numpy as np
 import numpy.typing as npt
@@ -1924,9 +1925,9 @@ class SingleTree:
             self.node_sample_weight = np.empty(num_nodes, dtype=np.float64)
 
             # BFS traversal through the tree structure
-            visited, queue = [], [start]
+            visited, queue = [], deque([start])
             while queue:
-                vertex = queue.pop(0)  # TODO(perf): benchmark this against deque.popleft()
+                vertex = queue.popleft()
                 is_branch_node = "split_index" in vertex
                 if is_branch_node:
                     vsplit_idx: int = vertex["split_index"]


### PR DESCRIPTION
## Overview

Fixes TODO.
From various benchmarks and articles we know that the theoretically time complexity
of queue.popleft() - O(1) is less that queue.pop(0) - O(n), we can effectively make an
improvement and reduce the time complexity from O(N^2) to O(N) for this BFS traversal.
references: https://wiki.python.org/moin/TimeComplexity


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
