### PR TITLE
Support LightGBM categorical GPU TreeSHAP

### DIFF
--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -5,13 +5,77 @@
 
 const float inf = std::numeric_limits<tfloat>::infinity();
 
+struct CategoryConstraint {
+  CategoryConstraint() = default;
+
+  __host__ __device__ static CategoryConstraint All() {
+    return CategoryConstraint{};
+  }
+
+  __host__ __device__ static CategoryConstraint Include(int categories) {
+    CategoryConstraint constraint;
+    constraint.has_include_categories = true;
+    constraint.include_categories = categories;
+    return constraint;
+  }
+
+  __host__ __device__ static CategoryConstraint Exclude(int categories) {
+    CategoryConstraint constraint;
+    constraint.exclude_categories = categories;
+    return constraint;
+  }
+
+  __host__ __device__ static bool CategoryInMask(int categories,
+                                                 float category) {
+    int category_int = static_cast<int>(category);
+    if (category_int < 1) {
+      return false;
+    }
+    int category_flag = 1 << (category_int - 1);
+    return (categories & category_flag) != 0;
+  }
+
+  __host__ __device__ bool Contains(float category) const {
+    bool included = !has_include_categories ||
+                    CategoryInMask(include_categories, category);
+    return included && !CategoryInMask(exclude_categories, category);
+  }
+
+  __host__ __device__ void Intersect(const CategoryConstraint &other) {
+    if (other.has_include_categories) {
+      include_categories = has_include_categories
+                               ? include_categories & other.include_categories
+                               : other.include_categories;
+      has_include_categories = true;
+    }
+    exclude_categories |= other.exclude_categories;
+    if (has_include_categories) {
+      include_categories &= ~exclude_categories;
+    }
+  }
+
+  bool has_include_categories = false;
+  int include_categories = 0;
+  int exclude_categories = 0;
+};
+
 struct ShapSplitCondition {
   ShapSplitCondition() = default;
   ShapSplitCondition(tfloat feature_lower_bound, tfloat feature_upper_bound,
                      bool is_missing_branch)
       : feature_lower_bound(feature_lower_bound),
         feature_upper_bound(feature_upper_bound),
-        is_missing_branch(is_missing_branch) {
+        is_missing_branch(is_missing_branch),
+        categories(CategoryConstraint::All()) {
+    assert(feature_lower_bound <= feature_upper_bound);
+  }
+  ShapSplitCondition(tfloat feature_lower_bound, tfloat feature_upper_bound,
+                     bool is_missing_branch,
+                     CategoryConstraint category_constraint)
+      : feature_lower_bound(feature_lower_bound),
+        feature_upper_bound(feature_upper_bound),
+        is_missing_branch(is_missing_branch),
+        categories(category_constraint) {
     assert(feature_lower_bound <= feature_upper_bound);
   }
 
@@ -20,12 +84,16 @@ struct ShapSplitCondition {
   tfloat feature_upper_bound;
   /*! Do missing values flow down this path? */
   bool is_missing_branch;
+  CategoryConstraint categories;
 
   // Does this instance flow down this path?
   __host__ __device__ bool EvaluateSplit(float x) const {
     // is nan
     if (isnan(x)) {
       return is_missing_branch;
+    }
+    if (!categories.Contains(x)) {
+      return false;
     }
     return x > feature_lower_bound && x <= feature_upper_bound;
   }
@@ -35,6 +103,7 @@ struct ShapSplitCondition {
   Merge(const ShapSplitCondition &other) {  // Combine duplicate features
     feature_lower_bound = max(feature_lower_bound, other.feature_lower_bound);
     feature_upper_bound = min(feature_upper_bound, other.feature_upper_bound);
+    categories.Intersect(other.categories);
     is_missing_branch = is_missing_branch && other.is_missing_branch;
   }
 };
@@ -74,23 +143,34 @@ void RecurseTree(
     return;
   }
 
-  // Add left split to the path
   unsigned left_child = tree.children_left[pos];
   bool is_left_default = tree.children_default[pos] == left_child;
   double left_zero_fraction =
       tree.node_sample_weights[left_child] / tree.node_sample_weights[pos];
-  // Encode the range of feature values that flow down this path
-  tmp_path->emplace_back(0, tree.features[pos], 0,
-                         ShapSplitCondition{-inf, tree.thresholds[pos],
-                                            is_left_default},
+  auto threshold_type = tree.threshold_types[pos];
+  auto threshold = tree.thresholds[pos];
+
+  ShapSplitCondition left_condition{-inf, threshold, is_left_default};
+  ShapSplitCondition right_condition{threshold, inf, !is_left_default};
+  if (threshold_type == 1) {
+    int categories = static_cast<int>(threshold);
+    left_condition =
+        ShapSplitCondition{-inf, inf, is_left_default,
+                           CategoryConstraint::Include(categories)};
+    right_condition =
+        ShapSplitCondition{-inf, inf, !is_left_default,
+                           CategoryConstraint::Exclude(categories)};
+  }
+
+  // Add left split to the path
+  tmp_path->emplace_back(0, tree.features[pos], 0, left_condition,
                          left_zero_fraction, 0.0f);
 
   RecurseTree(left_child, tree, tmp_path, paths, path_idx, num_outputs);
 
   // Add right split to the path
   tmp_path->back() = gpu_treeshap::PathElement<ShapSplitCondition>(
-      0, tree.features[pos], 0,
-      ShapSplitCondition{tree.thresholds[pos], inf, !is_left_default},
+      0, tree.features[pos], 0, right_condition,
       1.0 - left_zero_fraction, 0.0f);
 
   RecurseTree(tree.children_right[pos], tree, tmp_path, paths, path_idx,
@@ -322,19 +402,6 @@ void dense_tree_shap_gpu(const TreeEnsemble &trees,
                          const ExplanationDataset &data, tfloat *out_contribs,
                          const int feature_dependence, unsigned model_transform,
                          bool interactions) {
-  // Check for categorical features
-  bool has_categorical = false;
-  for (unsigned i = 0; i < trees.tree_limit * trees.max_nodes; i++) {
-    if (trees.threshold_types[i] != 0) {
-      has_categorical = true;
-      break;
-    }
-  }
-  if (has_categorical) {
-    std::cerr << "Warning: Categorical features detected. GPU TreeSHAP currently "
-                 "only supports numerical features. Results may be incorrect.\n";
-  }
-
   // see what transform (if any) we have
   transform_f transform = get_transform(model_transform);
 

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -268,7 +268,6 @@ def test_gpu_tree_explainer_shap_interactions(task, feature_perturbation):
     assert np.allclose(np.sum(shap_values, axis=(1, 2)) + ex.expected_value, margin, atol=1e-4)
 
 
-@pytest.mark.xfail(reason="Categorical features not correctly implemented for GPU TreeSHAP")
 @pytest.mark.parametrize("use_interactions", [False, True])
 def test_lightgbm_categorical_split(use_interactions):
     # GH 480
@@ -291,17 +290,10 @@ def test_lightgbm_categorical_split(use_interactions):
 
     explainer = shap.GPUTreeExplainer(model)
 
-    # Check that the warning is issued
-    with pytest.warns(
-        UserWarning,
-        match="Categorical features detected. GPU TreeSHAP currently only supports numerical features. Results may be incorrect.",
-    ):
-        if use_interactions:
-            # Check SHAP interaction values sum to model output
-            shap_interaction_values = explainer.shap_interaction_values(X.iloc[:10, :])
-            assert np.allclose(
-                shap_interaction_values.sum(axis=(1, 2)) + explainer.expected_value, preds[:10], atol=1e-4
-            )
-        else:
-            shap_values = explainer.shap_values(X.iloc[:10, :])
-            assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)
+    if use_interactions:
+        # Check SHAP interaction values sum to model output
+        shap_interaction_values = explainer.shap_interaction_values(X.iloc[:10, :])
+        assert np.allclose(shap_interaction_values.sum(axis=(1, 2)) + explainer.expected_value, preds[:10], atol=1e-4)
+    else:
+        shap_values = explainer.shap_values(X.iloc[:10, :])
+        assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)


### PR DESCRIPTION
## Overview

Part of #4182

Description of the changes proposed in this pull request:

This adds LightGBM categorical split support to `GPUTreeExplainer`.

Previously, the GPU TreeSHAP path extraction ignored `threshold_types` and treated LightGBM categorical bitmasks as numeric thresholds. That caused incorrect path conditions and additivity failures for LightGBM models with categorical splits.

This PR:

- Adds a small `CategoryConstraint` helper for GPU path conditions.
- Evaluates LightGBM categorical splits using the existing SHAP bitmask representation.
- Correctly merges repeated categorical constraints on the same feature during GPU TreeSHAP path deduplication.
- Removes the old warning that GPU TreeSHAP only supports numerical features.
- Converts the existing LightGBM categorical xfail test into a passing regression test for both SHAP values and interaction values.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)

Tested locally:

- `SHAP_ENABLE_CUDA=1 python -m pip wheel . --no-build-isolation --no-deps -w /tmp/shap-wheel`
- `pytest -o addopts='' tests/explainers/test_gpu_tree.py::test_lightgbm_categorical_split -q`
- `pytest -o addopts='' tests/explainers/test_gpu_tree.py -q`

Results:

- `test_lightgbm_categorical_split`: `2 passed`
- `tests/explainers/test_gpu_tree.py`: `38 passed`
- `pre-commit run --files shap/cext/_cext_gpu.cu tests/explainers/test_gpu_tree.py`: passed