### PR TITLE
fix: sync CoalitionExplainer.expected_value after explain_row computes base value

### DIFF
--- a/shap/explainers/_coalition.py
+++ b/shap/explainers/_coalition.py
@@ -230,6 +230,7 @@ class CoalitionExplainer(Explainer):
         if self._curr_base_value is None or not getattr(self.masker, "fixed_background", False):
             base_output = fm(m00.reshape(1, -1), zero_index=0)[0]
             self._curr_base_value = np.array(base_output) if isinstance(base_output, (list, tuple)) else base_output
+            self.expected_value = self._curr_base_value
 
         # Handle multi-output predictions
         if isinstance(self._curr_base_value, np.ndarray) and self._curr_base_value.ndim > 0:


### PR DESCRIPTION
## Problem
`CoalitionExplainer.expected_value` was never updated after calling 
the explainer. It remained `None` even though `_curr_base_value` was 
correctly computed in `explain_row`. This broke standard workflows 
like waterfall and force plots.

Closes #4902 

## Fix
After `_curr_base_value` is set in `explain_row`, we now sync 
`expected_value` to match it consistent with all other SHAP explainers.

## Changes
- `shap/explainers/_coalition.py`: one line added in `explain_row`

## Testing
Verified manually that `explainer.expected_value` is correctly 
populated after calling the explainer on sample data.