### PR TITLE
fix: remove deprecated unused title parameter from violin() and summary_plot()

### DIFF
--- a/shap/plots/_beeswarm.py
+++ b/shap/plots/_beeswarm.py
@@ -516,7 +516,6 @@ def is_color_map(color):
     return safe_isinstance(color, "matplotlib.colors.Colormap")
 
 
-# TODO: remove unused title argument / use title argument
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
 def summary_legacy(
     shap_values,
@@ -526,7 +525,6 @@ def summary_legacy(
     plot_type=None,
     color=None,
     axis_color="#333333",
-    title=None,
     alpha=1,
     show=True,
     sort=True,
@@ -691,7 +689,6 @@ def summary_legacy(
                 plot_type="dot",
                 color=color,
                 axis_color=axis_color,
-                title=title,
                 alpha=alpha,
                 show=show,
                 sort=sort,

--- a/shap/plots/_violin.py
+++ b/shap/plots/_violin.py
@@ -20,7 +20,6 @@ else:
     ORIENTATION_KWARG = dict(vert=False)  # type: ignore[dict-item]
 
 
-# TODO: remove unused title argument / use title argument
 # TODO: Add support for hclustering based explanations where we sort the leaf order by magnitude and then show the dendrogram to the left
 def violin(
     shap_values,
@@ -30,7 +29,6 @@ def violin(
     plot_type="violin",
     color=None,
     axis_color="#333333",
-    title=None,
     alpha=1,
     show=True,
     sort=True,
@@ -66,8 +64,6 @@ def violin(
         Color or colormap to use for the plot. If None, a default is chosen.
     axis_color : str, optional
         Color for the plot axes.
-    title : str or None, optional
-        Plot title (currently unused).
     alpha : float, optional
         Opacity of the plot elements.
     show : bool, optional
@@ -103,8 +99,6 @@ def violin(
     See `violin plot examples <https://shap.readthedocs.io/en/latest/example_notebooks/api_examples/plots/violin.html>`_.
 
     """
-    if title is not None:
-        warnings.warn("The `title` argument is unused and will be removed in a future release.", DeprecationWarning)
     # support passing an explanation object
     if str(type(shap_values)).endswith("Explanation'>"):
         shap_exp = shap_values


### PR DESCRIPTION
## Summary

Closes #4984 

Removes the long-deprecated `title` parameter from two plot functions:

- **`shap.plots.violin()`** (`_violin.py`): removes `title=None`, the docstring
  entry, the `DeprecationWarning` block, and the `# TODO: remove unused title
  argument` comment. The `warnings` import is retained (used elsewhere).
- **`shap.summary_plot()` / `summary_legacy()`** (`_beeswarm.py`): removes
  `title=None`, the matching `# TODO` comment, and the `title=title` keyword
  in the recursive `compact_dot` call path.

Both parameters were never wired to `plt.title()` or any other output; they
could not affect the produced plot.

## Breaking change

Callers passing `title=` to either function will now receive a `TypeError`
(unexpected keyword argument). This is intentional — the deprecation warning
in `violin()` has been in place, and `summary_legacy()` is the legacy wrapper
for `shap.summary_plot()`.

## Test plan

- [x] `tests/plots/test_violin.py` — 48 passed, 12 skipped
- [x] `tests/plots/test_beeswarm.py` — all pass
- [x] `tests/plots/test_summary.py` — all pass
- [x] Manual: `violin(title=...)` and `summary_plot(title=...)` now raise
  `TypeError: got an unexpected keyword argument 'title'`
