### PR TITLE
Add edge-case and behavioral tests for waterfall plot

### DIFF
--- a/tests/plots/test_waterfall_edge_cases.py
+++ b/tests/plots/test_waterfall_edge_cases.py
@@ -1,21 +1,11 @@
 """Edge-case and behavioral tests for the waterfall plot."""
 
-import matplotlib
-matplotlib.use("Agg")
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
 
 import shap
-
-
-@pytest.fixture(autouse=True)
-def _close_figures_between_tests():
-    plt.close("all")
-    yield
-    plt.close("all")
 
 
 def _make_explanation(values, *, data=None, feature_names=None, base_value=0.0):
@@ -44,7 +34,6 @@ def test_waterfall_show_false_returns_current_axis():
     ax = shap.plots.waterfall(explanation, show=False)
 
     assert ax is plt.gca()
-    assert ax is not None
 
 
 def test_waterfall_empty_values_not_supported():
@@ -59,7 +48,12 @@ def test_waterfall_empty_values_not_supported():
 def test_waterfall_feature_names_fallback_when_none():
     """Ensure fallback feature naming works when feature_names=None."""
     plt.figure()
-    explanation = _make_explanation([0.4, -0.2], data=None, feature_names=None)
+    explanation = shap.Explanation(
+        values=np.array([0.4, -0.2]),
+        base_values=0.0,
+        data=None,
+        feature_names=None,
+    )
 
     ax = shap.plots.waterfall(explanation, show=False)
     tick_text = [tick.get_text().strip() for tick in ax.get_yticklabels() if tick.get_text().strip()]
@@ -95,7 +89,6 @@ def test_waterfall_all_positive_values_render_positive_contributions():
     ax = shap.plots.waterfall(explanation, show=False)
 
     assert ax is plt.gca()
-    assert ax is not None
 
 
 def test_waterfall_all_negative_values_render_negative_contributions():
@@ -107,7 +100,6 @@ def test_waterfall_all_negative_values_render_negative_contributions():
     ax = shap.plots.waterfall(explanation, show=False)
 
     assert ax is plt.gca()
-    assert ax is not None
 
 
 def test_waterfall_respects_max_display():
@@ -123,8 +115,10 @@ def test_waterfall_respects_max_display():
 
     # allow small flexibility due to "others" grouping
     assert len(tick_labels) > 0
+    assert len(tick_labels) <= len(values) + 2  # allow flexibility
+
 
 def test_waterfall_rejects_non_explanation():
     """Ensure non-Explanation inputs raise TypeError."""
     with pytest.raises(TypeError):
-        shap.plots.waterfall([1, 2, 3])
+        shap.plots.waterfall([1, 2, 3], show=False)

--- a/tests/plots/test_waterfall_edge_cases.py
+++ b/tests/plots/test_waterfall_edge_cases.py
@@ -1,0 +1,130 @@
+"""Edge-case and behavioral tests for the waterfall plot."""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import shap
+
+
+@pytest.fixture(autouse=True)
+def _close_figures_between_tests():
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def _make_explanation(values, *, data=None, feature_names=None, base_value=0.0):
+    """Build a minimal valid one-row Explanation for waterfall plot tests."""
+    values = np.asarray(values, dtype=float)
+
+    if data is None:
+        data = np.arange(len(values), dtype=float)
+
+    if feature_names is None:
+        feature_names = [f"feature_{i}" for i in range(len(values))]
+
+    return shap.Explanation(
+        values=values,
+        base_values=float(base_value),
+        data=data,
+        feature_names=feature_names,
+    )
+
+
+def test_waterfall_show_false_returns_current_axis():
+    """Ensure show=False returns the current matplotlib axis."""
+    plt.figure()
+    explanation = _make_explanation([0.3, -0.1, 0.2])
+
+    ax = shap.plots.waterfall(explanation, show=False)
+
+    assert ax is plt.gca()
+    assert ax is not None
+
+
+def test_waterfall_empty_values_not_supported():
+    """Ensure empty SHAP values raise an error (unsupported case)."""
+    plt.figure()
+
+    with pytest.raises((ValueError, IndexError)):
+        explanation = _make_explanation([], data=np.array([]), feature_names=[])
+        shap.plots.waterfall(explanation, show=False)
+
+
+def test_waterfall_feature_names_fallback_when_none():
+    """Ensure fallback feature naming works when feature_names=None."""
+    plt.figure()
+    explanation = _make_explanation([0.4, -0.2], data=None, feature_names=None)
+
+    ax = shap.plots.waterfall(explanation, show=False)
+    tick_text = [tick.get_text().strip() for tick in ax.get_yticklabels() if tick.get_text().strip()]
+
+    assert tick_text
+    assert len(tick_text) >= len(explanation.values)
+
+
+def test_waterfall_accepts_pandas_series_features():
+    """Ensure pandas Series input is handled correctly."""
+    plt.figure()
+    features = pd.Series([1.5, 3.0], index=["age", "income"])
+
+    explanation = shap.Explanation(
+        values=np.array([0.2, -0.1]),
+        base_values=0.0,
+        data=features,
+        feature_names=None,
+    )
+
+    ax = shap.plots.waterfall(explanation, show=False)
+
+    assert ax is not None
+    assert len(ax.get_yticklabels()) > 0
+
+
+def test_waterfall_all_positive_values_render_positive_contributions():
+    """Ensure all-positive SHAP values render correctly."""
+    plt.figure()
+    values = np.array([0.1, 0.25, 0.05])
+    explanation = _make_explanation(values)
+
+    ax = shap.plots.waterfall(explanation, show=False)
+
+    assert ax is plt.gca()
+    assert ax is not None
+
+
+def test_waterfall_all_negative_values_render_negative_contributions():
+    """Ensure all-negative SHAP values render correctly."""
+    plt.figure()
+    values = np.array([-0.1, -0.25, -0.05])
+    explanation = _make_explanation(values)
+
+    ax = shap.plots.waterfall(explanation, show=False)
+
+    assert ax is plt.gca()
+    assert ax is not None
+
+
+def test_waterfall_respects_max_display():
+    """Ensure max_display limits the number of displayed features."""
+    plt.figure()
+
+    values = np.random.randn(20)
+    explanation = _make_explanation(values)
+
+    ax = shap.plots.waterfall(explanation, max_display=5, show=False)
+
+    tick_labels = [t.get_text().strip() for t in ax.get_yticklabels() if t.get_text().strip()]
+
+    # allow small flexibility due to "others" grouping
+    assert len(tick_labels) > 0
+
+def test_waterfall_rejects_non_explanation():
+    """Ensure non-Explanation inputs raise TypeError."""
+    with pytest.raises(TypeError):
+        shap.plots.waterfall([1, 2, 3])


### PR DESCRIPTION
## Overview

Closes #3690 (partial)

Description of the changes proposed in this pull request:

This PR adds edge-case and behavioral tests for the waterfall plot to improve test coverage and robustness across different input scenarios.

### Key additions:

- Verified that `show=False` correctly returns the current matplotlib axis
- Added test for unsupported empty SHAP values
- Tested fallback behavior when `feature_names=None`
- Added support tests for pandas Series inputs
- Verified behavior for all-positive and all-negative SHAP values
- Added test for `max_display` parameter behavior
- Added validation for invalid (non-Explanation) inputs

These tests focus on functional behavior and avoid brittle assertions tied to matplotlib internals.  
They are implemented in a separate test module to complement existing mpl-based visual tests without modifying them.

---

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)