### PR TITLE
TEST: Reduce excessive warnings in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,9 @@ filterwarnings = [
   "ignore:.*typing.io is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*is_datetime64tz_dtype is deprecated.*:DeprecationWarning:.*pyspark.*",
   "ignore:.*'force_all_finite' was renamed to 'ensure_all_finite' in 1.6.*:FutureWarning:.*sklearn.*",
+
+  "ignore::DeprecationWarning:matplotlib",
+  "ignore::DeprecationWarning:numpy",
 ]
 markers = ["xslow: mark test as extremely slow (not run unless explicitly requested)"]
 

--- a/tests/explainers/conftest.py
+++ b/tests/explainers/conftest.py
@@ -1,6 +1,12 @@
 import time
+import warnings
 
 import pytest
+
+# Suppress known third-party deprecation warnings that clutter test output
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="matplotlib")
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="numpy")
 
 
 def load_tokenizer_model(name: str, retries: int) -> tuple:


### PR DESCRIPTION
Fixes #4865

This PR reduces noise in the test output by suppressing known third-party deprecation warnings from matplotlib and numpy using pytest configuration.

This improves readability of test results and makes it easier to identify real issues, without affecting SHAP functionality.

No functional changes were made.