### PR TITLE
test: increase test coverage for SamplingExplainer

### DIFF
--- a/tests/explainers/test_sampling.py
+++ b/tests/explainers/test_sampling.py
@@ -56,9 +56,7 @@ def test_front_page_model_agnostic():
 
 def test_sampling_explainer_with_pandas_input_call():
     """Test __call__ method with pandas DataFrame input returns Explanation object."""
-    explainer = shap.SamplingExplainer(
-        lambda x: np.zeros(x.shape[0]), np.ones((5, 4)), nsamples=100
-    )
+    explainer = shap.SamplingExplainer(lambda x: np.zeros(x.shape[0]), np.ones((5, 4)), nsamples=100)
     X = pd.DataFrame(np.ones((2, 4)), columns=["a", "b", "c", "d"])
     result = explainer(X, nsamples=100)
     assert hasattr(result, "values")
@@ -68,9 +66,7 @@ def test_sampling_explainer_with_pandas_input_call():
 
 def test_sampling_explainer_with_numpy_input_call():
     """Test __call__ method with numpy array input returns Explanation object."""
-    explainer = shap.SamplingExplainer(
-        lambda x: np.zeros(x.shape[0]), np.ones((5, 4)), nsamples=100
-    )
+    explainer = shap.SamplingExplainer(lambda x: np.zeros(x.shape[0]), np.ones((5, 4)), nsamples=100)
     X = np.ones((2, 4))
     result = explainer(X, nsamples=100)
     assert hasattr(result, "values")
@@ -81,9 +77,7 @@ def test_sampling_explainer_single_varying_feature():
     """Test explain() when only one feature varies — phi should capture all effect."""
     background = np.zeros((10, 3))
     # model returns sum of features
-    explainer = shap.SamplingExplainer(
-        lambda x: x.sum(axis=1), background, nsamples=100
-    )
+    explainer = shap.SamplingExplainer(lambda x: x.sum(axis=1), background, nsamples=100)
     # only first feature varies from background (all zeros)
     x = np.array([[5.0, 0.0, 0.0]])
     shap_values = explainer.shap_values(x, nsamples=100)
@@ -94,9 +88,7 @@ def test_sampling_explainer_single_varying_feature():
 def test_sampling_explainer_no_varying_feature():
     """Test explain() when no features vary — all phi should be zero."""
     background = np.ones((10, 3))
-    explainer = shap.SamplingExplainer(
-        lambda x: x.sum(axis=1), background, nsamples=100
-    )
+    explainer = shap.SamplingExplainer(lambda x: x.sum(axis=1), background, nsamples=100)
     # input same as background mean — no variation
     x = np.ones((1, 3))
     shap_values = explainer.shap_values(x, nsamples=100)
@@ -116,9 +108,7 @@ def test_sampling_explainer_invalid_link():
 def test_sampling_estimate_shape():
     """Test that sampling_estimate returns correct shapes."""
     background = np.random.rand(20, 4)
-    explainer = shap.SamplingExplainer(
-        lambda x: x.sum(axis=1), background, nsamples=100
-    )
+    explainer = shap.SamplingExplainer(lambda x: x.sum(axis=1), background, nsamples=100)
     x = np.random.rand(4)
     explainer.X_masked = np.zeros((200, 4))
     mean, var = explainer.sampling_estimate(0, lambda x: x.sum(axis=1), x, background, nsamples=10)
@@ -128,6 +118,7 @@ def test_sampling_estimate_shape():
 def test_sampling_explainer_multioutput():
     """Test SamplingExplainer with multi-output model."""
     background = np.zeros((10, 3))
+
     # model returns 2 outputs
     def multi_output(x):
         return np.column_stack([x.sum(axis=1), x.sum(axis=1) * 2])

--- a/tests/explainers/test_sampling.py
+++ b/tests/explainers/test_sampling.py
@@ -52,3 +52,88 @@ def test_front_page_model_agnostic():
     # use Kernel SHAP to explain test set predictions
     explainer = shap.SamplingExplainer(svm.predict_proba, X_train, nsamples=100)
     explainer.shap_values(X_test)
