### PR TITLE
FIX: scatter multi-feature show=False now returns Figure

### DIFF
--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -140,7 +140,7 @@ def scatter(
         ymin = parse_axis_limit(ymin, shap_values.values, is_shap_axis=True)
         ymax = parse_axis_limit(ymax, shap_values.values, is_shap_axis=True)
         ymin, ymax = _suggest_buffered_limits(ymin, ymax, shap_values.values)
-        _ = plt.subplots(1, len(inds), figsize=(min(6 * len(inds), 15), 5))
+        fig, _ = plt.subplots(1, len(inds), figsize=(min(6 * len(inds), 15), 5))
         for i in inds:
             ax = plt.subplot(1, len(inds), i + 1)
             scatter(shap_values[:, i], color=color, show=False, ax=ax, ymin=ymin, ymax=ymax)
@@ -160,7 +160,8 @@ def scatter(
             plt.legend()
         if show:
             plt.show()
-        return
+        else:
+            return fig
 
     if len(shap_values.shape) != 1:
         raise DimensionError(

--- a/shap/plots/_scatter.py
+++ b/shap/plots/_scatter.py
@@ -120,8 +120,13 @@ def scatter(
     Returns
     -------
     ax : matplotlib Axes object
-        Returns the :external+mpl:class:`~matplotlib.axes.Axes` object with the plot drawn onto it. Only
-        returned if ``show=False``.
+        When a **single feature** is plotted and ``show=False``, returns the
+        :external+mpl:class:`~matplotlib.axes.Axes` object so the plot can be
+        further customised.
+    fig : matplotlib Figure object
+        When **multiple features** are plotted and ``show=False``, returns the
+        :external+mpl:class:`~matplotlib.figure.Figure` object containing all
+        subplots. Use ``fig.axes`` to access the individual Axes.
 
     Examples
     --------

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -73,7 +73,6 @@ def test_scatter_multifeature_show_false_returns_figure(explainer):
     result = shap.plots.scatter(explanation[:, ["Age", "Workclass"]], show=False)
     assert result is not None, "scatter() returned None with show=False; expected a matplotlib Figure"
     assert hasattr(result, "savefig"), f"Expected a Figure object, got {type(result)}"
-    plt.close("all")
 
 
 @pytest.fixture()

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -64,6 +64,18 @@ def test_scatter_custom(explainer):
     return plt.gcf()
 
 
+def test_scatter_multifeature_show_false_returns_figure(explainer):
+    """scatter() with multiple features and show=False must return a Figure, not None.
+
+    Regression test for GH #4805.
+    """
+    explanation = explainer(explainer.data)
+    result = shap.plots.scatter(explanation[:, ["Age", "Workclass"]], show=False)
+    assert result is not None, "scatter() returned None with show=False; expected a matplotlib Figure"
+    assert hasattr(result, "savefig"), f"Expected a Figure object, got {type(result)}"
+    plt.close("all")
+
+
 @pytest.fixture()
 def categorical_explanation():
     """Adopted from explainer in conftest.py but using a categorical input."""


### PR DESCRIPTION
## Overview

Closes #4805

`shap.plots.scatter` documents that it returns a `matplotlib.axes.Axes` when `show=False`, enabling callers to further customise or save the figure. The single-feature code path correctly returns `ax`, but the multi-feature subplot path always returned `None` due to a bare `return` statement after the `if show: plt.show()` block.

**Root cause** (`shap/plots/_scatter.py`, multi-feature branch):
```python
# before
_ = plt.subplots(...)   # figure reference discarded
...
if show:
    plt.show()
return              # always None
```

**Fix**: capture the figure from `plt.subplots` and return it when `show=False`:
```python
# after
fig, _ = plt.subplots(...)
...
if show:
    plt.show()
else:
    return fig      # callers can now save / further modify the figure
```

This makes the multi-feature path consistent with the single-feature path and with the documented return contract.

## Checklist

- [x] All pre-commit checks pass.
- [x] Unit tests added (regression test `test_scatter_multifeature_show_false_returns_figure` in `tests/plots/test_scatter.py`)