### PR TITLE
feat: add TreeEnsemble.from_trees classmethod for scikit-learn trees

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1578,6 +1578,7 @@ class TreeEnsemble:
                 self.base_offset = (np.ones(self.num_outputs) * self.base_offset).astype(self.internal_dtype)
             self.base_offset = self.base_offset.flatten()
             assert len(self.base_offset) == self.num_outputs
+
     @classmethod
     def from_trees(
         cls,
@@ -1590,7 +1591,7 @@ class TreeEnsemble:
         objective: str | None = None,
         data: npt.NDArray[Any] | None = None,
         data_missing: npt.NDArray[np.bool_] | None = None,
-    ) -> "TreeEnsemble":
+    ) -> TreeEnsemble:
         """Create a TreeEnsemble directly from a list of scikit-learn tree objects.
 
         This classmethod provides a standardized interface for constructing a
@@ -1683,6 +1684,7 @@ class TreeEnsemble:
                 break
 
         return obj
+
     def _set_xgboost_model_attributes(
         self,
         data: npt.NDArray[Any] | None,

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1578,7 +1578,111 @@ class TreeEnsemble:
                 self.base_offset = (np.ones(self.num_outputs) * self.base_offset).astype(self.internal_dtype)
             self.base_offset = self.base_offset.flatten()
             assert len(self.base_offset) == self.num_outputs
+    @classmethod
+    def from_trees(
+        cls,
+        trees: list,
+        normalize: bool = False,
+        scaling: float | None = None,
+        base_offset: float = 0.0,
+        model_output: str = "raw_value",
+        tree_output: str = "raw_value",
+        objective: str | None = None,
+        data: npt.NDArray[Any] | None = None,
+        data_missing: npt.NDArray[np.bool_] | None = None,
+    ) -> "TreeEnsemble":
+        """Create a TreeEnsemble directly from a list of scikit-learn tree objects.
 
