### PR TITLE
fix: pin catboost>=1.2.8 and ngboost>=0.5.8 for numpy 2.0 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,9 @@ test = [
   "pytest-cov",
   "xgboost",
   "lightgbm",
-  'catboost; python_version < "3.14"',  # TODO: pending 3.14 support
+  'catboost>=1.2.8; python_version < "3.14"',  # TODO: pending 3.14 support. Requires >=1.2.8 for numpy 2.0, see GH #3922
   'gpboost==1.6.3.1; python_version < "3.14"',  # TODO: pending 3.14 support, see GH #4210
-  "ngboost",
+  "ngboost>=0.5.8",  # Requires >=0.5.8 for numpy 2.0, see GH #3922
   "pyspark",
   "pyod",
   "transformers < 4.54.0",  # TODO: fix once tests pass for 4.54.0
@@ -127,9 +127,9 @@ test = [
   "pytest-cov",
   "xgboost",
   "lightgbm",
-  'catboost; python_version < "3.14"',         # TODO: pending 3.14 support
+  'catboost>=1.2.8; python_version < "3.14"',   # TODO: pending 3.14 support. Requires >=1.2.8 for numpy 2.0, see GH #3922
   'gpboost==1.6.3.1; python_version < "3.14"', # TODO: pending 3.14 support, see GH #4210
-  "ngboost",
+  "ngboost>=0.5.8",                             # Requires >=0.5.8 for numpy 2.0, see GH #3922
   "pyspark",
   "pyod",
   "transformers < 4.54.0",                     # TODO: fix once tests pass for 4.54.0


### PR DESCRIPTION


## Overview

Closes #3922

Pin minimum versions of `catboost` and `ngboost` to ensure compatibility with numpy 2.0:

- `catboost>=1.2.8` - first release with numpy 2.x support ([[catboost/catboost#2671](https://github.com/catboost/catboost/issues/2671)](https://github.com/catboost/catboost/issues/2671))
- `ngboost>=0.5.8` - includes numpy 2.0 natural gradient fix ([[stanfordmlgroup/ngboost#358](https://github.com/stanfordmlgroup/ngboost/issues/358)](https://github.com/stanfordmlgroup/ngboost/issues/358))

Updated both `[project.optional-dependencies]` and `[dependency-groups]` sections in `pyproject.toml`.

## Checklist

- [x] All [[pre-commit checks](https://pre-commit.com/#install)](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)

No new tests needed - existing catboost and ngboost tests (`test_catboost`, `test_catboost_categorical`, `test_catboost_interactions`, `test_ngboost_models_prediction_equal`, `test_ngboost_sum_of_shap_values`, etc.) already cover this and pass with numpy 2.x.

Verification-:
```

============================= test session starts =============================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /ojus/.local/share/mise/installs/python/3.12.12/bin/python3
cachedir: .pytest_cache
Matplotlib: 3.10.8
Freetype: 2.6.1
hypothesis profile 'default'
rootdir: /Users/ojus/pc/ESoC/shap
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, timeout-2.4.0, mpl-0.19.0, hypothesis-6.151.9, asyncio-1.3.0, xdoctest-1.3.0, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 116 items / 107 deselected / 9 selected                             

tests/explainers/test_tree.py::test_ngboost_models_prediction_equal[1.0] PASSED [ 11%]
tests/explainers/test_tree.py::test_ngboost_models_prediction_equal[0.9] PASSED [ 22%]
tests/explainers/test_tree.py::test_ngboost_sum_of_shap_values[1.0] PASSED [ 33%]
tests/explainers/test_tree.py::test_ngboost_sum_of_shap_values[0.9] PASSED [ 44%]
tests/explainers/test_tree.py::test_catboost PASSED                     [ 55%]
tests/explainers/test_tree.py::test_catboost_categorical PASSED         [ 66%]
tests/explainers/test_tree.py::test_catboost_interactions PASSED        [ 77%]
tests/explainers/test_tree.py::test_catboost_regression_interactions PASSED [ 88%]
tests/explainers/test_tree.py::test_catboost_column_names_with_special_characters PASSED [100%]

===================== 9 passed, 107 deselected in 10.38s ======================


```