### PR TITLE
TEST: add mismatched feature_names handling test

### DIFF
--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,18 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+def test_mismatched_feature_names_does_not_crash():
+    """GH #4826: Explanation allows mismatched feature_names without crashing.
+
+    When feature_names length does not match any axis of values, the object
+    should still be created successfully with feature_names stored as provided.
+    """
+    values = np.ones((10, 4))
+    mismatched_names = ["a", "b", "c"]  # 3 names for 4 features
+
+    exp = shap.Explanation(values=values, feature_names=mismatched_names)
+
+    assert isinstance(exp, shap.Explanation)
+    assert exp.feature_names == mismatched_names


### PR DESCRIPTION
## Summary

Add a regression test for mismatched `feature_names` handling in `Explanation`.

This PR adds test coverage for the current flexible behavior where `Explanation` accepts `feature_names` whose length does not match the shape of `values`, and still creates the object successfully.

Fixes #4826

## Changes Made

* Added `test_mismatched_feature_names_does_not_crash()` to `tests/test_explanation.py`
* Verifies that `Explanation(...)` initializes successfully when:

  * `values.shape == (10, 4)`
  * `feature_names` contains 3 entries
* Confirms `feature_names` is preserved as provided

## Why This Matters

The current implementation allows non-matching `feature_names` lengths instead of enforcing strict validation. This test documents and protects that behavior.

Benefits:

* Improves test coverage
* Prevents accidental regressions
* Ensures edge-case robustness
* Aligns tests with existing API behavior

## Testing

Verified that the following works without errors:

```python id="a1m9xq"
values = np.ones((10, 4))
names = ["a", "b", "c"]

exp = shap.Explanation(values=values, feature_names=names)
```

Assertions:

* `isinstance(exp, shap.Explanation)`
* `exp.feature_names == names`

## Notes

This PR adds tests only. No production code behavior was changed.
