### PR TITLE
fix bugs and improve docs in textual entailment notebook

### DIFF
--- a/notebooks/text_examples/text_entailment/Textual Entailment Explanation Demo.ipynb
+++ b/notebooks/text_examples/text_entailment/Textual Entailment Explanation Demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "desirable-above",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Multi-Input Text Explanation: Textual Entailment with Facebook BART\n"
@@ -10,577 +10,269 @@
   },
   {
    "cell_type": "markdown",
-   "id": "packed-capitol",
+   "id": "87c75d75",
    "metadata": {},
    "source": [
-    "This notebook demonstrates how to get explanations for the output of the Facebook BART model trained on the mnli dataset and used for textual entailment. We use an example from the snli dataset due to mnli not being supported in the required environment for shap. \n",
+    "## About This Notebook\n",
     "\n",
-    "BART: https://huggingface.co/facebook/bart-large-mnli\n"
+    "**Textual entailment** is a natural language inference task: given a *premise* and a *hypothesis*, the model determines whether the hypothesis is true given the premise (*entailment*), false (*contradiction*), or cannot be determined (*neutral*).\n",
+    "\n",
+    "**Example:**\n",
+    "- Premise: *\"A man is playing guitar on stage.\"*\n",
+    "- Hypothesis: *\"A musician is performing live.\"* → **Entailment**\n",
+    "- Hypothesis: *\"The stage is empty.\"* → **Contradiction**\n",
+    "- Hypothesis: *\"The man is happy.\"* → **Neutral**\n",
+    "\n",
+    "**Why SHAP?** SHAP reveals which specific words in the premise and hypothesis most influenced the model's classification decision, making its reasoning interpretable.\n",
+    "\n",
+    "**Model**: [`facebook/bart-large-mnli`](https://huggingface.co/facebook/bart-large-mnli) — a BART model fine-tuned on MNLI for three-class entailment.\n",
+    "\n",
+    "**Dataset note**: We use [SNLI](https://huggingface.co/datasets/snli) instead of MNLI because MNLI is not available in this environment. Both datasets share the same three-label schema, so the model applies without modification.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "prescription-terrorist",
+   "id": "1890d1be",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import scipy as sp\n",
+    "import torch\n",
     "from datasets import load_dataset\n",
     "from transformers import AutoModelForSequenceClassification, AutoTokenizer\n",
+    "from transformers import logging as hf_logging\n",
     "\n",
     "import shap"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "written-network",
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ea3fd5f3",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "### Load model and tokenizer"
+    "import datasets\n",
+    "import transformers\n",
+    "\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "\n",
+    "print(f\"shap:         {shap.__version__}\")\n",
+    "print(f\"transformers: {transformers.__version__}\")\n",
+    "print(f\"datasets:     {datasets.__version__}\")\n",
+    "print(f\"torch:        {torch.__version__}\")\n",
+    "print(f\"device:       {device}\")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "meaning-terminology",
+   "cell_type": "markdown",
+   "id": "dae1eabb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Some weights of the model checkpoint at facebook/bart-large-mnli were not used when initializing BartForSequenceClassification: ['model.encoder.version', 'model.decoder.version']\n",
-      "- This IS expected if you are initializing BartForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
-      "- This IS NOT expected if you are initializing BartForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
-     ]
-    }
-   ],
    "source": [
-    "model = AutoModelForSequenceClassification.from_pretrained(\"facebook/bart-large-mnli\")\n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"facebook/bart-large-mnli\")"
+    "### Load model and tokenizer\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "general-sessions",
+   "id": "e505e4b7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Reusing dataset snli (C:\\Users\\v-jocelinsu\\.cache\\huggingface\\datasets\\snli\\plain_text\\1.0.0\\bb1102591c6230bd78813e229d5dd4c7fbf4fc478cec28f298761eb69e5b537c)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Premise: A boy is jumping on skateboard in the middle of a red bridge.\n",
-      "Hypothesis: The boy skates down the sidewalk.\n",
-      "The true label is: contradiction\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# load dataset\n",
-    "dataset = load_dataset(\"snli\")\n",
-    "snli_label_map = {0: \"entailment\", 1: \"neutral\", 2: \"contradiction\"}\n",
-    "example_ind = 6\n",
-    "premise, hypothesis, label = (\n",
-    "    dataset[\"train\"][\"premise\"][example_ind],\n",
-    "    dataset[\"train\"][\"hypothesis\"][example_ind],\n",
-    "    dataset[\"train\"][\"label\"][example_ind],\n",
-    ")\n",
-    "print(\"Premise: \" + premise)\n",
-    "print(\"Hypothesis: \" + hypothesis)\n",
-    "true_label = snli_label_map[label]\n",
-    "print(f\"The true label is: {true_label}\")"
+    "# Suppress a harmless checkpoint warning about unused weight keys\n",
+    "# ('model.encoder.version', 'model.decoder.version') that are metadata fields\n",
+    "# not used by BartForSequenceClassification. This is expected for this checkpoint.\n",
+    "hf_logging.set_verbosity_error()\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(\"facebook/bart-large-mnli\").to(device)\n",
+    "hf_logging.set_verbosity_warning()\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"facebook/bart-large-mnli\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "concerned-sequence",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "contradiction probability: 99.95%\n",
-      "neutral probability: 0.03%\n",
-      "entailment probability: 0.02%\n"
-     ]
-    }
-   ],
+   "id": "28ce826d",
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# test model\n",
-    "input_ids = tokenizer.encode(premise, hypothesis, return_tensors=\"pt\")\n",
+    "# Verify model is on the correct device.\n",
+    "print(\"Model device:\", next(model.parameters()).device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12d007c6",
+   "metadata": {},
+   "source": [
+    "### Load data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a3758ef0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = load_dataset(\"snli\")\n",
+    "\n",
+    "snli_label_map = {0: \"entailment\", 1: \"neutral\", 2: \"contradiction\"}\n",
+    "example_ind = 6\n",
+    "\n",
+    "premise = dataset[\"train\"][\"premise\"][example_ind]\n",
+    "hypothesis = dataset[\"train\"][\"hypothesis\"][example_ind]\n",
+    "label = dataset[\"train\"][\"label\"][example_ind]\n",
+    "\n",
+    "print(type(premise), type(hypothesis))\n",
+    "print(\"Premise:   \", premise)\n",
+    "print(\"Hypothesis:\", hypothesis)\n",
+    "print(\"True label:\", snli_label_map[label])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f83b5d18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# BART-MNLI outputs logits in order: [contradiction, neutral, entailment] (index 0, 1, 2).\n",
+    "# Confirmed by the model card: https://huggingface.co/facebook/bart-large-mnli\n",
+    "bart_label_map = {0: \"contradiction\", 1: \"neutral\", 2: \"entailment\"}\n",
+    "\n",
+    "input_ids = tokenizer.encode(premise, hypothesis, return_tensors=\"pt\").to(device)\n",
     "logits = model(input_ids)[0]\n",
     "probs = logits.softmax(dim=1)\n",
     "\n",
-    "bart_label_map = {0: \"contradiction\", 1: \"neutral\", 2: \"entailment\"}\n",
     "for i, lab in bart_label_map.items():\n",
     "    print(f\"{lab} probability: {probs[0][i] * 100:0.2f}%\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ready-majority",
+   "id": "a0d4b457",
    "metadata": {},
    "source": [
-    "## Run shap values"
+    "## Run SHAP Values\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "sunrise-modification",
+   "execution_count": 7,
+   "id": "753ba6ad",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import scipy as sp\n",
-    "import torch\n",
-    "\n",
-    "\n",
-    "# wrapper function for model\n",
-    "# takes in masked string which is in the form: premise <separator token(s)> hypothesis\n",
+    "# SHAP requires a callable that takes a list of strings and returns a numeric array.\n",
+    "# Each string is a masked version of the concatenated premise + hypothesis.\n",
+    "# We return log-odds (logit of softmax) so SHAP values are additive in log-odds space.\n",
     "def f(x):\n",
     "    outputs = []\n",
     "    for _x in x:\n",
-    "        encoding = torch.tensor([tokenizer.encode(_x)])\n",
+    "        encoding = torch.tensor([tokenizer.encode(_x)]).to(device)\n",
     "        output = model(encoding)[0].detach().cpu().numpy()\n",
     "        outputs.append(output[0])\n",
     "    outputs = np.array(outputs)\n",
     "    scores = (np.exp(outputs).T / np.exp(outputs).sum(-1)).T\n",
-    "    val = sp.special.logit(scores)\n",
-    "    return val"
+    "    return sp.special.logit(scores)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e29dc3ec",
+   "metadata": {},
+   "source": [
+    "### Create an explainer object\n",
+    "\n",
+    "`shap.Explainer` automatically selects `PartitionExplainer` for text inputs — it is model-agnostic and works by hierarchically masking token groups. An *alpha state* warning may appear; this is expected and does not affect correctness.\n",
+    "\n",
+    "`output_names` maps the three output columns to their label strings `[contradiction, neutral, entailment]`, matching the BART-MNLI logit order.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "realistic-survivor",
+   "execution_count": 8,
+   "id": "ac5830eb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "explainers.Partition is still in an alpha state, so use with caution...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Construct explainer\n",
     "bart_labels = [\"contradiction\", \"neutral\", \"entailment\"]\n",
     "explainer = shap.Explainer(f, tokenizer, output_names=bart_labels)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "cardiovascular-deposit",
+   "execution_count": 9,
+   "id": "d7441643",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "A boy is jumping on skateboard in the middle of a red bridge.</s></s>The boy skates down the sidewalk.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# encode then decode premise, hypothesis to get concatenated sentences\n",
-    "encoded = tokenizer(premise, hypothesis)[\"input_ids\"][\n",
-    "    1:-1\n",
-    "]  # ignore the start and end tokens, since tokenizer will naturally add them\n",
+    "# Encode premise+hypothesis together, strip the leading <s> and trailing </s> tokens\n",
+    "# (indices [1:-1]) so the explainer's tokenizer can add them back naturally during masking.\n",
+    "encoded = tokenizer(premise, hypothesis)[\"input_ids\"][1:-1]\n",
     "decoded = tokenizer.decode(encoded)\n",
     "print(decoded)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "retired-scheduling",
+   "execution_count": 10,
+   "id": "cb893aa7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=0.0, max=48.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Partition explainer: 2it [00:17, 18.00s/it]                                                                            "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      ".values =\n",
-      "array([[[-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [-0.18482581,  0.11629296, -0.05710324],\n",
-      "        [ 0.49238822, -0.37113822, -0.48107536],\n",
-      "        [ 0.49238822, -0.37113822, -0.48107536],\n",
-      "        [ 0.49238822, -0.37113822, -0.48107536],\n",
-      "        [ 0.49238822, -0.37113822, -0.48107536],\n",
-      "        [ 0.65840166, -0.54717401, -0.45434223],\n",
-      "        [ 0.65840166, -0.54717401, -0.45434223],\n",
-      "        [ 0.65840166, -0.54717401, -0.45434223],\n",
-      "        [ 0.65840166, -0.54717401, -0.45434223],\n",
-      "        [ 0.        ,  0.        ,  0.        ],\n",
-      "        [ 0.21500799, -0.29488914,  0.00956938],\n",
-      "        [ 0.21500799, -0.29488914,  0.00956938],\n",
-      "        [ 0.21500799, -0.29488914,  0.00956938],\n",
-      "        [ 0.21500799, -0.29488914,  0.00956938],\n",
-      "        [ 0.88112425, -0.62802847, -0.69218032],\n",
-      "        [ 0.88112425, -0.62802847, -0.69218032],\n",
-      "        [ 1.51606662, -1.12249615, -1.38898808],\n",
-      "        [ 1.51606662, -1.12249615, -1.38898808],\n",
-      "        [ 0.43230298, -0.19067168, -0.23281629],\n",
-      "        [ 0.        ,  0.        ,  0.        ]]])\n",
-      "\n",
-      ".base_values =\n",
-      "array([[-1.50853336, -0.49898115, -0.23684637]])\n",
-      "\n",
-      ".data =\n",
-      "array([['', 'A ', 'boy ', 'is ', 'jumping ', 'on ', 'skate', 'board ',\n",
-      "        'in ', 'the ', 'middle ', 'of ', 'a ', 'red ', 'bridge', '.',\n",
-      "        '</s>', '</s>', 'The ', 'boy ', 'sk', 'ates ', 'down ', 'the ',\n",
-      "        'sidewalk', '.', '']], dtype='<U8')\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "shap_values = explainer([decoded])  # wrap input in list\n",
-    "print(shap_values)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "declared-contractor",
-   "metadata": {},
-   "source": [
-    "## Explanation Visualization"
+    "test_output = f([decoded])\n",
+    "print(\"Output shape:\", test_output.shape)  # expect (1, 3)\n",
+    "test_probs = sp.special.expit(test_output)\n",
+    "print(\"Softmax sums to ~1:\", test_probs.sum(axis=1))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "automated-dating",
+   "execution_count": 11,
+   "id": "cf0d8ea0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<br/><b>0th instance:</b><br/>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <script>\n",
-       "        function selectVizType_nmbtewsihdtboerwlsju(selectObject) {\n",
-       "\n",
-       "          /* Hide all viz */\n",
-       "\n",
-       "            var elements = document.getElementsByClassName(\"nmbtewsihdtboerwlsju_viz_container\")\n",
-       "          for (var i = 0; i < elements.length; i++){\n",
-       "              elements[i].style.display = 'none';\n",
-       "          }\n",
-       "\n",
-       "          var value = selectObject.value;\n",
-       "          if ( value === \"saliency-plot\" ){\n",
-       "              document.getElementById('nmbtewsihdtboerwlsju_saliency_plot_container').style.display  = \"block\";\n",
-       "          }\n",
-       "          else if ( value === \"heatmap\" ) {\n",
-       "              document.getElementById('nmbtewsihdtboerwlsju_heatmap_container').style.display  = \"block\";\n",
-       "          }\n",
-       "        }\n",
-       "    </script>\n",
-       "    \n",
-       "    <html>\n",
-       "    <div id=\"nmbtewsihdtboerwlsju_viz_container\">\n",
-       "      <div id=\"nmbtewsihdtboerwlsju_viz_header\" style=\"padding:15px;border-style:solid;margin:5px;font-family:sans-serif;font-weight:bold;\">\n",
-       "        Visualization Type:\n",
-       "        <select name=\"viz_type\" id=\"nmbtewsihdtboerwlsju_viz_type\" onchange=\"selectVizType_nmbtewsihdtboerwlsju(this)\">\n",
-       "          <option value=\"heatmap\" selected=\"selected\">Input/Output - Heatmap</option>\n",
-       "          <option value=\"saliency-plot\">Saliency Plot</option>\n",
-       "        </select>\n",
-       "      </div>\n",
-       "      <div id=\"nmbtewsihdtboerwlsju_content\" style=\"padding:15px;border-style:solid;margin:5px;\">\n",
-       "          <div id = \"nmbtewsihdtboerwlsju_saliency_plot_container\" class=\"nmbtewsihdtboerwlsju_viz_container\" style=\"display:none\"> \n",
-       "              \n",
-       "        <div id=\"asrqkhtlyspgznzuxowz_saliency_plot\" class=\"asrqkhtlyspgznzuxowz_viz_content\">\n",
-       "            <div style=\"margin:5px;font-family:sans-serif;font-weight:bold;\">\n",
-       "                <span style=\"font-size: 20px;\"> Saliency Plot </span>\n",
-       "                <br>\n",
-       "                x-axis: Output Text\n",
-       "                <br>\n",
-       "                y-axis: Input Text\n",
-       "            </div>\n",
-       "            <table border = \"1\" cellpadding = \"5\" cellspacing = \"5\" style=\"overflow-x:scroll;display:block;\"><tr><th></th><th>A boy is jumping on skateboard </th><th>in the middle of </th><th>a red bridge.</th><th>&lt;/s&gt;</th><th>&lt;/s&gt;The boy sk</th><th>ates down </th><th>the sidewalk</th><th>.</th><th></th></tr><tr><th>contradiction</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.4876213111507228)\">-1.479</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.6531590413943356)\">1.97</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.8738760150524857)\">2.634</th><th style=\"background:rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\">0.0</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.2826698356110118)\">0.86</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.5822142998613588)\">1.762</th><th style=\"background:rgba(255.0, 13.0, 87.0, 1.0)\">3.032</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.14078035254505847)\">0.432</th><th style=\"background:rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\">0.0</th></tr><tr><th>neutral</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.306318082788671)\">0.93</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.4876213111507228)\">-1.485</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.7241037829273124)\">-2.189</th><th style=\"background:rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\">0.0</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.3851455733808674)\">-1.18</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.41667656961774613)\">-1.256</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.7398692810457517)\">-2.245</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.06195286195286191)\">-0.191</th><th style=\"background:rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\">0.0</th></tr><tr><th>entailment</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.14866310160427798)\">-0.457</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.6373935432758963)\">-1.924</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.597979797979798)\">-1.817</th><th style=\"background:rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\">0.0</th><th style=\"background:rgba(255.0, 13.0, 87.0, 0.00677361853832443)\">0.038</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.4560903149138443)\">-1.384</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.9211725094078036)\">-2.778</th><th style=\"background:rgba(30.0, 136.0, 229.0, 0.06983561101208147)\">-0.233</th><th style=\"background:rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\">0.0</th></tr></table>\n",
-       "        </div>\n",
-       "    \n",
-       "          </div>\n",
-       "          \n",
-       "          <div id = \"nmbtewsihdtboerwlsju_heatmap_container\" class=\"nmbtewsihdtboerwlsju_viz_container\">\n",
-       "              \n",
-       "        <div id=\"wbanqvtvicltjcqgtboe_heatmap\" class=\"wbanqvtvicltjcqgtboe_viz_content\">\n",
-       "          <div id=\"wbanqvtvicltjcqgtboe_heatmap_header\" style=\"padding:15px;margin:5px;font-family:sans-serif;font-weight:bold;\">\n",
-       "            <div style=\"display:inline\">\n",
-       "              <span style=\"font-size: 20px;\"> Input/Output - Heatmap </span>\n",
-       "            </div>\n",
-       "            <div style=\"display:inline;float:right\">\n",
-       "              Layout :\n",
-       "              <select name=\"alignment\" id=\"wbanqvtvicltjcqgtboe_alignment\" onchange=\"selectAlignment_wbanqvtvicltjcqgtboe(this)\">\n",
-       "                <option value=\"left-right\" selected=\"selected\">Left/Right</option>\n",
-       "                <option value=\"top-bottom\">Top/Bottom</option>\n",
-       "              </select>\n",
-       "            </div>\n",
-       "          </div>\n",
-       "          <div id=\"wbanqvtvicltjcqgtboe_heatmap_content\" style=\"display:flex;\">\n",
-       "            <div id=\"wbanqvtvicltjcqgtboe_input_container\" style=\"padding:15px;border-style:solid;margin:5px;flex:1;\">\n",
-       "              <div id=\"wbanqvtvicltjcqgtboe_input_header\" style=\"margin:5px;font-weight:bold;font-family:sans-serif;margin-bottom:10px\">\n",
-       "                Input Text\n",
-       "              </div>\n",
-       "              <div id=\"wbanqvtvicltjcqgtboe_input_content\" style=\"margin:5px;font-family:sans-serif;\">\n",
-       "                  <div id=\"wbanqvtvicltjcqgtboe_input_node_52_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_52_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_52_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_51_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_51_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_51_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_49_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_49_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_49_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_46_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_46_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_46_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_39_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_39_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_39_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_27_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_27_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_27_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_0_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_0_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_0_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" ></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_1_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_1_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_1_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >A </div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_28_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_28_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_28_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_2_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_2_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_2_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >boy </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_3_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_3_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_3_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >is </div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_40_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_40_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_40_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_29_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_29_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_29_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_4_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_4_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_4_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >jumping </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_5_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_5_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_5_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >on </div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_30_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_30_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_30_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_6_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_6_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_6_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >skate</div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_7_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_7_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_7_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >board </div></div></div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_47_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_47_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_47_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_41_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_41_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_41_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_31_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_31_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_31_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_8_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_8_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_8_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >in </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_9_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_9_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_9_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >the </div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_32_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_32_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_32_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_10_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_10_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_10_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >middle </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_11_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_11_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_11_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >of </div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_44_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_44_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_44_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_38_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_38_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_38_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_33_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_33_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_33_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_12_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_12_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_12_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >a </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_13_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_13_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_13_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >red </div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_14_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_14_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_14_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >bridge</div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_15_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_15_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_15_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >.</div></div></div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_16_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_16_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_16_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >&lt;/s&gt;</div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_50_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_50_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_50_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_48_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_48_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_48_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_42_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_42_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_42_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_34_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_34_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_34_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_17_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_17_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_17_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >&lt;/s&gt;</div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_18_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_18_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_18_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >The </div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_35_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_35_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_35_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_19_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_19_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_19_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >boy </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_20_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_20_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_20_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >sk</div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_45_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_45_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_45_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_43_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_43_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_43_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_36_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_36_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_36_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_21_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_21_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_21_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >ates </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_22_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_22_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_22_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >down </div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_37_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_37_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_37_content\" style=\"display:inline;\"><div id=\"wbanqvtvicltjcqgtboe_input_node_23_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_23_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_23_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >the </div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_24_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_24_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_24_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >sidewalk</div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_25_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_25_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_25_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >.</div></div></div></div></div></div><div id=\"wbanqvtvicltjcqgtboe_input_node_26_container\" style=\"display:inline;text-align:center\"><div id=\"wbanqvtvicltjcqgtboe_input_node_26_label\" style=\"display:none; padding-top: 0px; font-size:12px;\"></div><div id=\"wbanqvtvicltjcqgtboe_input_node_26_content\"style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" ></div></div></div></div></div></div>\n",
-       "              </div>\n",
-       "            </div>\n",
-       "            <div id=\"wbanqvtvicltjcqgtboe_output_container\" style=\"padding:15px;border-style:solid;margin:5px;flex:1;\">\n",
-       "              <div id=\"wbanqvtvicltjcqgtboe_output_header\" style=\"margin:5px;font-weight:bold;font-family:sans-serif;margin-bottom:10px\">\n",
-       "                Output Text\n",
-       "              </div>\n",
-       "              <div id=\"wbanqvtvicltjcqgtboe_output_content\" style=\"margin:5px;font-family:sans-serif;\">\n",
-       "                  <div style='display:inline; text-align:center;'><div id='wbanqvtvicltjcqgtboe_output_flat_value_label_0'style='display:none;color: #999; padding-top: 0px; font-size:12px;'></div><div id='wbanqvtvicltjcqgtboe_output_flat_token_0'style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >contradiction </div></div><div style='display:inline; text-align:center;'><div id='wbanqvtvicltjcqgtboe_output_flat_value_label_1'style='display:none;color: #999; padding-top: 0px; font-size:12px;'></div><div id='wbanqvtvicltjcqgtboe_output_flat_token_1'style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >neutral </div></div><div style='display:inline; text-align:center;'><div id='wbanqvtvicltjcqgtboe_output_flat_value_label_2'style='display:none;color: #999; padding-top: 0px; font-size:12px;'></div><div id='wbanqvtvicltjcqgtboe_output_flat_token_2'style='display: inline; background:transparent; border-radius: 3px; padding: 0px;cursor: default;cursor: pointer;'onmouseover=\"onMouseHoverFlat_wbanqvtvicltjcqgtboe(this.id)\" onmouseout=\"onMouseOutFlat_wbanqvtvicltjcqgtboe(this.id)\" onclick=\"onMouseClickFlat_wbanqvtvicltjcqgtboe(this.id)\" >entailment </div></div>\n",
-       "              </div>\n",
-       "            </div>\n",
-       "          </div>\n",
-       "        </div>\n",
-       "    \n",
-       "        <script>\n",
-       "            function selectAlignment_wbanqvtvicltjcqgtboe(selectObject) {\n",
-       "                var value = selectObject.value;\n",
-       "                if ( value === \"left-right\" ){\n",
-       "                  document.getElementById('wbanqvtvicltjcqgtboe_heatmap_content').style.display  = \"flex\";\n",
-       "                }\n",
-       "                else if ( value === \"top-bottom\" ) {\n",
-       "                  document.getElementById('wbanqvtvicltjcqgtboe_heatmap_content').style.display  = \"inline\";\n",
-       "                }\n",
-       "            }\n",
-       "            \n",
-       "            var wbanqvtvicltjcqgtboe_heatmap_flat_state = null;\n",
-       "            \n",
-       "            function onMouseHoverFlat_wbanqvtvicltjcqgtboe(id) {\n",
-       "                if (wbanqvtvicltjcqgtboe_heatmap_flat_state === null) {\n",
-       "                    setBackgroundColors_wbanqvtvicltjcqgtboe(id);\n",
-       "                    document.getElementById(id).style.backgroundColor  = \"grey\";\n",
-       "                }\n",
-       "                \n",
-       "                if (getIdSide_wbanqvtvicltjcqgtboe(id) === 'input' && getIdSide_wbanqvtvicltjcqgtboe(wbanqvtvicltjcqgtboe_heatmap_flat_state) === 'output'){\n",
-       "                \n",
-       "                    label_content_id = token_id_to_node_id_mapping_wbanqvtvicltjcqgtboe[wbanqvtvicltjcqgtboe_heatmap_flat_state][id];\n",
-       "                    \n",
-       "                    if (document.getElementById(label_content_id).previousElementSibling.style.display == 'none'){\n",
-       "                        document.getElementById(label_content_id).style.textShadow = \"0px 0px 1px #000000\";\n",
-       "                    }\n",
-       "                    \n",
-       "                }\n",
-       "                \n",
-       "            }\n",
-       "            \n",
-       "            function onMouseOutFlat_wbanqvtvicltjcqgtboe(id) {\n",
-       "                if (wbanqvtvicltjcqgtboe_heatmap_flat_state === null) {\n",
-       "                    cleanValuesAndColors_wbanqvtvicltjcqgtboe(id);\n",
-       "                    document.getElementById(id).style.backgroundColor  = \"transparent\";\n",
-       "                }\n",
-       "                \n",
-       "                if (getIdSide_wbanqvtvicltjcqgtboe(id) === 'input' && getIdSide_wbanqvtvicltjcqgtboe(wbanqvtvicltjcqgtboe_heatmap_flat_state) === 'output'){\n",
-       "                \n",
-       "                    label_content_id = token_id_to_node_id_mapping_wbanqvtvicltjcqgtboe[wbanqvtvicltjcqgtboe_heatmap_flat_state][id];\n",
-       "                    \n",
-       "                    if (document.getElementById(label_content_id).previousElementSibling.style.display == 'none'){\n",
-       "                        document.getElementById(label_content_id).style.textShadow = \"inherit\";\n",
-       "                    }\n",
-       "                    \n",
-       "                }\n",
-       "                \n",
-       "            }\n",
-       "\n",
-       "            function onMouseClickFlat_wbanqvtvicltjcqgtboe(id) {\n",
-       "                if (wbanqvtvicltjcqgtboe_heatmap_flat_state === id) {\n",
-       "                    \n",
-       "                    // If the clicked token was already selected\n",
-       "                    \n",
-       "                    document.getElementById(id).style.backgroundColor  = \"transparent\";\n",
-       "                    cleanValuesAndColors_wbanqvtvicltjcqgtboe(id);\n",
-       "                    wbanqvtvicltjcqgtboe_heatmap_flat_state = null;\n",
-       "                }\n",
-       "                else {\n",
-       "                    if (wbanqvtvicltjcqgtboe_heatmap_flat_state === null) {\n",
-       "                    \n",
-       "                        // No token previously selected, new token clicked on\n",
-       "                    \n",
-       "                        cleanValuesAndColors_wbanqvtvicltjcqgtboe(id)\n",
-       "                        wbanqvtvicltjcqgtboe_heatmap_flat_state = id;\n",
-       "                        document.getElementById(id).style.backgroundColor  = \"grey\";\n",
-       "                        setLabelValues_wbanqvtvicltjcqgtboe(id);\n",
-       "                        setBackgroundColors_wbanqvtvicltjcqgtboe(id);\n",
-       "                    }\n",
-       "                    else {\n",
-       "                        if (getIdSide_wbanqvtvicltjcqgtboe(wbanqvtvicltjcqgtboe_heatmap_flat_state) === getIdSide_wbanqvtvicltjcqgtboe(id)) {\n",
-       "                        \n",
-       "                            // User clicked a token on the same side as the currently selected token\n",
-       "                            \n",
-       "                            cleanValuesAndColors_wbanqvtvicltjcqgtboe(wbanqvtvicltjcqgtboe_heatmap_flat_state)\n",
-       "                            document.getElementById(wbanqvtvicltjcqgtboe_heatmap_flat_state).style.backgroundColor  = \"transparent\";\n",
-       "                            wbanqvtvicltjcqgtboe_heatmap_flat_state = id;\n",
-       "                            document.getElementById(id).style.backgroundColor  = \"grey\";\n",
-       "                            setLabelValues_wbanqvtvicltjcqgtboe(id);\n",
-       "                            setBackgroundColors_wbanqvtvicltjcqgtboe(id);\n",
-       "                        }\n",
-       "                        else{\n",
-       "                            \n",
-       "                            if (getIdSide_wbanqvtvicltjcqgtboe(id) === 'input') {\n",
-       "                                label_content_id = token_id_to_node_id_mapping_wbanqvtvicltjcqgtboe[wbanqvtvicltjcqgtboe_heatmap_flat_state][id];\n",
-       "                                \n",
-       "                                if (document.getElementById(label_content_id).previousElementSibling.style.display == 'none') {\n",
-       "                                    document.getElementById(label_content_id).previousElementSibling.style.display = 'block';\n",
-       "                                    document.getElementById(label_content_id).parentNode.style.display = 'inline-block';\n",
-       "                                    document.getElementById(label_content_id).style.textShadow = \"0px 0px 1px #000000\";\n",
-       "                                  }\n",
-       "                                else {\n",
-       "                                    document.getElementById(label_content_id).previousElementSibling.style.display = 'none';\n",
-       "                                    document.getElementById(label_content_id).parentNode.style.display = 'inline';\n",
-       "                                    document.getElementById(label_content_id).style.textShadow  = \"inherit\"; \n",
-       "                                  }\n",
-       "                                \n",
-       "                            }\n",
-       "                            else {\n",
-       "                                if (document.getElementById(id).previousElementSibling.style.display == 'none') {\n",
-       "                                    document.getElementById(id).previousElementSibling.style.display = 'block';\n",
-       "                                    document.getElementById(id).parentNode.style.display = 'inline-block';\n",
-       "                                  }\n",
-       "                                else {\n",
-       "                                    document.getElementById(id).previousElementSibling.style.display = 'none';\n",
-       "                                    document.getElementById(id).parentNode.style.display = 'inline';\n",
-       "                                  }\n",
-       "                            }\n",
-       "                        \n",
-       "                        }\n",
-       "                    }\n",
-       "                \n",
-       "                }\n",
-       "            }\n",
-       "\n",
-       "            function setLabelValues_wbanqvtvicltjcqgtboe(id) {\n",
-       "                for(const token in shap_values_wbanqvtvicltjcqgtboe[id]){\n",
-       "                    document.getElementById(token).innerHTML = shap_values_wbanqvtvicltjcqgtboe[id][token];\n",
-       "                    document.getElementById(token).nextElementSibling.title = 'SHAP Value : ' + shap_values_wbanqvtvicltjcqgtboe[id][token];\n",
-       "                }\n",
-       "            }\n",
-       "\n",
-       "            function setBackgroundColors_wbanqvtvicltjcqgtboe(id) {\n",
-       "                for(const token in colors_wbanqvtvicltjcqgtboe[id]){\n",
-       "                    document.getElementById(token).style.backgroundColor  = colors_wbanqvtvicltjcqgtboe[id][token];\n",
-       "                }\n",
-       "            }\n",
-       "\n",
-       "            function cleanValuesAndColors_wbanqvtvicltjcqgtboe(id) {\n",
-       "                for(const token in shap_values_wbanqvtvicltjcqgtboe[id]){\n",
-       "                    document.getElementById(token).innerHTML = \"\";\n",
-       "                    document.getElementById(token).nextElementSibling.title = \"\";\n",
-       "                }\n",
-       "                 for(const token in colors_wbanqvtvicltjcqgtboe[id]){\n",
-       "                    document.getElementById(token).style.backgroundColor  = \"transparent\";\n",
-       "                    document.getElementById(token).previousElementSibling.style.display = 'none';\n",
-       "                    document.getElementById(token).parentNode.style.display = 'inline';\n",
-       "                    document.getElementById(token).style.textShadow  = \"inherit\"; \n",
-       "                }\n",
-       "            }\n",
-       "            \n",
-       "            function getIdSide_wbanqvtvicltjcqgtboe(id) {\n",
-       "                if (id === null) {\n",
-       "                    return 'null'\n",
-       "                }\n",
-       "                return id.split(\"_\")[1];\n",
-       "            }\n",
-       "        </script>\n",
-       "    <script> colors_wbanqvtvicltjcqgtboe = {\"wbanqvtvicltjcqgtboe_input_node_0_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_1_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_2_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_3_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_4_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_5_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_6_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_7_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(30.0, 136.0, 229.0, 0.05407011289364222)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(255.0, 13.0, 87.0, 0.030421865715983164)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.014656367597544028)\"}, \"wbanqvtvicltjcqgtboe_input_node_8_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.16442859972271742)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.11713210536739943)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.1565458506634977)\"}, \"wbanqvtvicltjcqgtboe_input_node_9_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.16442859972271742)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.11713210536739943)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.1565458506634977)\"}, \"wbanqvtvicltjcqgtboe_input_node_10_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.16442859972271742)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.11713210536739943)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.1565458506634977)\"}, \"wbanqvtvicltjcqgtboe_input_node_11_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.16442859972271742)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.11713210536739943)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.1565458506634977)\"}, \"wbanqvtvicltjcqgtboe_input_node_12_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.219607843137255)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.18019409784115656)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.14866310160427798)\"}, \"wbanqvtvicltjcqgtboe_input_node_13_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.219607843137255)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.18019409784115656)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.14866310160427798)\"}, \"wbanqvtvicltjcqgtboe_input_node_14_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.219607843137255)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.18019409784115656)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.14866310160427798)\"}, \"wbanqvtvicltjcqgtboe_input_node_15_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.219607843137255)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.18019409784115656)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.14866310160427798)\"}, \"wbanqvtvicltjcqgtboe_input_node_16_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_input_node_17_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.06983561101208159)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.09348385818974048)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_input_node_18_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.06983561101208159)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.09348385818974048)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_input_node_19_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.06983561101208159)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.09348385818974048)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_input_node_20_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.06983561101208159)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.09348385818974048)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_input_node_21_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.29055258467023165)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.2038423450188156)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.22749059219647463)\"}, \"wbanqvtvicltjcqgtboe_input_node_22_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.29055258467023165)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.2038423450188156)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.22749059219647463)\"}, \"wbanqvtvicltjcqgtboe_input_node_23_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.5112695583283818)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.3772628243216478)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.46397306397306387)\"}, \"wbanqvtvicltjcqgtboe_input_node_24_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.5112695583283818)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.3772628243216478)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.46397306397306387)\"}, \"wbanqvtvicltjcqgtboe_input_node_25_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(255.0, 13.0, 87.0, 0.14078035254505847)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(30.0, 136.0, 229.0, 0.06195286195286191)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(30.0, 136.0, 229.0, 0.06983561101208147)\"}, \"wbanqvtvicltjcqgtboe_input_node_26_content\": {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_output_flat_token_1\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_output_flat_token_2\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_0\": {\"wbanqvtvicltjcqgtboe_input_node_46_content\": \"rgba(30.0, 136.0, 229.0, 0.4955040602099425)\", \"wbanqvtvicltjcqgtboe_input_node_41_content\": \"rgba(255.0, 13.0, 87.0, 0.6610417904535549)\", \"wbanqvtvicltjcqgtboe_input_node_44_content\": \"rgba(255.0, 13.0, 87.0, 0.8817587641117054)\", \"wbanqvtvicltjcqgtboe_input_node_16_content\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_input_node_42_content\": \"rgba(255.0, 13.0, 87.0, 0.2826698356110118)\", \"wbanqvtvicltjcqgtboe_input_node_36_content\": \"rgba(255.0, 13.0, 87.0, 0.5743315508021392)\", \"wbanqvtvicltjcqgtboe_input_node_37_content\": \"rgba(255.0, 13.0, 87.0, 1.0)\", \"wbanqvtvicltjcqgtboe_input_node_25_content\": \"rgba(255.0, 13.0, 87.0, 0.17231134878193693)\", \"wbanqvtvicltjcqgtboe_input_node_26_content\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_1\": {\"wbanqvtvicltjcqgtboe_input_node_46_content\": \"rgba(255.0, 13.0, 87.0, 0.306318082788671)\", \"wbanqvtvicltjcqgtboe_input_node_41_content\": \"rgba(30.0, 136.0, 229.0, 0.4955040602099425)\", \"wbanqvtvicltjcqgtboe_input_node_44_content\": \"rgba(30.0, 136.0, 229.0, 0.731986531986532)\", \"wbanqvtvicltjcqgtboe_input_node_16_content\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_input_node_42_content\": \"rgba(30.0, 136.0, 229.0, 0.39302832244008723)\", \"wbanqvtvicltjcqgtboe_input_node_36_content\": \"rgba(30.0, 136.0, 229.0, 0.4324420677361853)\", \"wbanqvtvicltjcqgtboe_input_node_37_content\": \"rgba(30.0, 136.0, 229.0, 0.7714002772826302)\", \"wbanqvtvicltjcqgtboe_input_node_25_content\": \"rgba(30.0, 136.0, 229.0, 0.03042186571598325)\", \"wbanqvtvicltjcqgtboe_input_node_26_content\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_2\": {\"wbanqvtvicltjcqgtboe_input_node_46_content\": \"rgba(30.0, 136.0, 229.0, 0.14866310160427798)\", \"wbanqvtvicltjcqgtboe_input_node_41_content\": \"rgba(30.0, 136.0, 229.0, 0.6452762923351159)\", \"wbanqvtvicltjcqgtboe_input_node_44_content\": \"rgba(30.0, 136.0, 229.0, 0.6058625470390175)\", \"wbanqvtvicltjcqgtboe_input_node_16_content\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\", \"wbanqvtvicltjcqgtboe_input_node_42_content\": \"rgba(255.0, 13.0, 87.0, 0.00677361853832443)\", \"wbanqvtvicltjcqgtboe_input_node_36_content\": \"rgba(30.0, 136.0, 229.0, 0.42455931867696567)\", \"wbanqvtvicltjcqgtboe_input_node_37_content\": \"rgba(30.0, 136.0, 229.0, 0.8896415131709249)\", \"wbanqvtvicltjcqgtboe_input_node_25_content\": \"rgba(30.0, 136.0, 229.0, 0.1565458506634977)\", \"wbanqvtvicltjcqgtboe_input_node_26_content\": \"rgba(230.2941176470614, 26.505882352939775, 102.59215686274348, 0.0)\"}}\n",
-       " shap_values_wbanqvtvicltjcqgtboe = {\"wbanqvtvicltjcqgtboe_input_node_0_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_1_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_2_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_3_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_4_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_5_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_6_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_7_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": -0.185, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.116, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.057}, \"wbanqvtvicltjcqgtboe_input_node_8_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.492, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.371, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.481}, \"wbanqvtvicltjcqgtboe_input_node_9_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.492, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.371, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.481}, \"wbanqvtvicltjcqgtboe_input_node_10_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.492, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.371, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.481}, \"wbanqvtvicltjcqgtboe_input_node_11_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.492, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.371, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.481}, \"wbanqvtvicltjcqgtboe_input_node_12_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.658, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.547, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.454}, \"wbanqvtvicltjcqgtboe_input_node_13_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.658, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.547, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.454}, \"wbanqvtvicltjcqgtboe_input_node_14_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.658, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.547, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.454}, \"wbanqvtvicltjcqgtboe_input_node_15_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.658, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.547, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.454}, \"wbanqvtvicltjcqgtboe_input_node_16_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.0, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.0, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": 0.0}, \"wbanqvtvicltjcqgtboe_input_node_17_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.215, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.295, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": 0.01}, \"wbanqvtvicltjcqgtboe_input_node_18_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.215, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.295, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": 0.01}, \"wbanqvtvicltjcqgtboe_input_node_19_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.215, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.295, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": 0.01}, \"wbanqvtvicltjcqgtboe_input_node_20_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.215, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.295, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": 0.01}, \"wbanqvtvicltjcqgtboe_input_node_21_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.881, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.628, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.692}, \"wbanqvtvicltjcqgtboe_input_node_22_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.881, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.628, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.692}, \"wbanqvtvicltjcqgtboe_input_node_23_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 1.516, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -1.122, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -1.389}, \"wbanqvtvicltjcqgtboe_input_node_24_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 1.516, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -1.122, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -1.389}, \"wbanqvtvicltjcqgtboe_input_node_25_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.432, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": -0.191, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": -0.233}, \"wbanqvtvicltjcqgtboe_input_node_26_content\": {\"wbanqvtvicltjcqgtboe_output_flat_value_label_0\": 0.0, \"wbanqvtvicltjcqgtboe_output_flat_value_label_1\": 0.0, \"wbanqvtvicltjcqgtboe_output_flat_value_label_2\": 0.0}, \"wbanqvtvicltjcqgtboe_output_flat_token_0\": {\"wbanqvtvicltjcqgtboe_input_node_46_label\": \"-1.479/8\", \"wbanqvtvicltjcqgtboe_input_node_41_label\": \"1.97/4\", \"wbanqvtvicltjcqgtboe_input_node_44_label\": \"2.634/4\", \"wbanqvtvicltjcqgtboe_input_node_16_label\": \"0.0\", \"wbanqvtvicltjcqgtboe_input_node_42_label\": \"0.86/4\", \"wbanqvtvicltjcqgtboe_input_node_36_label\": \"1.714/2\", \"wbanqvtvicltjcqgtboe_input_node_37_label\": \"2.984/2\", \"wbanqvtvicltjcqgtboe_input_node_25_label\": \"0.528\", \"wbanqvtvicltjcqgtboe_input_node_26_label\": \"0.0\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_1\": {\"wbanqvtvicltjcqgtboe_input_node_46_label\": \"0.93/8\", \"wbanqvtvicltjcqgtboe_input_node_41_label\": \"-1.485/4\", \"wbanqvtvicltjcqgtboe_input_node_44_label\": \"-2.189/4\", \"wbanqvtvicltjcqgtboe_input_node_16_label\": \"0.0\", \"wbanqvtvicltjcqgtboe_input_node_42_label\": \"-1.18/4\", \"wbanqvtvicltjcqgtboe_input_node_36_label\": \"-1.301/2\", \"wbanqvtvicltjcqgtboe_input_node_37_label\": \"-2.29/2\", \"wbanqvtvicltjcqgtboe_input_node_25_label\": \"-0.102\", \"wbanqvtvicltjcqgtboe_input_node_26_label\": \"0.0\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_2\": {\"wbanqvtvicltjcqgtboe_input_node_46_label\": \"-0.457/8\", \"wbanqvtvicltjcqgtboe_input_node_41_label\": \"-1.924/4\", \"wbanqvtvicltjcqgtboe_input_node_44_label\": \"-1.817/4\", \"wbanqvtvicltjcqgtboe_input_node_16_label\": \"0.0\", \"wbanqvtvicltjcqgtboe_input_node_42_label\": \"0.038/4\", \"wbanqvtvicltjcqgtboe_input_node_36_label\": \"-1.259/2\", \"wbanqvtvicltjcqgtboe_input_node_37_label\": \"-2.653/2\", \"wbanqvtvicltjcqgtboe_input_node_25_label\": \"-0.483\", \"wbanqvtvicltjcqgtboe_input_node_26_label\": \"0.0\"}}\n",
-       " token_id_to_node_id_mapping_wbanqvtvicltjcqgtboe = {\"wbanqvtvicltjcqgtboe_output_flat_token_0\": {\"wbanqvtvicltjcqgtboe_input_node_0_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_1_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_2_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_3_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_4_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_5_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_6_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_7_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_8_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_9_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_10_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_11_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_12_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_13_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_14_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_15_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_16_content\": \"wbanqvtvicltjcqgtboe_input_node_16_content\", \"wbanqvtvicltjcqgtboe_input_node_17_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_18_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_19_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_20_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_21_content\": \"wbanqvtvicltjcqgtboe_input_node_36_content\", \"wbanqvtvicltjcqgtboe_input_node_22_content\": \"wbanqvtvicltjcqgtboe_input_node_36_content\", \"wbanqvtvicltjcqgtboe_input_node_23_content\": \"wbanqvtvicltjcqgtboe_input_node_37_content\", \"wbanqvtvicltjcqgtboe_input_node_24_content\": \"wbanqvtvicltjcqgtboe_input_node_37_content\", \"wbanqvtvicltjcqgtboe_input_node_25_content\": \"wbanqvtvicltjcqgtboe_input_node_25_content\", \"wbanqvtvicltjcqgtboe_input_node_26_content\": \"wbanqvtvicltjcqgtboe_input_node_26_content\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_1\": {\"wbanqvtvicltjcqgtboe_input_node_0_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_1_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_2_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_3_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_4_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_5_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_6_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_7_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_8_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_9_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_10_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_11_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_12_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_13_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_14_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_15_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_16_content\": \"wbanqvtvicltjcqgtboe_input_node_16_content\", \"wbanqvtvicltjcqgtboe_input_node_17_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_18_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_19_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_20_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_21_content\": \"wbanqvtvicltjcqgtboe_input_node_36_content\", \"wbanqvtvicltjcqgtboe_input_node_22_content\": \"wbanqvtvicltjcqgtboe_input_node_36_content\", \"wbanqvtvicltjcqgtboe_input_node_23_content\": \"wbanqvtvicltjcqgtboe_input_node_37_content\", \"wbanqvtvicltjcqgtboe_input_node_24_content\": \"wbanqvtvicltjcqgtboe_input_node_37_content\", \"wbanqvtvicltjcqgtboe_input_node_25_content\": \"wbanqvtvicltjcqgtboe_input_node_25_content\", \"wbanqvtvicltjcqgtboe_input_node_26_content\": \"wbanqvtvicltjcqgtboe_input_node_26_content\"}, \"wbanqvtvicltjcqgtboe_output_flat_token_2\": {\"wbanqvtvicltjcqgtboe_input_node_0_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_1_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_2_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_3_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_4_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_5_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_6_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_7_content\": \"wbanqvtvicltjcqgtboe_input_node_46_content\", \"wbanqvtvicltjcqgtboe_input_node_8_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_9_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_10_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_11_content\": \"wbanqvtvicltjcqgtboe_input_node_41_content\", \"wbanqvtvicltjcqgtboe_input_node_12_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_13_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_14_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_15_content\": \"wbanqvtvicltjcqgtboe_input_node_44_content\", \"wbanqvtvicltjcqgtboe_input_node_16_content\": \"wbanqvtvicltjcqgtboe_input_node_16_content\", \"wbanqvtvicltjcqgtboe_input_node_17_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_18_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_19_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_20_content\": \"wbanqvtvicltjcqgtboe_input_node_42_content\", \"wbanqvtvicltjcqgtboe_input_node_21_content\": \"wbanqvtvicltjcqgtboe_input_node_36_content\", \"wbanqvtvicltjcqgtboe_input_node_22_content\": \"wbanqvtvicltjcqgtboe_input_node_36_content\", \"wbanqvtvicltjcqgtboe_input_node_23_content\": \"wbanqvtvicltjcqgtboe_input_node_37_content\", \"wbanqvtvicltjcqgtboe_input_node_24_content\": \"wbanqvtvicltjcqgtboe_input_node_37_content\", \"wbanqvtvicltjcqgtboe_input_node_25_content\": \"wbanqvtvicltjcqgtboe_input_node_25_content\", \"wbanqvtvicltjcqgtboe_input_node_26_content\": \"wbanqvtvicltjcqgtboe_input_node_26_content\"}}\n",
-       "</script> \n",
-       " \n",
-       "          </div>\n",
-       "      </div>\n",
-       "    </div>\n",
-       "    </html>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "shap_values = explainer([decoded])\n",
+    "\n",
+    "print(\"shap_values shape:\", shap_values.shape)  # expect (1, num_tokens, 3)\n",
+    "print(\"output_names:\", shap_values.output_names)  # expect ['contradiction', 'neutral', 'entailment']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84e4c9f5",
+   "metadata": {},
+   "source": [
+    "## Explanation Visualization\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c4484a3c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "shap.plots.text(shap_values)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "italian-martin",
+   "id": "2e4002a6",
    "metadata": {},
    "source": [
-    "## Input Partition Tree - Dendrogram"
+    "## Input Partition Tree — Dendrogram\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "radical-harris",
+   "execution_count": 13,
+   "id": "0ba63eb6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,99 +282,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "homeless-foundation",
+   "execution_count": 14,
+   "id": "716595d4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 0.  1. 12.  2.]\n",
-      " [ 2.  3. 12.  2.]\n",
-      " [ 4.  5. 12.  2.]\n",
-      " [ 6.  7. 12.  2.]\n",
-      " [ 8.  9. 12.  2.]\n",
-      " [10. 11. 12.  2.]\n",
-      " [12. 13. 12.  2.]\n",
-      " [17. 18. 12.  2.]\n",
-      " [19. 20. 12.  2.]\n",
-      " [21. 22. 12.  2.]\n",
-      " [23. 24. 12.  2.]\n",
-      " [33. 14. 13.  3.]\n",
-      " [27. 28. 14.  4.]\n",
-      " [29. 30. 14.  4.]\n",
-      " [31. 32. 14.  4.]\n",
-      " [34. 35. 14.  4.]\n",
-      " [36. 37. 14.  4.]\n",
-      " [38. 15. 15.  4.]\n",
-      " [43. 25. 16.  5.]\n",
-      " [39. 40. 18.  8.]\n",
-      " [41. 44. 18.  8.]\n",
-      " [42. 45. 19.  9.]\n",
-      " [46. 47. 26. 16.]\n",
-      " [48. 26. 40. 10.]\n",
-      " [49. 16. 47. 17.]\n",
-      " [51. 50. 57. 27.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "Z = shap_values[0].abs.clustering\n",
-    "Z[-1][2] = Z[-2][2] + 10  # last row's distance is extremely large, so make it a more reasonable value\n",
+    "\n",
+    "# Each row in Z is [left_child, right_child, distance, count] from hierarchical clustering.\n",
+    "# The last merge (Z[-1]) often has an extremely large distance value because it represents\n",
+    "# joining the two top-level clusters. This makes the dendrogram unreadable with a\n",
+    "# wildly elongated top branch. We cap it relative to the second-to-last merge distance.\n",
+    "assert Z is not None, \"Clustering is None — text plot may not render correctly.\"\n",
+    "if Z is not None and len(Z) >= 2:\n",
+    "    Z[-1][2] = Z[-2][2] + 10\n",
     "print(Z)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "honey-difference",
+   "execution_count": 15,
+   "id": "7e311363",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['' 'A ' 'boy ' 'is ' 'jumping ' 'on ' 'skate' 'board ' 'in ' 'the '\n",
-      " 'middle ' 'of ' 'a ' 'red ' 'bridge' '.' '</s>' '</s>' 'The ' 'boy ' 'sk'\n",
-      " 'ates ' 'down ' 'the ' 'sidewalk' '.' '']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "labels_arr = shap_values[0].data\n",
+    "# Fast tokenizers (use_fast=True, the default) return clean token strings.\n",
+    "# Slow tokenizers (use_fast=False) prepend 'Ġ' to space-following tokens.\n",
+    "# This helper handles both cases transparently.\n",
+    "def clean_tokens(tokens):\n",
+    "    return [t[1:] if t.startswith(\"\\u0120\") else t for t in tokens]\n",
     "\n",
-    "# # clean labels of unusal characters (only for slow tokenizer, if use_fast=False)\n",
-    "# labels_arr = []\n",
-    "# for token in shap_values[0].data:\n",
-    "#     if token[0] == 'Ġ':\n",
-    "#         labels_arr.append(token[1:])\n",
-    "#     else:\n",
-    "#         labels_arr.append(token)\n",
+    "\n",
+    "labels_arr = clean_tokens(shap_values[0].data)\n",
     "print(labels_arr)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "empty-divide",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAACigAAANqCAYAAAAdKVETAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAABbAElEQVR4nOzdT4jn933f8dfH3oSUtsLZeKtdpArFxN5FsIoMix2TQlu7KWJVKh8ku3EpYhHIhx5SUmjdnlpIIbk07alY4E51qFtZ24Y10SJqVKelYNSuElWTyFrbXWJjsWNtuzZKLwWnnx72Z1UoK89o9zXznd/M4wHD7+8w78Obr2bYpz6/MecMAAAAAAAAAAAAQNN7lh4AAAAAAAAAAAAAOHgEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoO7IXv6w97///fPee+/dyx8JAAAAAAAAAAAA7KIXX3zxf845j739+T0NFO+9995cunRpL38kAAAAAAAAAAAAsIvGGN++2fM+4hkAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1B1ZegAAAAAAuJkvvvCdXHjptaXHAAAAADgwHn7grnzmo/csPQZwiDhBEQAAAIB96cJLr+WVq28sPQYAAADAgfDK1Tf8z6DAnnOCIgAAAAD71n0n7sjTn/3Y0mMAAAAArL1Pf/5rS48AHEJOUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQN2RnbxpjPGHSf4oyR8n+eGc88wY42iSp5Pcm+QPk3xqzvn93RkTAAAAAAAAAAAAWCfv5gTFvzznfGDOeWb1+HNJnp9zfjDJ86vHAAAAAAAAAAAAALf1Ec8PJ3lqdf+pJJ+87WkAAAAAAAAAAACAA2GngeJM8h/GGC+OMZ5YPXfnnPPq6v5Wkjvr0wEAAAAAAAAAAABr6cgO3/cX5pyvjTH+XJKvjDFefeuLc845xpg3+8ZV0PhEktxzzz23NSwAAAAAAAAAAACwHnZ0guKc87XV7etJfivJR5J8b4xxIklWt6+/w/c+Oec8M+c8c+zYsc7UAAAAAAAAAAAAwL62baA4xvjTY4w/+6P7Sf5qkt9P8uUkj63e9liSC7s1JAAAAAAAAAAAALBedvIRz3cm+a0xxo/e/8U553NjjP+W5EtjjMeTfDvJp3ZvTAAAAAAAAAAAAGCdbBsozjmvJPn5mzz/v5J8YjeGAgAAAAAAAAAAANbbth/xDAAAAAAAAAAAAPBuCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIC6I0sPAAAAHC5ffOE7ufDSa0uPAcAaeOXqG0mST3/+awtPAsB+9/ADd+UzH71n6TEAAACAt3GCIgAAsKcuvPTam8EJAPw49524I/eduGPpMQDY5165+ob/CQoAAAD2KScoAgAAe+6+E3fk6c9+bOkxAACAA8BJuwAAALB/OUERAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgbseB4hjjvWOM3xtj/Pbq8c+OMV4YY3xrjPH0GOMnd29MAAAAAAAAAAAAYJ28mxMUfyXJ19/y+DeS/Oac8+eSfD/J483BAAAAAAAAAAAAgPV1ZCdvGmPcneShJP8kya+OMUaSjyf5zOotTyX5R0n+xS7MCAAAAAAAAACsiS++8J1ceOm1pccA3uaVq28kST79+a8tPAlwMw8/cFc+89F7lh6jbqcnKP6zJH8vyf9dPf6ZJD+Yc/5w9fi7Se662TeOMZ4YY1waY1y6du3a7cwKAAAAAAAAAOxzF1567c0QCtg/7jtxR+47ccfSYwA38crVNw5s3L/tCYpjjL+W5PU554tjjL/0bn/AnPPJJE8myZkzZ+a7/X4AAAAAAAAAYL3cd+KOPP3Zjy09BgCshYN8sulOPuL5F5P89THG2SQ/leSOJP88yfvGGEdWpyjeneRgJpwAAAAAAAAAAADAu7btRzzPOf/BnPPuOee9Sf5Gkv845/ybSb6a5JHV2x5LcmHXpgQAAAAAAAAAAADWyraB4o/x95P86hjjW0l+JskXOiMBAAAAAAAAAAAA624nH/H8pjnn7yT5ndX9K0k+0h8JAAAAAAAAAAAAWHe3c4IiAAAAAAAAAAAAwE0JFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB12waKY4yfGmP81zHGfx9j/MEY4x+vnv/ZMcYLY4xvjTGeHmP85O6PCwAAAAAAAAAAAKyDnZyg+H+SfHzO+fNJHkjy4BjjF5L8RpLfnHP+XJLvJ3l816YEAAAAAAAAAAAA1sq2geK84X+vHv7E6msm+XiS86vnn0ryyd0YEAAAAAAAAAAAAFg/OzlBMWOM944xXkryepKvJPkfSX4w5/zh6i3fTXLXO3zvE2OMS2OMS9euXSuMDAAAAAAAAAAAAOx3OwoU55x/POd8IMndST6S5NROf8Cc88k555k555ljx47d2pQAAAAAAAAAAADAWtlRoPgjc84fJPlqko8led8Y48jqpbuTvNYdDQAAAAAAAAAAAFhX2waKY4xjY4z3re7/qSS/lOTruREqPrJ622NJLuzSjAAAAAAAAAAAAMCaObL9W3IiyVNjjPfmRtD4pTnnb48xXknyb8cYv5bk95J8YRfnBAAAAAAAAAAAANbItoHinPPlJB++yfNXknxkN4YCAAAAAAAAAAAA1tu2H/EMAAAAAAAAAAAA8G4JFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdUeWHgCAA+bSRrJ5fukpANjPth6+cbvxa8vOAcD+dvqR5My5pacAAAAAAOA2CBQB6No8n2xtJsdPLz0JAPvU0/dcWHoEAPa7rc0btwJFAAAAAIC1JlAEoO/46eTcs0tPAQAArKuNh5aeAAAAAACAgvcsPQAAAAAAAAAAAABw8AgUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABA3baB4hjjz48xvjrGeGWM8QdjjF9ZPX90jPGVMcY3V7c/vfvjAgAAAAAAAAAAAOtgJyco/jDJ351z3pfkF5L87THGfUk+l+T5OecHkzy/egwAAAAAAAAAAACwfaA457w65/zd1f0/SvL1JHcleTjJU6u3PZXkk7s0IwAAAAAAAAAAALBmdnKC4pvGGPcm+XCSF5LcOee8unppK8md7/A9T4wxLo0xLl27du12ZgUAAAAAAAAAAADWxI4DxTHGn0ny75L8nTnnG299bc45k8ybfd+c88k555k555ljx47d1rAAAAAAAAAAAADAethRoDjG+InciBP/9Zzz36+e/t4Y48Tq9RNJXt+dEQEAAAAAAAAAAIB1s22gOMYYSb6Q5Otzzn/6lpe+nOSx1f3HklzojwcAAAAAAAAAAACsoyM7eM8vJvlbSTbHGC+tnvuHSX49yZfGGI8n+XaST+3KhAAAAAAAAAAAAMDa2TZQnHP+lyTjHV7+RHccAAAAAAAAAAAA4CDY9iOeAQAAAAAAAAAAAN4tgSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACg7sjSAwAAAAAAAACHxzPfeCYXr1xcegxgF12+/heTJOeee3LhSYDdcvYDZ/Pohx5degxgDQgUAQAAAAAAgD1z8crFXL5+OSePnlx6FGCXfPjD/2npEYBddPn65SQRKAI7IlAEAAAAAAAA9tTJoyez8eDG0mMAALfg3HPnlh4BWCPvWXoAAAAAAAAAAAAA4OARKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHVHlh4ADrRLG8nm+aWngL219fKN242Hlp0D9trpR5Iz55aeAoDd5Pd72Dv+roC95e8ZAAAAAHaJExRhN22eT7Y2l54C9tbx+298wWGytSlYATgM/H4Pe8ffFbB3/D0DAAAAwC5ygiLstuOnk3PPLj0FALvJyT4Ah4ff7wE4aPw9AwAAAMAucoIiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUHdk6QEAAAAAAAAAADhYnvnGM7l45eLSY7ALXr3+apLk3HPnFp6E3XD2A2fz6IceXXoMDhAnKAIAAAAAAAAAUHXxysVcvn556THYBaeOnsqpo6eWHoNdcPn6ZWExdU5QBAAAAAAAAACg7uTRk9l4cGPpMYAdciomu8EJigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKg7svQAAAAAAADvyqWNZPP80lMcDFsv37jdeGjZOQ6K048kZ84tPQUAAADAvuEERQAAAABgvWyeT7Y2l57iYDh+/40vbt/WpnAWAAAA4G2coAgAAAAArJ/jp5Nzzy49Bfx/TqEEAAAA+BOcoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQd2TpAdgDlzaSzfNLT3E4bb1843bjoWXnOKxOP5KcObf0FLB3XO+X43q/LNd7DhvX++W43i/PNR8AgKJnvvFMLl65uPQYh9Kr119Nkpx7zu/3Szj7gbN59EOPLj0G7BnX++W43i/L9R7YL5ygeBhsnk+2Npee4nA6fv+NL/be1qZ/uOfwcb1fjuv9clzvOYxc75fjer8s13wAAMouXrmYy9cvLz3GoXTq6KmcOnpq6TEOpcvXLwu1OHRc75fjer8c13tgP3GC4mFx/HRy7tmlp4C941QbDivXew4b13sOK9d7DiPXfAAAdsHJoyez8eDG0mPAnnGKGYeV6z2Hjes9sJ84QREAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACg7sjSAwAAAAAAN3FpI9k8v/QU+9PWyzduNx5ado796vQjyZlzS08BAAAAAE5QBAAAAIB9afN8srW59BT70/H7b3zxJ21tClsBAAAA2DecoAgAAAAA+9Xx08m5Z5eegnXiVEkAAAAA9hEnKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKDuyNIDrIVLG8nm+aWnuHVbL9+43Xho2Tlu1elHkjPnlp7i8LH3y7P7y1jn3bf33Cp7vyx7vwx7vyx7v4x13vtk/Xff3i/D3i/L3gMceM9845lcvHJx6TFu2avXX02SnHtuff97dfYDZ/Pohx5deoxDZ513395zq+z9suz9Muz9suw9HBxOUNyJzfPJ1ubSU9y64/ff+FpHW5vr/Q8J68zeL8vuL2edd9/ec6vs/XLs/XLs/XLs/XLWee+T9d59e78ce78cew9wKFy8cjGXr19eeoxbduroqZw6emrpMW7Z5euX1zaaWHfrvPv2nltl75dj75dj75dj7+FgcYLiTh0/nZx7dukpDp91PSHgoLD3y7H7y7L7y7D3y7L3y7D3y7L3y7D3y7L3y7D3y7L3y7D3AIfGyaMns/HgxtJjHErrfCLSQWD3l2Hvl2Xvl2Hvl2Xvl2Hv4WBxgiIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoG7bQHGM8S/HGK+PMX7/Lc8dHWN8ZYzxzdXtT+/umAAAAAAAAAAAAMA62ckJiv8qyYNve+5zSZ6fc34wyfOrxwAAAAAAAAAAAABJdhAozjn/c5Lrb3v64SRPre4/leST3bEAAAAAAAAAAACAdbaTExRv5s4559XV/a0kd77TG8cYT4wxLo0xLl27du0WfxwAAAAAAAAAAACwTm41UHzTnHMmmT/m9SfnnGfmnGeOHTt2uz8OAAAAAAAAAAAAWAO3Gih+b4xxIklWt6/3RgIAAAAAAAAAAADW3a0Gil9O8tjq/mNJLnTGAQAAAAAAAAAAAA6CbQPFMca/SfK1JCfHGN8dYzye5NeT/NIY45tJ/srqMQAAAAAAAAAAAECS5Mh2b5hz/vI7vPSJ8iwAAAAAAAAAAADAAXGrH/EMAAAAAAAAAAAA8I4EigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQAAAAAAAAAAAKgTKAIAAAAAAAAAAAB1AkUAAAAAAAAAAACgTqAIAAAAAAAAAAAA1AkUAQAAAAAAAAAAgDqBIgAAAAAAAAAAAFAnUAQAAAAAAAAAAADqBIoAAAAAAAAAAABAnUARAAAAAAAAAAAAqBMoAgAAAAAAAAAAAHUCRQAAAAAAAAAAAKBOoAgAAAAAAAAAAADUCRQBAAAAAAAAAACAOoEiAAAAAAAAAAAAUCdQBAAAAAAAAAAAAOoEigAAAAAAAAAAAECdQBEAAAAAAAAAAACoEygCAAAAAAAAAAAAdQJFAAAAAAAAAAAAoE6gCAAAAAAAAAAAANQJFAEAAAAAAAAAAIA6gSIAAAAAAAAAAABQJ1AEAAAAAAAAAAAA6gSKAAAAAAAAAAAAQJ1AEQCA/9fenYd7O5b7H39/kClEI6FU2sq0d6koDVsoMkXmKXNIJU2KUirJULGTqGTa1FbqR4PK1iA0SUkKGTJU0iAzD87fH9e99l57HXbH7nnute61vuv9+seansN5fJ/13N/7vq7PdZ6SJEmSJEmSJEmSJPXOgKIkSZIkSZIkSZIkSZIkSeqdAUVJkiRJkiRJkiRJkiRJktQ7A4qSJEmSJEmSJEmSJEmSJKl3BhQlSZIkSZIkSZIkSZIkSVLvDChKkiRJkiRJkiRJkiRJkqTeGVCUJEmSJEmSJEmSJEmSJEm9M6AoSZIkSZIkSZIkSZIkSZJ6Z0BRkiRJkiRJkiRJkiRJkiT1zoCiJEmSJEmSJEmSJEmSJEnqnQFFSZIkSZIkSZIkSZIkSZLUOwOKkiRJkiRJkiRJkiRJkiSpdwYUJUmSJEmSJEmSJEmSJElS7wwoSpIkSZIkSZIkSZIkSZKk3hlQlCRJkiRJkiRJkiRJkiRJvTOgKEmSJEmSJEmSJEmSJEmSemdAUZIkSZIkSZIkSZIkSZIk9c6AoiRJkiRJkiRJkiRJkiRJ6p0BRUmSJEmSJEmSJEmSJEmS1DsDipIkSZIkSZIkSZIkSZIkqXcGFCVJkiRJkiRJkiRJkiRJUu8MKEqSJEmSJEmSJEmSJEmSpN4ZUJQkSZIkSZIkSZIkSZIkSb0zoChJkiRJkiRJkiRJkiRJknpnQFGSJEmSJEmSJEmSJEmSJPXOgKIkSZIkSZIkSZIkSZIkSeqdAUVJkiRJkiRJkiRJkiRJktQ7A4qSJEmSJEmSJEmSJEmSJKl3BhQlSZIkSZIkSZIkSZIkSVLvDChKkiRJkiRJkiRJkiRJkqTeGVCUJEmSJEmSJEmSJEmSJEm9M6AoSZIkSZIkSZIkSZIkSZJ6Z0BRkiRJkiRJkiRJkiRJkiT1zoCiJEmSJEmSJEmSJEmSJEnqnQFFSZIkSZIkSZIkSZIkSZLUOwOKkiRJkiRJkiRJkiRJkiSpdwYUJUmSJEmSJEmSJEmSJElS7wwoSpIkSZIkSZIkSZIkSZKk3hlQlCRJkiRJkiRJkiRJkiRJvTOgKEmSJEmSJEmSJEmSJEmSemdAUZIkSZIkSZIkSZIkSZIk9c6AoiRJkiRJkiRJkiRJkiRJ6p0BRUmSJEmSJEmSJEmSJEmS1DsDipIkSZIkSZIkSZIkSZIkqXcGFCVJkiRJkiRJkiRJkiRJUu8MKEqSJEmSJEmSJEmSJEmSpN4ZUJQkSZIkSZIkSZIkSZIkSb0zoChJkiRJkiRJkiRJkiRJknpnQFGSJEmSJEmSJEmSJEmSJPXOgKIkSZIkSZIkSZIkSZIkSeqdAUVJkiRJkiRJkiRJkiRJktQ7A4qSJEmSJEmSJEmSJEmSJKl3BhQlSZIkSZIkSZIkSZIkSVLvDChKkiRJkiRJkiRJkiRJkqTeGVCUJEmSJEmSJEmSJEmSJEm9M6AoSZIkSZIkSZIkSZIkSZJ6Z0BRkiRJkiRJkiRJkiRJkiT1zoCiJEmSJEmSJEmSJEmSJEnqnQFFSZIkSZIkSZIkSZIkSZLUOwOKkiRJkiRJkiRJkiRJkiSpdwYUJUmSJEmSJEmSJEmSJElS7wwoSpIkSZIkSZIkSZIkSZKk3hlQlCRJkiRJkiRJkiRJkiRJvTOgKEmSJEmSJEmSJEmSJEmSemdAUZIkSZIkSZIkSZIkSZIk9c6AoiRJkiRJkiRJkiRJkiRJ6p0BRUmSJEmSJEmSJEmSJEmS1DsDipIkSZIkSZIkSZIkSZIkqXcGFCVJkiRJkiRJkiRJkiRJUu8MKEqSJEmSJEmSJEmSJEmSpN7NU0AxyQZJrkrymyQH9lWUJEmSJEmSJEmSJEmSJEma2eY6oJhkfuA4YENgZWC7JCv3VZgkSZIkSZIkSZIkSZIkSZq55qWD4guA31TVdVX1APA5YLN+ypIkSZIkSZIkSZIkSZIkSTNZqmru/mCyJbBBVe3Rfb4TsGZV7Tfh5/YC9uo+XQm4au7LlSRJkiRJkiRJkiRJkiRJ08xTq+oJE7+4wGT/X6vqRODEyf7/SJIkSZIkSZIkSZIkSZKk6WNeRjzfAiw/7vPluq9JkiRJkiRJkiRJkiRJkqRZbl4Cij8GnpnkaUkWBLYFzumnLEmSJEmSJEmSJEmSJEmSNJPN9YjnqnowyX7AN4D5gZOq6pe9VSZJkiRJkiRJkiRJkiRJkmasVNXQNUiSJEmSJEmSJEmSJEmSpBEzLyOeJUmSJEmSJEmSJEmSJEmSHpEBRUmSJEmSJEmSJEmSJEmS1DsDipIkSZIkSZIkSZIkSZIkqXcGFCVJkvQ/JMnf+1ySJP3fJVlh6Bok6ZF4ny9JkmYa718kSRP53iDNDAYUJUmS9F+SpKqq+/ipSRbCe8YpleTRQ9cgSepHklcBZyZ5/NC1SFMtyVP83Z9exjZtkqyQZDFg8YFLkiRJ+oeMW7d8ZZLVhq5HkjS8ce8N2yVZbuh6JD0yN5s1rSR50oTP/R2dJpIsMHQNo2z8yY4kbhBMc57E0Sgb9yB3AHAscCKwZ5Ilh6xrtui6bF2UZPWhaxlFdgcdnq/59DQusOLfT4+SLAxsBLwTWCbJCwcuSZoySZYG3gq81pDi9FFVlWRT4BTgMOCQJE8buCxpUoy7v3F9eYr52ms2cv9k8iVZO8k/dx8vCrwFuG/YqqSp5/vr1HKtbHpLskqS14770tbA/UPVI+nv8w1M00aSZwG/T/LRJHsCVNXD3ff8XR1Qkn8CPtl10VLPJnQr2x/YP8kSw1alv6fb1FkryYpD1zIqkqyfZNVuI1MDS7IxsHFVbQYsDzynqm73/Xhyde8HNwCnAycmWWngkkbKhPfblZMsOPa5psaEv4O1uu5Nnmgd2Pi/F2DRQYsZMVV1H3A9cBJwMnDFoAXNMkkWGbqG2ayq/gCcDywDbJvkMQOXJP5r7e09wBbAHGB14M/e52sUjbu/WTDJSkmeN2hBs4iv/dT53w7heV2fWu6fTJm1ga8keU5V3QMU7X6GJPMbIpp6SV6Q5AlD1zHbjNs73z7Jfkle0X3uv4GeuZY5IzwXeEWSHbp/AwsBj0nyqIHrkvQIfEjRdHIXcDHwB2CrJKcm2TTJEmM3W5pa425mFwQeAuYfsJyRNe7mdm9gK+CzVXWHpy6nn3GLfKsA7wK+mOTpw1Y18yXZFTgBOAJ4o92Fpl6Sidf3BWnjKPcBHgDe0H3d7iqTaNwmzk+APwOndJvImkdJ5hv3frsfcBZwTpLXJHncsNXNHhP+Do4CdgI+n2SZQQub5cb9vbwO+EyS9yTZceCyZrxxz1IXdv+tqrpzwvc0SbrrzBFJPpRkqaHrmcUeB6wM7A3sYCfFaWEJ4GvAmsCLgL2r6g5gdUMVGgUTQ1ndWtuRwDdpB4J9D54kvvbDGHcv//okhwLHJXmC+ylTw/2TqTF2famqI2gHvz6b5KnAz2j3m9Bee+81p1CStwDvBRYbuJRZKckOwCG0g6ZfSLJ911jD99seuZY5fSV5UZJdquo04KvAOsAewDXA3bQQO679S9OLAUVNG1V1M/AjWtL9VbQF092Ar3ancJ45ZH2z1FgXv6uAJ9FudtWTJK9IsmX38fzAi4EPt0+zL3B8ktcPWaP+p+4BbxPg34ELgF/RHkb+adjKZq4k2wAvpG1c7k8Lq2+RZK0h65pNum42r+0+3qy7Lv2O9jC3TVVtUFUPJHkzcFCSBQcsd+R1r/OHgS8CVwJndKFozYNxJ4tfTduMXxv4ArAesIkLFVMnyZrA5rTXfkngj8CtjxCU1hTqDgtsB3wQeCmwxrAVzVzjNs+qe8/8ObAi8J9JLuk2jN00mETds9RWwOG0NYVjkqw8bFWzT5LXAG8C9gXOBFbCToqDSbJC9+FvgJcBxwJbVtW1STagXf+d5NAjn5uGUVUPJ1ksyWFJPgxsCXyCtrb5LTuoTx5f++F09z5b0NYr1wHeOmxFs4r7J5Os6142tqazD3A1cB5wEbAz8JYkXwa+BBydZMmBSp1V0qbvbAG8uqqu77rKPWPoukbZ+DWEJOsC6wJbd8HdV9O6uG7r+23/XMucthag7VftVFVnAN8BNqDta50LnJvkHOCsJAsPV+bM57Ot+mRAUdPCuBurA2mJ9sfTOimuDvyS1qnsgCSPHqbC2adbvP73JLtX1RxgP+DR3ck09eNm4NIkT6+qh4Af07qUnUQ7+XcN8FQ3L6edVwIfqKqPAbvQFj9OTWJnuX9QWov1TWkPd6mqq2kPDrcDr03yggHLm03uAJZKcjNt3NuXgF/TrknfS7JjF1zZGfhIVT0wXKmjZ8Li0qOApwL7V9VJwJ60oOKJSZ49UIkz2oTDAMsBbwSWqKrbq+rTtAXtNWndux87YKkja+x3fNzv+gPAt4C9gFWA7brNhg2SeOp+iiRZPf+zQ+vitAW85wMPA2/rfm6Fqa9uZhu3ebY38Gng34DnVdU7gEtonQ2e6KbB5EiyBO3Q47bAa4DLum8dnWSVid2d1L9x1/unAedX1Q1V9UHgUlq3iT18z50a496D/wW4JMlHq+ovwOdo78U7dOHEI4ATquq2wYodMd0G2MmxK+WUGbu+d//dHXgK8P9o4YllaPsgZwxW4AjztZ8WlqetrW0MXEvbrF/YzeTJ5f7J1JjQ8X934IKqOhA4FLgHOI62frYv8Paqun2gUmeFcff6C9P2tzZLchjwKdr47VUHK27Ejfu3MD/wz7T987WTLFZVF9BCimeMrYNq7rmWOTNU1feAXWlB9Z2r6nTgbNrz7tm0NaEtgR2q6r7hKp3ZfLZV3xwfqmlhQgeJa4CjaV07DqiqL6d1T/xTVd09WJGzQHcabWyj7Fba38Obk/wz8ERgEVrXg99O+FnNhaq6sjvR95duIeOYJBcAf6iq25JsDWxG2zC+Y8ha1XSLrYsAz6F13noAOAfYiHZCbbequmXAEmeMJItW1T1J9qSFcv8jyaZV9YvuIXs94IZBi5wluvfgy4D7gAeBh6vq9iTHAy+gnb5/CNipqq4YsNSRM/69tAuBPkQLKG4KXFJVDyU5j9YF6uNJNjQg+g+7Gbg3yVOq6sYkRwLvT/Kmqjqmqk7vHrJXpb3+mjyL0DYPbqAFnhesqhUBkuxGW0i9aKjiZqFdgGckeXtVXUX7/f8+cHlVvQL+K2C3YJJPVNWDw5U686R1jns9LYy1I7BNdx06IMnptIW9jR2917+quiOtC/2zgM2rap1ureE2YBtal7j7h6xxFE1YH3gU7TnpIuDtSV5YVZdU1alJdgKeTDdqSZMnyfzdveRGtI20k4B9ktxBCySuSesw+iTgnVX1Vdd5+lNV9yXZs6q83kyBsd/3sc+r6pgJ318N+GxVzUkyn++//fG1n3oTX/MkCwDL0g783gK8pqoe7MJcdwGnDFPpaHL/ZBhJFgE2BA4C5nS/30/uvv0Z2gSYnw9V3yyzYpLrgZ/QQnL70P4dHA0cANgtvWdj15LuufblwIFVtX6Se4B/AdZKclFVXZDkZbTufuqHa5nTzMT31qr6fpL9aZMz5quqk5MU7e9m06r6HPD7YaodDT7bqm/x/ljTTZKVgO8Cx1XV+4euZ7YYd5P7r7RQ3G+Ab3chumVoXVTWBe6kjQH6w2DFjpi09uBfAQ6uqhO6oMT2tHEcW1XVLwctUCR5Lm0T7Qra4sdXgU91odK1gR2AhYCvV9UXhqt0ZugCD2sCc4DTaMH099IW8l7TXYsWNIg1eSY+yHULHIvQOha/jHadvzXJyt37wAKGUyZPkhcCh3aLS8vSTmSeXFVHJNmediL22Kr63aCFzlBjhwGA11fV8UnWpwWHLqiqY7ufWaKqPAzQoySrA7dU1Z/TRo5tBHwTOIs27vYQ4EfAX4GtgV2r6hdD1TtbpHVNnK+7th9B63Dzbtrm5Qdp9/pv5b/vRbepqiuHqnemSvIu4IGqOiqtc83OwAZVNdbRdZmqcoF0EnWHHE+idVJ5Ki0s+raqunHQwkZcd+BiVdpz003AWrTRh1fQrjNvonUvuHmwIkdckqWBe7qw7mNonSM+WVVndd+7CPhCta6ujD13GaLQTNcdKP028Hng+HEHwZ5HGzO/TVX9dMASR5av/dSZcMhxfdoEql/RDmZ8B3hrtzG/M21S1aZV9Zuh6h017p8MK8letDDcTbTJL9cBS9HWl7/s7/rkS/JG4FXAlbS1nMOBB7t/F1vT1vdfVVU3DFbkLJDkZOBXVfXhJAfSuuh+lXY9unfQ4mY41zKntwn3QZvQDkbeWlU/S7IO8DHgqKo6LclWwPdde5OmH0fbaNrpOngcCMyfZNGh65ktuoeIdYETgRtpJy8/lGSnqvp9VR0AbAf8lHbCXj2pqh/STgAenmSPaq2mH6Z1/DCcOJAusEW36PRF4CjgSFqIbkvg9UlOpbULP4F2CmfpIWqdScZ1FDqGtmC3Ca1D3zuAAKd3PzpnkAJngQkPcm9KcgzwCeBeWkjlB8C5Sd4AHJVkKcOJkyfJ84HjgRu7U3630Dom7pLWZetQ4DTDiXOv2nifFwKHdu+z3wI+DmzeBaYxnNivrrvBTsDx3ebYpsDJwNq0kUx30UYwjT2P7uSC3uTrgnJ7A/t3AfS3A78D3kfb2PkkrfPZV2ld/7YznDjXrgRe0r3OD1QbKb9U10UIF0inxI20Q2AfAT4MvM9w4uRKsgdtVPw5tPuX5Wld5y+jjVbaGXiD4cTJk+RRtFDuyUmWrKq/0cKhdwJ0QYldaJ2e3tZ97YHuv4YTNeMk2TjJEt2n5wHfrapPdGucY2vKywCfMSDXL1/7qZfWEfcz3cfb0tYij6AdMnqQNt75wG6tcm/aoXcDWz1y/2Rwp9K6Qu/SPcveBaxPO9Dr7/okS7Ih7Z5+E+DZwAq0a89iXWD6PbTrzg1D1TjKkuyR5PwkzwE+DSyQZKWqOpz2b2E92t6K5pJrmdPfuD2t/YCDgacD30ry4qr6Nu1A5AeTbFtVZ7n2Jk1PdlDUtNR19jgC2Laq7hm6ntmiC6PcUVWndCftX0Qbg3Xw2CZCkrNpYyePHLDUkZRkDeDHwI5VdcbQ9QiSvIi2yfYh2pjtnWmLTyfRTskuSxuLuwIt7LJ1F7LW/+J/6Si0Pq1T00LAkgaxpkZ36nUL2nX+clowcfeq+lN3+vL5wHsMSvfrkbrTdBvEGwP7A7+oNo5pcVpXy6qq26a+0tHThUG/Cbylqk7qTlZeY1BiciR5Bi1suyWtQ+g5SValbSj8BTijqq4essbZJONG6iU5gRZKP7aqrkvyEeDxwAeq6upuURZP3s+9rnPrW2kbBN+hXc/fDWxYVX8arrLZpQtrLQ083B0AUI8mHHpZFHg/7RDSS2khuA26e5oFaN3oF3J9Z3J1XcyWpnVwWpx2MGw3YHPaBtqtadMBDgBeDOxVVd8cql5pXiRZDtiPtkl/C+36cwTtYNK6tO65h9Pu/5d2g7I/vvZTrwsGnQxcTwtIXEfbhF+e9sz1OODfaCOHF6CNoPSecxK4fzK87n5nV9oa2nZVdcWwFc0OXbeyZWiNNbYCNum6cK9ON1LYrqGTJ8l6wHG0A2DPAO4HLq6qE7rvP97r/rxzLXN6mrD2sCatmcyGwOto7wf/RFt/uCDJS2hdMK8brGBJf5cdFDUtVdWvMZw46ZLMP+FLi9JutOhO2v+M1k1lrJPcosCSwNemrMhZpKouBdYALh26ltkqyXJJjh7rnkg7Ebgj8FBV3Qp8CbiZthD7oqq6hrbhvDuws+HE/5NH6ij0eGClqrrHcOLkGfd7PXYicCVgW1o49GJa18pzkzyhO325g+HEfk14mH51ku2TPLNbtP46rYvZamkjte+sqj8aTuxPVf2YFoj+dNfh4NuGE/uV5IljHeKAp9HGSF5J6+TxhG7j4BO0scJbJFl4oFJnjbFr/7hw4u60139zWvfulbtOH7cCxyRZsaruNZw4b7rOrZ+gddh+Gy2stYcbBlOrquZU1U2GE/s34Z5mX9oo51toG2Y7V9V6XThxf9rm5UOu70yuJPN31/pVgAVph42OpHXY+gFwSpITadMBPkgLFj0wULnSPOvu4+8F3tzdt8xH6wa9Bq3L1vnAy6oxINcjX/upleSVwNHARlW1Fi2k+CqALiRxDvBn2kSq1arqDu85++P+ybS0MC0kt7XhxMmR5FFpI7VJsnXa+ObrgTfTDre/sgsnvoF2IOavhhMnR5LXJNm6qs4HvgF8FziNdijg+LRpVXjdn3uuZU5/49YelgOupgtJ09YaVqXdJ52f5IVVdaHhRGl6s4OiNAslWbyq7uw+fgmwIvBr4Bpap4/HV9UeSVahjY7YeexUSJKFqur+gUqXJl33MHIH8LuqmpPks7RTaZtW1e1JnkkbZ/D/qupXXWeWhcf+Tenvs6PQ8JJsQOsAejOwKvCxqnpx972/0caW7zMWZlH/kryZ1r3yEmB14NSqOmNcJ8U3VNXlQ9Y4yrpxKPcYKu9f9x55HO30/BK0rk2L0IL9y9I2MW9L8k/A37rwvyZRkgW7jYP5gDVpI+XXoG2ivZs20vnIqro+yQeA4w1z9avbpExV3T10LVLfkmxGC+C+iXb45S20cZ5nJdkGeBd2mZ9UXTDxoe7jNYBzgR1oXbWeT+uk9Xraff+ytHWf5YFjgc3LkYiagSZ0hj6L9gz7ZVq3vlu6r38W+H1VvWuwQkeQr/3USvIKWhDlQuCgqrqqO3D6H7QO0Zt1P/cvtMN4p1TVH4eqd5S4fzK9PdJ0EvUrybG0e8qr+O/xwe+grfX8hLaWsB/wWoOi/Zn4u92t4x8DHEbrYPlK/nvM9ta0NRzDWPPAtczpa8LByFVo6wu7V9V93f7KQlV1eNpI7lfSul669iBNcwYUpVmm2yA7j3ZT+0taR7gfdd+en7ZIvQdtc2Ex2qi3L43dCPjwp1E1YWPnK7QTsa/oOn8cS/fQV1V/TbJIVd07fmFW/3dJnkwLZ21KG03zvqr6+bBVja4kawN3VdXPkzyadt1/fVVd040tOIIWUnk2bRzTkVV1/XAVj7a00fEHVNWWSd5JW0y6FLigCym+CTi7qm4atFBpLiU5itZR4uCqOjZttOcKtPvLVYDd7Aw6+brOic8Evg08v6p+l+R5tG5aW1XVn5I8jvZc8CfadelXw1UsaaZJsiytM993qmqnJAvRgnCr0K77C9EOvfxiuCpHW/dctTbt8NwDSf6V9sy6b3eQ7pnAx4AbgbeOO3B3Ju392AMxmlHG1m2659oHq+r+JGsBLwc+0m1WLk8bL/xgVb22+3OuZc4jX/upl2Rd2uGi9wFLA08EvlJVF3br+yfQ1i637NbsF6wqO+P2wP0TzWbjfo9Xp3VHn1NVq3TfWxlYmbau/zfgOMOJ/ZkQxno5cDetS/19wBuBO4G9aWOG3502gefBwQoeIa5lTm9JlqiqO5KcDDyqqnZIsgOwAa2r9wtpI549cC3NAAYUpVkoyea0sQ930264Lk7yNGBX2iLSoV2r5DlVdasP1Rp14x68Hz3W3SbJ6cBjgC26Toon0gJc69BOKRtMnEd2FJoaSd4OvIHWBfSyJN8AXldVN3QbCPvSToKvAbyqqn49YLkj5xFOvj6BNo5mLdqi0ia0MXv/ChxdVacPUafUlyQr0n6/D6BtVp7eff25tA3MM10wmjpJjqCNc34x7TT4CbSR8hdV1R+794jn00JEdjKW9A9JsgUtPLF/VZ3ZhaMXp3VpvbOq/jJogSOuC57fC/yOdn+5GG206uuq6rzuZz4OLAe8p6ouTxtVuURV/XWgsqV50m0Yn01bz7y8C+p+mHaP+bVuneFVVfWF7uc9WNoTX/upleT5tE34i5OsBOxI61h2blVd1L3eZ9IOpO7g+n2/3D/RbJZkQdr+x4NJTgX+GXhOVT2c5BlVda2/8/0bt0f1RmAn2gj5Z9ICiSd27wXHAI8FXl5Vdw1X7WhxLXP66oKIb6U12Tgb+Cht1PnZwEbA04FvVNUvBytS0j9kgaELkDT1uhN9dwJfpN1cXQzcBPwQ2Kr7mZvH/bwPGhpp3YPfBsCeSW4AzquqHbuQ4n8k2bqq9kqysqfS+lNV9wxdwygb2wyoqiOSLA58Nm0M38+AxwM3VNVNSU6jhVYW8kG7XxNOvq5JGx9/d1XdmGRLWtfEe5JcTdtU/uaA5Uq9qDYq8jdpI+M/0P33HuBlwOFe+ydfFxAau4c/ldYd99vAi2j3/1sBmya5hXbaeBvDiZLmRlWdneQB4LDutudztPudOwYubeR195k/6QJCxwCXA5+ijdk+IMkTaSP5nkcbg/VLgGpTAwwnasYZ92z1Ktp4vcsBqnWJPgE4PMnvq+oyWsensT9jQG4e+doPo6p+DP+1tnNVFxLaCdik+yu5OMm2tEMBrt/3zP0TzVZJ9qN1SbwzycFVtXO3R/KTJMcBuybZ1INI/enu5/9abWLX8sC2tEYDv++6Vn4myV+6AwAbJFnGcGK/XMuc1i6mdRHdB9gM+D7wgqr6PPDlAeuSNJcMKEqzVFWdn2QX4Mgk13bdDu4CVu4Wsm/zwVqzRdpYmnfSRnSsDmyW5OldSPHrtNM4m1TVlUPWKf1fjd8MSLIPcDVtPM1FtHE0yydZrPv4r9g5a1KMCye+mTbK+Vbg7iRfov19/DTJCrTFjo2r6o9D1Sr1rarOTTKHdsJ1DrCjC3pTY9y1Z39gS1qX1h2Bn9C65V4FrAc8g/b3cu0wlUoaBVX1lSQPAScmub+qvjR0TbNBd8juFcBqwDnAxsD2wH8CR9O6Pv0NOMpuEhoF49Yon0cLSczXdXJarKq+n+QTwHOT/GLsYKnrmv3wtR/W2NpOVV3THTDdHtguyUNV9UNaJ11NAvdPNNsk2ZcWwN0e+Clt/figbo/kA8DatE7dhhN7kmRZ2n37Fd01/k7gflr3VqrqyiRnAMuP/Zmq+v0Qtc4GrmVOH0l2BIq2h/Ih2r+JVYGXAlt2950nD1ehpLllQFGaxbqTgA8Cp3QnLu8D3m9AQrNJ9xB4FHBxVX0xyXm0MYg7JDmzqjZMG50lzRjjwimvA3YHNquq05JcB7wDOI4WWlwUuL+q7hys2BGX5Om0k6/r0l7v1Wkjtw+kdTN7MXBEVV0zWJHSJKmq85Jc2n1829D1jLokqwGLVdUl3ZdWBT5cVecCZyc5lnbSeL2q+nQcuyepJ1X19SS7AQaep0g3bmwz4HNVdWGSvwKvBQJ8tqq+kWTBqnrAEXwaFUk2BtahdRV6OMl6wC5JDqOtaT4XmG/IGkeVr/300IUUPw9sDlw/dD2zgfsnmi2SLEG7lm9LCyleBjwIfCrJ3lV18Ni95ZB1jqDfAZcCqwBbVtWpSa6idW9dv/uZxYHlvKefGq5lDuMRfr9vBvYGVgCeQuto+QHgRNra5g+nukZJ/YjvZZKSbAEcCuxZVZd4o6vZJMlStO6J29IeAn/Uff2bwJFV9a0h65PmVpJFgDOB42mLSpsDT6Z10ZpDG+n58+EqHE3jukmk62zzLOCUqlqz+/6SwCHAZd2ik++5kuZZkoVoQZVvA/NV1a1JPg7cXFWHdz/zFOBC4DZgTVqe3YCiJM0QSeavqoeShLaR+QDt3v7a7r5zHWA/4LvACVV1/4DlSr0Z92y1L62z0GOApwHPAc4A/qOq7kiyVFU5wrxHvvbTU5JHVdWcoeuYTdw/0WzQrSs8C/hYVa3T3XPeBnwSONRwYr/GvcfuBrwGWJrWKe6rwMeA5wNfp631bFlVvx6qVmkyjX9PTbI9rcHazbRpYC8HtgB2Br4J7Ow9pzSzGVCUBECSx9qaXbPBuAe/NYDlgO9W1e1J3kYbd/hRWuePc4AdquqnA5YrzZMkewH7ADcBvwauA5aiBRS/XFW/GbC8kdaNbr6xCyt+EqCq9u6+90Hg4ap6t4vakvqSZH7aqeIPAcfQNhJ+ALyjqj7TLfI9HTitqn47XKWSpH9EksXHOp4neSnwaNoG5ruAY6vq38b97LrAnzyIpFHThSb+BPwGuBF4N3B7Vd1oV+jJ5WsvNe6faDZI8kzgJGBf4KnATsDbqurGQQsbUUl2AN4K7ALsCswPXFJVZyTZrPuxK528o1E2bs92H9oBvA/QgrrrV9V/JnkUbSLYMsDudjGWZjYDipKkWSfJy4HTaJ0l1qYFE28EDqKNXv0xcIgnYjXTJVkYWI3WVeUvSXYEdgM28NRrv5K8CHhKVX0uyRtoi0q/Bn5LCzxvDryMNqJjN9porKuHqlfSaJi4KZxkWWAb2nigo7svn0y7Hr0Q2KyqrpzqOiVJcyfJosB5tOD5L4EvAT+ldZR4CbAiraPNxwcrUpoiSZ4NLAhc7jrN1PK1l6TZoQul70/bL3kysJVrCJMnyaHAnVV1ZJIFgdfR1nROpHUpvm/QAqVJlORptMkvc5I8mdY59HXA1sCWwAbAAmOTAezYLY0GA4qSpFlh3CmcxWkbOXdU1feTHEJrEb41cDXwelrb8HdW1VUGFDUKksxHC8ztD2xXVVcMW9HoSbIR8HHgdOAZtK4SKwAvpo3AeiOwPXAP8CPHckjqU5JX064v1wHX00Z8Pgf4CHAlrdvWwlV161A1SpLmTpLNgQOBu4GDq+riJCsCrwReBKwDfKqqDhmwTGlK2blvOL72kjTaum5lS9Omv9wydD2jrFvL2QU4qKp+2X3tB8D3gMOq6vbBipMmUZInAIfQpr98qKoeSHIUsBBtOsy2VXVvkv2Bi6rqx8NVK6lP8w1dgCRJU6ELJ24MXAIcTOtmRlW9DzgL+DrwLOAM4CfAIV33OWkULAw8DGxtOHFyVNVXgb1o15aqqmuBC4EzgQWAp1bVJ6vqVMOJkuZVkoz7eFvgeGB92jVnTeDfaPcz7wb+tar+ZjhRkmamqvoSrdv/GrTDdNC6dN8MXEubCvCtYaqThmFAbji+9pI02qpqTlXdZDhxSnyH1iV9+yTrdvtXdwHHGE7UiPsrberUUrTGDgAP0SZPvboLJ25NG/nsSGdphCwwdAGSJE2FbhzN5sA7aScA10iydxcY+kB3MvBxVfWrJCfSTgjaQl8joaruSXKy3UAnV1V9K8lBwMlJtqmqzwNXd6P5ng38YtgKJY2C8d2dkzwFKODFVXVtkp2AE2gjUY4HHqAtdkuSZrCqOj/JLsCRSa6tqjOT3A5sDBxdVdfb/V+SJEmaOarq9iTH0SZ8HQQ8CBxgOFSjrqoeTLI88ETgJUnurKp3JFkBOC/JrcBKwK5V9dsha5XUL0c8S5JGXpInAZcB36iqXZM8ltZl6GXAVVV1zKAFShop3WnXY4FTgZ8B76ed/Lt2yLokzXwTwolvBHYAFqeNcj69qu5LsiNwOPCaqvrhcNVKkvqWZBPgFFqn7vto1/5zh61KkiRJ0rxI8mhabuOuoWuRJluS7WiT7nakHbpbBriiqj6RZA1gEeDGqrpxwDIlTQI7KEqSRlqSJ1fV75IcAHwwyUur6ntJzgMWBF6a5Cne6ErqS1V9JckCwBeBrwCbVdV1A5claQSMCye+GngesBOwB7AasFaS71fV6UkeBG4brFBJ0qSoqnOT7AEcCuxZVZfYOVGSJEma2arq7qFrkCZLkjWBBarqou5LywInVdVlSa4GNgL264K6H6uqOUPVKmly2UFRkjSykiwDHAZcUlUndh2F3ktrC35hkiWBRarq9wOWKWlEJXkZ8NuqumHoWiSNjiTLApcA36qq3ZMsTBsFtCRwDvDtqnpwwBIlSZMsyWOr6i9D1yFJkiRJ0t/TTQK4FHiwqv6YZCPg3cBeVXV59zPfAK4G3ltVfx6uWkmTab6hC5AkabJ0wcMLgecl2aWqTqcFFL/QdVK83XCipMlSVd81nCipb1V1C7A/sGGS7arqPuB9wBzglbQO0ZKkEWY4UZIkSZI0nSWZD9okAOAJwDldWPES4AvAm5Os202KWQD4oOFEabQ54lmSNBKSLA+8p6r2TLIasGFVHVFVJyW5H1i3m3x1SpL5MaQvSZJmqKo6u7u/+VASqurMJG8Hlqqqe4auT5IkSZIkSdLslLYh+3D38b7APbRQ4n7AvcDXgL8BBwP3AQdU1R8GKlfSFHHEsyRpZCT5F+BuYBlgH+AnVXV09713AbsBh1XVSd3XUr4RSpKkGSrJhsCJtEW8s4auR5IkSZIkSZIAkrwO2BPYrKpu6T7fGPhoVV2QZBGAqrp3yDolTQ27R0mSZrwkAaiqnwEfpW3UHwesnORt3Y99Dbga+MHYnzOcKEmSZrKq+jrtAMalQ9ciSZIkSZIkSQBd+HBD4CDggS6cuBzwJOC9SdavqnsNJ0qzhx0UJUkjJ8nZwPLAm+lufIGVgP2q6vwha5MkSZIkSZIkSZKkUZZkL9rEu5uAXwPXAU/sPr+gqn47YHmSppgBRUnSyEgyX1U93H18DrAEsAWwHvCHqvrekPVJkiRJkiRJkiRJ0qhLsjCwGnBtVf0lyQ7A7sAGVfXAsNVJmmoGFCVJI2VCSPE8gKraYOL3JEmSJEmSJEmSJEmTJ8l8wK7A/sB2VXXFsBVJGsJ8QxcgSVKfqurh7kZ3LJh4b5Ijxr43aHGSJEmSJEmSJEmSNHssDDwMbG04UZq9DChKkkbO+JAicC7wpCQLDFmTJEmSJEmSJEmSJM0mVXUPcHJV/WroWiQNx7CGJGkkjeuWeB3wg6p6cMh6JEmSJEmSJEmSJGm2qaoaugZJw4rXAUmSJEmSJEmSJEmSJEmS1DdHPEuSJEmSJEmSJEmSJEmSpN4ZUJQkSZIkSZIkSZIkSZIkSb0zoChJkiRJkiRJkiRJkiRJknpnQFGSJEmSJEmSJEmSJEmSJPXOgKIkSZIkSZIkSZIkSZIkSerd/wfYc1UttV6v5QAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 3312x1080 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": 16,
+   "id": "ed2c666f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fig = plt.figure(figsize=(len(Z) + 20, 15))\n",
     "dn = dendrogram(Z, labels=labels_arr)\n",
@@ -691,16 +331,49 @@
   },
   {
    "cell_type": "markdown",
-   "id": "further-sword",
+   "id": "9b25482b",
    "metadata": {},
    "source": [
-    "## Benchmarking"
+    "---\n",
+    "## Interpretation Guide\n",
+    "\n",
+    "### How to read the SHAP text plot for textual entailment\n",
+    "\n",
+    "Unlike summarization or translation (one output row), textual entailment produces **three output rows** — one per class: `contradiction`, `neutral`, and `entailment`. Each row shows which input tokens pushed the model towards or away from that class.\n",
+    "\n",
+    "### Colour key\n",
+    "\n",
+    "| Colour | Meaning |\n",
+    "|--------|---------|\n",
+    "| 🔴 **Red** (positive SHAP) | This token *increased* the log-odds of the selected class. |\n",
+    "| 🔵 **Blue** (negative SHAP) | This token *suppressed* the log-odds of the selected class. |\n",
+    "| ⬜ **White** | Near-zero SHAP — the token had little effect on this class. |\n",
+    "\n",
+    "### Cross-class patterns\n",
+    "\n",
+    "A token that is **strongly red for \"contradiction\"** and **strongly blue for \"entailment\"** is one the model associates with opposition — negation words like *not*, *never*, or *no* typically show this pattern.\n",
+    "\n",
+    "### The `</s></s>` separator tokens\n",
+    "\n",
+    "BART uses `</s></s>` as the boundary between premise and hypothesis. These structural tokens usually receive near-zero attribution. Non-zero values here may indicate the model is sensitive to where the boundary falls.\n",
+    "\n",
+    "### The clustering dendrogram\n",
+    "\n",
+    "The dendrogram shows how `PartitionExplainer` grouped tokens hierarchically before computing attributions. Tokens merged early (short branches) were treated as a unit during masking — attributions are therefore assigned to spans, not individual tokens.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b13a496",
+   "metadata": {},
+   "source": [
+    "## Benchmarking\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "mature-submission",
+   "execution_count": 17,
+   "id": "accee424",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,8 +383,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "sublime-reason",
+   "execution_count": 18,
+   "id": "050182a8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,50 +393,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "breeding-roulette",
+   "execution_count": 19,
+   "id": "0fa9526b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=0.0, max=1.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEGCAYAAAB7DNKzAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqFklEQVR4nO3dd3yV9fn/8dcFCQl7BkRWGEGJgggBsVbFMqpCxYnaugfVtm5/39q66mpta1u1tu5RtcVdRUCtAxQHaEA2IoEwAghhb8i4fn+cmzZicjhAcu6cc97PxyMP7nXO/b5Dcq587vH5mLsjIiJSlTphBxARkdpNhUJERKJSoRARkahUKEREJCoVChERiSot7ADVrVWrVp6dnR12DBGRhDJ16tQ17p5V2bqkKxTZ2dnk5+eHHUNEJKGY2ZKq1unUk4iIRKVCISIiUalQiIhIVEl3jaIyJSUlFBUVsWPHjrCjpJzMzEzat29Penp62FFEZD+lRKEoKiqicePGZGdnY2Zhx0kZ7s7atWspKiqic+fOYccRkf2UEqeeduzYQcuWLVUk4szMaNmypVpyIgkuJQoFoCIREn3fRRJfSpx6EklV+YvX8dHXxWHHkDg5qGl9fnxUx2p/XxWKOHr99dc57bTTmDdvHoceeigAEydO5L777mPs2LH/3e6iiy5i+PDhnHnmmZSUlHDrrbfy6quv0rhxYzIyMrjttts46aSTvvXeDz30EPfffz8LFy6kuLiYVq1aVZrhl7/8JePGjQPg1ltv5eyzz476enfnmmuuYfz48TRo0IBnnnmGPn36ALB06VIuu+wyli1bhpkxfvx49FR87TF25gqufWE6peWOGnapoXeHZioUiW706NF8//vfZ/To0dxxxx0xvebWW29l5cqVzJ49m4yMDFatWsWHH374ne2OOeYYhg8fzsCBA6t8r3HjxjFt2jSmT5/Ozp07GThwICeddBJNmjSp8vVvvfUWCxYsYMGCBUyZMoUrr7ySKVOmAHDBBRdw8803M2TIELZs2UKdOilzJrPWe+mLZdz02kz6dmrOkxf1o0mm7jqT/adCESdbtmzh448/ZsKECfzoRz+KqVBs27aNxx9/nMLCQjIyMgBo06YNI0eO/M62Rx555F7fb+7cuRx33HGkpaWRlpZGr169ePvttxk5cmSVr3/jjTe44IILMDMGDBjAhg0bWLlyJevXr6e0tJQhQ4YA0KhRo73uX+Ljuc8Wc+sbczi+exaPnNeX+vXqhh1JElzKFYo73pzD3BWbqvU9cw9uwu0/OizqNm+88QYnnngi3bt3p2XLlkydOpW+fftGfU1BQQEdO3akSZMm1ZLziCOO4I477uCGG25g27ZtTJgwgdzc3KivWb58OR06dPjvfPv27Vm+fDlFRUU0a9aM008/ncLCQgYPHsy9995L3br6UArTl0vX85s35zK4R2v+9pM+ZKTp/0MOnM4VxMno0aM555xzADjnnHMYPXo0UPVdQTVxt9DQoUM5+eST+d73vse5557L0Ucfvd8f7KWlpUyaNIn77ruPL774gkWLFvHMM89Ub2DZJ1t3lnLdi9M5qEkmfxrZW0VCqk1oLQoz6wA8C7QBHHjM3R/YYxsDHgBOBrYBF7n7tAPZ797+8q8J69at44MPPmDWrFmYGWVlZZgZf/zjH2nZsiXr16//zvatWrWiW7duLF26lE2bNlVbq+Lmm2/m5ptvBuDHP/4x3bt3j7p9u3btWLZs2X/ni4qKaNeuHaWlpfTu3ZsuXboAcOqppzJ58mQuvfTSaskp++7ON+eyZN02Rl8+gKb1dU1Cqk+YLYpS4AZ3zwUGAD83sz3Pg5wE5ARfo4CH4xuxerzyyiucf/75LFmyhMWLF7Ns2TI6d+7MpEmTyMnJYcWKFcybNw+AJUuWMGPGDHr37k2DBg249NJLueaaa9i1axcAxcXFvPzyy/uVo6ysjLVr1wIwc+ZMZs6cydChQ6O+5pRTTuHZZ5/F3Zk8eTJNmzalbdu29OvXjw0bNlBcHLn18oMPPtjraSypOW/P/oYX85dxxfFdGdClZdhxJMmEVijcfeXu1oG7bwbmAe322GwE8KxHTAaamVnbOEc9YKNHj+a000771rIzzjiD0aNHk5GRwfPPP8/FF19M7969OfPMM3niiSdo2rQpAHfffTdZWVnk5uZy+OGHM3z48EpbFw8++CDt27enqKiIXr16cdlllwGQn5//3+mSkhKOPfZYcnNzGTVqFM8//zxpaWlRX3/yySfTpUsXunXrxuWXX87f//53AOrWrct9993HoEGD6NmzJ+7O5ZdfXjPfQIlq1aYd3PTaTA5v14TrBkdvIYrsD3P3sDNgZtnAR8Dh7r6pwvKxwL3u/nEw/z7wS3fP3+P1o4i0OOjYsWPfJUu+Pf7GvHnz6NGjR40eg1RN3/+aU17uXPj053yxeB1jrzqWbq1195nsHzOb6u55la0L/WK2mTUCXgWurVgk9oW7P+buee6el5VV6Uh+Iknp6U8XM2nBGm4ZlqsiITUm1EJhZulEisQ/3f21SjZZDnSoMN8+WCaS8r76ZhO/f/srBvdozU9q4Glckd1CKxTBHU1PAvPc/c9VbDYGuMAiBgAb3X3l/uyvNpxiS0X6vteMHSVlXPvCdJpkpnHvGb3U+aLUqDAfuDsGOB+YZWbTg2W/BjoCuPsjwHgit8YWELk99uL92VFmZiZr165VV+Nxtns8iszMzLCjJJ0/vD2fr77ZzNMX9aNVo4yw40iSC61QBBeoo35qe+TP0Z8f6L52382z+1ZOiZ/dI9xJ9fno62Ke+qSQC4/uxAmHtg47jqSAlOjCIz09XSOsSVJYt3UXN748g5zWjfjVybqTTOIjJQqFSLL49WuzWL9tF09f3I/MdHXRIfER+u2xIhKbCV+t5u0533D9kEM47OCmYceRFKJCIZIASsrKuWvcXLq0asil39dpVIkvFQqRBPDcZ0tYVLyVW4b3oF6afm0lvvQTJ1LLrdu6i/vf+5pjc1pxwiG6y0niT4VCpJb7y7tfs3VXGbcOz9VzQBIKFQqRWmz+N5v555Ql/OSojnRv0zjsOJKiVChEail3566xc2mcma7uwyVUKhQitdT781bzccEarh2cQ/OG9cKOIylMhUKkFtpVWs494+fRNash5w3oFHYcSXEqFCK10LOfLaZwzVZuGZ5Lel39mkq49BMoUsus3bKTB95fwMBDsnQ7rNQKKhQitcyf3v2abbvKuGWYOv2T2kGFQqQWmbdyEy98vpTzB3SiW2vdDiu1gwqFSC3h7tz55lya1E/n2sE5YccR+S8VCpFa4p05q/hs0VquH9KdZg10O6zUHioUIrXAztIyfjt+Ht3bNOLH/TuGHUfkW1QoRGqBRz9cxNJ127h1eC5puh1Wahn9RIqEbPGarTw0oYBhvdpybE5W2HFEvkOFQiRE7s6tb8wmo24dbhueG3YckUqpUIiEaOzMlUxasIYbf3gIbZpkhh1HpFIqFCIh2bSjhDvHzqVnu6bqz0lqtbSwA4ikInfn16/NYt3WXTx5YR5162hAIqm91KIQCcFL+csYO3Ml1w/pTq/2zcKOIxKVCoVInBWs3sztY+ZwTLeWXHF817DjiOxVqIXCzJ4ys9VmNruK9QPNbKOZTQ++bot3RpHqtKOkjF/860sa1kvjLyN765STJISwr1E8AzwEPBtlm0nuPjw+cURq1t3j5vLVN5t5+uJ+tNZdTpIgQm1RuPtHwLowM4jEy9uzV/L85KWMOq6LxpmQhJII1yiONrMZZvaWmR1W2QZmNsrM8s0sv7i4ON75RPaqaP02/u+VmRzRvik3Dj0k7Dgi+6S2F4ppQCd3PwL4K/B6ZRu5+2PunufueVlZ6gJBapfSsnKueWE65Q4Pnnsk9dJq+6+dyLfV6p9Yd9/k7luC6fFAupm1CjmWyD65/70FTF2ynntOO5xOLRuGHUdkn9XqQmFmB5mZBdP9ieRdG24qkdh9WrCGv00s4Ky+7RnRu13YcUT2S6h3PZnZaGAg0MrMioDbgXQAd38EOBO40sxKge3AOe7uIcUV2Sdrtuzkmhen06VVQ+4YUenlNZGEEGqhcPdz97L+ISK3z4oklPJy58aXZ7BxewnPXtKfBvXCvhNdZP/pp1ekmm3cVsLd4+YycX4xd404jB5tm4QdSeSAqFCIVBN3Z8yMFdw1di7rtu7ip8d3Ua+wkhRUKET2k7tTtH47kxetZUrhOiYvWkvR+u0c0b4pz1zcn8PbNQ07oki1UKEQiZG7s3jtNqYEhWHKorWs2LgDgBYN69E/uwXXDMrh9D7t1YeTJBUVCpG9WLBqM099UsgHX61m1aadALRqVI+jOrfkii4tOKpzS3JaN6KOioMkKRUKkUq4O1MK1/HYR4v44KvVZKbXYUjuQQwICkPXrIYEj/iIJD0VCpEKSsvKeWv2Nzw+aREzizbSsmE9rh/SnfMGdKJFw3phxxMJhQqFCLB1Zykv5S/jyY8LKVq/nS6tGvLb03pyep92ZKbXDTueSKhUKCSllZSV89AHBTz9SSGbdpSS16k5tw7PZUiPNrrmIBJQoZCUtXFbCT/711Q+KVjLDw9rw6jjutK3U/OwY4nUOioUkpIK12zl0me+YNn6bdx31hGc2bd92JFEai0VCkk5KzZs57S/f4IB/7xsAP07twg7kkitpkIhKeeON+ewo6SMcVcfS9esRmHHEan1avV4FCLV7b25q3hnziquHpSjIiESIxUKSRnbdpVy+5g5dG/TiMuP7RJ2HJGEoVNPkjIeeH8Byzds5+Urjia9rv5GEomVflskJXz1zSaenFTI2Xkd6Jeti9ci+0KFQpJeeblz879n0zgzjZtOOjTsOCIJZ6+FwszOimWZSG31Uv4ypi5Zz69P7kFz9dckss9iaVH8KsZlIrXOmi07+d1bX9G/cws9VCeyn6q8mG1mJwEnA+3M7MEKq5oApTUdTKQ6/Hb8PLbtKuW3px2ubsFF9lO0u55WAPnAKcDUCss3A9fVZCiR6vDpwjW8Nm05Pz+hK91aNw47jkjCqrJQuPsMYIaZ/dPd1YKQhLKztIxbXp9Nhxb1+cUJOWHHEUlosTxHscDMfM+F7q4nlqTWevTDRSwq3sozF/ejfj2NJyFyIGIpFHkVpjOBswDdiC611uI1W3loQgHDerVl4CGtw44jkvD2eteTu6+t8LXc3e8HhlXHzs3sKTNbbWazq1hvZvagmRWY2Uwz61Md+5Xk5e7c+sZsMurW4bbhuWHHEUkKe21R7PHhXIdIC6O6uv54BngIeLaK9ScBOcHXUcDDwb8ilXpnzjdMWrCGO045jDZNMsOOI5IUYvnA/1OF6VJgMTCyOnbu7h+ZWXaUTUYAz7q7A5PNrJmZtXX3ldWxf0ku5eXOn9/9mq5ZDTlvQKew44gkjb0WCnc/IR5BqtAOWFZhvihY9q1CYWajgFEAHTt2jFs4qV3GzVrJ16u28Ndzj6SuxrsWqTaxdOHRMrhOMM3MpprZA2bWMh7hYuXuj7l7nrvnZWVlhR1HQlBW7tz/3td0b9OIYT3bhh1HJKnE0oXHC0AxcAZwZjD9Yk2GqmA50KHCfPtgmci3vDljBQuLt3Ld4O7UUWtCpFrFUijauvtd7l4YfN0NtKnpYIExwAXB3U8DgI26PiF7Ki0r54H3F9CjbRN+eNhBYccRSTqxXMz+j5mdA7wUzJ8JvFMdOzez0cBAoJWZFQG3A+kA7v4IMJ5If1MFwDbg4urYrySXN6avoHDNVh47v69aEyI1wCI3FEXZwGwz0BAoCxbVBbYG0+7uTWou3r7Ly8vz/Pz8sGNInJSXO0Pv/4i0OsZb1xyrjv9E9pOZTXX3vMrWxXLXk3pTk1rr/a9WU7B6Cw+c01tFQqSGxHLX0/uxLBOJN3fn4YkFtG9eX3c6idSgaONRZAINiFw/aA7s/nOtCZFnGURC9cXi9UxbuoG7RhxGWl2N6itSU6KdevopcC1wMDCtwvJNRLrdEAnVwxMLaNmwHmflddj7xiKy36KNR/EA8ICZXeXuf41jJpG9mrdyExPmF3Pj0O5kpqsbcZGaFMvtsRvN7II9F7p7VR35idS4Rz9cSMN6dTl/QHbYUUSSXiyFol+F6UxgEJFTUSoUEopl67bx5syVXHJMNk0bpIcdRyTpxXJ77FUV582sGZFuPURC8cSkRdQxuPT7GmRRJB7251aRrUDn6g4iEou1W3byYv4yTjuyHQc11XgTIvEQy8BFbwK7H9+uA+Tyv+48ROLqH58uZmdpOaOO6xp2FJGUEcs1ivsqTJcCS9y9qIbyiFRpy85S/vHZEobmtqFb60ZhxxFJGbGceloKNA6+VqpISFhe+HwpG7eXcMXxak2IxFO0J7ObAE8AfYEZweLeZjYVuNTdN8UhnwgAu0rLeWJSIUd1bsGRHZuHHUckpURrUTwIzAVy3P10dz8d6ArMQk9mS5y9Pn0532zawc9O6BZ2FJGUE+0axTHuflHFBR7pk/xOM1tQo6lEKigvdx79cCG5bZtwXE6rsOOIpJz97UlN/TlL3Lw7bxULi7dyxcCu6kpcJATRCsWnZnab7fGbaWa3Ap/VbCyRiEhX4gvp0KI+Jx+uYU5FwhDt1NNVwJNAgZlND5b1Br4ELq3ZWCIRUwrXMX3ZBu469XB1JS4Skmi9x24CzjKzrkQesgOY6+4L45JMUlp5uTP6i6X84e35tGqUwVl924cdSSRlxdLX00JAxUHiZvbyjdz8+mxmLNvAgC4tuPvUnupKXCREsTyZLRIXG7eX8Of/zOe5yUto0TCD+8/uzYjeB+sCtkjIVCgkdO7O69OXc8+4r1i3dSfnD+jE9UMPoWl9dSEuUhtEezK7RbQXuvu66o8jqWbBqs3c8vpsphSu44gOzXjm4n4c3q5p2LFEpIJoLYqpRHqNrazd74AGA5D95u789YMCHnx/AQ0z0vjtaT05p18H6tTRaSaR2ibaXU8ac0JqzGMfLeLP737Nj444mN/8KJeWjTLCjiQiVdjrjekWcV7woB1m1tHM+td8NElWr3+5nN+99RXDe7XlgbN7q0iI1HKxPMH0d+Bo4MfB/Gbgb9WxczM70czmm1mBmd1UyfqLzKzYzKYHX5dVx34lPJ8UrOH/vTKDAV1a8KeRR+hUk0gCiOWup6PcvY+ZfQng7uvNrN6B7tjM6hIpOEOAIuALMxvj7nP32PRFd//Fge5Pwrd1Zym/+Nc0urRqxKPn55GRpmcjRBJBLC2KkuBD3QHMLAsor4Z99wcK3H2Ru+8CXgBGVMP7Si01+vOlrN9Wwu/O6KlbX0USSCyF4kHg30BrM7sH+Bj4bTXsux2wrMJ8UbBsT2eY2Uwze8XMOlT2RmY2yszyzSy/uLi4GqJJddtVWs6THxfSv3ML+mjgIZGEstdC4e7/BP4P+B2wEjjV3V+u6WCBN4Fsd+8FvAv8o4qMj7l7nrvnZWVlxSma7Is3Z6xg5cYdXKlhTEUSTqwP3K0GRldcVw0P3C0HKrYQ2gfL/svd11aYfQL4wwHuU0JQXu48+tFCDj2oMQMPUSEXSTSxPnDXEVgfTDcDlgIH+pzFF0COmXUmUiDO4X93VgFgZm3dfWUwewow7wD3KSGYMH81X6/awl/OPkL9NokkoL0+cGdmjwP/dvfxwfxJwKkHumN3LzWzXwDvAHWBp9x9jpndCeS7+xjgajM7BSgF1gEXHeh+Jf4e+XAh7ZrVZ3ivg8OOIiL7IZbbYwe4++W7Z9z9LTOrllNAQfEZv8ey2ypM/wr4VXXsS8Ixdck6vli8ntt/lEu6Bh4SSUixFIoVZnYL8Hww/xNgRc1FkmTy8MRFNG+Qztn9Kr1hTUQSQCx/4p0LZBG5RfbfQOtgmUhUBas38968VVxwdDYN6qlHe5FEFcsId+uAa8yscWTWt9R8LEkGj364iMz0Olz4veywo4jIAYilU8CeQfcds4E5ZjbVzA6v+WiSyFZu3M7r05dzdl4HWjQ84B5fRCREsZx6ehS43t07uXsn4AbgsZqNJYnuqY8LKXe47FgNWyKS6GIpFA3dfcLuGXefCDSssUSS8DZuK+FfU5YyvFdbOrRoEHYcETlAsVxhXBSMRfFcMH8esKjmIkmie37KErbuKmPUcWpNiCSDWFoUlxC56+m14CsrWCbyHTtKynj6k0KO657FYQdr7GuRZBDLXU/rgavjkEWSwKvTilizZRdXHK/WhEiyiNYp4JhoL3T3U6o/jiSysnLn8Y8WcUT7phzdpWXYcUSkmkRrURxNZLyI0cAUIh0CilTpnTnfsHjtNh7+SR91/ieSRKIVioOIDFN6LpFeXccBo919TjyCSWJxdx75cCGdWzVk6GEHhR1HRKpRlRez3b3M3d929wuBAUABMDHo8VXkWx6ftIiZRRsZdVwX6tZRa0IkmUS9mG1mGcAwIq2KbP43LKrIf705YwW/Hf8Vw3q15ew8df4nkmyiXcx+FjicSDfgd7j77LilkoTxeeE6bnhpBv2ym/Ons46gjloTIkknWoviPGArcA2RAYR2LzcinQM2qeFsUsu9P28V1780g/Yt6vP4BXlkptcNO5KI1IBoI9xplBmp1OrNO7jjzbmMm7mS7m0a8eSF/WjWQB3/iSQrDRIgMXN3Xspfxj3j5rGjpJwbhnTnp8d3pV6a/qYQSWYqFBKTRcVb+NVrs5hSuI7+nVvwu9N70jWrUdixRCQOVCgkql2l5Tz20UIe/KCAzLQ63Ht6T0bmddBFa5EUokIhVZq2dD2/enUW81dtZljPttx+Si6tG2eGHUtE4kyFQir1xvTlXPvidNo2yeTJC/MY1KNN2JFEJCQqFPIdW3aWctfYefTu0IznLj2KRhn6MRFJZbpdRb7j4YkFrNmyk9t/dJiKhIioUMi3Fa3fxuOTCjm198H07tAs7DgiUguEWijM7EQzm29mBWZ2UyXrM8zsxWD9FDPLDiFmSvnD2/OpY/B/Jx4adhQRqSVCKxRmVhf4G3ASkAuca2a5e2x2KbDe3bsBfwF+H9+UqWXa0vWMmbGCUcd24eBm9cOOIyK1RJgtiv5AgbsvcvddwAvAiD22GQH8I5h+BRhkGhGnRrg7d42dS+vGGfz0+K5hxxGRWiTMQtGOyAh6uxUFyyrdxt1LgY3Ad8bYNLNRZpZvZvnFxcU1FDe5jZmxgi+XbuDGHx5CQ13AFpEKkuJitrs/5u557p6XlZUVdpyEs6OkjD+8PZ/DDm7CmX3ahx1HRGqZMAvFcqDiKDftg2WVbmNmaUBTYG1c0qWQJz8uZPmG7dwyLFddc4jId4RZKL4Acsyss5nVA84BxuyxzRjgwmD6TOADd/c4Zkx6qzfv4O8TChia24aju37nrJ6ISHhPZrt7aTD+9jtAXeApd59jZncC+e4+BngSeM7MCoB1RIqJVKM/vfM1u8rK+fXJPcKOIiK1VKhXLd19PJGhVisuu63C9A7grHjnShVzV2zipanLuOSYzmS3ahh2HBGppZLiYrbsO3fn7nFzaVY/nat/kBN2HBGpxVQoUtR781bz6cK1XDu4O00bpIcdR0RqMRWKFLSrtJzfjp9H16yG/PiojmHHEZFaToUiBT0/eQmFa7Zyy7Bc0uvqR0BEotOnRIrZsG0XD7y/gGNzWjHwED2cKCJ7p0KRYh54fwGbd5Rwy7Bc1G2WiMRChSKFLCzewnOfLeGc/h055KDGYccRkQShQpFCfjd+HpnpdblucPewo4hIAlGhSBGfFKzhvXmr+fkJ3chqnBF2HBFJICoUKaCs3Ll73DzaN6/Pxcdkhx1HRBKMCkUKeGXqMuat3MRNJx1KZnrdsOOISIJRoUhyW3aWct9/vqZvp+YM69k27DgikoBUKJLcIxMXUrx5J7cM66HbYUVkv6hQJLHlG7bz+KRFjOh9MEd2bB52HBFJUCoUSeyPb38FwP+deGjISUQkkalQJKnpyzbw+vQVXHZsZ9o1qx92HBFJYCoUScjduWvsXFo1yuDKgd3CjiMiCU6FIgmNm7WSqUvWc+PQ7jTKCHUQQxFJAioUSWZHSRn3vvUVhx7UmLPyOoQdR0SSgApFknn6k8UUrd/OLcNyqVtHt8OKyIFToUgia7bs5G8TChh0aGu+n9Mq7DgikiRUKJLIX979mh0lZfx6WI+wo4hIElGhSBJfr9rM6M+Xct6ATnTNahR2HBFJIioUSeKecfNolJHGNYNywo4iIklGhSIJTJy/mg+/LubqQTk0b1gv7DgikmRUKBLclp2l3DV2LtktG3DB0dlhxxGRJBRKoTCzFmb2rpktCP6ttMc6Myszs+nB15h456ztSsrKufL5qSxeu427T+1JvTTVfRGpfmF9stwEvO/uOcD7wXxltrt77+DrlPjFq/3cnV++OpNJC9bwu9N66nZYEakxYRWKEcA/gul/AKeGlCMhuTt/eGc+r01bzvVDujOyn57AFpGaE1ahaOPuK4Ppb4A2VWyXaWb5ZjbZzE6t6s3MbFSwXX5xcXF1Z61VdpSUccPLM3h44kLO7d+Rq36gTv9EpGbVWI9xZvYecFAlq26uOOPubmZexdt0cvflZtYF+MDMZrn7wj03cvfHgMcA8vLyqnqvhLdiw3Z++txUZi3fyLWDc7j6BzkatU5EalyNFQp3H1zVOjNbZWZt3X2lmbUFVlfxHsuDfxeZ2UTgSOA7hSIVTF60lp//cxo7S8t5/II8huRW1QgTEaleYZ16GgNcGExfCLyx5wZm1tzMMoLpVsAxwNy4Jawl3J2nPynkJ09MoVmDdF7/+TEqEiISV2ENVnAv8JKZXQosAUYCmFkecIW7Xwb0AB41s3IiBe1ed0+pQrGjpIxf/3sWr01bzpDcNvx55BE0zkwPO5aIpJhQCoW7rwUGVbI8H7gsmP4U6BnnaPtk044S0uoYDepV/7exaP02rnh+KnNWbOK6wd256gfdqKNuw0UkBBr+bD8UrN7ME5MKee3L5TSoV5cbhx7Cuf07Vtv4D58uXMMv/vUlJaXlPHFBHoN66FSTiIRHhWIf7Cgp45evzuSN6SvISKvDmX3bs3D1Fm55fTajP1/KnSMOo2+nFvv13u7OtKUbeOqTQt6atZKuWY149Py+dFFPsCISMhWKGG3fVcao5/KZtGANPz+hK5cc05mWjTJwd8bOXMk94+ZxxsOfcXqfdtx00qG0bpwZ0/vuKi1n/KyVPP1JITOKNtI4M43Lju3C1YNyNN61iNQK5p5cjx3k5eV5fn5+tb7n1p2lXPaPfCYXruX3Z/RiZCVjUW/dWcpDEwp4YtIiMtLqcu3gHC78XjbpdSu/sWztlp38a8pSnpu8hNWbd9IlqyEXfy+b0/u0p6EKhIjEmZlNdfe8StepUES3eUcJlzzzBVOXrOfPI3tz6pHtom6/qHgLd7w5lw+/LiandSN+c8phHNPtf/0wzV2xiac/KeSNGSvYVVrOcd2zuOSYbI7LydLFahEJjQrFftq4vYQLn/qc2cs38sA5RzKsV9uYXufuvDdvNXeOncOyddvJbduEbbtKWbNlF1t2llI/vS5n9G3HRd/LplvrxtWSVUTkQEQrFDrHUYX1W3dx/lNTmP/NZv7+kz4MPayy3kgqZ2YMyW3DsTmteGLSIj5duJYuWQ3JapxBdsuGnNq7HU0b6HkIEUkMalFUYs2WnZz3xBQWrdnKo+f15YRDW1dTOhGR2kktin2wetMOfvLEFJat38ZTF/bTOA8ikvJUKCpYuXE7P358Cqs27eCZi/szoEvLsCOJiIROhSKwcuN2zn50Muu27uLZS/qTl71/D86JiCQbFYpAk8x0clo34qpBOfTu0CzsOCIitYYKRaBhRhpPXtQv7BgiIrVOWONRiIhIglChEBGRqFQoREQkKhUKERGJSoVCRESiUqEQEZGoVChERCQqFQoREYkq6XqPNbNiYMkBvEUrYE01xUkUqXbMqXa8oGNOFQdyzJ3cPauyFUlXKA6UmeVX1dVuskq1Y0614wUdc6qoqWPWqScREYlKhUJERKJSofiux8IOEIJUO+ZUO17QMaeKGjlmXaMQEZGo1KIQEZGoVChERCSqlCwUZnaimc03swIzu6mS9Rlm9mKwfoqZZYcQs1rFcMzXm9lcM5tpZu+bWacwclanvR1zhe3OMDM3s4S/lTKWYzazkcH/9Rwz+1e8M1a3GH62O5rZBDP7Mvj5PjmMnNXFzJ4ys9VmNruK9WZmDwbfj5lm1ueAd+ruKfUF1AUWAl2AesAMIHePbX4GPBJMnwO8GHbuOBzzCUCDYPrKVDjmYLvGwEfAZCAv7Nxx+H/OAb4EmgfzrcPOHYdjfgy4MpjOBRaHnfsAj/k4oA8wu4r1JwNvAQYMAKYc6D5TsUXRHyhw90Xuvgt4ARixxzYjgH8E068Ag8zM4pixuu31mN19grtvC2YnA+3jnLG6xfL/DHAX8HtgRzzD1ZBYjvly4G/uvh7A3VfHOWN1i+WYHWgSTDcFVsQxX7Vz94+AdVE2GQE86xGTgWZm1vZA9pmKhaIdsKzCfFGwrNJt3L0U2Ai0jEu6mhHLMVd0KZG/SBLZXo85aJJ3cPdx8QxWg2L5f+4OdDezT8xsspmdGLd0NSOWY/4NcJ6ZFQHjgaviEy00+/r7vldpBxRHko6ZnQfkAceHnaUmmVkd4M/ARSFHibc0IqefBhJpNX5kZj3dfUOYoWrYucAz7v4nMzsaeM7MDnf38rCDJYpUbFEsBzpUmG8fLKt0GzNLI9JcXRuXdDUjlmPGzAYDNwOnuPvOOGWrKXs75sbA4cBEM1tM5FzumAS/oB3L/3MRMMbdS9y9EPiaSOFIVLEc86XASwDu/hmQSaTzvGQV0+/7vkjFQvEFkGNmnc2sHpGL1WP22GYMcGEwfSbwgQdXiRLUXo/ZzI4EHiVSJBL9vDXs5ZjdfaO7t3L3bHfPJnJd5hR3zw8nbrWI5Wf7dSKtCcysFZFTUYvimLG6xXLMS4FBAGbWg0ihKI5ryvgaA1wQ3P00ANjo7isP5A1T7tSTu5ea2S+Ad4jcMfGUu88xszuBfHcfAzxJpHlaQOSi0TnhJT5wMR7zH4FGwMvBdful7n5KaKEPUIzHnFRiPOZ3gKFmNhcoA/6fuydsaznGY74BeNzMriNyYfuiRP7Dz8xGEyn2rYLrLrcD6QDu/giR6zAnAwXANuDiA95nAn+/REQkDlLx1JOIiOwDFQoREYlKhUJERKJSoRARkahUKEREJCoVCklIZlZmZtPNbLaZvWxmDULIMNDMvlfFut+Y2Y17LFscPLsQV2Y2cX8fJDSzZ8zszOrOJIlFhUIS1XZ37+3uhwO7gCtieVHwpH11GQhUWihEkokKhSSDSUA3M2sY9NX/eTD2wAgAM7vIzMaY2QfA+2bWyMyeNrNZQX/9ZwTbDTWzz8xsWtBKaRQsX2xmdwTLZ5nZoRYZo+QK4LqgZXNsrGHNLNvM5pnZ48GYEP8xs/rBuolm9hczyw+26Wdmr5nZAjO7u8J7vG5mU4PXjwqW1Q1aALODnNftsd86wfq7g23/aGZfBN+DnwbbmJk9ZJHxHd4DWu//f4ski5R7MluSS9BCOAl4m0g/VR+4+yVm1gz4PPiwg0j//b3cfZ2Z/Z5ItwY9g/doHpwSugUY7O5bzeyXwPXAncHr17h7HzP7GXCju19mZo8AW9z9vv2IngOc6+6Xm9lLwBnA88G6Xe6eZ2bXAG8AfYn0ELDQzP4SPEl9SXAs9YEvzOxVIBtoF7SyCL4Hu6UB/yQyhsE9QXHZ6O79zCwD+MTM/gMcCRxCZNyGNsBc4Kn9OD5JIioUkqjqm9n0YHoSkW5XPgVOqXBtIBPoGEy/6+67+/AfTIVuWdx9vZkNJ/Lh+EnQhUk94LMK+3st+HcqcHoM+arq8mD38kJ3351/KpEP+d12dy8yC5izu58eM1tEpLO3tcDVZnZasF0HIoVnPtDFzP4KjAP+U+E9HwVecvd7gvmhQK8K1x+aBu9xHDDa3cuAFUErTFKcCoUkqu3u3rviAot8wp/h7vP3WH4UsHUv72dEism5Vazf3ZtuGbH93qwF9hwspjGwIfi3Yu+8ZUD9SvZVvsd25UCamQ0kUuyOdvdtZjYRyAwK3hHAD4mcFhsJXBK89lPgBDP7k7vvIHK8V7n7OxUDWoIPEyo1Q9coJJm8A1wVFIzdPeJW5l3g57tnzKw5kd5jjzGzbsGyhmbWfS/720zkQ78yHxFp3TQO3u90YEbwl/qBagqsD4rEoUS6SN/dG2wdd3+VyGm0imMlP0mks7iXgtN17wBXmll68NruZtYwyH12cA2jLZEhciXFqVBIMrmLSC+aM81sTjBfmbuB5sFF3xnACe5eTGQQo9FmNpPIaadD97K/N4HTKruY7e4zgYeAj4NTZFcAl+3fYX3H20RaFvOAe4kUOYiMYjYx2N/zwK/2yPRnIuNlPwc8QeT6wzQzm03k1FQa8G9gQbDuWb59+k1SlHqPFRGRqNSiEBGRqFQoREQkKhUKERGJSoVCRESiUqEQEZGoVChERCQqFQoREYnq/wNdbtdX3DEUNAAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sper = benchmark.perturbation.SequentialPerturbation(explainer.model, explainer.masker, sort_order, perturbation)\n",
     "xs, ys, auc = sper.model_score(shap_values, [decoded])\n",
     "sper.plot(xs, ys, auc)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "liked-lounge",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Overview

Closes #3036

This PR fixes bugs and improves the `Textual Entailment Explanation Demo` notebook.

- **CPU safety**: Made model and tensor loading device-agnostic.
- **Noisy warning**: Suppressed the expected unused-weights warning on model load.
- **Clustering hack**: Added a defensive guard and explanation for the dendrogram distance patch.
- **Dead code**: Replaced commented-out token-cleaning block with a live `clean_tokens()` utility.
- **Docs**: Rewrote the intro, added version-printing cell, inline comments, and an Interpretation Guide.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
