### PR TITLE
fix: unpack np.where() tuple in potential_interactions() to prevent ValueError

### DIFF
--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -76,8 +76,8 @@ def potential_interactions(shap_values_column: Any, shap_values_matrix: Any) -> 
     This just bins the SHAP values for a feature along that feature's value. For true Shapley interaction
     index values for SHAP see the interaction_contribs option implemented in XGBoost.
     """
-    # ignore inds that are identical to the column
-    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)
+    # ignore inds that are identical to the column; np.where returns a tuple, index [0] to get the array
+    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)[0]
 
     X = shap_values_matrix.data
 


### PR DESCRIPTION
## Summary

`potential_interactions()` in `shap/utils/_general.py` stored the raw return
value of `np.where()` a **tuple** of arrays and used it for membership
testing with `i in ignore_inds`.

When any two features had near-identical SHAP patterns, `np.where()` returned
a non-empty tuple like `(array([0, 2]),)`. Python's `in` operator then evaluated
`i == array([0, 2])`, producing a boolean array, and raising:

ValueError: The truth value of an array with more than one element is ambiguous.



The bug was latent when no features matched (empty array is falsy), making it
hard to catch in typical tests.

## Change

`shap/utils/_general.py`

```diff
-    # ignore inds that are identical to the column
-    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)
+    # ignore inds that are identical to the column; np.where returns a tuple, index [0] to get the array
+    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)[0]
i in ignore_inds on lines 102 and 110 now correctly performs scalar
membership testing against a 1-D numpy array.