### PR TITLE
DOC: complete docstring for fill_counts()

### DIFF
--- a/shap/plots/_utils.py
+++ b/shap/plots/_utils.py
@@ -188,7 +188,12 @@ def fill_internal_max_values(partition_tree, leaf_values):
 
 
 def fill_counts(partition_tree):
-    """This updates the"""
+    """Fill the fourth column of the partition tree with each cluster's leaf count.
+
+    ``partition_tree`` is updated in-place: for each internal node row ``i``,
+    ``partition_tree[i, 3]`` is set to the total number of leaves in that subtree
+    (children in columns 0 and 1 are either leaf indices or pointers to child rows).
+    """
     M = partition_tree.shape[0] + 1
     for i in range(partition_tree.shape[0]):
         val = 0


### PR DESCRIPTION
## Overview

Closes #4986

Description of the changes proposed in this pull request:

Completes the docstring for `fill_counts()` in `shap/plots/_utils.py`, which previously ended mid-sentence (`"""This updates the"""`). The new text documents that the fourth column (index 3) of the partition tree is updated **in place** with each internal node's subtree leaf count, and how child references in columns 0 and 1 are interpreted.

No runtime behavior change.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature) — *not applicable (documentation-only).*
