### PR TITLE
FIX: Handle pandas nullable dtypes in TreeExplainer background data

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -249,7 +249,7 @@ class TreeExplainer(Explainer):
             )
 
         if isinstance(data, pd.DataFrame):
-            self.data = data.values
+            self.data = data.to_numpy(dtype=np.float64, na_value=np.nan)
         elif isinstance(data, DenseData):
             self.data = data.data
         else:

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3015,3 +3015,24 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+def test_tree_explainer_nullable_dataframe_background():
+    import pandas as pd
+    import numpy as np
+    import shap
+    from sklearn.ensemble import RandomForestRegressor
+
+    # create dataframe with nullable dtype
+    X = pd.DataFrame({
+        "a": pd.Series([1, 2, pd.NA], dtype="Int64"),
+        "b": [0.1, 0.2, 0.3]
+    })
+    y = [1, 2, 3]
+
+    # train model
+    model = RandomForestRegressor().fit(X.fillna(0), y)
+
+    # should not raise error
+    explainer = shap.TreeExplainer(model, data=X)
+
+    assert explainer is not None

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3016,17 +3016,15 @@ def test_nullable_pandas_dtype():
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
 
+
 def test_tree_explainer_nullable_dataframe_background():
     import pandas as pd
-    import numpy as np
-    import shap
     from sklearn.ensemble import RandomForestRegressor
 
+    import shap
+
     # create dataframe with nullable dtype
-    X = pd.DataFrame({
-        "a": pd.Series([1, 2, pd.NA], dtype="Int64"),
-        "b": [0.1, 0.2, 0.3]
-    })
+    X = pd.DataFrame({"a": pd.Series([1, 2, pd.NA], dtype="Int64"), "b": [0.1, 0.2, 0.3]})
     y = [1, 2, 3]
 
     # train model


### PR DESCRIPTION
## Overview

Closes #4911

Fixes an issue where TreeExplainer fails when background data is a pandas DataFrame with nullable dtypes (e.g., Int64 with pd.NA).

The root cause is that background data was converted using `.values`, which can produce object dtype arrays. These arrays later fail in numeric operations inside the C extension.

This PR updates the conversion to use `to_numpy(dtype=np.float64, na_value=np.nan)`, ensuring consistent numeric handling.

A regression test is included to cover this case.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)