### PR TITLE
BUG: Fix feature_names corruption when slicing Explanation with 2D output_names

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -322,6 +322,7 @@ class Explanation(metaclass=MetaExplanation):
 
         # convert any OpChains or magic strings
         pos = -1
+        manually_handled_indices = set()
         for t in item:
             pos += 1
 
@@ -367,7 +368,7 @@ class Explanation(metaclass=MetaExplanation):
                             data=np.array(new_data),
                             display_data=self.display_data,
                             instance_names=self.instance_names,
-                            feature_names=np.array(new_data),  # FIXME: this is probably a bug
+                            feature_names=self.feature_names,
                             output_names=t,
                             output_indexes=self.output_indexes,
                             lower_bounds=self.lower_bounds,
@@ -378,6 +379,7 @@ class Explanation(metaclass=MetaExplanation):
                             clustering=self.clustering,
                         )
                         new_self.op_history = copy.copy(self.op_history)
+                        manually_handled_indices.add(pos)
                         # new_self = copy.deepcopy(self)
                         # new_self.values = np.array(new_values)
                         # new_self.base_values = np.array(new_base_values)
@@ -404,6 +406,7 @@ class Explanation(metaclass=MetaExplanation):
                     new_self.feature_names = t
                     new_self.clustering = None
                     # return new_self
+                    manually_handled_indices.add(pos)
 
             if isinstance(t, (np.int8, np.int16, np.int32, np.int64)):
                 t = int(t)
@@ -414,7 +417,7 @@ class Explanation(metaclass=MetaExplanation):
                 item = tuple(tmp)
 
         # call slicer for the real work
-        item = tuple(v for v in item)  # SML I cut out: `if not isinstance(v, str)`
+        item = tuple(v for idx, v in enumerate(item) if idx not in manually_handled_indices)
         if len(item) == 0:
             return new_self  # type: ignore
         if new_self is None:

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,22 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+def test_feature_names_preservation_when_slicing_with_2d_output_names(random_seed):
+    """Checks that slicing an Explanation by a 2D output_names string preserves original feature_names."""
+    rs = np.random.RandomState(random_seed)
+    n_instances, n_features, n_outputs = 3, 4, 2
+    featnames = ["feat_a", "feat_b", "feat_c", "feat_d"]
+    outnames = np.array([["out_x", "out_y"]] * n_instances)
+
+    exp = shap.Explanation(
+        values=rs.randn(n_instances, n_features, n_outputs),
+        base_values=rs.randn(n_instances, n_outputs),
+        data=rs.randn(n_instances, n_features),
+        feature_names=featnames,
+        output_names=outnames,
+    )
+
+    sliced = exp[:, :, "out_x"]
+    assert list(sliced.feature_names) == featnames


### PR DESCRIPTION
### Summary
This PR fixes **Issue #4982**: `BUG: feature_names set to data values instead of feature names when slicing Explanation with 2D output_names`.

### Cause of the bug
When slicing a 3D `Explanation` (e.g. `instances` × `features` × `outputs`) by a string output name when the explanation has per-instance (2D) `output_names`, the slice is handled manually inside `Explanation.__getitem__` around line 370.
However:
1. The constructor is called with `feature_names=np.array(new_data)`. Since `new_data` contains the raw numeric data values for each instance, this completely overwrites the original string `feature_names` with the numeric features data, causing downstream plots to use the raw numeric values as feature labels.
2. In addition, the slicer `__getitem__` is subsequently called with the original `item` tuple, which still contains the string output name. This causes an `IndexError: too many indices for array` when the string index was not converted to an integer and the sliced `new_self` is already 2D instead of 3D.

### Solution
1. Changed `feature_names=np.array(new_data)` to `feature_names=self.feature_names` in the 2D `output_names` slice constructor, which correctly preserves the original string feature names of the features dimension.
2. Kept track of `manually_handled_indices` in the slice loop, and filtered them out from the `item` tuple before passing it to `new_self._s.__getitem__(item)`. This ensures that only the remaining dimensions (such as instances or features) are sliced, and prevents `IndexError` when slicing with 2D outputs or features.

### Testing
- Added `test_feature_names_preservation_when_slicing_with_2d_output_names` under `tests/test_explanation.py` to verify that slicing a 3D explanation by a 2D output_name successfully preserves original feature names.
- Confirmed that all 15 tests in `tests/test_explanation.py` pass successfully.