### PR TITLE
Add basic validation for cost in Action class

### DIFF
--- a/shap/actions/_action.py
+++ b/shap/actions/_action.py
@@ -2,6 +2,11 @@ class Action:
     """Abstract action class."""
 
     def __init__(self, cost):
+        if not isinstance(cost, (int, float)):
+            raise TypeError("Cost must be a number")
+        if cost < 0:
+            raise ValueError("Cost must be non-negative")
+
         self.cost = cost
         self._group_index = 0
         self._grouped_index = 0
@@ -10,6 +15,8 @@ class Action:
         raise NotImplementedError
 
     def __lt__(self, other_action):
+        if not isinstance(other_action, Action):
+            return NotImplemented
         return self.cost < other_action.cost
 
     def __repr__(self):

--- a/tests/actions/test_action.py
+++ b/tests/actions/test_action.py
@@ -58,3 +58,18 @@ def test_action_comparisons_and_properties():
     # Test default initialized properties
     assert action_cheap._group_index == 0
     assert action_cheap._grouped_index == 0
+
+
+def test_action_invalid_cost_type():
+    with pytest.raises(TypeError):
+        shap.actions.Action(cost="invalid")
+
+
+def test_action_negative_cost():
+    with pytest.raises(ValueError):
+        shap.actions.Action(cost=-5)
+
+
+def test_action_valid_cost():
+    a = shap.actions.Action(cost=10)
+    assert a.cost == 10


### PR DESCRIPTION
Fixes #4815

This PR adds a small validation check for the `cost` parameter in the `Action` class.

## What I noticed
Right now, the `Action` class accepts any value for `cost`. This means it's possible to pass things like strings, None, or negative values, which can later cause issues during comparisons (for example in `__lt__`).

## What I changed
- Added a type check to ensure `cost` is numeric (int or float)
- Added a check to ensure `cost` is non-negative
- Added a few simple tests to cover these cases

## Why this helps
This prevents invalid Action objects from being created and avoids potential runtime errors or unexpected behavior later in execution.

## Notes
I kept the change minimal and focused only on validation to avoid affecting existing behavior.

Happy to make any changes if needed.