### PR TITLE
FIX: Apply title argument in legacy summary plot

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -1147,6 +1147,10 @@ def summary_legacy(
         plt.xlabel(labels["GLOBAL_VALUE"], fontsize=13)
     else:
         plt.xlabel(labels["VALUE"], fontsize=13)
+
+    if title is not None:
+        plt.title(title)
+
     plt.tight_layout()
     if show:
         plt.show()

--- a/tests/plots/test_summary.py
+++ b/tests/plots/test_summary.py
@@ -31,6 +31,19 @@ def test_summary_with_data():
     return fig
 
 
+def test_summary_plot_applies_title():
+    title = "Custom summary title"
+
+    shap.summary_plot(
+        np.random.randn(20, 5),
+        np.random.randn(20, 5),
+        title=title,
+        show=False,
+    )
+
+    assert plt.gca().get_title() == title
+
+
 @pytest.mark.mpl_image_compare
 def test_summary_multi_class():
     """Check a multiclass run."""


### PR DESCRIPTION
## Overview

Closes #4962 

Description of the changes proposed in this pull request:

- Apply the `title` argument in the legacy `summary_plot` path.
- Add a regression test for `shap.summary_plot(..., title=...)`.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
