### PR TITLE
DOCS: Modernize Census income XGBoost notebook to use Explanation object API

### DIFF
--- a/notebooks/tabular_examples/tree_based_models/Census income classification with XGBoost.ipynb
+++ b/notebooks/tabular_examples/tree_based_models/Census income classification with XGBoost.ipynb
@@ -214,7 +214,8 @@
    "source": [
     "# this takes a minute or two since we are explaining over 30 thousand samples in a model with over a thousand trees\n",
     "explainer = shap.TreeExplainer(model)\n",
-    "shap_values = explainer.shap_values(X)"
+    "shap_values = explainer(X)\n",
+    "shap_values.display_data = X_display.values"
    ]
   },
   {
@@ -260,7 +261,7 @@
     }
    ],
    "source": [
-    "shap.force_plot(explainer.expected_value, shap_values[0, :], X_display.iloc[0, :])"
+    "shap.plots.force(shap_values[0])"
    ]
   },
   {
@@ -306,7 +307,7 @@
     }
    ],
    "source": [
-    "shap.force_plot(explainer.expected_value, shap_values[:1000, :], X_display.iloc[:1000, :])"
+    "shap.plots.force(shap_values[:1000])"
    ]
   },
   {
@@ -335,7 +336,7 @@
     }
    ],
    "source": [
-    "shap.summary_plot(shap_values, X_display, plot_type=\"bar\")"
+    "shap.plots.bar(shap_values)"
    ]
   },
   {
@@ -366,7 +367,7 @@
     }
    ],
    "source": [
-    "shap.summary_plot(shap_values, X)"
+    "shap.plots.beeswarm(shap_values)"
    ]
   },
   {
@@ -508,7 +509,7 @@
    ],
    "source": [
     "for name in X_train.columns:\n",
-    "    shap.dependence_plot(name, shap_values, X, display_features=X_display)"
+    "    shap.plots.scatter(shap_values[:, name])"
    ]
   },
   {
@@ -722,7 +723,9 @@
    },
    "outputs": [],
    "source": [
-    "shap_values_ind = shap.TreeExplainer(model_ind).shap_values(X)"
+    "explainer_ind = shap.Explainer(model_ind, X)\n",
+    "shap_values_ind = explainer_ind(X)\n",
+    "shap_values_ind.display_data = X_display.values"
    ]
   },
   {
@@ -958,7 +961,7 @@
    ],
    "source": [
     "for name in X_train.columns:\n",
-    "    shap.dependence_plot(name, shap_values_ind, X, display_features=X_display)"
+    "    shap.plots.scatter(shap_values_ind[:, name])"
    ]
   }
  ],


### PR DESCRIPTION
## Overview

Closes #3036

This PR modernizes the heavily-used `Census income classification with XGBoost.ipynb` tutorial to eliminate legacy deprecation warnings and showcase the modern `Explanation` object plotting APIs.

Changes made:
- Upgraded the explainer extraction to use the modern `explainer(X)` callable.
- Leveraged `shap_values.display_data` to globally map categorical strings instead of raw numbers.
- Replaced all legacy `shap.force_plot` calls with `shap.plots.force`.
- Replaced all legacy `shap.summary_plot` calls with native `shap.plots.bar` and `shap.plots.beeswarm`.
- Replaced all legacy `shap.dependence_plot` calls with the new `shap.plots.scatter`.

## Checklist

- [x] All pre-commit checks pass.
