### PR TITLE
FIX: Swap axes for CatBoost multi-output interactions

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -834,7 +834,7 @@ class TreeExplainer(Explainer):
             # note we pull off the last column and keep it as our expected_value
             if len(phi.shape) == 4:
                 self.expected_value = getattr(self, "expected_value", [phi[0, i, -1, -1] for i in range(phi.shape[1])])
-                return [phi[:, i, :-1, :-1] for i in range(phi.shape[1])]  # type: ignore[return-value]
+                return np.swapaxes(phi[:, :, :-1, :-1], axis1=1, axis2=3)
             else:
                 self.expected_value = getattr(self, "expected_value", phi[0, -1, -1])
                 return phi[:, :-1, :-1]


### PR DESCRIPTION


## Description

Closes #4845.

This PR fixes a small API inconsistency in `TreeExplainer.shap_interaction_values()` where CatBoost multi-output models were mistakenly returning a Python list instead of an `np.ndarray`. 

## The Issue
In the v0.45.0 release, the API was standardized so that multi-output SHAP values and interaction values are consistently returned as `np.ndarray`s (with the outputs stacked on the last dimension). While [shap_values()](cci:1://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_kernel.py:228:4-345:38) was correctly updated, and XGBoost/LightGBM were handled in PR #3318, the interaction values output for CatBoost was overlooked and retained an old list comprehension.

This breaks downstream array operations where users expect to be able to check `.shape` or matrix-multiply the output immediately, throwing `AttributeError: 'list' object has no attribute 'shape'` errors out of nowhere.

## The Fix
I've dropped the list comprehension on line 823 of [_tree.py](cci:7://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_tree.py:0:0-0:0) and replaced it with `np.swapaxes(phi[:, :, :-1, :-1], axis1=1, axis2=3)`. This matches exactly how the XGBoost implementation handles interaction array extraction just a few lines above.

The [TreeExplainer](cci:2://file:///c:/Users/aftab/Desktop/shap/shap/explainers/_tree.py:114:0-928:19) test suite still passes perfectly locally!
