### PR TITLE
TEST: Improve AdditiveForceVisualizer test with meaningful assertionsFix formatting after pre-commit hook

### DIFF
--- a/javascript/tests/render.spec.jsx
+++ b/javascript/tests/render.spec.jsx
@@ -1,10 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { AdditiveForceVisualizer } from "../visualizers";
 import React from 'react';
 
 describe('AdditiveForceVisualizer', () => {
   it('renders correctly', () => {
-    // Render the component
     const { container } = render(
       <AdditiveForceVisualizer
         baseValue={0.0}
@@ -25,7 +24,14 @@ describe('AdditiveForceVisualizer', () => {
       />
     );
 
-    // Compare with snapshot
+    // ✅ Snapshot
     expect(container).toMatchSnapshot();
+
+    // ✅ Check SVG exists (D3 rendering container)
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+
+    // ✅ Check main container rendered
+    expect(container.firstChild).not.toBeNull();
   });
 });


### PR DESCRIPTION
closes, #4821

I noticed that the existing test for AdditiveForceVisualizer relied only on snapshot testing. While snapshots are useful, they don’t always ensure that the component is rendered correctly in a meaningful way.

This PR improves the test by adding a few additional assertions alongside the existing snapshot test.

## Changes
- Kept the existing snapshot test
- Added a check to ensure the SVG element is rendered
- Added a basic check to confirm the component mounts correctly

## Note
Since this component uses D3 for rendering inside SVG, text content is not reliably accessible in the test environment. Because of this, the assertions focus on structural checks instead of text-based checks.

## Why
This makes the test more robust while keeping it stable and compatible with the current rendering approach.

Happy to make any changes if needed.