### PR TITLE
FIX: Implement missing __rtruediv__ operator for Explanation objects

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -501,6 +501,9 @@ class Explanation(metaclass=MetaExplanation):
     def __truediv__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:
         return self._apply_binary_operator(other, operator.truediv, "__truediv__")
 
+    def __rtruediv__(self, other: Explanation | npt.NDArray[Any] | float | int) -> Explanation:  # type: ignore[misc]
+        return self._apply_binary_operator(other, lambda a, b: b / a, "__rtruediv__")
+
     def _numpy_func(self, fname: str, **kwargs: Any) -> Explanation:
         """Apply a numpy-style function to this Explanation."""
         new_self = copy.copy(self)

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,28 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+def test_explanation_rtruediv():
+    """Checks that __rtruediv__ correctly computes other / self, not self / other."""
+    import numpy as np
+    import shap
+
+    exp = shap.Explanation(values=np.array([1.0, 2.0, 4.0]))
+
+    # Test 1: float / explanation gives correct inverted values
+    result = 4.0 / exp
+    assert isinstance(result, shap.Explanation)
+    assert np.allclose(result.values, [4.0, 2.0, 1.0])
+
+    # Test 2: int / explanation (covers non-float scalars)
+    result_int = 8 / exp
+    assert isinstance(result_int, shap.Explanation)
+    assert np.allclose(result_int.values, [8.0, 4.0, 2.0])
+
+    # Test 3: operand-order regression guard — must NOT equal explanation / scalar
+    forward = (exp / 4.0).values
+    assert not np.allclose(result.values, forward), (
+        "__rtruediv__ returned same result as __truediv__ - operand order is wrong"
+    )
+

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -249,10 +249,6 @@ def test_cohorts_generation_with_one_feature():
 
 def test_explanation_rtruediv():
     """Checks that __rtruediv__ correctly computes other / self, not self / other."""
-    import numpy as np
-
-    import shap
-
     exp = shap.Explanation(values=np.array([1.0, 2.0, 4.0]))
 
     # Test 1: float / explanation gives correct inverted values

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -250,6 +250,7 @@ def test_cohorts_generation_with_one_feature():
 def test_explanation_rtruediv():
     """Checks that __rtruediv__ correctly computes other / self, not self / other."""
     import numpy as np
+
     import shap
 
     exp = shap.Explanation(values=np.array([1.0, 2.0, 4.0]))
@@ -269,4 +270,3 @@ def test_explanation_rtruediv():
     assert not np.allclose(result.values, forward), (
         "__rtruediv__ returned same result as __truediv__ - operand order is wrong"
     )
-


### PR DESCRIPTION
Fixes #4785.

### Description
The `Explanation` class implements `__truediv__` but is missing `__rtruediv__`. This causes `1.0 / shap_values` to crash with a `TypeError`, breaking algebraic symmetry with the existing right-hand operator support (`__radd__`, `__rmul__`).

This PR adds `__rtruediv__` with explicitly reversed operands (`lambda a, b: b / a`) to prevent repeating the same operand-order bug seen in `__rsub__` before #4709.

### Tests added
- `float / explanation` — core behaviour
- `int / explanation` — non-float scalar edge case
- Operand-order regression guard confirming `other / self` is computed, not `self / other`

### Note on NumPy array behaviour
A test for `numpy_array / explanation` was considered but omitted. When the left operand is an ndarray, NumPy's own `__truediv__` takes precedence and `Explanation.__rtruediv__` is never invoked. This matches the existing behaviour across all other right-hand operators in the class (`__radd__`, `__rmul__`) and is not specific to this PR.

### Checklist
- [x] Unit tests added covering float and int divisors
- [x] Operand-order regression guard included
- [x] All existing tests pass locally