### PR TITLE
FIX: Prevent IndexError by unpacking 3D multi-class Explanations in bar plots

### DIFF
--- a/shap/plots/_bar.py
+++ b/shap/plots/_bar.py
@@ -78,7 +78,14 @@ def bar(
     style = get_style()
     # convert Explanation objects to dictionaries
     if isinstance(shap_values, Explanation):
-        cohorts = {"": shap_values}
+        if len(shap_values.shape) == 3:
+            # Unpack 3D multi-class explanations into a dictionary of 2D cohorts
+            cohort_names = getattr(shap_values, "output_names", None)
+            if cohort_names is None:
+                cohort_names = [f"Class {i}" for i in range(shap_values.shape[2])]
+            cohorts = {str(cohort_names[i]): shap_values[:, :, i] for i in range(shap_values.shape[2])}
+        else:
+            cohorts = {"": shap_values}
     elif isinstance(shap_values, Cohorts):
         cohorts = shap_values.cohorts
     elif isinstance(shap_values, dict):


### PR DESCRIPTION
## Overview

Closes #2238, Closes #1906, Closes #1865.

## Description:
When plotting multi-class data (e.g., from `RandomForestClassifier` or `CatBoostClassifier`), `shap.plots.bar` throws an `IndexError`.

This occurs because the function expects 1D or 2D Explanation arrays. When passed a 3D array `(samples, features, classes)`, it bypasses the if `len(exp.shape) == 2`: averaging logic. This causes the downstream rendering loops to misinterpret the sample axis as the feature axis, resulting in massive out-of-bounds index errors when attempting to fetch feature names.

This PR intercepts 3D Explanations at the top of the function and unpacks them into a dictionary of 2D cohorts (one for each class). This seamlessly integrates with the existing multi-cohort rendering logic, allowing the plot to generate grouped bars for multi-class models as intended.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] I have read CONTRIBUTING.md
- [ ] Unit tests added (if fixing a bug or adding a new feature)
