### PR TITLE
FIX: replace mutable default argument indices=[] with indices=None in SequentialPerturbation

### DIFF
--- a/shap/benchmark/_sequential.py
+++ b/shap/benchmark/_sequential.py
@@ -91,7 +91,7 @@ class SequentialPerturbation:
         explanation,
         *model_args,
         percent=0.01,
-        indices=[],
+        indices=None,
         y=None,
         label=None,
         silent=False,


### PR DESCRIPTION
## Summary

`SequentialPerturbation.__call__` used a mutable list as a default argument (`indices=[]`), which can cause unintended shared state across calls. Additionally, `indices` is not used anywhere in the method body.

This is the same issue as #4812 (fixed in `ExplanationError.__call__`), but was overlooked in `_sequential.py`.

- Replace `indices=[]` with `indices=None`

This contribution is part of my ESoC 2026 application.
