### PR TITLE
ENH: Plot overhaul for heatmap — explicit matplotlib Axes interface (#3411)

### DIFF
--- a/shap/plots/_heatmap.py
+++ b/shap/plots/_heatmap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -13,12 +15,12 @@ def heatmap(
     instance_order=Explanation.hclust(),  # type: ignore
     feature_values=Explanation.abs.mean(0),  # type: ignore
     feature_order=None,
-    max_display=10,
+    max_display: int = 10,
     cmap=colors.red_white_blue,
-    show=True,
-    plot_width=8,
-    ax=None,
-):
+    show: bool = True,
+    plot_width: int = 8,
+    ax: plt.Axes | None = None,
+) -> plt.Axes:
     """Create a heatmap plot of a set of SHAP values.
 
     This plot is designed to show the population substructure of a dataset using supervised
@@ -177,7 +179,7 @@ def heatmap(
 
     m = cm.ScalarMappable(cmap=cmap)
     m.set_array([min(vmin, -vmax), max(-vmin, vmax)])
-    cb = plt.colorbar(
+    cb = ax.get_figure().colorbar(
         m,
         ticks=[min(vmin, -vmax), max(-vmin, vmax)],
         ax=ax,


### PR DESCRIPTION
## Overview
Closes #3800, part of #3411.

Completes the remaining checklist items for the heatmap plot overhaul:

- Add `from __future__ import annotations` so the `X | Y` union type syntax works on Python < 3.10
- Add type hints to `max_display`, `show`, `plot_width`, `ax`, and return type (`-> plt.Axes`)
- Replace `plt.colorbar()` with `ax.get_figure().colorbar()` — the last remaining implicit pyplot call in this function

The `ax` parameter and `return ax` were already present. This PR completes what was missing.

AI usage disclosure: I used Claude for guidance and did almost all of the work by myself. I reviewed and understood every line; the from __future__ import enables union type syntax on Python < 3.10, the type hints follow the same pattern as _beeswarm.py, and replacing plt.colorbar() with ax.get_figure().colorbar() removes the last implicit pyplot call in this function

## Checklist
- [x] All pre-commit checks pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)