### PR TITLE
FIX: Prevent PyTorchDeep memory leak by correcting remove_attributes traversal

### DIFF
--- a/shap/explainers/_deep/deep_pytorch.py
+++ b/shap/explainers/_deep/deep_pytorch.py
@@ -81,18 +81,19 @@ class PyTorchDeep(Explainer):
         """Removes the x and y attributes which were added by the forward handles
         Recursively searches for non-container layers
         """
-        for child in model.children():
-            if "nn.modules.container" in str(type(child)):
+        children = list(model.children())
+        if children:
+            for child in children:
                 self.remove_attributes(child)
-            else:
-                try:
-                    del child.x
-                except AttributeError:
-                    pass
-                try:
-                    del child.y
-                except AttributeError:
-                    pass
+        else:
+            try:
+                del model.x
+            except AttributeError:
+                pass
+            try:
+                del model.y
+            except AttributeError:
+                pass
 
     def gradient(self, idx, inputs):
         import torch


### PR DESCRIPTION


## Description

Closes #4839.

This PR fixes a bug in `PyTorchDeep.remove_attributes` that causes a pretty severe memory leak when running `DeepExplainer` on models that use custom `nn.Module` subclasses. 

Basically, the [remove_attributes](cci:1://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_deep/deep_pytorch.py:79:4-95:20) method was using a hard-coded check (`"nn.modules.container" in str(type(child))`) to decide if a module was a container. This meant it would only recurse into things like `Sequential` or `ModuleList`. If a model had any custom wrapper blocks (like a custom ResNet block or an attention layer), the method treated the whole block as a leaf node. As a result, it silently failed to clean up the `.x` and `.y` temporary trace tensors attached to the *actual* leaf layers nested inside. Because those tensors retain their Autograd graph, this caused a major memory leak and could even pollute subsequent [shap_values](cci:1://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_linear.py:414:4-478:21) calls with stale data.

## Changes
- I removed the brittle string check and changed the traversal logic to match what is already successfully used in [add_handles()](cci:1://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_deep/deep_pytorch.py:65:4-77:27). It now simply checks `list(model.children())` — if there are children, it recurses; if not, it cleans up the attributes. 

All existing `PyTorchDeep` tests pass with this change!