+        This classmethod provides a standardized interface for constructing a
+        TreeEnsemble without relying on model-type dispatch in ``__init__``.
+        It targets scikit-learn's internal tree structure, as documented here:
+        https://scikit-learn.org/stable/auto_examples/tree/plot_unveil_tree_structure.html
+
+        Parameters
+        ----------
+        trees : list
+            A list of fitted scikit-learn estimator objects (e.g. from
+            ``RandomForestClassifier.estimators_``) or a list of raw
+            ``sklearn.tree._classes.DecisionTree`` internal tree objects.
+        normalize : bool
+            If True, normalizes leaf values to probabilities (use for classifiers).
+        scaling : float or None
+            Scaling factor applied to each tree's leaf values. If None, defaults
+            to ``1.0 / len(trees)`` (average of trees).
+        base_offset : float
+            The base score or intercept of the model.
+        model_output : str
+            The output type of the model (e.g. "raw_value", "probability").
+        tree_output : str
+            The unit of values in the leaves of the trees.
+        objective : str or None
+            The training objective of the model (e.g. "squared_error").
+        data : np.ndarray or None
+            Background dataset for computing node sample weights.
+        data_missing : np.ndarray or None
+            Boolean mask indicating missing values in data.
+
+        Returns
+        -------
+        TreeEnsemble
+            A TreeEnsemble object ready for use with TreeExplainer.
+
+        Examples
+        --------
+        >>> from sklearn.ensemble import RandomForestClassifier
+        >>> from sklearn.datasets import load_iris
+        >>> import shap
+        >>> X, y = load_iris(return_X_y=True)
+        >>> model = RandomForestClassifier(n_estimators=10, random_state=42).fit(X, y)
+        >>> ensemble = TreeEnsemble.from_trees(
+        ...     model.estimators_,
+        ...     normalize=True,
+        ... )
+        >>> explainer = shap.TreeExplainer(ensemble)
+        """
+        if len(trees) == 0:
+            raise ValueError("The `trees` list must not be empty.")
+
+        _scaling = scaling if scaling is not None else 1.0 / len(trees)
+
+        # Support both raw estimator objects (with .tree_) and raw tree objects
+        parsed_trees = []
+        for t in trees:
+            raw_tree = t.tree_ if hasattr(t, "tree_") else t
+            parsed_trees.append(
+                SingleTree(
+                    raw_tree,
+                    normalize=normalize,
+                    scaling=_scaling,
+                    data=data,
+                    data_missing=data_missing,
+                )
+            )
+
+        obj = cls.__new__(cls)
+        obj.model_type = "internal"
+        obj.trees = parsed_trees
+        obj.base_offset = base_offset
+        obj.model_output = model_output
+        obj.objective = objective
+        obj.tree_output = tree_output
+        obj.internal_dtype = parsed_trees[0].values.dtype.type
+        obj.input_dtype = np.float32
+        obj.data = data
+        obj.data_missing = data_missing
+        obj.fully_defined_weighting = True
+        obj.tree_limit = None
+        obj.num_stacked_models = 1
+        obj.cat_feature_indices = None
+        obj.original_model = None
+
+        # Check if all leaves have background sample weight
+        for t in parsed_trees:
+            if np.min(t.node_sample_weight) <= 0:
+                obj.fully_defined_weighting = False
+                break
+
+        return obj
     def _set_xgboost_model_attributes(
         self,
         data: npt.NDArray[Any] | None,

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3015,3 +3015,62 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+    
+
+def test_tree_ensemble_from_trees_random_forest_classifier():
+    """Test TreeEnsemble.from_trees with sklearn RandomForestClassifier."""
+    pytest.importorskip("sklearn")
+    from sklearn.datasets import load_iris
+    from sklearn.ensemble import RandomForestClassifier
+    from shap.explainers._tree import TreeEnsemble
+
+    X, y = load_iris(return_X_y=True)
+    model = RandomForestClassifier(n_estimators=10, random_state=42).fit(X, y)
+
+    ensemble = TreeEnsemble.from_trees(model.estimators_, normalize=True)
+
+    assert ensemble is not None
+    assert len(ensemble.trees) == 10
+    assert ensemble.model_type == "internal"
+    assert ensemble.tree_output == "raw_value"
+
+
+def test_tree_ensemble_from_trees_random_forest_regressor():
+    """Test TreeEnsemble.from_trees with sklearn RandomForestRegressor."""
+    pytest.importorskip("sklearn")
+    from sklearn.datasets import load_diabetes
+    from sklearn.ensemble import RandomForestRegressor
+    from shap.explainers._tree import TreeEnsemble
+
+    X, y = load_diabetes(return_X_y=True)
+    model = RandomForestRegressor(n_estimators=10, random_state=42).fit(X, y)
+
+    ensemble = TreeEnsemble.from_trees(model.estimators_, normalize=False)
+
+    assert ensemble is not None
+    assert len(ensemble.trees) == 10
+    assert ensemble.model_type == "internal"
+
+
+def test_tree_ensemble_from_trees_single_decision_tree():
+    """Test TreeEnsemble.from_trees with a single DecisionTreeClassifier."""
+    pytest.importorskip("sklearn")
+    from sklearn.datasets import load_iris
+    from sklearn.tree import DecisionTreeClassifier
+    from shap.explainers._tree import TreeEnsemble
+
+    X, y = load_iris(return_X_y=True)
+    model = DecisionTreeClassifier(random_state=42).fit(X, y)
+
+    ensemble = TreeEnsemble.from_trees([model], normalize=True)
+
+    assert ensemble is not None
+    assert len(ensemble.trees) == 1
+
+
+def test_tree_ensemble_from_trees_empty_raises():
+    """Test that from_trees raises ValueError on empty list."""
+    from shap.explainers._tree import TreeEnsemble
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        TreeEnsemble.from_trees([])

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3015,13 +3015,14 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
-    
+
 
 def test_tree_ensemble_from_trees_random_forest_classifier():
     """Test TreeEnsemble.from_trees with sklearn RandomForestClassifier."""
     pytest.importorskip("sklearn")
     from sklearn.datasets import load_iris
     from sklearn.ensemble import RandomForestClassifier
+
     from shap.explainers._tree import TreeEnsemble
 
     X, y = load_iris(return_X_y=True)
@@ -3040,6 +3041,7 @@ def test_tree_ensemble_from_trees_random_forest_regressor():
     pytest.importorskip("sklearn")
     from sklearn.datasets import load_diabetes
     from sklearn.ensemble import RandomForestRegressor
+
     from shap.explainers._tree import TreeEnsemble
 
     X, y = load_diabetes(return_X_y=True)
@@ -3057,6 +3059,7 @@ def test_tree_ensemble_from_trees_single_decision_tree():
     pytest.importorskip("sklearn")
     from sklearn.datasets import load_iris
     from sklearn.tree import DecisionTreeClassifier
+
     from shap.explainers._tree import TreeEnsemble
 
     X, y = load_iris(return_X_y=True)


### PR DESCRIPTION
## [ESoC 2026] Prototype: TreeEnsemble.from_trees classmethod

This PR is a prototype contribution for the ESoC 2026 "Unify SHAP value 
calculation from Tree-based Models" project idea, referencing issue #4212.

### What this adds
- A `from_trees` classmethod on `TreeEnsemble` that accepts a list of 
  scikit-learn estimator objects and constructs a valid `TreeEnsemble` 
  without going through the existing model-type dispatch in `__init__`
- Supports `RandomForestClassifier`, `RandomForestRegressor`, 
  `DecisionTreeClassifier`, `DecisionTreeRegressor` and any estimator 
  with a `.tree_` attribute
- 4 passing tests covering classifier, regressor, single tree, and 
  empty input validation

### Next steps (full project scope)
- Extend interface to all currently supported tree libraries
- Add exhaustive test suite against all models
- Build usage notebook
- Add `DeprecationWarnings` to smaller library adapters

Happy to iterate based on mentor feedback.