### PR TITLE
FIX: Correct variance calculation of mean SHAP values in GradientExplainer

### DIFF
--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -394,7 +394,7 @@ class _TFGradient(Explainer):
                 for a in range(len(X)):
                     samples = grad[a] * samples_delta[a]
                     phis[a][j] = samples.mean(0)
-                    phi_vars[a][j] = samples.var(0) / np.sqrt(samples.shape[0])  # estimate variance of means
+                    phi_vars[a][j] = samples.var(0) / samples.shape[0]  # estimate variance of means
 
                 # TODO: this could be avoided by integrating between endpoints if no local smoothing is used
                 # correct the sum of the values to equal the output of the model using a linear
@@ -685,7 +685,7 @@ class _PyTorchGradient(Explainer):
                 for t in range(len(self.data)):
                     samples = grad[t] * samples_delta[t]
                     phis[t][j] = samples.mean(0)
-                    phi_vars[t][j] = samples.var(0) / np.sqrt(samples.shape[0])  # estimate variance of means
+                    phi_vars[t][j] = samples.var(0) / samples.shape[0]  # estimate variance of means
 
             output_phis.append(phis[0] if len(self.data) == 1 else phis)
             output_phi_vars.append(phi_vars[0] if not self.multi_input else phi_vars)


### PR DESCRIPTION


## Description

Closes #4842.

This PR fixes a mathematical error in [GradientExplainer](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_gradient.py:21:0-177:141) where the variance of the sample mean was being substantially overestimated.

## The Issue
In both the TensorFlow and PyTorch backend implementations ([_TFGradient](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_gradient.py:180:0-461:30) and [_PyTorchGradient](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_gradient.py:464:0-714:65)), when `return_variances=True` is passed, the code estimates the variance of the mean SHAP values using `samples.var(0) / np.sqrt(N)`. This is mathematically incorrect — the correct formula for the variance of the sample mean is `Var(X) / N`. Dividing by the square root caused the returned variance estimates to be much larger than they actually were.

Interestingly, this is the exact same logic bug that was recently reported and fixed in [SamplingExplainer](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_sampling.py:15:0-226:42) (#4767), it must have just been carried over to [GradientExplainer](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_gradient.py:21:0-177:141) as well. 

## The Fix
I have simply replaced `np.sqrt(samples.shape[0])` with `samples.shape[0]` on the two affected lines in [_gradient.py](cci:7://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_gradient.py:0:0-0:0). 

Ran the existing [GradientExplainer](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_gradient.py:21:0-177:141) tests locally and everything passes without issues!
