### PR TITLE
BUG: fix crash in shap.plots.monitoring for short input arrays

### DIFF
--- a/shap/plots/_monitoring.py
+++ b/shap/plots/_monitoring.py
@@ -58,10 +58,18 @@ def monitoring(ind, shap_values, features, feature_names=None, show=True):
         # stat, pval = scipy.stats.mannwhitneyu(v[:i], v[i:], alternative="two-sided")
         _, pval = scipy.stats.ttest_ind(ys[:i], ys[i:])
         pvals.append(pval)
-    min_pval = np.min(pvals)
-    min_pval_ind = float(np.argmin(pvals) * inc + inc)
 
-    if min_pval < 0.05 / shap_values.shape[1]:
+    if pvals:
+        min_pval = np.min(pvals)
+        min_pval_ind = np.argmin(pvals)
+    else:
+        min_pval = None
+        min_pval_ind = None
+
+    if min_pval_ind is not None:
+        min_pval_ind = float(min_pval_ind * inc + inc)
+
+    if min_pval is not None and min_pval < 0.05 / shap_values.shape[1]:
         plt.axvline(min_pval_ind, linestyle="dashed", color="#666666", alpha=0.2)
 
     plt.scatter(xs, ys, s=10, c=features[:, ind], cmap=colors.red_blue)

--- a/tests/plots/test_monitoring.py
+++ b/tests/plots/test_monitoring.py
@@ -1,0 +1,15 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import shap
+
+
+def test_monitoring_short_input_does_not_crash():
+    """Ensure monitoring plot does not crash for small input arrays."""
+
+    shap_values = np.ones((75, 2))
+    features = np.ones((75, 2))
+
+    shap.plots.monitoring(0, shap_values, features, show=False)
+
+    plt.close("all")


### PR DESCRIPTION
Fixes #4927

### Summary
This PR fixes a crash in `shap.plots.monitoring` when the input array is too small.

### Problem
For small inputs (e.g., <= 100 samples), the loop used to compute p-values does not execute, resulting in an empty `pvals` list. The subsequent call to `np.min(pvals)` raises a `ValueError` because it is applied to an empty array.

### Solution
Added a guard to check whether `pvals` is non-empty before computing `np.min()` and `np.argmin()`.  
If no p-values are available, the changepoint logic is skipped and the plot is still rendered normally.

### Changes
- Added condition to safely handle empty `pvals`
- Prevented reduction operations on empty arrays
- Preserved existing behavior for valid (larger) inputs

### Test
Added a test to ensure that:
```python
shap.plots.monitoring(..., show=False)