### PR TITLE
Fix hclust implicit return

### DIFF
--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -311,3 +311,5 @@ def hclust(
         return scipy.cluster.hierarchy.complete(dist)
     elif linkage == "average":
         return scipy.cluster.hierarchy.average(dist)
+
+    raise AssertionError(f"Unhandled linkage type: {linkage}")


### PR DESCRIPTION

## Summary

The `hclust()` function in `shap/utils/_clustering.py` validates the `linkage` parameter against `("single", "complete", "average")` early in the function (line 272), but the final return block uses an `if/elif/elif` chain without a terminal `else` clause. This means the function has an implicit `None` return path at the end.

## Problem

While the early validation guard prevents unknown linkage strings at runtime, the implicit `None` return causes two issues:

1. **Type narrowing failure:** Static analysis tools (Mypy) infer the return type as `NDArray | None` instead of `NDArray`, which forces all downstream callers to handle `None` unnecessarily.
2. **Refactoring fragility:** If a new linkage type is ever added to `known_linkages` without updating the return block, the function will silently return `None` instead of raising an error.

## Fix

Added an explicit `raise AssertionError(...)` after the `if/elif/elif` chain as a defensive unreachable backstop. This:

- Allows Mypy to prove the return type is always `NDArray` (never `None`)
- Ensures any future linkage additions that miss the return block will fail loudly
- Follows existing SHAP conventions (e.g., `AssertionError` is used elsewhere in maskers and explainers)

## Testing

All 6 existing tests in `tests/utils/test_clustering.py` pass. No new test is needed since the added line is unreachable by design (guarded by the `ValueError` on line 272).
