### PR TITLE
test: add test coverage for AdditiveExplainer

### DIFF
--- a/tests/explainers/test_additive.py
+++ b/tests/explainers/test_additive.py
@@ -7,13 +7,19 @@ import shap
 from shap.explainers._additive import AdditiveExplainer
 
 
+def _sum_model(x):
+    return x.sum(axis=1)
+
+
+def _double_first_feature(x):
+    return x[:, 0] * 2
+
+
 def _make_additive_explainer(n_features=4, n_background=10):
     """Helper to create a simple AdditiveExplainer with a linear additive model."""
     background = np.random.randn(n_background, n_features)
     masker = shap.maskers.Independent(background)
-    # simple additive model: sum of features
-    model = lambda x: x.sum(axis=1)
-    return AdditiveExplainer(model, masker), background, n_features
+    return AdditiveExplainer(_sum_model, masker), background, n_features
 
 
 def test_additive_explainer_init():
@@ -29,7 +35,6 @@ def test_additive_explainer_init():
 def test_additive_explainer_expected_value():
     """Test that expected value is computed correctly."""
     explainer, background, n_features = _make_additive_explainer()
-    # expected value should be close to mean of model output on background
     expected = background.sum(axis=1).mean()
     assert abs(float(explainer._expected_value) - expected) < 1e-6
 
@@ -61,8 +66,7 @@ def test_additive_explainer_zero_input():
     np.random.seed(0)
     background = np.random.randn(10, 3)
     masker = shap.maskers.Independent(background)
-    model = lambda x: x.sum(axis=1)
-    explainer = AdditiveExplainer(model, masker)
+    explainer = AdditiveExplainer(_sum_model, masker)
     X = np.zeros((1, 3))
     result = explainer(X, silent=True)
     assert result.values.shape == (1, 3)
@@ -88,9 +92,8 @@ def test_additive_explainer_explain_row():
 
 def test_additive_explainer_supports_model_with_masker_false():
     """Test that supports_model_with_masker returns False for unknown models."""
-    model = lambda x: x.sum(axis=1)
     masker = shap.maskers.Independent(np.random.randn(10, 4))
-    result = AdditiveExplainer.supports_model_with_masker(model, masker)
+    result = AdditiveExplainer.supports_model_with_masker(_sum_model, masker)
     assert result is False
 
 
@@ -98,8 +101,7 @@ def test_additive_explainer_single_feature():
     """Test AdditiveExplainer with a single feature."""
     background = np.random.randn(10, 1)
     masker = shap.maskers.Independent(background)
-    model = lambda x: x[:, 0] * 2
-    explainer = AdditiveExplainer(model, masker)
+    explainer = AdditiveExplainer(_double_first_feature, masker)
     X = np.random.randn(3, 1)
     result = explainer(X, silent=True)
     assert result.values.shape == (3, 1)
@@ -109,6 +111,5 @@ def test_additive_explainer_wrong_masker_raises():
     """Test that using non-Independent masker raises AssertionError."""
     background = np.random.randn(10, 4)
     masker = shap.maskers.Partition(background)
-    model = lambda x: x.sum(axis=1)
     with pytest.raises(AssertionError):
-        AdditiveExplainer(model, masker)
+        AdditiveExplainer(_sum_model, masker)

