### PR TITLE
fix: replace assert with raise ValueError/TypeError in _tree.py

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -463,8 +463,10 @@ class TreeExplainer(Explainer):
         if X.dtype != self.model.input_dtype:
             X = X.astype(self.model.input_dtype)
         X_missing = np.isnan(X, dtype=bool)
-        assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
-        assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
+        if not isinstance(X, np.ndarray):
+            raise TypeError("Unknown instance type: " + str(type(X)))
+        if len(X.shape) != 2:
+            raise ValueError("Passed input data matrix X must have 1 or 2 dimensions!")
 
         if self.model.model_output == "log_loss":
             if y is None:
@@ -608,7 +610,8 @@ class TreeExplainer(Explainer):
                     )
 
             elif self.model.model_type == "lightgbm":
-                assert not approximate, "approximate=True is not supported for LightGBM models!"
+                if approximate:
+                    raise ValueError("approximate=True is not supported for LightGBM models!")
                 phi = self.model.original_model.predict(X, num_iteration=tree_limit, pred_contrib=True)
                 # Note: the data must be joined on the last axis
                 if (
@@ -630,8 +633,10 @@ class TreeExplainer(Explainer):
                         raise ValueError(emsg) from e
 
             elif self.model.model_type == "catboost":  # thanks to the CatBoost team for implementing this...
-                assert not approximate, "approximate=True is not supported for CatBoost models!"
-                assert tree_limit == -1, "tree_limit is not yet supported for CatBoost models!"
+                if approximate:
+                    raise ValueError("approximate=True is not supported for CatBoost models!")
+                if tree_limit != -1:
+                    raise ValueError("tree_limit is not yet supported for CatBoost models!")
                 import catboost
 
                 if not isinstance(X, catboost.Pool):
@@ -778,9 +783,8 @@ class TreeExplainer(Explainer):
                 Return type for models with multiple outputs changed from list to np.ndarray.
 
         """
-        assert self.model.model_output == "raw", (
-            'Only model_output = "raw" is supported for SHAP interaction values right now!'
-        )
+        if self.model.model_output != "raw":
+            raise ValueError('Only model_output = "raw" is supported for SHAP interaction values right now!')
         # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
         transform = "identity"
 
@@ -814,7 +818,8 @@ class TreeExplainer(Explainer):
         elif (self.model.model_type == "catboost") and (
             self.feature_perturbation == "tree_path_dependent"
         ):  # thanks again to the CatBoost team for implementing this...
-            assert tree_limit == -1, "tree_limit is not yet supported for CatBoost models!"
+            if tree_limit != -1:
+                raise ValueError("tree_limit is not yet supported for CatBoost models!")
             import catboost
 
             if not isinstance(X, catboost.Pool):
@@ -1032,7 +1037,8 @@ class TreeEnsemble:
                 "causalml.inference.tree.CausalRandomForestRegressor",
             ],
         ):
-            assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
+            if not hasattr(model, "estimators_"):
+                raise ValueError("Model has no `estimators_`! Have you called `model.fit`?")
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
             scaling = 1.0 / len(model.estimators_)  # output is average of trees
@@ -1072,7 +1078,8 @@ class TreeEnsemble:
                 "skopt.learning.forest.ExtraTreesRegressor",
             ],
         ):
-            assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
+            if not hasattr(model, "estimators_"):
+                raise ValueError("Model has no `estimators_`! Have you called `model.fit`?")
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
             scaling = 1.0 / len(model.estimators_)  # output is average of trees
@@ -1116,7 +1123,8 @@ class TreeEnsemble:
                 "sklearn.ensemble.forest.RandomForestClassifier",
             ],
         ):
-            assert hasattr(model, "estimators_"), "Model has no `estimators_`! Have you called `model.fit`?"
+            if not hasattr(model, "estimators_"):
+                raise ValueError("Model has no `estimators_`! Have you called `model.fit`?")
             self.internal_dtype = model.estimators_[0].tree_.value.dtype.type
             self.input_dtype = np.float32
             scaling = 1.0 / len(model.estimators_)  # output is average of trees
@@ -1469,7 +1477,8 @@ class TreeEnsemble:
                 "ngboost.api.NGBClassifier",
             ],
         ):
-            assert model.base_models, "The NGBoost model has empty `base_models`! Have you called `model.fit`?"
+            if not model.base_models:
+                raise ValueError("The NGBoost model has empty `base_models`! Have you called `model.fit`?")
             if self.model_output == "raw":
                 param_idx = 0  # default to the first parameter of the output distribution
                 warnings.warn(
@@ -1478,10 +1487,11 @@ class TreeEnsemble:
             elif isinstance(self.model_output, int):
                 param_idx = self.model_output
                 self.model_output = "raw"  # note that after loading we have a new model_output type
-            assert safe_isinstance(
+            if not safe_isinstance(
                 model.base_models[0][param_idx],
                 ["sklearn.tree.DecisionTreeRegressor", "sklearn.tree.tree.DecisionTreeRegressor"],
-            ), "You must use default_tree_learner!"
+            ):
+                raise ValueError("You must use default_tree_learner!")
             shap_trees = [trees[param_idx] for trees in model.base_models]
             self.internal_dtype = shap_trees[0].tree_.value.dtype.type
             self.input_dtype = np.float32
@@ -1516,9 +1526,8 @@ class TreeEnsemble:
         # build a dense numpy version of all the tree objects
         if self.trees is not None and self.trees:
             max_nodes = np.max([len(t.values) for t in self.trees])
-            assert len(np.unique([t.values.shape[1] for t in self.trees])) == 1, (
-                "All trees in the ensemble must have the same output dimension!"
-            )
+            if len(np.unique([t.values.shape[1] for t in self.trees])) != 1:
+                raise ValueError("All trees in the ensemble must have the same output dimension!")
             num_trees = len(self.trees)
             # important to be -1 in unused sections!! This way we can tell which entries are valid.
             self.children_left = -np.ones((num_trees, max_nodes), dtype=np.int32)
@@ -1565,7 +1574,10 @@ class TreeEnsemble:
             if not hasattr(self.base_offset, "__len__") or len(self.base_offset) == 0:
                 self.base_offset = (np.ones(self.num_outputs) * self.base_offset).astype(self.internal_dtype)
             self.base_offset = self.base_offset.flatten()
-            assert len(self.base_offset) == self.num_outputs
+            if len(self.base_offset) != self.num_outputs:
+                raise ValueError(
+                    f"base_offset length ({len(self.base_offset)}) does not match num_outputs ({self.num_outputs})!"
+                )
 
     def _set_xgboost_model_attributes(
         self,
@@ -1597,7 +1609,8 @@ class TreeEnsemble:
         # Currrently, XGBoost models derive the num_outputs attribute from the input
         # models, which is set during model load.
         if self.model_type == "xgboost":
-            assert hasattr(self, "_xgboost_n_outputs")
+            if not hasattr(self, "_xgboost_n_outputs"):
+                raise AttributeError("XGBoost model is missing '_xgboost_n_outputs'. Was the model loaded correctly?")
             return self._xgboost_n_outputs
 
         if self.num_stacked_models > 1:
@@ -1684,8 +1697,10 @@ class TreeEnsemble:
         if X.dtype.type != self.input_dtype:
             X = X.astype(self.input_dtype)
         X_missing = np.isnan(X, dtype=bool)
-        assert isinstance(X, np.ndarray), "Unknown instance type: " + str(type(X))
-        assert len(X.shape) == 2, "Passed input data matrix X must have 1 or 2 dimensions!"
+        if not isinstance(X, np.ndarray):
+            raise TypeError("Unknown instance type: " + str(type(X)))
+        if len(X.shape) != 2:
+            raise ValueError("Passed input data matrix X must have 1 or 2 dimensions!")
 
         if tree_limit < 0 or tree_limit > self.values.shape[0]:
             tree_limit = self.values.shape[0]

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -30,6 +30,65 @@ def test_unsupported_model_raises_error():
         _ = shap.TreeExplainer(CustomEstimator())
 
 
+def test_unfitted_model_raises_valueerror():
+    """Passing an unfitted model to TreeEnsemble should give ValueError, not AssertionError."""
+    from sklearn.ensemble import ExtraTreesRegressor
+
+    from shap.explainers._tree import TreeEnsemble
+
+    model = ExtraTreesRegressor()
+    with pytest.raises(ValueError, match="Have you called `model.fit`"):
+        TreeEnsemble(model)
+
+
+def test_catboost_unsupported_args():
+    """CatBoost doesn't support approximate or tree_limit, check we get ValueError."""
+    catboost = pytest.importorskip("catboost")
+
+    model = catboost.CatBoostRegressor(iterations=10, verbose=0, random_seed=0)
+    X = np.random.randn(50, 4)
+    model.fit(X, np.random.randn(50))
+    explainer = shap.TreeExplainer(model)
+
+    with pytest.raises(ValueError, match="approximate=True is not supported for CatBoost"):
+        explainer.shap_values(X[:3], approximate=True)
+
+    with pytest.raises(ValueError, match="tree_limit is not yet supported for CatBoost"):
+        explainer.shap_values(X[:3], tree_limit=5)
+
+
+def test_mismatched_tree_output_dims():
+    """TreeEnsemble should reject trees with different output dimensions."""
+    from shap.explainers._tree import TreeEnsemble
+
+    # two single-node trees: first has 1 output, second has 2
+    model_dict = {
+        "trees": [
+            {
+                "children_left": np.array([-1], dtype=np.int32),
+                "children_right": np.array([-1], dtype=np.int32),
+                "children_default": np.array([-1], dtype=np.int32),
+                "features": np.array([-2], dtype=np.int32),
+                "thresholds": np.array([0.0]),
+                "values": np.array([[1.0]]),
+                "node_sample_weight": np.array([10.0]),
+            },
+            {
+                "children_left": np.array([-1], dtype=np.int32),
+                "children_right": np.array([-1], dtype=np.int32),
+                "children_default": np.array([-1], dtype=np.int32),
+                "features": np.array([-2], dtype=np.int32),
+                "thresholds": np.array([0.0]),
+                "values": np.array([[1.0, 2.0]]),
+                "node_sample_weight": np.array([10.0]),
+            },
+        ],
+    }
+
+    with pytest.raises(ValueError, match="same output dimension"):
+        TreeEnsemble(model_dict)
+
+
 def test_large_background_dataset_warning():
     """A warning should be emitted when >1000 background samples are passed
     with feature_perturbation='interventional'. Regression test for GH#4385."""


### PR DESCRIPTION
## Overview

Closes #4820

`_tree.py` uses `assert` for input validation in 17 places. This is a problem because:

1. Users get `AssertionError` instead of `ValueError`/`TypeError`, which they can't catch with `except ValueError`
2. `python -O` strips assert statements entirely, so the checks silently disappear

For example, passing `approximate=True` to a CatBoost model raises `AssertionError` normally but silently runs and returns results under `python -O`:

```python
# normal python: AssertionError
# python -O: no error, returns results
explainer.shap_values(X, approximate=True)
```

This PR replaces the 17 user-facing asserts with `raise ValueError` / `raise TypeError` / `raise AttributeError` as appropriate. Error messages are kept the same (two got slightly more detail added).

The 5 asserts inside `XGBTreeModelLoader` are left alone since those check internal parsed data structures, not user input.

**What changed:**

- Unfitted model checks : `assert hasattr(model, "estimators_")` -> `raise ValueError`
- Input validation in `_validate_inputs` and `predict` : `assert isinstance` -> `raise TypeError`, `assert len(X.shape)` -> `raise ValueError`
- Unsupported param combos  `assert not approximate` -> `raise ValueError`
- Internal consistency : output dimension mismatch, base_offset length, xgboost n_outputs

No behavior change in normal mode. Same error messages, just the right exception types.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
