### PR TITLE
update-kernel-shap-notebook

### DIFF
--- a/notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb
+++ b/notebooks/tabular_examples/model_agnostic/Simple Kernel SHAP.ipynb
@@ -19,7 +19,14 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T14:03:53.264982Z",
+     "iopub.status.busy": "2026-04-30T14:03:53.264726Z",
+     "iopub.status.idle": "2026-04-30T14:03:53.519750Z",
+     "shell.execute_reply": "2026-04-30T14:03:53.519008Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -28,8 +35,8 @@
       "  reference = [0. 0. 0. 0.]\n",
       "          x = [ 1.62434536 -0.61175641 -0.52817175 -1.07296862]\n",
       "shap_values = [ 0.89146267 -0.43752168 -0.31836259 -0.58464256]\n",
-      " base_value = 10.000000000000002\n",
-      "   sum(phi) = 9.55093584213122\n",
+      " base_value = 10.0\n",
+      "   sum(phi) = 9.550935842131224\n",
       "       f(x) = 9.55093584213122\n"
      ]
     }
@@ -106,6 +113,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-30T14:03:53.547721Z",
+     "iopub.status.busy": "2026-04-30T14:03:53.547514Z",
+     "iopub.status.idle": "2026-04-30T14:03:56.216263Z",
+     "shell.execute_reply": "2026-04-30T14:03:56.215612Z"
+    },
     "scrolled": false
    },
    "outputs": [
@@ -113,8 +126,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "shap_values = [ 0.89146267 -0.43752168 -0.31836259 -0.58464256]\n",
-      "base value = 10.0\n"
+      ".values =\n",
+      "array([ 0.89146267, -0.43752168, -0.31836259, -0.58464256])\n",
+      "\n",
+      ".base_values =\n",
+      "array([10., 10., 10., 10.])\n",
+      "\n",
+      ".data =\n",
+      "array([ 1.62434536, -0.61175641, -0.52817175, -1.07296862])\n"
      ]
     }
    ],
@@ -122,9 +141,8 @@
     "import shap\n",
     "\n",
     "explainer = shap.KernelExplainer(f, np.reshape(reference, (1, len(reference))))\n",
-    "shap_values = explainer.shap_values(x)\n",
-    "print(\"shap_values =\", shap_values)\n",
-    "print(\"base value =\", explainer.expected_value)"
+    "shap_values = explainer(x)\n",
+    "print(shap_values)"
    ]
   }
  ],
@@ -145,7 +163,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.14.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Overview

Closes #3036

Description of the changes proposed in this pull request:
This PR modernizes the `Simple Kernel SHAP.ipynb` notebook to resolve deprecation warnings. The legacy `explainer.shap_values(x)` implementation has been successfully migrated to utilize the modern `Explanation` object API via the callable `explainer(x)`. The notebook has been re-executed top-to-bottom to ensure full reproducibility and correct data formatting.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
