### PR TITLE
FIX: allow cohorts with non-string labels

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -715,7 +715,7 @@ class Explanation(metaclass=MetaExplanation):
             return _auto_cohorts(self, max_cohorts=cohorts)
         if isinstance(cohorts, (list, tuple, np.ndarray)):
             cohorts = np.array(cohorts)
-            return Cohorts(**{name: self[cohorts == name] for name in np.unique(cohorts)})
+            return Cohorts(**{str(name): self[cohorts == name] for name in np.unique(cohorts)})
         raise TypeError("The given set of cohort indicators is not recognized! Please give an array or int.")
 
     def _flatten_feature_names(self) -> dict[Any, list[Any]]:

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,24 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+@pytest.mark.parametrize(
+    "labels, expected_keys",
+    [
+        (np.array([0, 1] * 25), {"0", "1"}),
+        (np.array([True, False] * 25), {"False", "True"}),
+        (np.array(["A", "B"] * 25), {"A", "B"}),
+    ],
+)
+def test_explanation_cohorts_accepts_non_string_labels(labels, expected_keys):
+    exp = shap.Explanation(
+        values=np.random.randn(50, 4),
+        base_values=np.zeros(50),
+        feature_names=list("abcd"),
+    )
+
+    cohorts = exp.cohorts(labels)
+
+    assert isinstance(cohorts, shap.Cohorts)
+    assert set(cohorts.cohorts.keys()) == expected_keys


### PR DESCRIPTION
## Summary

Closes shap/shap#4801.

This PR updates `Explanation.cohorts()` so cohort labels are converted to strings before being passed into the `Cohorts` constructor. This prevents `TypeError: keywords must be strings` when labels are integers or booleans.

## Changes

- Convert cohort labels to strings in `Explanation.cohorts()`.
- Add regression tests for integer, boolean, and string cohort labels.

## Testing

I attempted to run:

```bash
pytest tests/test_explanation.py -k "cohorts_accepts_non_string_labels"