### PR TITLE
fix: remove redundant Callable and Iterator imports (TYPE_CHECKING)

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import operator
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, cast
 

--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -4,7 +4,6 @@ import copy
 import os
 import re
 import sys
-from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 


### PR DESCRIPTION
## Overview

Close #4810 

Removes redundant imports of `Callable` and `Iterator` from module level in files using `from __future__ import annotations`.

These imports are already correctly placed inside `TYPE_CHECKING` blocks, so the module-level imports are unused and trigger pyflakes warnings.
Description of the changes proposed in this pull request:
### Changes:
- Removed `Callable` import from `shap/_explanation.py`
- Removed `Iterator` import from `shap/utils/_general.py`
- Kept imports inside `TYPE_CHECKING` blocks unchanged

### Reason:
With postponed evaluation of annotations enabled, type hints are not evaluated at runtime. Therefore, these imports are only needed for static type checking.

This resolves warnings like:
- redefinition of unused 'Callable'
- redefinition of unused 'Iterator'

### Impact:
- No functional changes
- Pure cleanup


## Checklist

- [x] All pre-commit checks pass
- [ ] Unit tests added (not required for this cleanup)