### PR TITLE
docs: complete truncated docstring in fill_counts()

### DIFF
--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -188,7 +188,7 @@ def fill_internal_max_values(partition_tree, leaf_values):
 
 
 def fill_counts(partition_tree):
-    """This updates the"""
+    """This fills the fourth column of the partition tree matrix with the leaf count for each cluster."""
     M = partition_tree.shape[0] + 1
     for i in range(partition_tree.shape[0]):
         val = 0


### PR DESCRIPTION
## Summary

Closes #4986 

The docstring in `shap/plots/_utils.py::fill_counts` was cut off mid-sentence:

```python
# Before
def fill_counts(partition_tree):
    """This updates the"""

# After
def fill_counts(partition_tree):
    """This fills the fourth column of the partition tree matrix with the leaf count for each cluster."""
The new wording is consistent with the adjacent fill_internal_max_values() docstring
("This fills the forth column of the partition tree matrix with the max leaf value in
that cluster.") and accurately describes what the function computes.

Test plan

- [ ]  tests/plots/test_utils.py 18 passed
- [ ]  tests/utils/test_general.py 18 passed