### PR TITLE
MAINT: enable kw_only=True on StyleConfig now that Python 3.9 is dropped

### DIFF
--- a/shap/plots/_style.py
+++ b/shap/plots/_style.py
@@ -30,8 +30,7 @@ type RGBAColorType = (
 type ColorType = RGBColorType | RGBAColorType | np.ndarray
 
 
-# TODO: Use dataclass(kw_only=True) when we drop Python 3.9
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class StyleConfig:
     """A complete set of configuration options for matplotlib-based shap plots."""
 


### PR DESCRIPTION
## Overview

While looking at `shap/plots/_style.py` I noticed a TODO waiting to drop Python 3.9 support, but `pyproject.toml` already requires Python 3.12, so that condition was met a while ago.

Removed the comment and added `kw_only=True` to `StyleConfig`. The only callsite already uses keyword arguments so nothing breaks.

## Checklist

- [x] All `pre-commit` checks pass.
- [x] `ruff check` and `ruff format` pass.
- [x] Existing tests in `tests/plots/test_style.py` pass (7/7, no regressions).