### PR TITLE
DOCS: Clarify Explanation array dimensions and TreeExplainer slicing for scikit-learn classifiers

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -107,12 +107,12 @@ class Explanation(metaclass=MetaExplanation):
     Attributes
     ----------
     values : numpy.ndarray
-        The SHAP values. For regression or single-output models, this is a 2D array 
-        of shape `(n_samples, n_features)`. For multi-output models (such as 
-        scikit-learn classifiers), this is a 3D array of shape 
+        The SHAP values. For regression or single-output models, this is a 2D array
+        of shape `(n_samples, n_features)`. For multi-output models (such as
+        scikit-learn classifiers), this is a 3D array of shape
         `(n_samples, n_features, n_classes)`.
     base_values : numpy.ndarray
-        The expected value of the model output (the average prediction over the 
+        The expected value of the model output (the average prediction over the
         background dataset).
     data : numpy.ndarray
         The original input features used to compute the SHAP values.

--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -103,6 +103,19 @@ class Explanation(metaclass=MetaExplanation):
 
     The *class* methods such as `Explanation.max` return OpChain objects that represent
     a set of dot chained operations without actually running them.
+
+    Attributes
+    ----------
+    values : numpy.ndarray
+        The SHAP values. For regression or single-output models, this is a 2D array 
+        of shape `(n_samples, n_features)`. For multi-output models (such as 
+        scikit-learn classifiers), this is a 3D array of shape 
+        `(n_samples, n_features, n_classes)`.
+    base_values : numpy.ndarray
+        The expected value of the model output (the average prediction over the 
+        background dataset).
+    data : numpy.ndarray
+        The original input features used to compute the SHAP values.
     """
 
     def __init__(

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -375,7 +375,26 @@ class TreeExplainer(Explainer):
 
         Returns
         -------
-            shap.Explanation object containing the given data and the SHAP values.
+        Explanation
+            A `shap.Explanation` object containing the computed SHAP values, base values, 
+            and the original data. For multi-output models (like scikit-learn classifiers), 
+            the Explanation values will be 3-dimensional.
+
+        Examples
+        --------
+        Explaining a scikit-learn Random Forest classifier and plotting a waterfall 
+        plot for the positive class:
+
+        >>> import shap
+        >>> import sklearn
+        >>> X, y = shap.datasets.iris()
+        >>> y[y == 2] = 1 # make binary
+        >>> model = sklearn.ensemble.RandomForestClassifier(random_state=0).fit(X, y)
+        >>> explainer = shap.TreeExplainer(model)
+        >>> shap_values = explainer(X)
+        >>> # scikit-learn classifiers output probabilities for both classes. 
+        >>> # Slice the explanation to plot sample 0, all features, and the positive class (1):
+        >>> shap.plots.waterfall(shap_values[0, :, 1])
         """
         start_time = time.time()
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -376,13 +376,13 @@ class TreeExplainer(Explainer):
         Returns
         -------
         Explanation
-            A `shap.Explanation` object containing the computed SHAP values, base values, 
-            and the original data. For multi-output models (like scikit-learn classifiers), 
+            A `shap.Explanation` object containing the computed SHAP values, base values,
+            and the original data. For multi-output models (like scikit-learn classifiers),
             the Explanation values will be 3-dimensional.
 
         Examples
         --------
-        Explaining a scikit-learn Random Forest classifier and plotting a waterfall 
+        Explaining a scikit-learn Random Forest classifier and plotting a waterfall
         plot for the positive class:
 
         >>> import shap
@@ -392,7 +392,7 @@ class TreeExplainer(Explainer):
         >>> model = sklearn.ensemble.RandomForestClassifier(random_state=0).fit(X, y)
         >>> explainer = shap.TreeExplainer(model)
         >>> shap_values = explainer(X)
-        >>> # scikit-learn classifiers output probabilities for both classes. 
+        >>> # scikit-learn classifiers output probabilities for both classes.
         >>> # Slice the explanation to plot sample 0, all features, and the positive class (1):
         >>> shap.plots.waterfall(shap_values[0, :, 1])
         """


### PR DESCRIPTION
## Overview
Closes #2268.

Description of the changes proposed in this pull request:
Users frequently encounter a `ValueError` when passing scikit-learn classifier outputs directly into `shap.plots.waterfall`, because `sklearn` classifiers return probabilities for both classes, resulting in a 3D Explanation object `(n_samples, n_features, n_classes)`.

This PR updates the docstrings to prevent this confusion:

1. `shap/_explanation.py`: Explicitly defines the dimensions of the `values` attribute for both single-output and multi-output models.
2. `shap/explainers/_tree.py`: Documents that calling the explainer returns an `Explanation` object and adds a concrete code example demonstrating how to slice a binary `sklearn` classifier's SHAP values `(shap_values[0, :, 1])` for use in a waterfall plot.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] I have read `CONTRIBUTING.md`.
- [ ] Unit tests added (if fixing a bug or adding a new feature)

AI Usage: I read the complete discussion in issue #2268 and explained it to the coding assistant, it generated refined text documentation.