--- a/tests/explainers/test_additive.py
+++ b/tests/explainers/test_additive.py
@@ -1,0 +1,112 @@
+"""Unit tests for the AdditiveExplainer."""
+import numpy as np
+import pytest
+import shap
+from shap.explainers._additive import AdditiveExplainer
+
+
+def _make_additive_explainer(n_features=4, n_background=10):
+    """Helper to create a simple AdditiveExplainer with a linear additive model."""
+    background = np.random.randn(n_background, n_features)
+    masker = shap.maskers.Independent(background)
+    # simple additive model: sum of features
+    model = lambda x: x.sum(axis=1)
+    return AdditiveExplainer(model, masker), background, n_features
+
+
+def test_additive_explainer_init():
+    """Test that AdditiveExplainer initializes correctly."""
+    explainer, background, n_features = _make_additive_explainer()
+    assert explainer is not None
+    assert hasattr(explainer, "_expected_value")
+    assert hasattr(explainer, "_zero_offset")
+    assert hasattr(explainer, "_input_offsets")
+    assert len(explainer._input_offsets) == n_features
+
+
+def test_additive_explainer_expected_value():
+    """Test that expected value is computed correctly."""
+    explainer, background, n_features = _make_additive_explainer()
+    # expected value should be close to mean of model output on background
+    expected = background.sum(axis=1).mean()
+    assert abs(float(explainer._expected_value) - expected) < 1e-6
+
+
+def test_additive_explainer_shap_values_shape():
+    """Test that SHAP values have correct shape."""
+    explainer, background, n_features = _make_additive_explainer(n_features=4)
+    X = np.random.randn(3, n_features)
+    result = explainer(X, silent=True)
+    assert result.values.shape == (3, n_features)
+
+
+def test_additive_explainer_additivity():
+    """Test that SHAP values sum to model output minus expected value."""
+    np.random.seed(42)
+    explainer, background, n_features = _make_additive_explainer(n_features=4)
+    X = np.random.randn(5, n_features)
+    result = explainer(X, silent=True)
+    model_output = X.sum(axis=1)
+    expected = float(explainer._expected_value)
+    for i in range(len(X)):
+        shap_sum = result.values[i].sum()
+        diff = model_output[i] - expected
+        assert abs(shap_sum - diff) < 1e-5, f"Additivity failed for sample {i}"
+
+
+def test_additive_explainer_zero_input():
+    """Test SHAP values for zero input."""
+    np.random.seed(0)
+    background = np.random.randn(10, 3)
+    masker = shap.maskers.Independent(background)
+    model = lambda x: x.sum(axis=1)
+    explainer = AdditiveExplainer(model, masker)
+    X = np.zeros((1, 3))
+    result = explainer(X, silent=True)
+    assert result.values.shape == (1, 3)
+
+
+def test_additive_explainer_explain_row():
+    """Test explain_row returns expected keys."""
+    explainer, background, n_features = _make_additive_explainer()
+    x = np.random.randn(n_features)
+    row_result = explainer.explain_row(
+        x,
+        max_evals="auto",
+        main_effects=False,
+        error_bounds=False,
+        outputs=None,
+        silent=True,
+    )
+    assert "values" in row_result
+    assert "expected_values" in row_result
+    assert "main_effects" in row_result
+    assert len(row_result["values"]) == n_features
+
+
+def test_additive_explainer_supports_model_with_masker_false():
+    """Test that supports_model_with_masker returns False for unknown models."""
+    model = lambda x: x.sum(axis=1)
+    masker = shap.maskers.Independent(np.random.randn(10, 4))
+    result = AdditiveExplainer.supports_model_with_masker(model, masker)
+    assert result is False
+
+
+def test_additive_explainer_single_feature():
+    """Test AdditiveExplainer with a single feature."""
+    background = np.random.randn(10, 1)
+    masker = shap.maskers.Independent(background)
+    model = lambda x: x[:, 0] * 2
+    explainer = AdditiveExplainer(model, masker)
+    X = np.random.randn(3, 1)
+    result = explainer(X, silent=True)
+    assert result.values.shape == (3, 1)
+
+
+def test_additive_explainer_wrong_masker_raises():
+    """Test that using non-Independent masker raises AssertionError."""
+    background = np.random.randn(10, 4)
+    masker = shap.maskers.Partition(background)
+    model = lambda x: x.sum(axis=1)
+    with pytest.raises(AssertionError):
+        AdditiveExplainer(model, masker)

--- a/tests/explainers/test_additive.py
+++ b/tests/explainers/test_additive.py
@@ -1,6 +1,8 @@
 """Unit tests for the AdditiveExplainer."""
+
 import numpy as np
 import pytest
+
 import shap
 from shap.explainers._additive import AdditiveExplainer
 


### PR DESCRIPTION
## [ESoC 2026] Add test coverage for AdditiveExplainer

This PR adds 9 new tests for `AdditiveExplainer` — there was previously 
no test file for `shap/explainers/_additive.py`.

### What this adds
- Test correct initialization and attribute setup
- Test expected value computation accuracy
- Test SHAP values output shape
- Test additivity property (SHAP values sum to model output minus expected value)
- Test zero input handling
- Test `explain_row` return structure
- Test `supports_model_with_masker` returns False for unknown models
- Test single feature model
- Test wrong masker type raises AssertionError

All 9 tests pass locally.