### PR TITLE
FIX: Improve GPU TreeExplainer parity

### DIFF
--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -76,19 +76,21 @@ void RecurseTree(
 
   // Add left split to the path
   unsigned left_child = tree.children_left[pos];
+  bool is_left_default = tree.children_default[pos] == left_child;
   double left_zero_fraction =
       tree.node_sample_weights[left_child] / tree.node_sample_weights[pos];
   // Encode the range of feature values that flow down this path
   tmp_path->emplace_back(0, tree.features[pos], 0,
-                         ShapSplitCondition{-inf, tree.thresholds[pos], false},
+                         ShapSplitCondition{-inf, tree.thresholds[pos],
+                                            is_left_default},
                          left_zero_fraction, 0.0f);
 
   RecurseTree(left_child, tree, tmp_path, paths, path_idx, num_outputs);
 
-  // Add left split to the path
+  // Add right split to the path
   tmp_path->back() = gpu_treeshap::PathElement<ShapSplitCondition>(
       0, tree.features[pos], 0,
-      ShapSplitCondition{tree.thresholds[pos], inf, false},
+      ShapSplitCondition{tree.thresholds[pos], inf, !is_left_default},
       1.0 - left_zero_fraction, 0.0f);
 
   RecurseTree(tree.children_right[pos], tree, tmp_path, paths, path_idx,

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -105,6 +105,27 @@ class GPUTreeExplainer(TreeExplainer):
 
         return out
 
+    def _get_shap_output(self, phi, flat_output):
+        """Pull off the last column of ``phi`` and keep it as our expected_value."""
+        if self.model.num_outputs == 1:
+            if self.model.model_output != "log_loss":
+                self.expected_value = phi[0, -1, 0]
+            if flat_output:
+                out = phi[0, :-1, 0]
+            else:
+                out = phi[:, :-1, 0]
+        else:
+            if self.model.model_output != "log_loss":
+                self.expected_value = [phi[0, -1, i] for i in range(phi.shape[2])]
+            if flat_output:
+                out = [phi[0, :-1, i] for i in range(self.model.num_outputs)]
+            else:
+                out = [phi[:, :-1, i] for i in range(self.model.num_outputs)]
+
+        if self.model.model_output == "probability_doubled":
+            out = [-out, out]
+        return out
+
     def shap_interaction_values(self, X, y=None, tree_limit=None):
         """Estimate the SHAP interaction values for a set of samples.
 

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -105,27 +105,6 @@ class GPUTreeExplainer(TreeExplainer):
 
         return out
 
-    def _get_shap_output(self, phi, flat_output):
-        """Pull off the last column of ``phi`` and keep it as our expected_value."""
-        if self.model.num_outputs == 1:
-            if self.model.model_output != "log_loss":
-                self.expected_value = phi[0, -1, 0]
-            if flat_output:
-                out = phi[0, :-1, 0]
-            else:
-                out = phi[:, :-1, 0]
-        else:
-            if self.model.model_output != "log_loss":
-                self.expected_value = [phi[0, -1, i] for i in range(phi.shape[2])]
-            if flat_output:
-                out = [phi[0, :-1, i] for i in range(self.model.num_outputs)]
-            else:
-                out = [phi[:, :-1, i] for i in range(self.model.num_outputs)]
-
-        if self.model.model_output == "probability_doubled":
-            out = [-out, out]
-        return out
-
     def shap_interaction_values(self, X, y=None, tree_limit=None):
         """Estimate the SHAP interaction values for a set of samples.
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -2279,8 +2279,11 @@ class XGBTreeModelLoader:
                 emsg = f"Expected the base_score to contain a list or float, received {base_score}"
                 raise ValueError(emsg) from e
         if isinstance(base_score, (list, tuple, np.ndarray)):
-            base_score = base_score[0]
-        base_score = float(base_score)
+            base_score = np.asarray(base_score, dtype=float)
+            if base_score.size == 1:
+                base_score = float(base_score[0])
+        else:
+            base_score = float(base_score)
         self.base_score = base_score
         if self.name_obj in ("binary:logistic", "reg:logistic"):
             self.base_score = scipy.special.logit(base_score)

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -105,7 +105,9 @@ def _xgboost_n_iterations(tree_limit: int, num_stacked_models: int) -> int:
 
 
 def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
-    if model.model_type == "xgboost" and model.cat_feature_indices is not None:
+    if model.model_type == "xgboost" and (
+        model.cat_feature_indices is not None or getattr(model, "_xgb_enable_categorical", False)
+    ):
         raise NotImplementedError(
             "Categorical split is not yet supported. You can still use"
             " TreeExplainer with `feature_perturbation=tree_path_dependent`."
@@ -988,6 +990,7 @@ class TreeEnsemble:
         self.tree_limit = None  # used for limiting the number of trees we use by default (like from early stopping)
         self.num_stacked_models = 1  # If this is greater than 1 it means we have multiple stacked models with the same number of trees in each model (XGBoost multi-output style)
         self.cat_feature_indices = None  # If this is set it tells us which features are treated categorically
+        self._xgb_enable_categorical = False
 
         # we use names like keras
         objective_name_map = {
@@ -1358,6 +1361,7 @@ class TreeEnsemble:
             # Some properties of the sklearn API are passed to a DMatrix object in
             # xgboost We need to make sure we do the same here - GH #3313
             self._xgb_dmatrix_props = get_xgboost_dmatrix_properties(model)
+            self._xgb_enable_categorical = bool(self._xgb_dmatrix_props.get("enable_categorical", False))
         elif safe_isinstance(model, ["xgboost.sklearn.XGBRegressor", "xgboost.sklearn.XGBRanker"]):
             self.original_model = model.get_booster()
             self._set_xgboost_model_attributes(
@@ -1369,6 +1373,7 @@ class TreeEnsemble:
             # Some properties of the sklearn API are passed to a DMatrix object in
             # xgboost We need to make sure we do the same here - GH #3313
             self._xgb_dmatrix_props = get_xgboost_dmatrix_properties(model)
+            self._xgb_enable_categorical = bool(self._xgb_dmatrix_props.get("enable_categorical", False))
         elif safe_isinstance(model, "lightgbm.basic.Booster"):
             assert_import("lightgbm")
             self.model_type = "lightgbm"

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -213,6 +213,8 @@ tasks = [
     rf_multiclass_classifier(),
 ]
 
+missing_value_tasks = tasks[:8]
+
 
 # pretty print tasks
 def idfn(task):
@@ -222,12 +224,13 @@ def idfn(task):
     return type(model).__module__ + "." + type(model).__qualname__
 
 
-@pytest.mark.parametrize("task", tasks, ids=idfn)
-@pytest.mark.parametrize("feature_perturbation", ["interventional", "tree_path_dependent"])
-def test_gpu_tree_explainer_shap(task, feature_perturbation):
-    model, X, _ = task
-    gpu_ex = shap.GPUTreeExplainer(model, X, feature_perturbation=feature_perturbation)
-    ex = shap.TreeExplainer(model, X, feature_perturbation=feature_perturbation)
+def assert_gpu_matches_cpu(task, feature_perturbation, X=None):
+    model, background, _ = task
+    if X is None:
+        X = background
+
+    gpu_ex = shap.GPUTreeExplainer(model, background, feature_perturbation=feature_perturbation)
+    ex = shap.TreeExplainer(model, background, feature_perturbation=feature_perturbation)
     host_shap = ex.shap_values(X, check_additivity=True)
     gpu_shap = gpu_ex.shap_values(X, check_additivity=True)
 
@@ -241,30 +244,20 @@ def test_gpu_tree_explainer_shap(task, feature_perturbation):
     assert np.allclose(host_shap, gpu_shap, 1e-3, 1e-3)
 
 
-def test_gpu_tree_matches_cpu_with_missing_values_and_updates_expected_value():
-    xgboost = pytest.importorskip("xgboost")
+@pytest.mark.parametrize("task", tasks, ids=idfn)
+@pytest.mark.parametrize("feature_perturbation", ["interventional", "tree_path_dependent"])
+def test_gpu_tree_explainer_shap(task, feature_perturbation):
+    assert_gpu_matches_cpu(task, feature_perturbation)
 
-    X, y = shap.datasets.diabetes()
-    model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=0)
-    model.fit(X, y)
 
-    X_nan = X.copy()
-    X_nan.loc[X_nan.sample(frac=0.1, random_state=0).index, "bmi"] = np.nan
+@pytest.mark.parametrize("task", missing_value_tasks, ids=idfn)
+@pytest.mark.parametrize("feature_perturbation", ["interventional", "tree_path_dependent"])
+def test_gpu_tree_explainer_shap_with_missing_values(task, feature_perturbation):
+    X = task[1].copy()
+    rows = np.arange(0, X.shape[0], 10)
+    X[rows, 0] = np.nan
 
-    cpu_ex = shap.TreeExplainer(model)
-    gpu_ex = shap.GPUTreeExplainer(model)
-
-    cpu_shap = cpu_ex.shap_values(X, check_additivity=True)
-    gpu_shap = gpu_ex.shap_values(X, check_additivity=True)
-
-    assert np.allclose(cpu_ex.expected_value, gpu_ex.expected_value, 1e-3, 1e-3)
-    assert np.allclose(cpu_shap, gpu_shap, 1e-3, 1e-3)
-
-    cpu_shap_nan = cpu_ex.shap_values(X_nan, check_additivity=True)
-    gpu_shap_nan = gpu_ex.shap_values(X_nan, check_additivity=True)
-
-    assert np.allclose(cpu_ex.expected_value, gpu_ex.expected_value, 1e-3, 1e-3)
-    assert np.allclose(cpu_shap_nan, gpu_shap_nan, 1e-3, 1e-3)
+    assert_gpu_matches_cpu(task, feature_perturbation, X)
 
 
 @pytest.mark.parametrize("task", tasks, ids=idfn)

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -213,9 +213,6 @@ tasks = [
     rf_multiclass_classifier(),
 ]
 
-missing_value_tasks = tasks[:8]
-
-
 # pretty print tasks
 def idfn(task):
     if isinstance(task, str):
@@ -250,14 +247,14 @@ def test_gpu_tree_explainer_shap(task, feature_perturbation):
     assert_gpu_matches_cpu(task, feature_perturbation)
 
 
-@pytest.mark.parametrize("task", missing_value_tasks, ids=idfn)
-@pytest.mark.parametrize("feature_perturbation", ["interventional", "tree_path_dependent"])
-def test_gpu_tree_explainer_shap_with_missing_values(task, feature_perturbation):
+def test_gpu_tree_explainer_shap_with_missing_values():
+    task = xgboost_base()
     X = task[1].copy()
     rows = np.arange(0, X.shape[0], 10)
     X[rows, 0] = np.nan
 
-    assert_gpu_matches_cpu(task, feature_perturbation, X)
+    for feature_perturbation in ["interventional", "tree_path_dependent"]:
+        assert_gpu_matches_cpu(task, feature_perturbation, X)
 
 
 @pytest.mark.parametrize("task", tasks, ids=idfn)

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -241,6 +241,32 @@ def test_gpu_tree_explainer_shap(task, feature_perturbation):
     assert np.allclose(host_shap, gpu_shap, 1e-3, 1e-3)
 
 
+def test_gpu_tree_matches_cpu_with_missing_values_and_updates_expected_value():
+    xgboost = pytest.importorskip("xgboost")
+
+    X, y = shap.datasets.diabetes()
+    model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=0)
+    model.fit(X, y)
+
+    X_nan = X.copy()
+    X_nan.loc[X_nan.sample(frac=0.1, random_state=0).index, "bmi"] = np.nan
+
+    cpu_ex = shap.TreeExplainer(model)
+    gpu_ex = shap.GPUTreeExplainer(model)
+
+    cpu_shap = cpu_ex.shap_values(X, check_additivity=True)
+    gpu_shap = gpu_ex.shap_values(X, check_additivity=True)
+
+    assert np.allclose(cpu_ex.expected_value, gpu_ex.expected_value, 1e-3, 1e-3)
+    assert np.allclose(cpu_shap, gpu_shap, 1e-3, 1e-3)
+
+    cpu_shap_nan = cpu_ex.shap_values(X_nan, check_additivity=True)
+    gpu_shap_nan = gpu_ex.shap_values(X_nan, check_additivity=True)
+
+    assert np.allclose(cpu_ex.expected_value, gpu_ex.expected_value, 1e-3, 1e-3)
+    assert np.allclose(cpu_shap_nan, gpu_shap_nan, 1e-3, 1e-3)
+
+
 @pytest.mark.parametrize("task", tasks, ids=idfn)
 @pytest.mark.parametrize("feature_perturbation", ["tree_path_dependent"])
 def test_gpu_tree_explainer_shap_interactions(task, feature_perturbation):

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -213,6 +213,7 @@ tasks = [
     rf_multiclass_classifier(),
 ]
 
+
 # pretty print tasks
 def idfn(task):
     if isinstance(task, str):


### PR DESCRIPTION
## Overview

Part of https://github.com/shap/shap/issues/4182

Description of the changes proposed in this pull request:

This fixes GPU TreeExplainer parity issues around missing values and XGBoost model metadata:

- Preserve XGBoost default/missing child routing when extracting paths for GPU TreeSHAP, so NaN values follow the same branch as the source model.
- Preserve vector-valued XGBoost `base_score` values instead of collapsing them to the first class, fixing multiclass additivity offsets.
- Tighten XGBoost categorical handling so sklearn models with `enable_categorical=True` raise the existing unsupported-categorical error even when the booster does not expose `feature_types`.
- Add focused GPU TreeExplainer parity coverage for NaN inputs.
- Remove a duplicate GPU SHAP output helper after the shared TreeExplainer output handling became sufficient.

Local verification:

- `pre-commit run --files shap/cext/_cext_gpu.cu shap/explainers/_tree.py tests/explainers/test_gpu_tree.py`
- `tests/explainers/test_gpu_tree.py`: `36 passed, 2 xfailed`

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
