### PR TITLE
fix(plots): honor custom ax in partial_dependence_plot

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -102,8 +102,8 @@ def partial_dependence(
             fig = plt.figure()
             ax1 = plt.gca()
         else:
-            fig = plt.gcf()
-            ax1 = plt.gca()
+            ax1 = ax
+            fig = ax.get_figure()
 
         # fig, ax1 = plt.subplots(figsize)
         ax2 = ax1.twinx()

--- a/tests/plots/test_partial_dependence.py
+++ b/tests/plots/test_partial_dependence.py
@@ -1,8 +1,5 @@
 """Tests for shap.partial_dependence_plot."""
 
-import matplotlib
-
-matplotlib.use("Agg")  # headless backend so tests don't pop windows
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -34,7 +31,7 @@ def test_partial_dependence_respects_custom_ax():
     def model(x):
         return x[:, 0] + 0.5 * x[:, 1]
 
-    fig, axes = plt.subplots(1, 2)
+    _, axes = plt.subplots(1, 2)
     try:
         shap.partial_dependence_plot(
             0,

--- a/tests/plots/test_partial_dependence.py
+++ b/tests/plots/test_partial_dependence.py
@@ -1,0 +1,59 @@
+"""Tests for shap.partial_dependence_plot."""
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless backend so tests don't pop windows
+import matplotlib.pyplot as plt
+import numpy as np
+
+import shap
+
+
+def test_partial_dependence_does_not_crash():
+    """Smoke test: the basic call path renders without error."""
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((30, 3))
+
+    def model(x):
+        return x[:, 0] + 0.5 * x[:, 1]
+
+    shap.partial_dependence_plot(0, model, X, ice=False, show=False)
+    plt.close("all")
+
+
+def test_partial_dependence_respects_custom_ax():
+    """Regression test for GH #3206.
+
+    Passing ``ax=`` must draw onto that axis. Previously the function
+    called ``plt.gca()`` in the ``else`` branch and ignored the caller's
+    axis, so multiple plots in a loop all stacked onto the last subplot.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((30, 3))
+
+    def model(x):
+        return x[:, 0] + 0.5 * x[:, 1]
+
+    fig, axes = plt.subplots(1, 2)
+    try:
+        shap.partial_dependence_plot(
+            0,
+            model,
+            X,
+            ice=False,
+            show=False,
+            ax=axes[0],
+        )
+        shap.partial_dependence_plot(
+            1,
+            model,
+            X,
+            ice=False,
+            show=False,
+            ax=axes[1],
+        )
+        # Both axes must have been drawn into. With the bug, only one would.
+        assert axes[0].has_data(), "ax=axes[0] should have been drawn into"
+        assert axes[1].has_data(), "ax=axes[1] should have been drawn into"
+    finally:
+        plt.close("all")


### PR DESCRIPTION
**Note for maintainers:** I'm aware of related PRs #4140, #4411, and #4481 which propose similar fixes for this issue. I implemented this independently while learning the codebase as part of my ESoC 2026 application, and I'm sharing it for transparency rather than expecting it to be merged. I'm happy to defer to whichever PR you prefer to merge, or to help test/review the others.

Closes #3206.

## Problem

`shap.partial_dependence_plot(..., ax=my_ax)` ignores the passed `ax`. The `else` branch of the axis setup block calls `plt.gca()` instead of using the caller's axis, so a loop drawing different features into separate subplots ends up stacking everything onto matplotlib's globally-current axis — typically just the last subplot.

## Reproduction

Verified locally on Windows / Python 3.13 / matplotlib 3.10.9 with this snippet:

```python
import matplotlib.pyplot as plt
import numpy as np
import shap

rng = np.random.default_rng(0)
X = rng.standard_normal((30, 3))
def model(x): return x[:, 0] + 0.5 * x[:, 1] - 0.3 * x[:, 2]

fig, axes = plt.subplots(1, 3, figsize=(12, 4))
for i in range(3):
    shap.partial_dependence_plot(i, model, X, ice=False, show=False, ax=axes[i])
```

**Before the fix:**
```
axes[0].has_data(): False
axes[1].has_data(): False
axes[2].has_data(): True
```

**After the fix:**
```
axes[0].has_data(): True
axes[1].has_data(): True
axes[2].has_data(): True
```

## Fix

Two-line change in `shap/plots/_partial_dependence.py`: in the `else` branch of the axis setup, use the passed `ax` directly and recover its figure via `ax.get_figure()` instead of falling back to `plt.gca()`.

## Test

Added `tests/plots/test_partial_dependence.py` with a regression test that creates two subplots, calls `partial_dependence_plot` with `ax=` for each, and asserts both axes have artists. Verified locally that the test fails on master (without this change) and passes with the fix applied.

## Scope

Limited to the 1D path, which is what the issue reports. The 2D (`ind=(a, b)`) surface path also overrides `ax` but fixing it would require the caller to pass a 3D projection axis — different signature contract, kept out of scope.

## Before / After
<img width="1200" height="400" alt="before" src="https://github.com/user-attachments/assets/37f0bdca-0c9c-44bb-b25a-59794f1e28cb" />

**Before:** Only the last subplot is drawn into.


<img width="1200" height="400" alt="after" src="https://github.com/user-attachments/assets/38583d56-5aef-4819-a03c-115c7c2b6f36" />

**After:** Each subplot has its own PDP.