### PR TITLE
Fix partial_dependence ax parameter bug

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -102,8 +102,8 @@ def partial_dependence(
             fig = plt.figure()
             ax1 = plt.gca()
         else:
-            fig = plt.gcf()
-            ax1 = plt.gca()
+            fig = ax.get_figure()
+            ax1 = ax
 
         # fig, ax1 = plt.subplots(figsize)
         ax2 = ax1.twinx()

--- a/tests/plots/test_partial_dependence.py
+++ b/tests/plots/test_partial_dependence.py
@@ -8,7 +8,6 @@ from sklearn.linear_model import LinearRegression
 
 import shap
 
-
 matplotlib.use("Agg")
 
 

--- a/tests/plots/test_partial_dependence.py
+++ b/tests/plots/test_partial_dependence.py
@@ -1,0 +1,98 @@
+"""Tests for the partial_dependence plot function."""
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import shap
+
+
+matplotlib.use("Agg")
+
+
+@pytest.fixture()
+def trained_model_and_data():
+    """Create a simple synthetic dataset and trained LinearRegression model."""
+    rng = np.random.RandomState(42)
+    X = rng.randn(50, 4)
+    # y is a linear combination so the model fits perfectly
+    y = X @ np.array([1.0, -2.0, 0.5, 3.0]) + 0.5
+    model = LinearRegression().fit(X, y)
+    feature_names = ["feat_0", "feat_1", "feat_2", "feat_3"]
+    return model, X, feature_names
+
+
+class TestPartialDependenceCustomAx:
+    """Regression tests for passing a custom ``ax`` to partial_dependence_plot."""
+
+    def test_each_subplot_gets_correct_feature_label(self, trained_model_and_data):
+        """When looping over a 2×2 subplot grid, each axes should display its
+        own feature name on the x-axis rather than all features ending up on
+        the same (last-active) axes.
+        """
+        model, X, feature_names = trained_model_and_data
+        fig, axes = plt.subplots(2, 2)
+        flat_axes = axes.flatten()
+
+        for i, ax in enumerate(flat_axes):
+            shap.partial_dependence_plot(
+                ind=i,
+                model=model.predict,
+                data=X,
+                feature_names=feature_names,
+                ax=ax,
+                ice=False,
+                show=False,
+            )
+
+        # Each subplot should have the corresponding feature as its xlabel
+        for i, ax in enumerate(flat_axes):
+            assert ax.get_xlabel() == feature_names[i], (
+                f"Subplot {i} xlabel is '{ax.get_xlabel()}', expected '{feature_names[i]}'"
+            )
+
+        plt.close(fig)
+
+    def test_returns_correct_figure_and_axes(self, trained_model_and_data):
+        """When ``show=False`` and a custom ``ax`` is provided, the returned
+        figure and axes should correspond to the supplied axes object.
+        """
+        model, X, feature_names = trained_model_and_data
+        fig, axes = plt.subplots(1, 2)
+
+        returned_fig, returned_ax = shap.partial_dependence_plot(
+            ind=0,
+            model=model.predict,
+            data=X,
+            feature_names=feature_names,
+            ax=axes[0],
+            ice=False,
+            show=False,
+        )
+
+        assert returned_fig is fig
+        assert returned_ax is axes[0]
+
+        plt.close(fig)
+
+    def test_default_ax_creates_new_figure(self, trained_model_and_data):
+        """When no ``ax`` is given, the function should create its own figure."""
+        model, X, feature_names = trained_model_and_data
+        plt.close("all")
+
+        returned_fig, returned_ax = shap.partial_dependence_plot(
+            ind=0,
+            model=model.predict,
+            data=X,
+            feature_names=feature_names,
+            ice=False,
+            show=False,
+        )
+
+        assert returned_fig is not None
+        assert returned_ax is not None
+        assert returned_ax.get_xlabel() == feature_names[0]
+
+        plt.close(returned_fig)


### PR DESCRIPTION
## Overview
Closes #3206

When a user passes a custom `ax=` argument to `shap.partial_dependence_plot`,
the function ignored it and called `plt.gca()` instead — which always returns
matplotlib's last active axes. This caused all features to be plotted on the
same axes when iterating over a subplot grid, leaving every other subplot empty.

Fix: use `ax.get_figure()` and `ax1 = ax` directly when `ax` is not `None`.
Only 2 lines changed in `shap/plots/_partial_dependence.py`.

## Checklist
- [x] All pre-commit checks pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)