### PR TITLE
Use TreeEnsemble directly in TreeExplainer and add cpu gpu equivalence tests for categories

### DIFF
--- a/shap/cext/_cext_gpu.cu
+++ b/shap/cext/_cext_gpu.cu
@@ -5,13 +5,77 @@
 
 const float inf = std::numeric_limits<tfloat>::infinity();
 
+struct CategoryConstraint {
+  CategoryConstraint() = default;
+
+  __host__ __device__ static CategoryConstraint All() {
+    return CategoryConstraint{};
+  }
+
+  __host__ __device__ static CategoryConstraint Include(int categories) {
+    CategoryConstraint constraint;
+    constraint.has_include_categories = true;
+    constraint.include_categories = categories;
+    return constraint;
+  }
+
+  __host__ __device__ static CategoryConstraint Exclude(int categories) {
+    CategoryConstraint constraint;
+    constraint.exclude_categories = categories;
+    return constraint;
+  }
+
+  __host__ __device__ static bool CategoryInMask(int categories,
+                                                 float category) {
+    int category_int = static_cast<int>(category);
+    if (category_int < 1) {
+      return false;
+    }
+    int category_flag = 1 << (category_int - 1);
+    return (categories & category_flag) != 0;
+  }
+
+  __host__ __device__ bool Contains(float category) const {
+    bool included = !has_include_categories ||
+                    CategoryInMask(include_categories, category);
+    return included && !CategoryInMask(exclude_categories, category);
+  }
+
+  __host__ __device__ void Intersect(const CategoryConstraint &other) {
+    if (other.has_include_categories) {
+      include_categories = has_include_categories
+                               ? include_categories & other.include_categories
+                               : other.include_categories;
+      has_include_categories = true;
+    }
+    exclude_categories |= other.exclude_categories;
+    if (has_include_categories) {
+      include_categories &= ~exclude_categories;
+    }
+  }
+
+  bool has_include_categories = false;
+  int include_categories = 0;
+  int exclude_categories = 0;
+};
+
 struct ShapSplitCondition {
   ShapSplitCondition() = default;
   ShapSplitCondition(tfloat feature_lower_bound, tfloat feature_upper_bound,
                      bool is_missing_branch)
       : feature_lower_bound(feature_lower_bound),
         feature_upper_bound(feature_upper_bound),
-        is_missing_branch(is_missing_branch) {
+        is_missing_branch(is_missing_branch),
+        categories(CategoryConstraint::All()) {
+    assert(feature_lower_bound <= feature_upper_bound);
+  }
+  ShapSplitCondition(tfloat feature_lower_bound, tfloat feature_upper_bound,
+                     bool is_missing_branch,
+                     CategoryConstraint category_constraint)
+      : feature_lower_bound(feature_lower_bound),
+        feature_upper_bound(feature_upper_bound),
+        is_missing_branch(is_missing_branch),
+        categories(category_constraint) {
     assert(feature_lower_bound <= feature_upper_bound);
   }
 
@@ -20,12 +84,16 @@ struct ShapSplitCondition {
   tfloat feature_upper_bound;
   /*! Do missing values flow down this path? */
   bool is_missing_branch;
+  CategoryConstraint categories;
 
   // Does this instance flow down this path?
   __host__ __device__ bool EvaluateSplit(float x) const {
     // is nan
     if (isnan(x)) {
       return is_missing_branch;
+    }
+    if (!categories.Contains(x)) {
+      return false;
     }
     return x > feature_lower_bound && x <= feature_upper_bound;
   }
@@ -35,6 +103,7 @@ struct ShapSplitCondition {
   Merge(const ShapSplitCondition &other) {  // Combine duplicate features
     feature_lower_bound = max(feature_lower_bound, other.feature_lower_bound);
     feature_upper_bound = min(feature_upper_bound, other.feature_upper_bound);
+    categories.Intersect(other.categories);
     is_missing_branch = is_missing_branch && other.is_missing_branch;
   }
 };
@@ -74,23 +143,34 @@ void RecurseTree(
     return;
   }
 
-  // Add left split to the path
   unsigned left_child = tree.children_left[pos];
   bool is_left_default = tree.children_default[pos] == left_child;
   double left_zero_fraction =
       tree.node_sample_weights[left_child] / tree.node_sample_weights[pos];
-  // Encode the range of feature values that flow down this path
-  tmp_path->emplace_back(0, tree.features[pos], 0,
-                         ShapSplitCondition{-inf, tree.thresholds[pos],
-                                            is_left_default},
+  auto threshold_type = tree.threshold_types[pos];
+  auto threshold = tree.thresholds[pos];
+
+  ShapSplitCondition left_condition{-inf, threshold, is_left_default};
+  ShapSplitCondition right_condition{threshold, inf, !is_left_default};
+  if (threshold_type == 1) {
+    int categories = static_cast<int>(threshold);
+    left_condition =
+        ShapSplitCondition{-inf, inf, is_left_default,
+                           CategoryConstraint::Include(categories)};
+    right_condition =
+        ShapSplitCondition{-inf, inf, !is_left_default,
+                           CategoryConstraint::Exclude(categories)};
+  }
+
+  // Add left split to the path
+  tmp_path->emplace_back(0, tree.features[pos], 0, left_condition,
                          left_zero_fraction, 0.0f);
 
   RecurseTree(left_child, tree, tmp_path, paths, path_idx, num_outputs);
 
   // Add right split to the path
   tmp_path->back() = gpu_treeshap::PathElement<ShapSplitCondition>(
-      0, tree.features[pos], 0,
-      ShapSplitCondition{tree.thresholds[pos], inf, !is_left_default},
+      0, tree.features[pos], 0, right_condition,
       1.0 - left_zero_fraction, 0.0f);
 
   RecurseTree(tree.children_right[pos], tree, tmp_path, paths, path_idx,
@@ -322,19 +402,6 @@ void dense_tree_shap_gpu(const TreeEnsemble &trees,
                          const ExplanationDataset &data, tfloat *out_contribs,
                          const int feature_dependence, unsigned model_transform,
                          bool interactions) {
-  // Check for categorical features
-  bool has_categorical = false;
-  for (unsigned i = 0; i < trees.tree_limit * trees.max_nodes; i++) {
-    if (trees.threshold_types[i] != 0) {
-      has_categorical = true;
-      break;
-    }
-  }
-  if (has_categorical) {
-    std::cerr << "Warning: Categorical features detected. GPU TreeSHAP currently "
-                 "only supports numerical features. Results may be incorrect.\n";
-  }
-
   // see what transform (if any) we have
   transform_f transform = get_transform(model_transform);
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -286,7 +286,14 @@ class TreeExplainer(Explainer):
         self.data_missing = None if self.data is None else pd.isna(self.data)
         self.feature_perturbation = feature_perturbation
         self.expected_value = None
-        self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
+        if isinstance(model, TreeEnsemble):
+            # Allow passing a pre-built TreeEnsemble directly. This makes it possible
+            # to construct trees by hand (e.g. with categorical splits, which the
+            # third-party model parsers are needed for otherwise) and explain them
+            # without round-tripping through an external model object.
+            self.model = model
+        else:
+            self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
         self.model_output = model_output
         # self.model_output = self.model.model_output # this allows the TreeEnsemble to translate model outputs types by how it loads the model
 

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -268,7 +268,6 @@ def test_gpu_tree_explainer_shap_interactions(task, feature_perturbation):
     assert np.allclose(np.sum(shap_values, axis=(1, 2)) + ex.expected_value, margin, atol=1e-4)
 
 
-@pytest.mark.xfail(reason="Categorical features not correctly implemented for GPU TreeSHAP")
 @pytest.mark.parametrize("use_interactions", [False, True])
 def test_lightgbm_categorical_split(use_interactions):
     # GH 480
@@ -291,17 +290,10 @@ def test_lightgbm_categorical_split(use_interactions):
 
     explainer = shap.GPUTreeExplainer(model)
 
-    # Check that the warning is issued
-    with pytest.warns(
-        UserWarning,
-        match="Categorical features detected. GPU TreeSHAP currently only supports numerical features. Results may be incorrect.",
-    ):
-        if use_interactions:
-            # Check SHAP interaction values sum to model output
-            shap_interaction_values = explainer.shap_interaction_values(X.iloc[:10, :])
-            assert np.allclose(
-                shap_interaction_values.sum(axis=(1, 2)) + explainer.expected_value, preds[:10], atol=1e-4
-            )
-        else:
-            shap_values = explainer.shap_values(X.iloc[:10, :])
-            assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)
+    if use_interactions:
+        # Check SHAP interaction values sum to model output
+        shap_interaction_values = explainer.shap_interaction_values(X.iloc[:10, :])
+        assert np.allclose(shap_interaction_values.sum(axis=(1, 2)) + explainer.expected_value, preds[:10], atol=1e-4)
+    else:
+        shap_values = explainer.shap_values(X.iloc[:10, :])
+        assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -6,6 +6,7 @@ import pytest
 import sklearn
 
 import shap
+from shap.explainers._tree import SingleTree, TreeEnsemble
 from shap.utils import assert_import
 
 try:
@@ -297,3 +298,88 @@ def test_lightgbm_categorical_split(use_interactions):
     else:
         shap_values = explainer.shap_values(X.iloc[:10, :])
         assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)
+
+
+def test_categorical_split_cpu_gpu_equivalence():
+    """
+    Check consistency with a dummy tree that a single categorical split yields the same results on GPU and CPU.
+    """
+    tree = {
+        "children_left": np.array([1, -1, -1], dtype=np.int32),
+        "children_right": np.array([2, -1, -1], dtype=np.int32),
+        "children_default": np.array([1, -1, -1], dtype=np.int32),
+        "features": np.array([0, -1, -1], dtype=np.int32),
+        "thresholds": np.array([2.0, 0.0, 0.0], dtype=np.float64),
+        "values": np.array([[0.8], [2.0], [-1.0]], dtype=np.float64),
+        "node_sample_weight": np.array([100.0, 60.0, 40.0], dtype=np.float64),
+    }
+    single_tree = SingleTree(tree)
+    single_tree.threshold_types = np.array([1, 0, 0], dtype=np.int32)
+    ensemble = TreeEnsemble([single_tree], model_output="raw")
+    ensemble.tree_output = "raw_value"
+    ensemble.objective = "squared_error"
+
+    X = np.array([[0.0], [1.0], [2.0], [3.0]])
+    cpu_explainer = shap.TreeExplainer(ensemble, feature_perturbation="tree_path_dependent")
+    gpu_explainer = shap.GPUTreeExplainer(ensemble)
+    shap_values_cpu = cpu_explainer.shap_values(X, check_additivity=False)
+    shap_values_gpu = gpu_explainer.shap_values(X, check_additivity=False)
+    np.testing.assert_allclose(shap_values_gpu, shap_values_cpu, atol=1e-5)
+
+
+def test_categorical_split_matches_binary_feature():
+    """
+    Tests that using the categorical feature for SHAP value computation gives the same result as using a binary feature that routes the same way. We compare values computed on gpu and cpu here to check consistency.
+    """
+    children_left = np.array([1, -1, -1], dtype=np.int32)
+    children_right = np.array([2, -1, -1], dtype=np.int32)
+    children_default = np.array([1, -1, -1], dtype=np.int32)
+    features = np.array([0, -1, -1], dtype=np.int32)
+    values = np.array([[0.8], [2.0], [-1.0]], dtype=np.float64)
+    node_sample_weight = np.array([100.0, 60.0, 40.0], dtype=np.float64)
+
+    cat_tree = {
+        "children_left": children_left,
+        "children_right": children_right,
+        "children_default": children_default,
+        "features": features,
+        "thresholds": np.array([1.0, 0.0, 0.0], dtype=np.float64),
+        "values": values,
+        "node_sample_weight": node_sample_weight,
+    }
+    cat_single = SingleTree(cat_tree)
+    cat_single.threshold_types = np.array([1, 0, 0], dtype=np.int32)
+    cat_ensemble = TreeEnsemble([cat_single], model_output="raw")
+    cat_ensemble.tree_output = "raw_value"
+    cat_ensemble.objective = "squared_error"
+
+    bin_tree = {
+        "children_left": children_left,
+        "children_right": children_right,
+        "children_default": children_default,
+        "features": features,
+        "thresholds": np.array([0.5, 0.0, 0.0], dtype=np.float64),
+        "values": values,
+        "node_sample_weight": node_sample_weight,
+    }
+    bin_single = SingleTree(bin_tree)
+    bin_ensemble = TreeEnsemble([bin_single], model_output="raw")
+    bin_ensemble.tree_output = "raw_value"
+    bin_ensemble.objective = "squared_error"
+
+    X_cat = np.array([[1.0], [2.0], [1.0], [2.0]])
+    X_bin = X_cat - 1.0
+
+    cat_cpu = shap.TreeExplainer(cat_ensemble, feature_perturbation="tree_path_dependent").shap_values(
+        X_cat, check_additivity=False
+    )
+    cat_gpu = shap.GPUTreeExplainer(cat_ensemble).shap_values(X_cat, check_additivity=False)
+    np.testing.assert_allclose(cat_gpu, cat_cpu, atol=1e-5)
+
+    bin_cpu = shap.TreeExplainer(bin_ensemble, feature_perturbation="tree_path_dependent").shap_values(
+        X_bin, check_additivity=False
+    )
+    bin_gpu = shap.GPUTreeExplainer(bin_ensemble).shap_values(X_bin, check_additivity=False)
+    np.testing.assert_allclose(bin_gpu, bin_cpu, atol=1e-5)
+    np.testing.assert_allclose(cat_gpu, bin_gpu, atol=1e-5)
+    np.testing.assert_allclose(cat_cpu, cat_gpu, atol=1e-5)


### PR DESCRIPTION
## Overview

This PR does two things:
1. enables the TreeExplainer to use TreeEnsembles directly
2. tests cpu/gpu equivalence tests for categories which uses 1.

The direct handling of the TreeEnsembles in the TreeExplainer is just used for testing here but could also be improved on later.



## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added ~(if fixing a bug or adding a new feature)~
