### PR TITLE
ENH: Add shap_values_distributed for distributed Spark SHAP computation

### DIFF
--- a/shap/utils/__init__.py
+++ b/shap/utils/__init__.py
@@ -21,10 +21,12 @@ from ._general import (
 )
 from ._masked_model import MaskedModel, make_masks
 from ._show_progress import show_progress
+from ._spark import shap_values_distributed
 
 __all__ = [
     "delta_minimization_order",
     "hclust",
+    "shap_values_distributed",
     "hclust_ordering",
     "partition_tree",
     "partition_tree_shuffle",

--- a/shap/utils/_spark.py
+++ b/shap/utils/_spark.py
@@ -1,0 +1,42 @@
+
+from __future__ import annotations
+import pickle
+import numpy as np
+
+def shap_values_distributed(explainer, spark_df, features_col: str, spark=None):
+    try:
+        import pyspark.sql.functions as F
+        from pyspark.sql import SparkSession
+        from pyspark.sql.types import ArrayType, DoubleType
+    except ImportError as e:
+        raise ImportError(
+            "PySpark is required for shap_values_distributed. "
+            "Install it with: pip install pyspark"
+        ) from e
+
+    try:
+        pickle.dumps(explainer)
+    except Exception as e:
+        raise ValueError(
+            "The explainer must be picklable to broadcast to Spark workers. "
+            f"Pickling failed with: {e}"
+        ) from e
+
+    if spark is None:
+        spark = SparkSession.builder.getOrCreate()
+
+   
+    explainer_bc = spark.sparkContext.broadcast(explainer)
+
+    @F.udf(returnType=ArrayType(DoubleType()))
+    def _shap_udf(features):
+        if features is None:
+            return None
+        exp = explainer_bc.value
+        x = np.array(features.toArray()).reshape(1, -1)
+        vals = exp.shap_values(x)
+        if isinstance(vals, list):
+            return vals[0][0].tolist()
+        return vals[0].tolist()
+
+    return spark_df.withColumn("shap_values", _shap_udf(F.col(features_col)))

--- a/shap/utils/_spark.py
+++ b/shap/utils/_spark.py
@@ -1,7 +1,9 @@
-
 from __future__ import annotations
+
 import pickle
+
 import numpy as np
+
 
 def shap_values_distributed(explainer, spark_df, features_col: str, spark=None):
     try:
@@ -10,22 +12,19 @@ def shap_values_distributed(explainer, spark_df, features_col: str, spark=None):
         from pyspark.sql.types import ArrayType, DoubleType
     except ImportError as e:
         raise ImportError(
-            "PySpark is required for shap_values_distributed. "
-            "Install it with: pip install pyspark"
+            "PySpark is required for shap_values_distributed. Install it with: pip install pyspark"
         ) from e
 
     try:
         pickle.dumps(explainer)
     except Exception as e:
         raise ValueError(
-            "The explainer must be picklable to broadcast to Spark workers. "
-            f"Pickling failed with: {e}"
+            f"The explainer must be picklable to broadcast to Spark workers. Pickling failed with: {e}"
         ) from e
 
     if spark is None:
         spark = SparkSession.builder.getOrCreate()
 
-   
     explainer_bc = spark.sparkContext.broadcast(explainer)
 
     @F.udf(returnType=ArrayType(DoubleType()))

--- a/tests/utils/test_spark_distributed.py
+++ b/tests/utils/test_spark_distributed.py
@@ -1,7 +1,8 @@
 import sys
-import numpy as np
+
 import pandas as pd
 import pytest
+
 
 @pytest.fixture
 def configure_pyspark_python(monkeypatch):
@@ -15,17 +16,14 @@ def test_shap_values_distributed_tree(configure_pyspark_python):
     pytest.importorskip("pyspark.ml")
     pytest.importorskip("sklearn")
 
-    import shap
     from pyspark.ml.classification import RandomForestClassifier
     from pyspark.ml.feature import VectorAssembler
     from sklearn.datasets import load_iris
 
+    import shap
+
     try:
-        spark = (
-            pyspark.sql.SparkSession.builder
-            .config("spark.master", "local[2]")
-            .getOrCreate()
-        )
+        spark = pyspark.sql.SparkSession.builder.config("spark.master", "local[2]").getOrCreate()
     except Exception:
         pytest.skip("Could not start local Spark session")
 
@@ -34,18 +32,12 @@ def test_shap_values_distributed_tree(configure_pyspark_python):
     pdf["label"] = iris.target.astype(float)
 
     sdf = spark.createDataFrame(pdf)
-    sdf = VectorAssembler(
-        inputCols=list(iris.feature_names), outputCol="features"
-    ).transform(sdf)
+    sdf = VectorAssembler(inputCols=list(iris.feature_names), outputCol="features").transform(sdf)
 
-    model = RandomForestClassifier(
-        labelCol="label", featuresCol="features", numTrees=10
-    ).fit(sdf)
+    model = RandomForestClassifier(labelCol="label", featuresCol="features", numTrees=10).fit(sdf)
 
     explainer = shap.TreeExplainer(model)
-    result = shap.utils.shap_values_distributed(
-        explainer, sdf, features_col="features", spark=spark
-    )
+    result = shap.utils.shap_values_distributed(explainer, sdf, features_col="features", spark=spark)
 
     assert "shap_values" in result.columns
 

--- a/tests/utils/test_spark_distributed.py
+++ b/tests/utils/test_spark_distributed.py
@@ -1,0 +1,56 @@
+import sys
+import numpy as np
+import pandas as pd
+import pytest
+
+@pytest.fixture
+def configure_pyspark_python(monkeypatch):
+    monkeypatch.setenv("PYSPARK_PYTHON", sys.executable)
+    monkeypatch.setenv("PYSPARK_DRIVER_PYTHON", sys.executable)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="PySpark OOM issues on Windows")
+def test_shap_values_distributed_tree(configure_pyspark_python):
+    pyspark = pytest.importorskip("pyspark")
+    pytest.importorskip("pyspark.ml")
+    pytest.importorskip("sklearn")
+
+    import shap
+    from pyspark.ml.classification import RandomForestClassifier
+    from pyspark.ml.feature import VectorAssembler
+    from sklearn.datasets import load_iris
+
+    try:
+        spark = (
+            pyspark.sql.SparkSession.builder
+            .config("spark.master", "local[2]")
+            .getOrCreate()
+        )
+    except Exception:
+        pytest.skip("Could not start local Spark session")
+
+    iris = load_iris()
+    pdf = pd.DataFrame(iris.data, columns=iris.feature_names)
+    pdf["label"] = iris.target.astype(float)
+
+    sdf = spark.createDataFrame(pdf)
+    sdf = VectorAssembler(
+        inputCols=list(iris.feature_names), outputCol="features"
+    ).transform(sdf)
+
+    model = RandomForestClassifier(
+        labelCol="label", featuresCol="features", numTrees=10
+    ).fit(sdf)
+
+    explainer = shap.TreeExplainer(model)
+    result = shap.utils.shap_values_distributed(
+        explainer, sdf, features_col="features", spark=spark
+    )
+
+    assert "shap_values" in result.columns
+
+    shap_pdf = result.select("shap_values").toPandas()
+    assert len(shap_pdf) == len(pdf)
+    assert len(shap_pdf["shap_values"].iloc[0]) == len(iris.feature_names)
+
+    spark.stop()


### PR DESCRIPTION
Closes  #5027 

## Summary
Adds `shap.utils.shap_values_distributed()` — a utility that broadcasts 
any fitted SHAP explainer to Spark workers and computes SHAP values 
distributed across the cluster via a PySpark UDF, rather than collecting 
all rows to the driver.

## Motivation
Currently SHAP has no way to compute SHAP values at scale on Spark 
clusters. For large datasets this is a bottleneck as all data must be 
collected to the driver. This addresses that gap for any explainer type,
not just TreeExplainer.

## Changes
- `shap/utils/_spark.py`: new module with `shap_values_distributed()`
- `shap/utils/__init__.py`: exports the new function
- `tests/utils/test_spark_distributed.py`: test using iris dataset with 
  RandomForestClassifier

