### PR TITLE
BUG: Ignore .mypy_cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ node_modules
 mpl-results
 # intermediate AI skill files
 .claude/disclosures/
+.mypy_cache/


### PR DESCRIPTION
Fixes #4879

This PR adds `.mypy_cache/` to `.gitignore` to prevent untracked cache files from appearing when running mypy from the repository root.
This ensures a cleaner working directory and avoids accidental commits of cache files.
No functional changes.

Happy to make adjustments.