### PR TITLE
FIX: Resolve ambiguous truth value error in potential_interactions

### DIFF
--- a/shap/utils/_general.py
+++ b/shap/utils/_general.py
@@ -77,7 +77,7 @@ def potential_interactions(shap_values_column: Any, shap_values_matrix: Any) -> 
     index values for SHAP see the interaction_contribs option implemented in XGBoost.
     """
     # ignore inds that are identical to the column
-    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)
+    ignore_inds = np.where((shap_values_matrix.values.T - shap_values_column.values).T.std(0) < 1e-8)[0]
 
     X = shap_values_matrix.data
 


### PR DESCRIPTION
### Description
Closes #2262.

### What does this PR do?
Resolves a ValueError: The truth value of an array with more than one element is ambiguous inside `shap.utils.potential_interactions`.

### Root Cause & Fix
`np.where()` returns a tuple of arrays. When the variance check resulted in multiple columns being ignored, `ignore_inds` contained a tuple with an array of multiple elements. The subsequent `i in ignore_inds` check caused NumPy to fail when comparing the integer i to the multi-element array.

Appending [0] to the `np.where()` call extracts the 1D array of indices, allowing standard Python iteration and in checks to function correctly.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
- [x] I have read `CONTRIBUTING.md`
- [x] pytest tests pass locally

AI Usage: No AI agent was used for generating code. 