### PR TITLE
FIX: Return axes from waterfall_legacy

### DIFF
--- a/shap/plots/_waterfall.py
+++ b/shap/plots/_waterfall.py
@@ -734,4 +734,4 @@ def waterfall_legacy(expected_value, shap_values=None, features=None, feature_na
     if show:
         plt.show()
     else:
-        return plt.gcf()
+        return plt.gca()

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.axes import Axes
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.tree import DecisionTreeRegressor
 
@@ -44,6 +45,14 @@ def test_waterfall_legacy(explainer):
     shap.plots._waterfall.waterfall_legacy(explainer.expected_value, shap_values[0], show=False)
     plt.tight_layout()
     return fig
+
+
+def test_waterfall_legacy_returns_axes_when_show_false():
+    shap_values = np.array([1.0, 2.0, 3.0, 4.0])
+
+    ax = shap.plots._waterfall.waterfall_legacy(0.0, shap_values, show=False)
+
+    assert isinstance(ax, Axes)
 
 
 @pytest.mark.mpl_image_compare(tolerance=3)


### PR DESCRIPTION
## Overview

Closes #4928

Description of the changes proposed in this pull request:

`waterfall_legacy(..., show=False)` returned the current `Figure`, while the newer `waterfall(..., show=False)` returns the current `Axes` so callers can customize the plot directly. This changes the legacy function to return `plt.gca()` and adds a focused regression test that does not depend on model fixtures.

## Rationale

The legacy function already customizes the current axes throughout the plotting code and uses `show=False` to support post-plot customization. Returning the axes matches that behavior and avoids the reported `Figure`-has-no-`set_title` failure.

## Tests

- `.venv/bin/python -m pytest tests/plots/test_waterfall.py::test_waterfall_legacy_returns_axes_when_show_false -q`
- `.venv/bin/python -m pytest tests/plots/test_waterfall.py -q`
- Manual reproduction script for `waterfall_legacy(..., show=False)` returning an `Axes` and accepting `ax.set_title(...)`
- `uvx ruff check shap/plots/_waterfall.py tests/plots/test_waterfall.py`
- `git diff --check`
- `uvx pre-commit run --files shap/plots/_waterfall.py tests/plots/test_waterfall.py`

## AI Disclosure

Developed with Codex assistance:
- **Autonomous**: inspected the issue and local code path, implemented the one-line return-value fix, added the regression test, and ran local validation.
- **Assisted**: no human-authored code changes were made during this session.
- **Advised**: no advisory-only changes.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
