### PR TITLE
Use Keras Input layers in explainer tests

### DIFF
--- a/tests/explainers/test_gradient.py
+++ b/tests/explainers/test_gradient.py
@@ -129,6 +129,7 @@ def test_tf_keras_mnist_cnn_tf215_and_lower(random_seed):
         Dense,
         Dropout,
         Flatten,
+        Input,
         MaxPooling2D,
     )
     from tensorflow.keras.models import Sequential
@@ -172,7 +173,8 @@ def test_tf_keras_mnist_cnn_tf215_and_lower(random_seed):
     y_test = tf.keras.utils.to_categorical(y_test, num_classes)
 
     model = Sequential()
-    model.add(Conv2D(32, kernel_size=(3, 3), activation="relu", input_shape=input_shape))
+    model.add(Input(shape=input_shape))
+    model.add(Conv2D(32, kernel_size=(3, 3), activation="relu"))
     model.add(Conv2D(64, (3, 3), activation="relu"))
     model.add(MaxPooling2D(pool_size=(2, 2)))
     model.add(Dropout(0.25))

--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -317,7 +317,8 @@ def test_kernel_explainer_with_tensors():
     X, _ = sklearn.datasets.make_classification(100, 6)
     model = tf.keras.Sequential(
         [
-            tf.keras.layers.Dense(10, input_shape=(6,), activation="relu"),
+            tf.keras.layers.Input(shape=(6,)),
+            tf.keras.layers.Dense(10, activation="relu"),
             tf.keras.layers.Dense(1, activation="sigmoid"),
         ]
     )


### PR DESCRIPTION
## Overview

Related to #3066

Description of the changes proposed in this pull request:

This updates TensorFlow/Keras explainer tests to use explicit `Input(...)` layers instead of passing `input_shape` directly to layers.

The change removes current Keras deprecation warnings in the affected tests and keeps the test setup aligned with current Keras guidance.



## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
