### PR TITLE
MAINT: Standardize 'ax' parameter handling in partial_dependence_plot

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -102,8 +102,8 @@ def partial_dependence(
             fig = plt.figure()
             ax1 = plt.gca()
         else:
-            fig = plt.gcf()
-            ax1 = plt.gca()
+            fig = ax.get_figure()
+            ax1 = ax
 
         # fig, ax1 = plt.subplots(figsize)
         ax2 = ax1.twinx()
@@ -236,8 +236,11 @@ def partial_dependence(
                 x1[i, j] = xs1[j]
                 vals[i, j] = model(features_tmp).mean()
 
-        fig = plt.figure()
-        ax = fig.add_subplot(111, projection="3d")
+        if ax is None:
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection="3d")
+        else:
+            fig = ax.get_figure()
 
         #         x = y = np.arange(-3.0, 3.0, 0.05)
         #         X, Y = np.meshgrid(x, y)

--- a/tests/plots/test_pdp_ax.py
+++ b/tests/plots/test_pdp_ax.py
@@ -1,0 +1,27 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import shap
+
+# PR #4922: Ax support in partial_dependence_plot
+# ---------------------------------------------------------------------------
+
+
+def test_pdp_respects_custom_ax():
+    """
+    Verify that partial_dependence_plot draws onto the provided Axes
+    instead of creating a new figure.
+    """
+    X, y = shap.datasets.adult(n_points=50)
+    model = shap.utils.MaskedModel(lambda x: x.sum(1), X, X)
+
+    fig, ax = plt.subplots()
+    initial_artists = len(ax.get_children())
+
+    # pdp internally might use different plot wrappers, we check if it populates the ax
+    shap.plots.partial_dependence(
+        "Age", model.predict, X, ice=False, model_expected_value=True, feature_expected_value=True, show=False, ax=ax
+    )
+
+    assert len(ax.get_children()) > initial_artists, "PDP failed to draw artists on the user-supplied Axes."
+    plt.close(fig)

--- a/tests/plots/test_pdp_ax.py
+++ b/tests/plots/test_pdp_ax.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
-import numpy as np
-import pytest
+
 import shap
 
 # PR #4922: Ax support in partial_dependence_plot

--- a/tests/plots/test_pdp_ax.py
+++ b/tests/plots/test_pdp_ax.py
@@ -14,9 +14,10 @@ def test_pdp_respects_custom_ax():
     """
     X, y = shap.datasets.adult(n_points=50)
 
-    # Simple model function that returns the sum of features
-    # This is more stable than using internal SHAP utility classes
-    model_func = lambda x: np.array(x).sum(axis=1)
+    # Simple model function that returns the sum of features.
+    # Using a def instead of lambda to satisfy ruff E731.
+    def model_func(x):
+        return np.array(x).sum(axis=1)
 
     fig, ax = plt.subplots()
     initial_artists = len(ax.get_children())

--- a/tests/plots/test_pdp_ax.py
+++ b/tests/plots/test_pdp_ax.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-
+import numpy as np
 import shap
 
 # PR #4922: Ax support in partial_dependence_plot
@@ -12,15 +12,19 @@ def test_pdp_respects_custom_ax():
     instead of creating a new figure.
     """
     X, y = shap.datasets.adult(n_points=50)
-    model = shap.utils.MaskedModel(lambda x: x.sum(1), X, X)
+    
+    # Simple model function that returns the sum of features
+    # This is more stable than using internal SHAP utility classes
+    model_func = lambda x: np.array(x).sum(axis=1)
 
     fig, ax = plt.subplots()
     initial_artists = len(ax.get_children())
 
     # pdp internally might use different plot wrappers, we check if it populates the ax
     shap.plots.partial_dependence(
-        "Age", model.predict, X, ice=False, model_expected_value=True, feature_expected_value=True, show=False, ax=ax
+        "Age", model_func, X, ice=False, model_expected_value=True, feature_expected_value=True, show=False, ax=ax
     )
 
+    # If artists were added to the axes, it means the plot was drawn on our supplied ax
     assert len(ax.get_children()) > initial_artists, "PDP failed to draw artists on the user-supplied Axes."
     plt.close(fig)

--- a/tests/plots/test_pdp_ax.py
+++ b/tests/plots/test_pdp_ax.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+
 import shap
 
 # PR #4922: Ax support in partial_dependence_plot
@@ -12,7 +13,7 @@ def test_pdp_respects_custom_ax():
     instead of creating a new figure.
     """
     X, y = shap.datasets.adult(n_points=50)
-    
+
     # Simple model function that returns the sum of features
     # This is more stable than using internal SHAP utility classes
     model_func = lambda x: np.array(x).sum(axis=1)


### PR DESCRIPTION
### Description
This PR resolves an inconsistency in `partial_dependence_plot` where the explicitly passed `ax` parameter was not being correctly utilized, leading the function to fallback on `plt.gca()`. 

By ensuring the function honors the provided axes object, this change improves the reliability of the plotting API when composing complex subplots or working in environments where explicit axes management is required.

### Changes
- Refactored `partial_dependence_plot` to correctly grab the figure and axes from the `ax` parameter if provided.
- Standardized the internal logic to align with the pattern used in other recent plotting API updates.
- Added a regression test to verify correct axes handling.

### Motivation 
- This work is part of the ongoing effort to improve plotting API consistency across the library. It directly contributes to the goals outlined in the plotting meta-issue.

**Fixes**: #4886

**Related to**: #3411