### PR TITLE
Fix/gradient explainer tf get session removed

### DIFF
--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -25,17 +25,12 @@ def _get_session(session):
         try:
             session = tf.compat.v1.keras.backend.get_session()
         except AttributeError:
-            # get_session was removed from Keras in 2023. Fall back to
-            # creating a new session directly via tf.compat.v1.Session()
-            try:
-                session = tf.compat.v1.Session()
-            except Exception:
-                session = None
-    if session is None:
-        try:
+            # get_session was removed from Keras in 2023.
+            # First check for an already-active default session before
+            # creating a new one to avoid discarding the caller's context.
             session = tf.compat.v1.get_default_session()
-        except Exception:
-            session = None
+            if session is None:
+                session = tf.compat.v1.Session()
     return session
 
 

--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -12,26 +12,31 @@ def _import_tf():
 
 def _get_session(session):
     """Common utility to get the session for the tensorflow-based explainer.
-
     Parameters
     ----------
     explainer : Explainer
-
         One of the tensorflow-based explainers.
-
     session : tf.compat.v1.Session
-
         An optional existing session.
-
     """
     _import_tf()
     # if we are not given a session find a default session
     if session is None:
         try:
             session = tf.compat.v1.keras.backend.get_session()
+        except AttributeError:
+            # get_session was removed from Keras in 2023. Fall back to
+            # creating a new session directly via tf.compat.v1.Session()
+            try:
+                session = tf.compat.v1.Session()
+            except Exception:
+                session = None
+    if session is None:
+        try:
+            session = tf.compat.v1.get_default_session()
         except Exception:
-            session = tf.keras.backend.get_session()
-    return tf.get_default_session() if session is None else session
+            session = None
+    return session
 
 
 def _get_graph(explainer):

--- a/shap/explainers/tf_utils.py
+++ b/shap/explainers/tf_utils.py
@@ -12,6 +12,7 @@ def _import_tf():
 
 def _get_session(session):
     """Common utility to get the session for the tensorflow-based explainer.
+
     Parameters
     ----------
     explainer : Explainer


### PR DESCRIPTION
## Overview



TensorFlow removed `tf.compat.v1.get_session()` and the global Keras session helpers in recent versions, which caused `_get_session` in `shap/explainers/tf_utils.py` to raise an `AttributeError` when no session was explicitly passed in.

This PR updates `_get_session` to first check whether a default TensorFlow session already exists before attempting to create a new one, falling back gracefully on newer TF versions where the old session APIs are no longer available.

## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
