### PR TITLE
Guard TF graph-mode warning behind eager execution

### DIFF
--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -90,7 +90,7 @@ class TFDeep(Explainer):
         if version.parse(tf.__version__) < version.parse("1.4.0"):
             warnings.warn("Your TensorFlow version is older than 1.4.0 and not supported.")
 
-        if version.parse(tf.__version__) >= version.parse("2.4.0"):
+        if version.parse(tf.__version__) >= version.parse("2.4.0") and tf.executing_eagerly():
             warnings.warn(
                 "Your TensorFlow version is newer than 2.4.0 and so graph support has been removed in eager mode and some static graphs may not be supported. See PR #1483 for discussion."
             )


### PR DESCRIPTION
## Overview

Closes #4237

Description of the changes proposed in this pull request:

This change updates the TensorFlow warning in `DeepExplainer` so it is only emitted when TensorFlow 2.4+ is actually running in eager mode.

Previously the warning also appeared for graph-mode execution, which is misleading because the warning text is specifically about eager-mode graph support being removed.



## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