+
+
+def test_sampling_explainer_with_pandas_input_call():
+    """Test __call__ method with pandas DataFrame input returns Explanation object."""
+    explainer = shap.SamplingExplainer(
+        lambda x: np.zeros(x.shape[0]), np.ones((5, 4)), nsamples=100
+    )
+    X = pd.DataFrame(np.ones((2, 4)), columns=["a", "b", "c", "d"])
+    result = explainer(X, nsamples=100)
+    assert hasattr(result, "values")
+    assert hasattr(result, "base_values")
+    assert result.values.shape[0] == 2
+
+
+def test_sampling_explainer_with_numpy_input_call():
+    """Test __call__ method with numpy array input returns Explanation object."""
+    explainer = shap.SamplingExplainer(
+        lambda x: np.zeros(x.shape[0]), np.ones((5, 4)), nsamples=100
+    )
+    X = np.ones((2, 4))
+    result = explainer(X, nsamples=100)
+    assert hasattr(result, "values")
+    assert result.values.shape[0] == 2
+
+
+def test_sampling_explainer_single_varying_feature():
+    """Test explain() when only one feature varies — phi should capture all effect."""
+    background = np.zeros((10, 3))
+    # model returns sum of features
+    explainer = shap.SamplingExplainer(
+        lambda x: x.sum(axis=1), background, nsamples=100
+    )
+    # only first feature varies from background (all zeros)
+    x = np.array([[5.0, 0.0, 0.0]])
+    shap_values = explainer.shap_values(x, nsamples=100)
+    # all effect should be on feature 0
+    assert abs(shap_values[0][0] - 5.0) < 1.0
+
+
+def test_sampling_explainer_no_varying_feature():
+    """Test explain() when no features vary — all phi should be zero."""
+    background = np.ones((10, 3))
+    explainer = shap.SamplingExplainer(
+        lambda x: x.sum(axis=1), background, nsamples=100
+    )
+    # input same as background mean — no variation
+    x = np.ones((1, 3))
+    shap_values = explainer.shap_values(x, nsamples=100)
+    assert np.sum(np.abs(shap_values)) < 1e-6
+
+
+def test_sampling_explainer_invalid_link():
+    """Test that non-identity link raises ValueError."""
+    with pytest.raises(ValueError, match="identity"):
+        shap.SamplingExplainer(
+            lambda x: np.zeros(x.shape[0]),
+            np.ones((5, 4)),
+            link="logit",
+        )
+
+
+def test_sampling_estimate_shape():
+    """Test that sampling_estimate returns correct shapes."""
+    background = np.random.rand(20, 4)
+    explainer = shap.SamplingExplainer(
+        lambda x: x.sum(axis=1), background, nsamples=100
+    )
+    x = np.random.rand(4)
+    explainer.X_masked = np.zeros((200, 4))
+    mean, var = explainer.sampling_estimate(0, lambda x: x.sum(axis=1), x, background, nsamples=10)
+    assert mean.shape == var.shape
+
+
+def test_sampling_explainer_multioutput():
+    """Test SamplingExplainer with multi-output model."""
+    background = np.zeros((10, 3))
+    # model returns 2 outputs
+    def multi_output(x):
+        return np.column_stack([x.sum(axis=1), x.sum(axis=1) * 2])
+
+    explainer = shap.SamplingExplainer(multi_output, background, nsamples=100)
+    x = np.random.rand(1, 3)
+    shap_values = explainer.shap_values(x, nsamples=100)
+    # shap_values shape is (1, n_features, n_outputs)
+    assert shap_values.shape[-1] == 2


### PR DESCRIPTION
## [ESoC 2026] Increase test coverage for SamplingExplainer

This PR adds 7 new tests for `SamplingExplainer` to increase coverage 
of `shap/explainers/_sampling.py`, as part of the ESoC 2026 project ideas.

### What this adds
- Test `__call__` with pandas DataFrame input
- Test `__call__` with numpy array input  
- Test single varying feature — phi captures full effect
- Test no varying features — all phi zero
- Test invalid link raises ValueError
- Test `sampling_estimate` output shapes
- Test multi-output model support

All 13 tests pass locally.