### PR TITLE
Deprecate shap_values() across all explainers, fully embrace __call__()

### DIFF
--- a/shap/explainers/_deep/__init__.py
+++ b/shap/explainers/_deep/__init__.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
+
 from ..._explanation import Explanation
 from .._explainer import Explainer
 
@@ -99,23 +106,21 @@ class DeepExplainer(Explainer):
         self.expected_value = self.explainer.expected_value
         self.explainer.framework = framework  # type: ignore
 
-    def __call__(self, X: list | np.ndarray | pd.DataFrame | torch.tensor) -> Explanation:  # type: ignore  # noqa: F821
-        """Return an explanation object for the model applied to X.
-
-        Parameters
-        ----------
-        X : list,
-            if framework == 'tensorflow': numpy.array, or pandas.DataFrame
-            if framework == 'pytorch': torch.tensor
-            A tensor (or list of tensors) of samples (where X.shape[0] == # samples) on which to
-            explain the model's output.
-
-        Returns
-        -------
-        shap.Explanation:
-        """
-        shap_values = self.shap_values(X)
-        return Explanation(values=shap_values, data=X)
+    def __call__(  # type: ignore[override]
+        self,
+        X: list | np.ndarray | pd.DataFrame,
+        ranked_outputs: int | None = None,
+        output_rank_order: str = "max",
+        check_additivity: bool = True,
+    ) -> Explanation:
+        """Return an explanation object for the model applied to X."""
+        sv = self.explainer.shap_values(X, ranked_outputs, output_rank_order, check_additivity=check_additivity)
+        if ranked_outputs is not None:
+            sv, output_indices = sv
+            exp = Explanation(values=sv, data=X)
+            exp.output_indices = output_indices
+            return exp
+        return Explanation(values=sv, data=X)
 
     def shap_values(self, X, ranked_outputs=None, output_rank_order="max", check_additivity=True):
         """Return approximate SHAP values for the model applied to the data given by X.
@@ -161,4 +166,10 @@ class DeepExplainer(Explainer):
                 Return type for models with multiple outputs and one input changed from list to np.ndarray.
 
         """
+        warnings.warn(
+            "shap_values() is deprecated and will be removed in a future release. "
+            "Use the explainer directly as a callable instead: explainer(X).",
+            FutureWarning,
+            stacklevel=2,
+        )
         return self.explainer.shap_values(X, ranked_outputs, output_rank_order, check_additivity=check_additivity)

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -96,26 +96,23 @@ class GradientExplainer(Explainer):
         elif framework == "pytorch":
             self.explainer = _PyTorchGradient(model, data, batch_size, local_smoothing)
 
