### PR TITLE
TEST: Make notebook execution kernel selection deterministic

### DIFF
--- a/scripts/run_notebooks_timeouts.py
+++ b/scripts/run_notebooks_timeouts.py
@@ -1,8 +1,8 @@
+import os
 import time
 from pathlib import Path
 
 import nbformat
-from jupyter_client import kernelspec
 from jupyter_client.manager import KernelManager
 from nbconvert.preprocessors import CellExecutionError, ExecutePreprocessor
 
@@ -76,7 +76,7 @@ def main():
     )
 
     ep = ExecutePreprocessor(timeout=TIMEOUT, log_level=40)
-    kernel_name = list(kernelspec.find_kernel_specs())[0]
+    kernel_name = os.environ.get("SHAP_KERNEL", "python3")
     km = KernelManager(kernel_name=kernel_name)
 
     encountered_failure = False


### PR DESCRIPTION
Fixes #4878

This PR makes notebook execution deterministic by replacing dynamic kernel selection with a fixed default kernel ("python3"), with optional override via environment variable.

Previously, the kernel was selected using:
list(kernelspec.find_kernel_specs())[0]

This could lead to non-deterministic behavior across environments.

## Changes
- Use "python3" as default kernel
- Allow override via SHAP_KERNEL environment variable
- Cleaned up unused and duplicate imports

## Benefits
- Improves reproducibility
- Prevents flaky behavior in CI
- Ensures consistent execution across environments

No functional changes beyond test stability.

Happy to make adjustments.