### PR TITLE
fix: use get_state/set_state to correctly save and restore RNG in dataset helpers

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -527,8 +527,8 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
         data, target = shap.datasets.corrgroups60()
 
     """
-    # set a constant seed
-    old_seed = np.random.seed()
+    # set a constant seed and save the current state so we can restore it
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -563,8 +563,8 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
     X = X_final
     y = f(X) + np.random.randn(N) * 1e-2
 
-    # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    # restore the previous global RNG state
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 
@@ -598,8 +598,8 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
         features, labels = shap.datasets.independentlinear60()
 
     """
-    # set a constant seed
-    old_seed = np.random.seed()
+    # set a constant seed and save the current state so we can restore it
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -617,8 +617,8 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
     X = X_start - X_start.mean(0)
     y = f(X) + np.random.randn(N) * 1e-2
 
-    # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    # restore the previous global RNG state
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 


### PR DESCRIPTION
## Summary

Closes #4988 

`np.random.seed()` always returns `None`  it does not return the current seed.
The existing save/restore pattern in `corrgroups60()` and `independentlinear60()`:

# Before (broken)
old_seed = np.random.seed()   # old_seed = None; also randomises the RNG!
np.random.seed(0)

np.random.seed(old_seed)      # np.random.seed(None) — re-randomises instead of restoring

Test plan

- [ ]  tests/test_datasets.py::test_corrgroups60 2 parametrize variants pass
- [ ]  tests/test_datasets.py::test_independentlinear60 2 parametrize variants pass
- [ ]  Manual: global RNG state is now correctly preserved after both calls