### PR TITLE
FIX: backport duplicate y-tick position fix from waterfall() to waterfall_legacy()

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -653,11 +653,9 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
             )
 
     # draw the y-ticks twice, once in gray and then again with just the feature names in black
-    plt.yticks(
-        list(range(num_features)) * 2,
-        yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]],
-        fontsize=13,
-    )
+    # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
+    ytick_pos = list(range(num_features)) + list(np.arange(num_features) + 1e-8)
+    plt.yticks(ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
 
     # put horizontal lines for each feature row
     for i in range(num_features):


### PR DESCRIPTION
## Summary

- `waterfall_legacy()` used `list(range(num_features)) * 2` for y-tick positions,
  producing duplicates (e.g. `[0,1,2,3,4,0,1,2,3,4]`).
- Matplotlib 3.3+ collapses duplicate tick positions, so the second layer of labels
  (black feature-name-only ticks) was silently dropped from the plot.
- The modern `waterfall()` already has the correct pattern at line 298 with an
  explanatory comment. This PR backports it to `waterfall_legacy()`.
 
 ## Issue

https://github.com/shap/shap/issues/4966

## Change

```diff
-    plt.yticks(
-        list(range(num_features)) * 2,
-        yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]],
-        fontsize=13,
-    )
+    # The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks
+    ytick_pos = list(range(num_features)) + list(np.arange(num_features) + 1e-8)
+    plt.yticks(ytick_pos, yticklabels[:-1] + [label.split("=")[-1] for label in yticklabels[:-1]], fontsize=13)
```

File: `shap/plots/_waterfall.py`, line 656–660

## Testing

The existing `test_waterfall_legacy` in `tests/plots/test_waterfall.py` (line 40)
uses `@pytest.mark.mpl_image_compare` and exercises this exact code path.

Run:
```bash
pytest tests/plots/test_waterfall.py::test_waterfall_legacy -v
```

The baseline image needs to be regenerated since the tick positions now correctly
produce two distinct rendered layers:
```bash
pytest tests/plots/test_waterfall.py::test_waterfall_legacy --mpl-generate-path=tests/plots/baseline
```

## Related

- Fixes: [issue link]
- The fix in the modern `waterfall()` was introduced in the same file at line 298
  with the comment `"The 1e-8 is so matplotlib 3.3 doesn't try and collapse the ticks"`
  but was never applied to the legacy function.
```