-    def __call__(self, X: Any, nsamples: int = 200) -> Explanation:  # type: ignore[override]
-        """Return an explanation object for the model applied to X.
-
-        Parameters
-        ----------
-        X : list,
-            if framework == 'tensorflow': np.array, or pandas.DataFrame
-            if framework == 'pytorch': torch.tensor
-            A tensor (or list of tensors) of samples (where X.shape[0] == # samples) on which to
-            explain the model's output.
-        nsamples : int
-            number of background samples
-
-        Returns
-        -------
-        shap.Explanation:
-
-        """
-        shap_values = self.shap_values(X, nsamples)
-        return Explanation(values=shap_values, data=X, feature_names=self.features)  # type: ignore[arg-type]
+    def __call__(  # type: ignore[override]
+        self,
+        X: Any,
+        nsamples: int = 200,
+        ranked_outputs: int | list[int] | None = None,
+        output_rank_order: Literal["max", "min", "max_abs", "custom"] = "max",
+        rseed: int | None = None,
+        return_variances: bool = False,
+    ) -> Explanation:
+        """Return an explanation object for the model applied to X."""
+        sv = self.explainer.shap_values(X, nsamples, ranked_outputs, output_rank_order, rseed, return_variances)  # type: ignore[arg-type]
+        if ranked_outputs is not None:
+            sv, output_indices = sv
+            exp = Explanation(values=sv, data=X, feature_names=self.features)  # type: ignore[arg-type]
+            exp.output_indices = output_indices
+            return exp
+        return Explanation(values=sv, data=X, feature_names=self.features)  # type: ignore[arg-type]
 
     def shap_values(
         self,
@@ -175,6 +172,12 @@ class GradientExplainer(Explainer):
                 from list to np.ndarray.
 
         """
+        warnings.warn(
+            "shap_values() is deprecated and will be removed in a future release. "
+            "Use the explainer directly as a callable instead: explainer(X).",
+            FutureWarning,
+            stacklevel=2,
+        )
         return self.explainer.shap_values(X, nsamples, ranked_outputs, output_rank_order, rseed, return_variances)  # type: ignore[arg-type]
 
 

--- a/shap/explainers/_kernel.py
+++ b/shap/explainers/_kernel.py
@@ -200,6 +200,8 @@ class KernelExplainer(Explainer):
         X: npt.NDArray[Any] | pd.DataFrame | scipy.sparse.spmatrix,
         l1_reg: str | float | bool = "num_features(10)",
         silent: bool = False,
+        nsamples: str | int = "auto",
+        gc_collect: bool = False,
     ) -> Explanation:
         start_time = time.time()
 
@@ -208,7 +210,7 @@ class KernelExplainer(Explainer):
         else:
             feature_names = getattr(self, "data_feature_names", None)  # type: ignore[assignment]
 
-        v = self.shap_values(X, l1_reg=l1_reg, silent=silent)
+        v = self._compute_shap_values(X, l1_reg=l1_reg, silent=silent, nsamples=nsamples, gc_collect=gc_collect)
         if isinstance(v, list):
             v = np.stack(v, axis=-1)  # put outputs at the end
 
@@ -283,6 +285,20 @@ class KernelExplainer(Explainer):
                 Return type for models with multiple outputs and one input changed from list to np.ndarray.
 
         """
+        warnings.warn(
+            "shap_values() is deprecated and will be removed in a future release. "
+            "Use the explainer directly as a callable instead: explainer(X).",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._compute_shap_values(X, **kwargs)
+
+    def _compute_shap_values(
+        self,
+        X: npt.NDArray[Any] | pd.DataFrame | pd.Series | scipy.sparse.spmatrix,
+        **kwargs: Any,
+    ) -> npt.NDArray[Any]:
+        """Internal implementation shared by ``__call__`` and the deprecated ``shap_values``."""
         # convert dataframes
         if isinstance(X, pd.Series):
             X = X.values

--- a/shap/explainers/_linear.py
+++ b/shap/explainers/_linear.py
@@ -9,6 +9,7 @@ from scipy.sparse import issparse
 from tqdm.auto import tqdm
 
 from .. import links, maskers
+from .._explanation import Explanation
 from ..utils._exceptions import (
     DimensionError,
     InvalidFeaturePerturbationError,
@@ -425,6 +426,33 @@ class LinearExplainer(Explainer):
             "clustering": None,
         }
 
+    def __call__(  # type: ignore[override]
+        self,
+        X: npt.NDArray[np.floating[Any]] | pd.DataFrame | pd.Series,
+    ) -> Explanation:
+        """Explain the model output for samples ``X``."""
+        feature_names: list[str] | None
+        if isinstance(X, pd.DataFrame):
+            feature_names = list(X.columns)
+        else:
+            feature_names = getattr(self, "data_feature_names", None)
+
+        v = self._compute_shap_values(X)
+        if isinstance(v, list):
+            v = np.stack(v, axis=-1)
+
+        if hasattr(self.expected_value, "__len__"):
+            ev_tiled = np.tile(self.expected_value, (v.shape[0], 1))
+        else:
+            ev_tiled = np.tile(self.expected_value, v.shape[0])
+
+        return Explanation(
+            values=v,
+            base_values=ev_tiled,
+            data=X.values if isinstance(X, (pd.DataFrame, pd.Series)) else X,
+            feature_names=feature_names,
+        )
+
     def shap_values(self, X: npt.NDArray[np.floating[Any]] | pd.DataFrame | pd.Series) -> npt.NDArray[np.floating[Any]]:
         """Estimate the SHAP values for a set of samples.
 
@@ -452,6 +480,18 @@ class LinearExplainer(Explainer):
                 Return type for models with multiple outputs changed from list to np.ndarray.
 
         """
+        warnings.warn(
+            "shap_values() is deprecated and will be removed in a future release. "
+            "Use the explainer directly as a callable instead: explainer(X).",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._compute_shap_values(X)
+
+    def _compute_shap_values(
+        self, X: npt.NDArray[np.floating[Any]] | pd.DataFrame | pd.Series
+    ) -> npt.NDArray[np.floating[Any]]:
+        """Internal implementation shared by ``__call__`` and the deprecated ``shap_values``."""
         # convert dataframes
         if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.values

--- a/shap/explainers/_sampling.py
+++ b/shap/explainers/_sampling.py
@@ -70,7 +70,7 @@ class SamplingExplainer(KernelExplainer):
         else:
             feature_names = None  # we can make self.feature_names from background data eventually if we have it
 
-        v = self.shap_values(X, nsamples=nsamples)
+        v = self._compute_shap_values(X, nsamples=nsamples)
         if isinstance(v, list):
             v = np.stack(v, axis=-1)  # put outputs at the end
         e = Explanation(v, self.expected_value, X, feature_names=feature_names)

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -395,7 +395,7 @@ class TreeExplainer(Explainer):
             feature_names = getattr(self, "data_feature_names", None)
 
         if not interactions:
-            v = self.shap_values(X, y=y, from_call=True, check_additivity=check_additivity, approximate=approximate)
+            v = self._compute_shap_values(X, y=y, check_additivity=check_additivity, approximate=approximate)
             if isinstance(v, list):
                 v = np.stack(v, axis=-1)  # put outputs at the end
         else:
@@ -519,7 +519,6 @@ class TreeExplainer(Explainer):
         tree_limit: int | None = None,
         approximate: bool = False,
         check_additivity: bool = True,
-        from_call: bool = False,
     ) -> npt.NDArray[Any]:
         """Estimate the SHAP values for a set of samples.
 
@@ -591,10 +590,29 @@ class TreeExplainer(Explainer):
                 a single value (raw margin/log-odds), resulting in SHAP values of shape
                 ``(#num_samples, #num_features)`` and ``expected_value`` as a scalar.
 
-            .. versionchanged:: 0.45.0
+           .. versionchanged:: 0.45.0
                 Return type for models with multiple outputs changed from list to np.ndarray.
 
         """
+        warnings.warn(
+            "shap_values() is deprecated and will be removed in a future release. "
+            "Use the explainer directly as a callable instead: explainer(X).",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self._compute_shap_values(
+            X, y=y, tree_limit=tree_limit, approximate=approximate, check_additivity=check_additivity
+        )
+
+    def _compute_shap_values(
+        self,
+        X: Any,
+        y: npt.NDArray[Any] | pd.Series | None = None,
+        tree_limit: int | None = None,
+        approximate: bool = False,
+        check_additivity: bool = True,
+    ) -> npt.NDArray[Any]:
+        """Internal implementation shared by ``__call__`` and the deprecated ``shap_values``."""
         # see if we have a default tree_limit in place.
         if tree_limit is None:
             tree_limit = -1 if self.model.tree_limit is None else self.model.tree_limit
@@ -635,10 +653,7 @@ class TreeExplainer(Explainer):
                     "objective" in self.model.original_model.params
                     and self.model.original_model.params["objective"] == "binary"
                 ):
-                    if not from_call:
-                        warnings.warn(
-                            "LightGBM binary classifier with TreeExplainer shap values output has changed to a list of ndarray"
-                        )
+                    pass  # LightGBM binary output format migration complete; warning removed in 0.46.0
                 if phi.shape[1] != X.shape[1] + 1:
                     try:
                         phi = phi.reshape(X.shape[0], phi.shape[1] // (X.shape[1] + 1), X.shape[1] + 1)


### PR DESCRIPTION
Part of the 1.0 tracker — "get rid of .shap_values and fully embrace Explainer.__call__ everywhere."

## What changed
`Explainer.__call__()` is now the canonical, fully-featured API across every built-in explainer (Deep, Gradient, Kernel, Tree, Linear, Sampling). Previously several `__call__` implementations silently dropped parameters that only `shap_values()` exposed (e.g. `ranked_outputs`, `nsamples`, `gc_collect`) — those are now first-class on `__call__` too.

`shap_values()` is kept as a thin, deprecated wrapper that emits `FutureWarning` and delegates to the same underlying logic, so no existing user code breaks.
    FIXES : #5028 
## Per-explainer notes
- **DeepExplainer / GradientExplainer**: `__call__` now accepts `ranked_outputs`, `output_rank_order`, etc. — previously only available via `.shap_values()`.
- **KernelExplainer**: `__call__` now accepts `nsamples` and `gc_collect`, previously silently dropped.
- **TreeExplainer**: removed the now-stale `from_call` parameter (was only gating a LightGBM output-format warning from the 0.45 migration, which is long complete).
- **LinearExplainer**: had no `__call__` at all before this PR — only `.shap_values()`. Added.
- **SamplingExplainer**: inherits the new deprecated `shap_values()` from `KernelExplainer` automatically.

## Backward compatibility
`shap_values()` still works, just warns:
```python
import warnings
warnings.filterwarnings("ignore", category=FutureWarning, module="shap")
```
or migrate:
```python
# before
sv = explainer.shap_values(X)
# after
sv = explainer(X).values
```

## Not in this PR
- Test coverage for the new `__call__` parameters and deprecation warnings (coming in a follow-up)
- `shap_interaction_values()` — out of scope
- Actual removal of `shap_values()` (this PR is the deprecation step; removal should wait out a deprecation cycle)
- Docs/notebook updates, plotting consistency, other 1.0-tracker items

## Sanity check
```bash
python -c "
import ast
for f in ['_deep/__init__', '_gradient', '_kernel', '_linear', '_sampling', '_tree']:
    ast.parse(open(f'shap/explainers/{f}.py').read())
print('all clean')
"
```