### PR TITLE
Fix minor bugs: f-string assert, sklearn import, masker condition

### DIFF
--- a/shap/_serializable.py
+++ b/shap/_serializable.py
@@ -185,7 +185,7 @@ class Deserializer:
         encoder_name = pickle.load(self.in_stream)
         log.debug("encoder_name = %s", encoder_name)
         if encoder_name == "custom_encoder" or callable(decoder):
-            assert callable(decoder), f"You must provide a callable custom decoder for the data item {name}!"
+            assert callable(decoder), f"You must provide a callable custom decoder for the data item {encoder_name}!"
             return decoder(self.in_stream)
         if encoder_name == "no_encoder":
             return None

--- a/shap/_serializable.py
+++ b/shap/_serializable.py
@@ -185,7 +185,7 @@ class Deserializer:
         encoder_name = pickle.load(self.in_stream)
         log.debug("encoder_name = %s", encoder_name)
         if encoder_name == "custom_encoder" or callable(decoder):
-            assert callable(decoder), "You must provide a callable custom decoder for the data item {name}!"
+            assert callable(decoder), f"You must provide a callable custom decoder for the data item {name}!"
             return decoder(self.in_stream)
         if encoder_name == "no_encoder":
             return None

--- a/shap/benchmark/metrics.py
+++ b/shap/benchmark/metrics.py
@@ -13,10 +13,7 @@ try:
 except Exception:
     pass
 
-try:
-    from sklearn.model_selection import train_test_split
-except Exception:
-    from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 
 def runtime(X, y, model_generator, method_name):

--- a/shap/maskers/_text.py
+++ b/shap/maskers/_text.py
@@ -130,7 +130,7 @@ class Text(Masker):
             sep_token = getattr_silent(self.tokenizer, "sep_token")
             for i, v in enumerate(mask):
                 # mask ignores separator tokens and keeps them unmasked
-                if v or sep_token == self._segments_s[i]:
+                if v or (sep_token is not None and sep_token == self._segments_s[i]):
                     out_parts.append(self._segments_s[i])
                     is_previous_appended_token_mask_token = False
                 else:


### PR DESCRIPTION
## Overview

Closes #4973

Fixes a few minor issues across the codebase:
- Corrects missing f-string interpolation in an assert message
- Removes deprecated sklearn.cross_validation import
- Clarifies masker condition logic for separator tokens

These changes are low-risk and improve correctness and code clarity.



## Checklist

- [x] All pre-commit checks pass.
- [ ] Unit tests added (not required for these minor fixes)