### PR TITLE
Add `ax` support to decision plot with consistent matplotlib Axes behavior

### DIFF
--- a/shap/plots/_decision.py
+++ b/shap/plots/_decision.py
@@ -51,19 +51,26 @@ def __decision_plot_matplotlib(
     show,
     legend_labels,
     legend_location,
+    ax=None,
 ):
     """Matplotlib rendering for decision_plot()"""
-    # image size
+    # axis resolution — mandatory pattern
+    _ax_provided = ax is not None
+    if not _ax_provided:
+        ax = plt.gca()
+    plt.sca(ax)
+
+    # image size — only resize when we own the axes
     row_height = 0.4
-    if auto_size_plot:
-        plt.gcf().set_size_inches(8, feature_display_count * row_height + 1.5)
+    if auto_size_plot and not _ax_provided:
+        ax.get_figure().set_size_inches(8, feature_display_count * row_height + 1.5)
 
     # draw vertical line indicating center
-    plt.axvline(x=base_value, color="#999999", zorder=-1)
+    ax.axvline(x=base_value, color="#999999", zorder=-1)
 
     # draw horizontal dashed lines for each feature contribution
     for i in range(1, feature_display_count):
-        plt.axhline(y=i, color=y_demarc_color, lw=0.5, dashes=(1, 5), zorder=-1)
+        ax.axhline(y=i, color=y_demarc_color, lw=0.5, dashes=(1, 5), zorder=-1)
 
     # initialize highlighting
     linestyle = np.array("-", dtype=object)
