### PR TITLE
FIX: Handle pandas nullable dtypes in TreeExplainer background data

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -236,6 +236,7 @@ class TreeExplainer(Explainer):
             self.data_feature_names = feature_names
         elif isinstance(data, pd.DataFrame):
             self.data_feature_names = list(data.columns)
+            data = data.to_numpy(dtype=float, na_value=np.nan)
 
         masker = data
         super().__init__(model, masker, feature_names=feature_names)
@@ -250,9 +251,7 @@ class TreeExplainer(Explainer):
                 "TreeExplainer does not support clustered data inputs! Please use shap.Explainer or pass an unclustered masker!"
             )
 
-        if isinstance(data, pd.DataFrame):
-            self.data = data.values
-        elif isinstance(data, DenseData):
+        if isinstance(data, DenseData):
             self.data = data.data
         else:
             self.data = data
@@ -421,7 +420,7 @@ class TreeExplainer(Explainer):
         # cf. GH dsgibbons#66, this conversion to numpy array should be done AFTER
         # calculation of shap values
         if isinstance(X, pd.DataFrame):
-            X_data = X.values
+            X_data = X.to_numpy(dtype=float, na_value=np.nan)
         elif safe_isinstance(X, "xgboost.core.DMatrix"):
             import xgboost
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3015,3 +3015,39 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+
+def test_nullable_pandas_dtype_background_data():
+    """TreeExplainer handles pandas nullable dtypes (Int64, Float64) in background data.
+
+    Previously, DataFrame.values on nullable dtypes produced object arrays,
+    which caused TypeError when passed to the C extension expecting float64.
+    Addresses #4911.
+    """
+    X = pd.DataFrame(
+        {
+            "x1": pd.array([1.0, 2.0, 3.0, 4.0, 5.0] * 20, dtype="Float64"),
+            "x2": pd.array([10, 20, 30, 40, 50] * 20, dtype="Int64"),
+        }
+    )
+    y = np.array([0, 1, 0, 1, 0] * 20)
+
+    model = DecisionTreeClassifier(max_depth=2, random_state=0)
+    model.fit(X, y)
+
+    # Background data with nullable dtypes
+    X_bg = pd.DataFrame(
+        {
+            "x1": pd.array([1.0, 2.0, 3.0], dtype="Float64"),
+            "x2": pd.array([10, 20, 30], dtype="Int64"),
+        }
+    )
+
+    # Confirm nullable dtypes are present (precondition)
+    assert X_bg["x1"].dtype == pd.Float64Dtype()
+    assert X_bg["x2"].dtype == pd.Int64Dtype()
+
+    # This should not raise TypeError from C extension
+    explainer = shap.TreeExplainer(model, data=X_bg)
+    sv = explainer.shap_values(X.iloc[:5])
+    assert sv.shape == (5, 2)


### PR DESCRIPTION
Fixes #4911

When background data is a pandas DataFrame with nullable dtypes (e.g., Int64, Float64), `DataFrame.values` produces object arrays that crash the C extension.

**Root Cause:** The masker converts DataFrame to numpy array using `.values`, which returns object dtype for nullable dtypes. The C extension expects float64.

**Fix:**
- Convert DataFrame to numpy with `to_numpy(dtype=float, na_value=np.nan)` at input (line 239), before masker processing
- Remove dead code: DataFrame check after masker conversion (unreachable since data is always numpy after conversion)
- Use `to_numpy()` instead of `.values` in `_build_explanation` for consistent nullable dtype handling

**Test:** Added `test_nullable_pandas_dtype_background_data` that verifies TreeExplainer works with nullable dtypes as background data.