### PR TITLE
Add edge-case and behavioral tests for shap/plots/_utils.py

### DIFF
--- a/tests/plots/test_utils.py
+++ b/tests/plots/test_utils.py
@@ -2,8 +2,14 @@ import matplotlib.pyplot as pl
 import numpy as np
 import pytest
 
+import shap
 from shap.plots import colors
-from shap.plots._utils import convert_color
+from shap.plots._utils import (
+    convert_color,
+    convert_ordering,
+    get_sort_order,
+    parse_axis_limit,
+)
 
 
 @pytest.mark.parametrize(
@@ -22,3 +28,87 @@ def test_convert_color(color, expected_result):
         assert np.allclose(result, expected_result)
     else:
         assert result == expected_result
+
+
+def test_convert_color_numpy_passthrough():
+    arr = np.array([0.1, 0.2, 0.3])
+    result = convert_color(arr)
+
+    assert np.array_equal(result, arr)
+
+
+def test_convert_color_invalid_string():
+    result = convert_color("not-a-color")
+    assert result == "not-a-color"
+
+
+def test_parse_axis_limit_percentile():
+    values = np.array([0, 1, 2, 3])
+    result = parse_axis_limit("percentile(50)", values, is_shap_axis=True)
+
+    assert np.isclose(result, np.nanpercentile(values, 50))
+
+
+def test_parse_axis_limit_invalid_string():
+    values = np.array([1, 2, 3])
+    with pytest.raises(ValueError):
+        parse_axis_limit("percentile(bad)", values, is_shap_axis=True)
+
+
+def test_parse_axis_limit_explanation_shap():
+    exp = shap.Explanation(values=np.array([2.0]), data=np.array([5.0]))
+    result = parse_axis_limit(exp, np.array([1, 2]), is_shap_axis=True)
+
+    assert result == 2.0
+
+
+def test_parse_axis_limit_explanation_data():
+    exp = shap.Explanation(values=np.array([2.0]), data=np.array([5.0]))
+    result = parse_axis_limit(exp, np.array([1, 2]), is_shap_axis=False)
+
+    assert result == 5.0
+
+
+def test_parse_axis_limit_float():
+    result = parse_axis_limit(3.14, np.array([1, 2]), is_shap_axis=True)
+    assert result == 3.14
+
+
+def test_parse_axis_limit_none():
+    result = parse_axis_limit(None, np.array([1, 2]), is_shap_axis=True)
+    assert result is None
+
+
+def test_convert_ordering_numpy():
+    ordering = np.array([2, 0, 1])
+    values = np.array([0.2, 0.1, 0.3])
+
+    result = convert_ordering(ordering, values)
+
+    assert np.array_equal(result, ordering)
+
+
+def test_convert_ordering_explanation_argsort():
+    exp = shap.Explanation(values=np.array([3.0, 1.0, 2.0]))
+    exp = exp.argsort  # triggers OpChain path
+
+    result = convert_ordering(exp, np.array([3.0, 1.0, 2.0]))
+
+    assert isinstance(result, np.ndarray)
+
+
+def test_get_sort_order_basic():
+    dist = np.array(
+        [
+            [0, 0.1, 0.9],
+            [0.1, 0, 0.2],
+            [0.9, 0.2, 0],
+        ]
+    )
+    clust_order = np.array([2, 0, 1])
+    feature_order = np.array([0, 1, 2])
+
+    result = get_sort_order(dist, clust_order, 0.5, feature_order)
+
+    assert isinstance(result, np.ndarray)
+    assert len(result) == len(feature_order)


### PR DESCRIPTION
## Overview

Closes #3690 (partial)

This PR improves test coverage for `shap/plots/_utils.py` as part of the ESoC 2026 warm-up contributions.

Description of the changes proposed in this pull request:

- Extended tests for `convert_color`, including numpy inputs and invalid strings
- Added comprehensive coverage for `parse_axis_limit`, including:
  - percentile parsing
  - invalid formats and error handling
  - handling of `shap.Explanation` objects (both SHAP axis and data axis cases)
  - float and None inputs
- Added tests for `convert_ordering` to validate behavior with numpy arrays and ordering logic
- Included a basic behavioral test for `get_sort_order`

The tests focus on functional correctness and avoid brittle assertions tied to matplotlib internals, ensuring stability across environments.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)