### PR TITLE
BUG: Fix global NumPy RNG state corruption in corrgroups60 and independentlinear60

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -528,7 +528,7 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
 
     """
     # set a constant seed
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -564,7 +564,7 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
     y = f(X) + np.random.randn(N) * 1e-2
 
     # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 
@@ -599,7 +599,7 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
 
     """
     # set a constant seed
-    old_seed = np.random.seed()
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -618,7 +618,7 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
     y = f(X) + np.random.randn(N) * 1e-2
 
     # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,6 @@
 """This file contains tests for the `shap.datasets` module."""
 
+import numpy as np
 import pytest
 
 import shap
@@ -146,3 +147,32 @@ def test_rank():
     assert y2.shape == (768,)
     assert q1.shape == (201,)
     assert q2.shape == (50,)
+
+
+def test_rng_preservation():
+    """Test that corrgroups60 and independentlinear60 do not corrupt the global numpy random state."""
+    # Set a specific seed and capture state
+    np.random.seed(42)
+    state_before = np.random.get_state()
+
+    # Call corrgroups60
+    shap.datasets.corrgroups60(n_points=100)
+    state_after_corrgroups = np.random.get_state()
+
+    # Assert state is identical
+    for a, b in zip(state_before, state_after_corrgroups):
+        if isinstance(a, np.ndarray):
+            assert np.array_equal(a, b)
+        else:
+            assert a == b
+
+    # Call independentlinear60
+    shap.datasets.independentlinear60(n_points=100)
+    state_after_independent = np.random.get_state()
+
+    # Assert state is identical
+    for a, b in zip(state_before, state_after_independent):
+        if isinstance(a, np.ndarray):
+            assert np.array_equal(a, b)
+        else:
+            assert a == b


### PR DESCRIPTION
### Summary
This PR fixes **Issue #4988**: `BUG: corrgroups60() and independentlinear60() silently corrupt global NumPy RNG state`.

### Cause of the bug
In `shap/datasets.py`, the functions `corrgroups60()` and `independentlinear60()` attempt to preserve the user's random seed/state across the generation by saving and restoring it:
```python
    # set a constant seed
    old_seed = np.random.seed()
    np.random.seed(0)
    ...
    # restore the previous numpy random seed
    np.random.seed(old_seed)
```
However, calling `np.random.seed()` (with no arguments) does not return the current state or seed; it sets the random seed to a new random value and returns `None`. Consequently, `old_seed` is always `None`.
Later, when calling `np.random.seed(old_seed)` (which evaluates to `np.random.seed(None)`), it completely re-initializes and re-randomizes the global random state from the operating system's source of entropy, destroying the original global NumPy RNG state.

### Solution
Instead of saving and restoring the seed with `np.random.seed(old_seed)`, we capture and restore the actual NumPy global random generator state using:
```python
    # set a constant seed
    old_state = np.random.get_state()
    np.random.seed(0)
    ...
    # restore the previous numpy random seed
    np.random.set_state(old_state)
```
This is the standard and correct way to preserve global NumPy random states.

### Testing
- Added `test_rng_preservation()` in `tests/test_datasets.py` which explicitly asserts that the global numpy random state is identical before and after calling both functions.
- Verified that all unit tests under `tests/test_datasets.py` pass successfully.