### PR TITLE
TEST: Remove external tokenizer dependency in SequentialPerturbation tests

### DIFF
--- a/tests/benchmark/perturbation.py
+++ b/tests/benchmark/perturbation.py
@@ -1,5 +1,4 @@
 import numpy as np
-from transformers import AutoTokenizer
 
 import shap.benchmark as benchmark
 from shap.maskers import FixedComposite, Image, Impute, Independent, Partition, Text
@@ -35,7 +34,7 @@ def test_init(random_seed):
     )
     assert sequential_perturbation.data_type == "tabular"
 
-    text_masker = Text(AutoTokenizer.from_pretrained("nateraw/bert-base-uncased-emotion", use_fast=True))
+    text_masker = Text(None)
     sequential_perturbation = benchmark.perturbation.SequentialPerturbation(
         model, text_masker, sort_order, perturbation
     )


### PR DESCRIPTION
Fixes #4838

This PR removes dependency on external tokenizer downloads in SequentialPerturbation tests.

## Changes
- Replaced AutoTokenizer usage with lightweight alternative
- Improves test reliability and CI stability
- Removes network dependency

No changes to functionality.

Happy to make any adjustments.