### PR TITLE
refactor: remove dead code from shap/plots/_violin.py plot

### DIFF
--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -352,12 +352,7 @@ def violin(
         plt.xlim(shap_min, shap_max)
 
     # draw the color bar
-    if (
-        color_bar
-        and features is not None
-        and plot_type != "bar"
-        and (plot_type != "layered_violin" or color in plt.colormaps)
-    ):
+    if color_bar and features is not None and (plot_type != "layered_violin" or color in plt.colormaps):
         import matplotlib.cm as cm
 
         m = cm.ScalarMappable(cmap=cmap if plot_type != "layered_violin" else plt.get_cmap(color))
@@ -411,10 +406,3 @@ def _trim_crange(values, nan_mask):
     cvals[cvals_imp < vmin] = vmin
 
     return vmin, vmax, cvals
-
-
-def shorten_text(text, length_limit):
-    if len(text) > length_limit:
-        return text[: length_limit - 3] + "..."
-    else:
-        return text


### PR DESCRIPTION
## Overview
This PR partially addresses #3690 to reduce dead code content.
This PR performs a small refactor-only cleanup in `shap/plots/_violin.py`.

## What Changed
- Removed unused helper function `shorten_text` (dead code).
- Simplified the color-bar condition by removing a redundant branch check.
- No intended behavior or API changes.

## Scope
- Single-file change only: `shap/plots/_violin.py`
- Refactoring only (no feature work, no bugfix behavior changes)

## Checklist
- [x] All pre-commit checks pass.
- [ ] Unit tests added (not needed for this dead-code cleanup)

---
---

## AI Disclosure
This PR was developed with assistance from Codex (OpenAI).

### Summary
Codex helped identify dead code candidates, apply a minimal single-file refactor, and keep the PR scoped to non-functional cleanup.

### Contributions
- **Autonomous:** Identified and removed unused helper code and redundant condition logic.
- **Assisted:** N/A.
- **Advised:** Suggested keeping unrelated generated test artifacts out of this PR.
