### PR TITLE
docs: update Explainer algorithm docstring to match implemented algorithms

### DIFF
--- a/shap/explainers/_explainer.py
+++ b/shap/explainers/_explainer.py
@@ -74,7 +74,7 @@ class Explainer(Serializable):
             units. For more details on how link functions work see any overview of link functions for generalized
             linear models.
 
-        algorithm : "auto", "permutation", "partition", "tree", or "linear"
+        algorithm : "auto", "permutation", "partition", "tree", "linear", "deep", "exact", or "additive"
             The algorithm used to estimate the Shapley values. There are many different algorithms that
             can be used to estimate the Shapley values (and the related value for constrained games), each
             of these algorithms have various tradeoffs and are preferable in different situations. By


### PR DESCRIPTION
Fixes #1597

The docstring for the `Explainer` class `algorithm` parameter was outdated and did not accurately reflect the algorithms currently implemented in the codebase. 

This PR updates the docstring to match the algorithms that are actively supported and initialized in the `__init__` method (`"auto", "permutation", "partition", "tree", "linear", "deep", "exact", "additive"`).