### PR TITLE
MAINT: replace deprecated `set_bad`/`set_over`/`set_under` with `with_extremes`

### DIFF
--- a/shap/plots/colors/_colors.py
+++ b/shap/plots/colors/_colors.py
@@ -44,9 +44,11 @@ for pos, l, c, h in zip(np.linspace(0, 1, nsteps), l_vals, c_vals, h_vals):  # n
     alphas.append((pos, 1.0, 1.0))
 
 red_blue = LinearSegmentedColormap("red_blue", {"red": reds, "green": greens, "blue": blues, "alpha": alphas})
-red_blue.set_bad(gray_rgb.tolist(), 1.0)
-red_blue.set_over(gray_rgb.tolist(), 1.0)
-red_blue.set_under(gray_rgb.tolist(), 1.0)  # "under" is incorrectly used instead of "bad" in the scatter plot
+red_blue = red_blue.with_extremes(
+    bad=gray_rgb.tolist(),
+    over=gray_rgb.tolist(),
+    under=gray_rgb.tolist(),  # "under" is incorrectly used instead of "bad" in the scatter plot
+)
 
 red_blue_no_bounds = LinearSegmentedColormap(
     "red_blue_no_bounds", {"red": reds, "green": greens, "blue": blues, "alpha": alphas}


### PR DESCRIPTION
## Overview

Fixes a `PendingDeprecationWarning` raised by matplotlib when importing `shap.plots.colors`:

```
PendingDeprecationWarning: The set_bad function will be deprecated in a future version.
Use cmap.with_extremes(bad=...) or Colormap(bad=...) instead.
```

The three mutable calls on `red_blue` in `shap/plots/colors/_colors.py` are replaced with a single `with_extremes(bad=..., over=..., under=...)` call, which is the modern matplotlib API. Behaviour is unchanged.

Relates to #3066.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.