### PR TITLE
fix: pass self.feature_names instead of data values in 2D output_names slice

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -367,7 +367,7 @@ class Explanation(metaclass=MetaExplanation):
                             data=np.array(new_data),
                             display_data=self.display_data,
                             instance_names=self.instance_names,
-                            feature_names=np.array(new_data),  # FIXME: this is probably a bug
+                            feature_names=self.feature_names,
                             output_names=t,
                             output_indexes=self.output_indexes,
                             lower_bounds=self.lower_bounds,
@@ -378,13 +378,10 @@ class Explanation(metaclass=MetaExplanation):
                             clustering=self.clustering,
                         )
                         new_self.op_history = copy.copy(self.op_history)
-                        # new_self = copy.deepcopy(self)
-                        # new_self.values = np.array(new_values)
-                        # new_self.base_values = np.array(new_base_values)
-                        # new_self.data = np.array(new_data)
-                        # new_self.output_names = t
-                        # new_self.feature_names = np.array(new_data)
-                        # new_self.clustering = None
+                        # The output dimension is fully resolved; pass only preceding dims
+                        # to the slicer so it doesn't choke on the string.
+                        item = item[:pos]
+                        break
 
                 # work around for 2D feature_names since they are not yet slicer supported
                 feature_names_dims = []

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,50 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+def test_getitem_2d_output_names_preserves_feature_names():
+    """Regression test: slicing by a 2D output name must preserve feature_names.
+
+    Previously, feature_names was incorrectly set to np.array(new_data) — numeric
+    data values — instead of the actual string feature names when slicing an
+    Explanation with per-instance (2D) output_names.
+
+    2D output_names must be passed as a numpy array so the slicer correctly
+    identifies the dimensional structure as (samples, outputs) rather than treating
+    the nested Python list as three-dimensional.
+    """
+    n_instances = 3
+    n_features = 4
+    n_outputs = 2
+    feature_names = ["feat_a", "feat_b", "feat_c", "feat_d"]
+
+    # np.array required: list-of-lists causes the slicer to misreport dimensions
+    output_names = np.array([["out_x", "out_y"] for _ in range(n_instances)])
+
+    rs = np.random.RandomState(42)
+    values = rs.randn(n_instances, n_features, n_outputs)
+    data = rs.randn(n_instances, n_features)
+    base_values = rs.randn(n_instances, n_outputs)
+
+    exp = shap.Explanation(
+        values=values,
+        base_values=base_values,
+        data=data,
+        feature_names=feature_names,
+        output_names=output_names,
+    )
+
+    # For a 3D Explanation (instances × features × outputs), select an output
+    # with exp[:, :, name] — this triggers the 2D output_names workaround.
+    sliced = exp[:, :, "out_x"]
+
+    # feature_names must be the original strings, not the numeric data values
+    assert list(sliced.feature_names) == feature_names, (
+        f"Expected {feature_names}, got {sliced.feature_names}"
+    )
+
+    # values must be the correct output column
+    assert sliced.values.shape == (n_instances, n_features)
+    for i in range(n_instances):
+        np.testing.assert_array_equal(sliced.values[i], values[i, :, 0])

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -284,9 +284,7 @@ def test_getitem_2d_output_names_preserves_feature_names():
     sliced = exp[:, :, "out_x"]
 
     # feature_names must be the original strings, not the numeric data values
-    assert list(sliced.feature_names) == feature_names, (
-        f"Expected {feature_names}, got {sliced.feature_names}"
-    )
+    assert list(sliced.feature_names) == feature_names, f"Expected {feature_names}, got {sliced.feature_names}"
 
     # values must be the correct output column
     assert sliced.values.shape == (n_instances, n_features)


### PR DESCRIPTION
## Reference Issue

issue - #4982 

## Summary

Fixes the self-documented `FIXME` in `shap/_explanation.py` (the 2D `output_names`
workaround inside `Explanation.__getitem__`).

- **Root cause**: The `Explanation` constructor was called with
  `feature_names=np.array(new_data)` — numeric data rows — instead of the actual
  feature names. Closes #<issue-number>.
- **Fix 1**: Changed to `feature_names=self.feature_names`.
- **Fix 2**: After the workaround fully builds `new_self`, the slicer was called
  again with the original `item` tuple still containing the string. Added
  `item = item[:pos]; break` so only the preceding (already-valid) dimensions
  are passed to the slicer.
- **Cleanup**: Removed the stale commented-out dead code block (old superseded
  implementation left beside the FIXME).
- **Test**: Added `test_getitem_2d_output_names_preserves_feature_names` as a
  regression test.

## Notes

`output_names` must be a `np.array` (not a Python list-of-lists) for the slicer
to correctly identify the `(samples, outputs)` dimensional structure. The test
documents this requirement. The list-of-lists misidentification is a separate
pre-existing issue.

## Test plan

- [x] New regression test passes
- [x] All 15 existing `test_explanation.py` tests pass
