### PR TITLE
TEST: Make PyTorch GradientExplainer test deterministic

### DIFF
--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -241,10 +241,17 @@ def test_tf_multi_inputs_multi_outputs():
 def test_pytorch_mnist_cnn():
     """The same test as above, but for pytorch"""
     # FIXME: this test should ideally pass with any random seed. See #2960
-    random_seed = 0
 
     torch = pytest.importorskip("torch")
+    random_seed = 0
     torch.manual_seed(random_seed)
+    np.random.seed(random_seed)
+
+    # Ensure deterministic behavior
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
     rs = np.random.RandomState(random_seed)
 
     from torch import nn


### PR DESCRIPTION
Fixes #4862

While reviewing this test, I noticed it relies on randomness and may not behave consistently across runs (as mentioned in the FIXME comment).

This PR makes the test deterministic by explicitly setting seeds for NumPy and PyTorch, and enabling deterministic behavior in PyTorch.

This helps ensure stable and reproducible test results, avoiding flaky behavior.

No changes were made to the model or test logic , only randomness handling was improved.

Happy to make any adjustments.