### PR TITLE
fix: typo "logloss" -> "log_loss" in TreeEnsemble.predict()

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1690,7 +1690,7 @@ class TreeEnsemble:
         if tree_limit < 0 or tree_limit > self.values.shape[0]:
             tree_limit = self.values.shape[0]
 
-        if output == "logloss":
+        if output == "log_loss":
             if y is None:
                 raise ValueError(
                     "Both samples and labels must be provided when explaining the loss"


### PR DESCRIPTION
## Overview

Closes #4828 (see also #1205 which reported the same bug in 2020 but was closed by the stale bot)

`TreeEnsemble.predict()` checks `output == "logloss"` on line 1693, but the actual value is `"log_loss"` (with underscore). Every other place in the file uses `"log_loss"`. Because of this typo the y-validation block never runs, so calling `predict(X, output="log_loss")` without passing `y` silently returns results instead of raising an error.

One-line fix: `"logloss"` -> `"log_loss"`.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)

No new unit tests added because this is a one-character typo fix , and all pre-existing testcases are passing.