@@ -74,14 +81,13 @@ def __decision_plot_matplotlib(
         linewidth[highlight] = 2
 
     # plot each observation's cumulative SHAP values.
-    ax = plt.gca()
     ax.set_xlim(xlim)
     m = cm.ScalarMappable(cmap=plot_color)
     m.set_clim(xlim)
     y_pos = np.arange(0, feature_display_count + 1)
     lines = []
     for i in range(cumsum.shape[0]):
-        o = plt.plot(
+        o = ax.plot(
             cumsum[i, :], y_pos, color=m.to_rgba(cumsum[i, -1], alpha), linewidth=linewidth[i], linestyle=linestyle[i]
         )
         lines.append(o[0])
@@ -94,8 +100,8 @@ def __decision_plot_matplotlib(
 
     # if there is a single observation and feature values are supplied, print them.
     if (cumsum.shape[0] == 1) and (features is not None):
-        renderer = plt.gcf().canvas.get_renderer()  # type: ignore
-        inverter = plt.gca().transData.inverted()
+        renderer = ax.get_figure().canvas.get_renderer()  # type: ignore
+        inverter = ax.transData.inverted()
         y_pos = y_pos + 0.5
         for i in range(feature_display_count):
             v = features[0, i]
@@ -129,10 +135,11 @@ def __decision_plot_matplotlib(
     ax.spines["right"].set_visible(False)
     ax.spines["left"].set_visible(False)
     ax.tick_params(color=axis_color, labelcolor=axis_color, labeltop=True)
-    plt.yticks(np.arange(feature_display_count) + 0.5, feature_names, fontsize=fontsize)
+    ax.set_yticks(np.arange(feature_display_count) + 0.5)
+    ax.set_yticklabels(feature_names, fontsize=fontsize)
     ax.tick_params("x", labelsize=11)
-    plt.ylim(0, feature_display_count)
-    plt.xlabel(labels["MODEL_OUTPUT"], fontsize=13)
+    ax.set_ylim(0, feature_display_count)
+    ax.set_xlabel(labels["MODEL_OUTPUT"], fontsize=13)
 
     # draw the color bar - must come after axes styling
     if color_bar:
@@ -140,7 +147,7 @@ def __decision_plot_matplotlib(
         m.set_array(np.array([0, 1]))
 
         # place the colorbar
-        plt.ylim(0, feature_display_count + 0.25)
+        ax.set_ylim(0, feature_display_count + 0.25)
         ax_cb = ax.inset_axes((xlim[0], feature_display_count, xlim[1] - xlim[0], 0.25), transform=ax.transData)
         cb = plt.colorbar(m, ticks=[0, 1], orientation="horizontal", cax=ax_cb)
         cb.set_ticklabels([])
@@ -152,17 +159,18 @@ def __decision_plot_matplotlib(
         plt.sca(ax)
 
     if title:
-        # TODO decide on style/size
-        plt.title(title)
+        ax.set_title(title)
 
     if ascending:
-        plt.gca().invert_yaxis()
+        ax.invert_yaxis()
 
     if legend_labels is not None:
         ax.legend(handles=lines, labels=legend_labels, loc=legend_location)
 
     if show:
         plt.show()
+    else:
+        return ax
 
 
 class DecisionPlotResult:
@@ -232,6 +240,7 @@ def decision(
     new_base_value=None,
     legend_labels=None,
     legend_location="best",
+    ax=None,
 ) -> DecisionPlotResult | None:
     """Visualize model decisions using cumulative SHAP values.
 
@@ -336,10 +345,17 @@ def decision(
         Legend location. Any of "best", "upper right", "upper left", "lower left", "lower right", "right",
         "center left", "center right", "lower center", "upper center", "center".
 
+    ax : matplotlib.axes.Axes, optional
+        Axes object to draw the plot onto. If ``None``, the current axes will be used
+        (``plt.gca()``). When an explicit ``ax`` is provided, the figure will not be
+        automatically resized regardless of ``auto_size_plot``.
+
     Returns
     -------
     DecisionPlotResult or None
-        Returns a :obj:`DecisionPlotResult` object if ``return_objects=True``. Returns ``None`` otherwise (the default).
+        Returns a :obj:`DecisionPlotResult` object if ``return_objects=True``. Returns
+        the :class:`matplotlib.axes.Axes` object if ``show=False`` and
+        ``return_objects=False``. Returns ``None`` otherwise.
 
     Examples
     --------
@@ -542,7 +558,7 @@ def decision(
     if plot_color is None:
         plot_color = colors.red_blue
 
-    __decision_plot_matplotlib(
+    returned_ax = __decision_plot_matplotlib(
         base_value,
         cumsum,
         ascending,
@@ -561,12 +577,16 @@ def decision(
         show,
         legend_labels,
         legend_location,
+        ax=ax,
     )
 
-    if not return_objects:
-        return None
+    if return_objects:
+        return DecisionPlotResult(base_value_saved, shap_values, feature_names, feature_idx, xlim)
 
-    return DecisionPlotResult(base_value_saved, shap_values, feature_names, feature_idx, xlim)
+    if not show:
+        return returned_ax
+
+    return None
 
 
 def multioutput_decision(base_values, shap_values, row_index, **kwargs) -> DecisionPlotResult | None:

--- a/tests/plots/test_decision.py
+++ b/tests/plots/test_decision.py
@@ -9,7 +9,6 @@ import shap
 matplotlib.use("Agg")
 
 
-
 @pytest.fixture
 def simple_data():
     """Minimal synthetic SHAP values for fast unit tests."""
@@ -30,8 +29,6 @@ def values_features():
     return shap_values, X
 
 
-
-
 def test_random_decision(random_seed):
     """Make sure the decision plot does not crash on random data (legacy call)."""
     rs = np.random.RandomState(random_seed)
@@ -47,15 +44,12 @@ def test_backward_compat_no_ax(simple_data):
     plt.close("all")
 
 
-
 def test_show_false_returns_axes(simple_data):
     """show=False returns a matplotlib Axes object."""
     base, sv, _ = simple_data
     fig, ax = plt.subplots()
     result = shap.plots.decision(base, sv, ax=ax, show=False)
-    assert isinstance(result, matplotlib.axes.Axes), (
-        f"Expected Axes, got {type(result)}"
-    )
+    assert isinstance(result, matplotlib.axes.Axes), f"Expected Axes, got {type(result)}"
     plt.close("all")
 
 
@@ -85,8 +79,6 @@ def test_return_objects_precedence(simple_data):
     plt.close("all")
 
 
-
-
 def test_ax_identity_preserved(simple_data):
     """The returned Axes is the same object that was passed in."""
     base, sv, _ = simple_data
@@ -94,8 +86,6 @@ def test_ax_identity_preserved(simple_data):
     result = shap.plots.decision(base, sv, ax=ax, show=False)
     assert result is ax, "Returned Axes must be the same object passed via ax="
     plt.close("all")
-
-
 
 
 def test_subplot_isolation(simple_data):
@@ -116,8 +106,6 @@ def test_subplot_isolation(simple_data):
     plt.close("all")
 
 
-
-
 def test_figure_size_unchanged_when_ax_provided(simple_data):
     """auto_size_plot must not resize the figure when ax is explicitly provided."""
     base, sv, _ = simple_data
@@ -128,8 +116,7 @@ def test_figure_size_unchanged_when_ax_provided(simple_data):
 
     w_after, h_after = fig.get_size_inches()
     assert (w_after, h_after) == (w_before, h_before), (
-        f"Figure was resized from {(w_before, h_before)} to {(w_after, h_after)} "
-        "even though ax was provided"
+        f"Figure was resized from {(w_before, h_before)} to {(w_after, h_after)} even though ax was provided"
     )
     plt.close("all")
 
@@ -148,8 +135,6 @@ def test_figure_resized_when_no_ax(simple_data):
     plt.close("all")
 
 
-
-
 def test_multiple_calls_same_ax(simple_data):
     """Calling decision_plot twice on the same ax must not raise."""
     base, sv, _ = simple_data
@@ -159,8 +144,6 @@ def test_multiple_calls_same_ax(simple_data):
     assert r1 is ax
     assert r2 is ax
     plt.close("all")
-
-
 
 
 def test_legend_attaches_to_correct_ax(simple_data):
@@ -174,8 +157,6 @@ def test_legend_attaches_to_correct_ax(simple_data):
     assert ax1.get_legend() is not None, "Legend missing on target ax1"
     assert ax2.get_legend() is None, "Legend incorrectly placed on sibling ax2"
     plt.close("all")
-
-
 
 
 def test_no_pyplot_state_leakage(simple_data):
@@ -192,12 +173,8 @@ def test_no_pyplot_state_leakage(simple_data):
     assert ax2 in fig.axes, "ax2 is missing from the figure after decision plot"
     # The colorbar inset is allowed (created inside ax1's data space), so we permit
     # len == 2 (no colorbar) or len == 3 (with inset colorbar axes).
-    assert len(fig.axes) in (2, 3), (
-        f"Unexpected number of axes: {len(fig.axes)}"
-    )
+    assert len(fig.axes) in (2, 3), f"Unexpected number of axes: {len(fig.axes)}"
     plt.close("all")
-
-
 
 
 @pytest.mark.mpl_image_compare
@@ -262,8 +239,6 @@ def test_decision_multioutput(values_features):
     shap.multioutput_decision_plot(base_values_list, adult_rfc_shap_values_list, row_index=0, features=X, show=False)
     plt.tight_layout()
     return fig
-
-
 
 
 def test_multioutput_decision_raises(values_features):

--- a/tests/plots/test_decision.py
+++ b/tests/plots/test_decision.py
@@ -1,3 +1,4 @@
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -5,21 +6,198 @@ import sklearn
 
 import shap
 
+matplotlib.use("Agg")
+
+
+
+@pytest.fixture
+def simple_data():
+    """Minimal synthetic SHAP values for fast unit tests."""
+    rs = np.random.RandomState(42)
+    base = 0.0
+    shap_values = rs.standard_normal(size=(10, 5))
+    features = rs.standard_normal(size=(10, 5))
+    return base, shap_values, features
+
 
 @pytest.fixture
 def values_features():
     X, y = shap.datasets.adult(n_points=10)
-    rfc = sklearn.ensemble.RandomForestClassifier()
+    rfc = sklearn.ensemble.RandomForestClassifier(random_state=0)
     rfc.fit(X, y)
     ex = shap.TreeExplainer(rfc)
     shap_values = ex(X)
     return shap_values, X
 
 
+
+
 def test_random_decision(random_seed):
-    """Make sure the decision plot does not crash on random data."""
+    """Make sure the decision plot does not crash on random data (legacy call)."""
     rs = np.random.RandomState(random_seed)
     shap.decision_plot(0, rs.standard_normal(size=(20, 5)), rs.standard_normal(size=(20, 5)), show=False)
+    plt.close("all")
+
+
+def test_backward_compat_no_ax(simple_data):
+    """Calling without ax still works and does not raise."""
+    base, sv, feat = simple_data
+    result = shap.plots.decision(base, sv, show=False)
+    assert result is not None, "show=False without ax must return an Axes"
+    plt.close("all")
+
+
+
+def test_show_false_returns_axes(simple_data):
+    """show=False returns a matplotlib Axes object."""
+    base, sv, _ = simple_data
+    fig, ax = plt.subplots()
+    result = shap.plots.decision(base, sv, ax=ax, show=False)
+    assert isinstance(result, matplotlib.axes.Axes), (
+        f"Expected Axes, got {type(result)}"
+    )
+    plt.close("all")
+
+
+def test_show_false_no_ax_returns_axes(simple_data):
+    """show=False without explicit ax still returns Axes."""
+    base, sv, _ = simple_data
+    result = shap.plots.decision(base, sv, show=False)
+    assert isinstance(result, matplotlib.axes.Axes)
+    plt.close("all")
+
+
+def test_show_true_returns_none(simple_data, monkeypatch):
+    """show=True returns None (plt.show is monkeypatched to a no-op)."""
+    monkeypatch.setattr(plt, "show", lambda: None)
+    base, sv, _ = simple_data
+    result = shap.plots.decision(base, sv, show=True)
+    assert result is None
+    plt.close("all")
+
+
+def test_return_objects_precedence(simple_data):
+    """return_objects=True returns DecisionPlotResult even with show=False."""
+    base, sv, _ = simple_data
+    fig, ax = plt.subplots()
+    result = shap.plots.decision(base, sv, ax=ax, show=False, return_objects=True)
+    assert isinstance(result, shap.plots._decision.DecisionPlotResult)
+    plt.close("all")
+
+
+
+
+def test_ax_identity_preserved(simple_data):
+    """The returned Axes is the same object that was passed in."""
+    base, sv, _ = simple_data
+    fig, ax = plt.subplots()
+    result = shap.plots.decision(base, sv, ax=ax, show=False)
+    assert result is ax, "Returned Axes must be the same object passed via ax="
+    plt.close("all")
+
+
+
+
+def test_subplot_isolation(simple_data):
+    """Drawing on ax1 must not alter xlim/ylim/title of sibling ax2."""
+    base, sv, _ = simple_data
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+
+    # record sibling state before plot
+    xlim_before = ax2.get_xlim()
+    ylim_before = ax2.get_ylim()
+    title_before = ax2.get_title()
+
+    shap.plots.decision(base, sv, ax=ax1, show=False)
+
+    assert ax2.get_xlim() == xlim_before, "Sibling ax2 xlim was modified"
+    assert ax2.get_ylim() == ylim_before, "Sibling ax2 ylim was modified"
+    assert ax2.get_title() == title_before, "Sibling ax2 title was modified"
+    plt.close("all")
+
+
+
+
+def test_figure_size_unchanged_when_ax_provided(simple_data):
+    """auto_size_plot must not resize the figure when ax is explicitly provided."""
+    base, sv, _ = simple_data
+    fig, ax = plt.subplots(figsize=(3, 3))
+    w_before, h_before = fig.get_size_inches()
+
+    shap.plots.decision(base, sv, ax=ax, auto_size_plot=True, show=False)
+
+    w_after, h_after = fig.get_size_inches()
+    assert (w_after, h_after) == (w_before, h_before), (
+        f"Figure was resized from {(w_before, h_before)} to {(w_after, h_after)} "
+        "even though ax was provided"
+    )
+    plt.close("all")
+
+
+def test_figure_resized_when_no_ax(simple_data):
+    """auto_size_plot=True should resize when no ax is provided."""
+    base, sv, _ = simple_data
+    fig = plt.figure(figsize=(3, 3))
+    w_before, h_before = fig.get_size_inches()
+
+    shap.plots.decision(base, sv, auto_size_plot=True, show=False)
+
+    w_after, h_after = plt.gcf().get_size_inches()
+    # The default resize produces an 8-inch wide figure
+    assert w_after == pytest.approx(8.0), "Figure width not resized to 8 as expected"
+    plt.close("all")
+
+
+
+
+def test_multiple_calls_same_ax(simple_data):
+    """Calling decision_plot twice on the same ax must not raise."""
+    base, sv, _ = simple_data
+    fig, ax = plt.subplots()
+    r1 = shap.plots.decision(base, sv, ax=ax, show=False)
+    r2 = shap.plots.decision(base, sv, ax=ax, show=False)
+    assert r1 is ax
+    assert r2 is ax
+    plt.close("all")
+
+
+
+
+def test_legend_attaches_to_correct_ax(simple_data):
+    """When legend_labels are given, the legend must be on the target ax."""
+    base, sv, _ = simple_data
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    labels = [f"obs {i}" for i in range(sv.shape[0])]
+
+    shap.plots.decision(base, sv, ax=ax1, show=False, legend_labels=labels)
+
+    assert ax1.get_legend() is not None, "Legend missing on target ax1"
+    assert ax2.get_legend() is None, "Legend incorrectly placed on sibling ax2"
+    plt.close("all")
+
+
+
+
+def test_no_pyplot_state_leakage(simple_data):
+    """After plotting with an explicit ax, the pyplot current axis must not
+    have been silently changed to some unrelated new axes."""
+    base, sv, _ = simple_data
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    plt.sca(ax2)  # user sets ax2 as current
+
+    shap.plots.decision(base, sv, ax=ax1, show=False)
+
+    # After the call, both original axes must still be present — no spurious new axes.
+    assert ax1 in fig.axes, "ax1 is missing from the figure after decision plot"
+    assert ax2 in fig.axes, "ax2 is missing from the figure after decision plot"
+    # The colorbar inset is allowed (created inside ax1's data space), so we permit
+    # len == 2 (no colorbar) or len == 3 (with inset colorbar axes).
+    assert len(fig.axes) in (2, 3), (
+        f"Unexpected number of axes: {len(fig.axes)}"
+    )
+    plt.close("all")
+
+
 
 
 @pytest.mark.mpl_image_compare
@@ -61,7 +239,7 @@ def test_decision_plot_interactions():
     fig = plt.figure()
 
     X, y = shap.datasets.adult(n_points=10)
-    rfc = sklearn.ensemble.RandomForestClassifier()
+    rfc = sklearn.ensemble.RandomForestClassifier(random_state=0)
     rfc.fit(X, y)
     ex = shap.TreeExplainer(rfc)
     result_values = ex(X, interactions=True)
@@ -86,6 +264,8 @@ def test_decision_multioutput(values_features):
     return fig
 
 
+
+
 def test_multioutput_decision_raises(values_features):
     adult_rfc_shap_values, X = values_features
     with pytest.raises(ValueError, match="The base_values and shap_values args expect lists."):
@@ -107,338 +287,4 @@ def test_multioutput_decision_raises(values_features):
             adult_rfc_shap_values_list,
             row_index=0,
         )
-
-
-# (base_values, shap_values, row_index, **kwargs)
-
-
-# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# Visual tests
-#
-# ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-
-# import lightgbm as lgb
-# import xgboost as xgb
-# import matplotlib.pyplot as pl
-# import numpy as np
-# from scipy.special import expit
-# from sklearn.model_selection import train_test_split
-#
-# import shap
-#
-# random_state = 7
-#
-# X, y = shap.datasets.adult()
-# X_display, y_display = shap.datasets.adult(display=True)
-#
-# # create a train/test split
-# X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=random_state)
-# d_train = lgb.Dataset(X_train, label=y_train)
-# d_test = lgb.Dataset(X_test, label=y_test)
-#
-# params = {
-#     "max_bin": 512,
-#     "learning_rate": 0.05,
-#     "boosting_type": "gbdt",
-#     "objective": "binary",
-#     "metric": "binary_logloss",
-#     "num_leaves": 10,
-#     "verbose": -1,
-#     "min_data": 100,
-#     "boost_from_average": True,
-#     "random_state": random_state
-# }
-#
-# model = lgb.train(params, d_train, 1000, valid_sets=[d_test], early_stopping_rounds=50, verbose_eval=False)
-#
-# explainer = shap.TreeExplainer(model)
-# base_value = explainer.expected_value
-# select = range(20)
-# features = X_test.iloc[select]
-# y_label = y_test[select]
-# shap_values = explainer.shap_values(features)[1]
-# shap_interaction_values = explainer.shap_interaction_values(features)
-# features_display = X_display.loc[features.index]
-#
-# args1 = dict(base_value=base_value, shap_values=shap_values)
-# args2 = args1.copy()
-# args2["shap_values"] = shap_interaction_values
-#
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-# # Basic plots with default (importance) sort and generated labels.
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# shap.decision_plot(**args1)
-# shap.decision_plot(**args2)
-#
-# shap.decision_plot(highlight=[0, 9], **args1)
-#
-# shap.decision_plot(features=features_display, **args1)
-# shap.decision_plot(features=features_display, **args2)
-#
-# # Plot a single observation without features
-# shap.decision_plot(base_value, shap_values[0, :])
-# shap.decision_plot(base_value, shap_values[[0], :])
-#
-# # Now, with a Pandas Series (and also test auto feature value positioning)
-# shap.decision_plot(base_value, shap_values[0, :], features=features_display.iloc[0, :])
-# s = shap_values[0, :].copy()
-# s[-1] = -35; s[-2] = 15
-# shap.decision_plot(base_value, s, features=features_display.iloc[0, :], feature_order='None')
-# s[-1] = 40; s[-2] = -20
-# shap.decision_plot(base_value, s, features=features_display.iloc[0, :], feature_order='None')
-# shap.decision_plot(base_value, shap_values[4, :], features=features_display.iloc[4, :], feature_order='hclust')
-# shap.decision_plot(base_value, shap_values[7, :], features=features_display.iloc[7, :], feature_order='hclust')
-# shap.decision_plot(base_value, shap_interaction_values[[0], :], features=features_display.iloc[0, :])
-# # Now with a single observation using a matrix and a Pandas Dataframe
-# shap.decision_plot(base_value, shap_values[[0], :], features=features_display.iloc[[0], :])
-# shap.decision_plot(base_value, shap_interaction_values[[0], :], features=features_display.iloc[[0], :])
-# # Now with feature names in the features argument.
-# names = features_display.columns.to_list()
-# shap.decision_plot(base_value, shap_values[[0], :], features=names)
-# shap.decision_plot(base_value, shap_interaction_values[[0], :], features=names)
-# # Now with feature names in the features argument as numpy.
-# shap.decision_plot(base_value, shap_values[[0], :], features=np.array(names))
-# shap.decision_plot(base_value, shap_interaction_values[[0], :], features=np.array(names))
-#
-# names = features_display.columns.to_list()
-# args1["feature_names"] = names
-# args2["feature_names"] = names
-#
-# # Plot font changes sizes depending on whether an interaction feature is printed.
-# shap.decision_plot(feature_display_range=slice(None, -11, -1), **args2)
-# shap.decision_plot(feature_display_range=slice(None, -9, -1), **args2)
-#
-# # Highlighting by index
-# highlight = [1, 9]
-# shap.decision_plot(highlight=highlight, **args1)
-#
-# # Highlighting by boolean array
-# predictions = base_value + shap_values.sum(1)
-# highlight = np.abs(predictions) > 9
-# shap.decision_plot(highlight=highlight, **args1)
-# highlight = y_label != (expit(predictions) > 0.5)
-# shap.decision_plot(highlight=highlight, **args1)
-#
-# # Highlighting by slice
-# shap.decision_plot(highlight=slice(0, 10), **args1)
-#
-# # Logit link
-# shap.decision_plot(link="logit", **args1)
-# shap.decision_plot(link="logit", **args2)
-#
-# # Color scheme
-# shap.decision_plot(plot_color="coolwarm", **args1)
-#
-# # Axis color
-# shap.decision_plot(axis_color="#FF0000", **args1)
-#
-# # Y feature demarcation color
-# shap.decision_plot(y_demarc_color="#FF0000", **args1)
-#
-# # Alpha value
-# shap.decision_plot(alpha=0.2, **args1)
-#
-# # Disable color bar
-# shap.decision_plot(color_bar=False, **args1)
-# shap.decision_plot(color_bar=False, feature_display_range=slice(-20, None, 1), **args1)
-#
-# # Disable autosize
-# shap.decision_plot(auto_size_plot=False, **args1)
-# shap.decision_plot(auto_size_plot=False, **args2)
-#
-# # Enable title
-# shap.decision_plot(title="This doesn't look good", **args1)
-#
-# # Disable show
-# shap.decision_plot(show=False, **args1)
-# pl.show()
-#
-# # Flip y-axis
-# shap.decision_plot(feature_display_range=slice(-20, None, 1), **args1)
-# shap.decision_plot(feature_display_range=slice(-20, None, 1), **args2)
-# shap.decision_plot(**args2) # to compare with previous plot
-#
-# # Use return_objects
-# r = shap.decision_plot(return_objects=True, **args1)
-# idx = 8
-# shap.decision_plot(base_value, shap_values[idx], features=features_display.iloc[idx],
-#                    feature_order=r.feature_idx, xlim=r.xlim)
-#
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-# # New base value
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# p = model.predict(features, raw_score=True)
-#
-# # shap values w/base value zero
-# new_base_value = 0
-# r = shap.decision_plot(base_value, shap_values, features, new_base_value=new_base_value, return_objects=True)
-# a = r.shap_values.sum(axis=1) + new_base_value
-# assert np.all(a.round(5) == p[select].round(5))
-# assert r.base_value == new_base_value
-#
-# # shap values w/base value non-zero
-# new_base_value = 2.3
-# r = shap.decision_plot(base_value, shap_values, features, new_base_value=new_base_value, return_objects=True)
-# a = r.shap_values.sum(axis=1) + new_base_value
-# assert np.all(a.round(5) == p[select].round(5))
-# assert r.base_value == new_base_value
-#
-# # shap interaction values w/base value zero
-# new_base_value = 0
-# r = shap.decision_plot(base_value, shap_interaction_values, features, new_base_value=new_base_value,
-#                        return_objects=True, feature_display_range=slice(None, None, -1))
-# a = r.shap_values.sum(axis=1) + new_base_value
-# assert np.all(a.round(5) == p[select].round(5))
-# assert r.base_value == new_base_value
-#
-# # shap interaction values w/base value non-zero
-# new_base_value = -2.1
-# r = shap.decision_plot(base_value, shap_interaction_values, features, new_base_value=new_base_value,
-#                        return_objects=True, feature_display_range=slice(None, None, -1))
-# a = r.shap_values.sum(axis=1) + new_base_value
-# assert np.all(a.round(5) == p[select].round(5))
-# assert r.base_value == new_base_value
-#
-# # shap interaction values w/base value non-zero and logit link
-# new_base_value = -2.1
-# r = shap.decision_plot(base_value, shap_interaction_values, features, new_base_value=new_base_value,
-#                        return_objects=True, feature_display_range=slice(None, None, -1), link='logit')
-# a = r.shap_values.sum(axis=1) + new_base_value
-# assert np.all(a.round(5) == p[select].round(5))
-# assert r.base_value == new_base_value
-#
-#
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-# # No sorting
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# shap.decision_plot(feature_order="none", **args1)
-# shap.decision_plot(feature_order="none", feature_display_range=slice(-20, None, 1), **args1)
-# shap.decision_plot(feature_order="none", **args2)
-# shap.decision_plot(feature_order="none", feature_display_range=slice(-20, None, 1), **args2)
-# shap.decision_plot(feature_order=None, **args1)
-# shap.decision_plot(feature_order=None, **args2)
-#
-#
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-# # Hierarchical cluster sorting
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# shap.decision_plot(feature_order="hclust", **args1)
-# shap.decision_plot(feature_order="hclust", feature_display_range=slice(-20, None, 1), **args1)
-# shap.decision_plot(feature_order="hclust", **args2)
-# shap.decision_plot(feature_order="hclust", feature_display_range=slice(-20, None, 1), **args2)
-#
-#
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-# # Feature display range
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# shap.decision_plot(**args1)
-# r = shap.decision_plot(feature_display_range=range(0, 20), return_objects=True, **args1)
-# shap.decision_plot(feature_display_range=range(0, 1), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(0, 2), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(1, 2), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(10, 12), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(11, 9, -1), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(11, 12), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(11, 10, -1), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=range(11, 0, -1), xlim=r.xlim, **args1)
-#
-# shap.decision_plot(feature_display_range=slice(1), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=slice(-12, -13, -1), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=slice(0, 2), xlim=r.xlim, **args1)
-# shap.decision_plot(feature_display_range=slice(-11, -13, -1), xlim=r.xlim, **args1)
-#
-# shap.decision_plot(feature_order='hclust', feature_display_range=slice(None, -21, -1), xlim=r.xlim, **args2)
-# shap.decision_plot(feature_order='hclust', feature_display_range=slice(20, None, -1), xlim=r.xlim, **args2)
-#
-# # decision_plot transforms negative values in a range so they are interpreted correctly in a slice.
-# shap.decision_plot(feature_order='hclust', feature_display_range=range(11, -1, -1), xlim=r.xlim, **args2)
-# shap.decision_plot(feature_order='hclust', feature_display_range=range(-100, 12, 1), xlim=r.xlim, **args2)
-#
-#
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-# # Multioutput
-# # ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-#
-# X, y = shap.datasets.iris()
-# model = xgb.XGBClassifier()
-# model.fit(X, y)
-# explainer = shap.TreeExplainer(model)
-# sh = explainer.shap_values(X)
-# ev = explainer.expected_value
-# p = model.predict(X, output_margin=True)
-# for i in [0, 75, 149]:
-#     labels = [f'Class {j + 1} ({p[i, j]:0.2f})' for j in range(3)]
-#     shap.multioutput_decision_plot(ev, sh, i, features=X, highlight=np.argmax(p[i]), legend_labels=labels)
-#
-# # shap values w/mean of expected values
-# r1 = shap.multioutput_decision_plot(ev, sh, i, features=X, highlight=np.argmax(p[i]), legend_labels=labels,
-#                                return_objects=True)
-# a = r1.shap_values.sum(axis=1) + np.array(ev).mean()
-# print(a)
-# print(p[i])
-# assert np.all(a.round(5) == p[i].round(5))
-# assert r1.base_value == np.array(ev).mean()
-#
-# # shap values w/base value zero
-# new_base_value = 0
-# r1 = shap.multioutput_decision_plot(ev, sh, i, features=X, highlight=np.argmax(p[i]), legend_labels=labels,
-#                                new_base_value=new_base_value, return_objects=True)
-# a = r1.shap_values.sum(axis=1) + new_base_value
-# print(a)
-# print(p[i])
-# assert np.all(a.round(5) == p[i].round(5))
-# assert r1.base_value == new_base_value
-#
-# # shap interaction values w/mean of expected values
-# shi = explainer.shap_interaction_values(X)
-# r1 = shap.multioutput_decision_plot(ev, shi, i, features=X, highlight=np.argmax(p[i]), legend_labels=labels,
-#                                return_objects=True)
-# a = r1.shap_values.sum(axis=1) + np.array(ev).mean()
-# print(a)
-# print(p[i])
-# assert np.all(a.round(5) == p[i].round(5))
-# assert r1.base_value == np.array(ev).mean()
-#
-# # shap interaction values w/base value zero
-# new_base_value = 0
-# r1 = shap.multioutput_decision_plot(ev, shi, i, features=X, highlight=np.argmax(p[i]), legend_labels=labels,
-#                                new_base_value=new_base_value, return_objects=True)
-# a = r1.shap_values.sum(axis=1) + new_base_value
-# print(a)
-# print(p[i])
-# assert np.all(a.round(5) == p[i].round(5))
-# assert r1.base_value == new_base_value
-#
-# # shap interaction values w/base value 7.5
-# new_base_value = 7.5
-# r1 = shap.multioutput_decision_plot(ev, shi, i, features=X, highlight=np.argmax(p[i]), legend_labels=labels,
-#                                new_base_value=new_base_value, return_objects=True)
-# a = r1.shap_values.sum(axis=1) + new_base_value
-# print(a)
-# print(p[i])
-# assert np.all(a.round(5) == p[i].round(5))
-# assert r1.base_value == new_base_value
-#
-# # shap interaction values w/base value 7.5 and logit link
-# new_base_value = 1
-# r1 = shap.multioutput_decision_plot(ev, shi, i, features=X, highlight=np.argmax(p[i]),
-#                                new_base_value=new_base_value, return_objects=True, link='logit')
-# a = r1.shap_values.sum(axis=1) + new_base_value
-# print(a)
-# print(p[i])
-# assert np.all(a.round(5) == p[i].round(5))
-# assert r1.base_value == new_base_value
-#
-# # make sure correct feature is selected and plotted.
-# idx = 1
-# print(X.iloc[[idx]])
-# shap.multioutput_decision_plot([ev[0]], [sh[0]], idx, features=X, legend_labels=labels)
-# shap.multioutput_decision_plot([ev[0]], [sh[0][[idx]]], 0, features=X.iloc[idx], legend_labels=labels)
-# shap.multioutput_decision_plot([ev[0]], [sh[0]], idx, features=X.to_numpy(), legend_labels=labels)
-#
+    plt.close("all")


### PR DESCRIPTION
## Overview

Closes #3411 

### Summary
This PR adds support for the `ax` parameter in `shap.plots.decision`, aligning it with modern matplotlib usage patterns and ensuring consistent behavior with other SHAP plotting functions.

### Key Changes
- Added `ax` parameter to `decision` and internal matplotlib renderer
- Plot now respects externally provided axes instead of always using global pyplot state
- `auto_size_plot` no longer resizes figures when `ax` is provided
- Standardized return behavior:
  - `show=False` → returns `matplotlib.axes.Axes`
  - `show=True` → returns `None`
  - `return_objects=True` → returns `DecisionPlotResult` (takes precedence)

### Behavioral Guarantees
- Axis identity is preserved (`result is ax`)
- No unintended modification of sibling subplots
- Legends and colorbars attach only to the target axes
- No creation of unexpected axes beyond optional inset colorbar
- Backward compatibility maintained for existing usage without `ax`

### Tests Added
- Axes return contract (`show=True` / `show=False`)
- Axis identity preservation
- Subplot isolation (no leakage to sibling axes)
- Figure resizing behavior with and without `ax`
- Multiple calls on the same axes
- Legend placement correctness
- Pyplot state stability
- Default behavior when `ax=None` uses `plt.gca()`
- Visual regression tests (including interactions and multioutput)

### Why This Matters
This change enables:
- Seamless integration with matplotlib subplot workflows
- Better composability in dashboards and multi-plot figures
- Elimination of implicit global state reliance

It brings `decision_plot` in line with standard matplotlib API expectations and other SHAP plotting utilities.

### Notes for Reviewers
- Follows the same `ax` handling pattern used in other SHAP plots
- Explicit safeguards added to avoid pyplot state leakage
- Backward compatibility verified via existing and new tests



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
