### PR TITLE
ENH: Add ax parameter to shap.plots.monitoring() for consistency

### DIFF
--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -14,14 +14,15 @@ def truncate_text(text, max_len):
         return text
 
 
-def monitoring(ind, shap_values, features, feature_names=None, show=True):
+def monitoring(ind, shap_values, features, feature_names=None, show=True, ax=None):
     """Create a SHAP monitoring plot.
 
-    (Note this function is preliminary and subject to change!!)
-    A SHAP monitoring plot is meant to display the behavior of a model
-    over time. Often the shap_values given to this plot explain the loss
-    of a model, so changes in a feature's impact on the model's loss over
-    time can help in monitoring the model's performance.
+    Note: this function is preliminary and subject to change.
+
+    A SHAP monitoring plot displays the behavior of a model over time. Often
+    the shap_values given to this plot explain the loss of a model, so changes
+    in a feature's impact on the model's loss over time can help in monitoring
+    the model's performance.
 
     Parameters
     ----------
@@ -37,6 +38,18 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     feature_names : list
         Names of the features (length # features)
 
+    show : bool
+        Whether to call ``plt.show()`` after rendering. Set to ``False`` when
+        embedding the plot in a larger figure.
+
+    ax : matplotlib.axes.Axes, optional
+        Axes object to draw the plot on. If ``None`` (default), a new figure
+        with ``figsize=(10, 3)`` is created.
+
+    Returns
+    -------
+    matplotlib.axes.Axes or None
+        The axes object when ``show=False``, otherwise ``None``.
     """
     if isinstance(features, pd.DataFrame):
         if feature_names is None:
@@ -48,7 +61,11 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     if feature_names is None:
         feature_names = np.array([labels["FEATURE"] % str(i) for i in range(num_features)])
 
-    plt.figure(figsize=(10, 3))
+    if ax is None:
+        _, ax = plt.subplots(figsize=(10, 3))
+    else:
+        show = False
+
     ys = shap_values[:, ind]
     xs = np.arange(len(ys))  # np.linspace(0, 12*2, len(ys))
 
@@ -62,20 +79,22 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
     min_pval_ind = float(np.argmin(pvals) * inc + inc)
 
     if min_pval < 0.05 / shap_values.shape[1]:
-        plt.axvline(min_pval_ind, linestyle="dashed", color="#666666", alpha=0.2)
+        ax.axvline(min_pval_ind, linestyle="dashed", color="#666666", alpha=0.2)
 
-    plt.scatter(xs, ys, s=10, c=features[:, ind], cmap=colors.red_blue)
+    ax.scatter(xs, ys, s=10, c=features[:, ind], cmap=colors.red_blue)
 
-    plt.xlabel("Sample index")
-    plt.ylabel(truncate_text(feature_names[ind], 30) + "\nSHAP value", size=13)
-    plt.gca().xaxis.set_ticks_position("bottom")
-    plt.gca().yaxis.set_ticks_position("left")
-    plt.gca().spines["right"].set_visible(False)
-    plt.gca().spines["top"].set_visible(False)
-    cb = plt.colorbar()
+    ax.set_xlabel("Sample index")
+    ax.set_ylabel(truncate_text(feature_names[ind], 30) + "\nSHAP value", size=13)
+    ax.xaxis.set_ticks_position("bottom")
+    ax.yaxis.set_ticks_position("left")
+    ax.spines["right"].set_visible(False)
+    ax.spines["top"].set_visible(False)
+    cb = ax.get_figure().colorbar(ax.collections[0], ax=ax)
     cb.outline.set_visible(False)  # type: ignore
-    bbox = cb.ax.get_window_extent().transformed(plt.gcf().dpi_scale_trans.inverted())
+    bbox = cb.ax.get_window_extent().transformed(ax.get_figure().dpi_scale_trans.inverted())
     cb.ax.set_aspect((bbox.height - 0.7) * 20)
     cb.set_label(truncate_text(feature_names[ind], 30), size=13)
     if show:
         plt.show()
+    else:
+        return ax

--- a/tests/plots/test_monitoring.py
+++ b/tests/plots/test_monitoring.py
@@ -1,0 +1,40 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+import shap
+
+
+def _make_data(n=200, p=5, seed=0):
+    rng = np.random.default_rng(seed)
+    shap_values = rng.standard_normal((n, p))
+    features = rng.standard_normal((n, p))
+    return shap_values, features
+
+
+def test_monitoring_show_false_returns_ax():
+    """show=False with no explicit ax returns an Axes object."""
+    shap_values, features = _make_data()
+    result = shap.plots.monitoring(0, shap_values, features, show=False)
+    assert result is not None
+    assert hasattr(result, "scatter")
+    plt.close("all")
+
+
+def test_monitoring_ax_parameter():
+    """Passing ax= returns that exact axes and leaves sibling axes untouched."""
+    shap_values, features = _make_data()
+    fig, axes = plt.subplots(1, 2)
+    result = shap.plots.monitoring(0, shap_values, features, show=False, ax=axes[0])
+    assert result is axes[0]
+    assert len(axes[1].collections) == 0
+    plt.close("all")
+
+
+def test_monitoring_dataframe_features():
+    """DataFrame features are handled correctly (column names used as feature_names)."""
+    shap_values, features_arr = _make_data()
+    features_df = pd.DataFrame(features_arr, columns=[f"f{i}" for i in range(features_arr.shape[1])])
+    result = shap.plots.monitoring(0, shap_values, features_df, show=False)
+    assert result is not None
+    plt.close("all")


### PR DESCRIPTION
## Overview

Closes #4819

`shap.plots.monitoring()` called `plt.figure(figsize=(10, 3))` unconditionally and used implicit `plt.` state throughout, making it impossible to embed a monitoring plot inside a subplot grid.

Added `ax=None` following the same pattern as `shap.plots.group_difference()`: when `ax=None` a new figure is created (existing behaviour preserved); when the caller supplies an `ax`, plotting targets that axes and `show` is forced to `False`. All `plt.gca()`, `plt.gcf()`, and implicit `plt.` draw calls replaced with explicit `ax.` / `ax.get_figure()` equivalents. Colorbar now attached via `ax.get_figure().colorbar(ax.collections[0], ax=ax)` so it binds to the correct axes in a composite figure. `show=False` now returns the `Axes` object.

Added `show` and `ax` to the docstring and tidied the informal header note.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)