### PR TITLE
Fix #3660: Remove Ġ and ▁ tokens from text plots

### DIFF
--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -326,7 +326,9 @@ def text(
     # fx_str = str(shap_values.base_values + values.sum())
 
     # uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
-    encoded_tokens = [t.replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "").replace("▁", "").replace("Ġ", "") for t in tokens]
+    encoded_tokens = [
+        t.replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "").replace("▁", "").replace("Ġ", "") for t in tokens
+    ]
     output_name = shap_values.output_names if isinstance(shap_values.output_names, str) else ""
     out += svg_force_plot(
         values,

--- a/shap/plots/_text.py
+++ b/shap/plots/_text.py
@@ -326,7 +326,7 @@ def text(
     # fx_str = str(shap_values.base_values + values.sum())
 
     # uuid = ''.join(random.choices(string.ascii_lowercase, k=20))
-    encoded_tokens = [t.replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "") for t in tokens]
+    encoded_tokens = [t.replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "").replace("▁", "").replace("Ġ", "") for t in tokens]
     output_name = shap_values.output_names if isinstance(shap_values.output_names, str) else ""
     out += svg_force_plot(
         values,
@@ -375,7 +375,7 @@ def text(
             }}"
             onmouseover="document.getElementById('_fb_{uuid}_ind_{i}').style.opacity = 1; document.getElementById('_fs_{uuid}_ind_{i}').style.opacity = 1;"
             onmouseout="document.getElementById('_fb_{uuid}_ind_{i}').style.opacity = 0; document.getElementById('_fs_{uuid}_ind_{i}').style.opacity = 0;"
-        >{token.replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "")}</div></div>"""
+        >{token.replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "").replace("▁", "").replace("Ġ", "")}</div></div>"""
     out += "</div>"
 
     if display:
@@ -900,7 +900,7 @@ def text_old(shap_values, tokens, partition_tree=None, num_starting_labels=0, gr
             + "}"
             + '"'
             + ">"
-            + tokens[i].replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "")
+            + tokens[i].replace("<", "&lt;").replace(">", "&gt;").replace(" ##", "").replace("▁", "").replace("Ġ", "")
             + "</div>"
             + "</div>"
         )

--- a/tests/plots/test_text.py
+++ b/tests/plots/test_text.py
@@ -51,3 +51,26 @@ def test_single_text_to_text():
         hierarchical_values=[test_hierarchical_values],
     )
     shap.plots.text(shap_values_test)
+
+
+def test_text_plot_strips_special_tokens():
+    """Ensure special tokens like Ġ and ▁ are stripped from the HTML output (GH #3660)."""
+    test_values = np.array([0.5, -0.2])
+    test_base_values = 0.0
+    test_data = np.array(["ĠHello", "▁world"], dtype=object)
+    
+    exp = shap.Explanation(
+        values=test_values,
+        base_values=test_base_values,
+        data=test_data,
+    )
+    
+    html = shap.plots.text(exp, display=False)
+    
+    # Assert the special tokens are gone
+    assert "Ġ" not in html
+    assert "▁" not in html
+    
+    # Assert the actual text remains
+    assert "Hello" in html
+    assert "world" in html

--- a/tests/plots/test_text.py
+++ b/tests/plots/test_text.py
@@ -58,19 +58,19 @@ def test_text_plot_strips_special_tokens():
     test_values = np.array([0.5, -0.2])
     test_base_values = 0.0
     test_data = np.array(["ĠHello", "▁world"], dtype=object)
-    
+
     exp = shap.Explanation(
         values=test_values,
         base_values=test_base_values,
         data=test_data,
     )
-    
+
     html = shap.plots.text(exp, display=False)
-    
+
     # Assert the special tokens are gone
     assert "Ġ" not in html
     assert "▁" not in html
-    
+
     # Assert the actual text remains
     assert "Hello" in html
     assert "world" in html


### PR DESCRIPTION
## Overview

Closes #3660 <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
* **Fixes #3660:** Added `.replace("Ġ", "").replace("▁", "")` to the token parsing logic in the main `text()` and `text_old()` functions within `shap/plots/_text.py`. This aligns the behavior with `heatmap()` and `saliency_plot()`, which were already stripping the Byte-Level BPE space tokens.
* **Adds Unit Test:** Added `test_text_plot_strips_special_tokens` in `tests/plots/test_text.py` using a mocked Explanation object to explicitly verify that these tokens do not bleed into the generated HTML.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
