### PR TITLE
FIX: Support LightGBM native categorical splits in path-dependent TreeExplainer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 # Enabled via: SHAP_ENABLE_CUDA=1 pip install .
 # ==============================================================================
 
-if(ENV{SHAP_ENABLE_CUDA})
+if($ENV{SHAP_ENABLE_CUDA})
   message(MESSAGE "SHAP_ENABLE_CUDA is set, attempting to build the GPU extension...")
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -11,6 +11,15 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args);
 static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args);
 
+static bool has_categorical_splits(PyArrayObject *threshold_types_array) {
+    const int *threshold_types = (const int*)PyArray_DATA(threshold_types_array);
+    const npy_intp size = PyArray_SIZE(threshold_types_array);
+    for (npy_intp i = 0; i < size; ++i) {
+        if (threshold_types[i] == 1) return true;
+    }
+    return false;
+}
+
 static PyMethodDef module_methods[] = {
     {"dense_tree_shap", _cext_dense_tree_shap, METH_VARARGS, "C implementation of Tree SHAP for dense."},
     {"dense_tree_predict", _cext_dense_tree_predict, METH_VARARGS, "C implementation of tree predictions."},
@@ -118,6 +127,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     PyObject *node_sample_weights_obj;
     int max_depth;
@@ -135,8 +145,8 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
+        args, "OOOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &node_sample_weights_obj,
         &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
         &out_contribs_obj, &feature_dependence, &model_output, &interactions
     )) return NULL;
@@ -148,6 +158,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *node_sample_weights_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -164,6 +175,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
+        cat_bitsets_array == NULL ||
         values_array == NULL || node_sample_weights_array == NULL || X_array == NULL ||
         X_missing_array == NULL || out_contribs_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
@@ -172,6 +184,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         Py_XDECREF((PyObject*)node_sample_weights_array);
         Py_XDECREF((PyObject*)X_array);
@@ -180,6 +193,31 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
         if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
         if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
         //PyArray_ResolveWritebackIfCopy(out_contribs_array);
+        Py_XDECREF((PyObject*)out_contribs_array);
+        Py_XDECREF((PyObject*)base_offset_array);
+        return NULL;
+    }
+
+    if (feature_dependence == FEATURE_DEPENDENCE::global_path_dependent &&
+        has_categorical_splits(threshold_types_array)) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "feature_perturbation='global_path_dependent' does not support categorical splits."
+        );
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)node_sample_weights_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        Py_XDECREF((PyObject*)y_array);
+        Py_XDECREF((PyObject*)R_array);
+        Py_XDECREF((PyObject*)R_missing_array);
         Py_XDECREF((PyObject*)out_contribs_array);
         Py_XDECREF((PyObject*)base_offset_array);
         return NULL;
@@ -199,6 +237,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weights_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -215,7 +254,8 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     // these are just a wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types, cat_bitsets,
+        static_cast<size_t>(PyArray_SIZE(cat_bitsets_array)), values,
         node_sample_weights, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );
@@ -233,6 +273,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     Py_XDECREF((PyObject*)node_sample_weights_array);
     Py_XDECREF((PyObject*)X_array);
@@ -258,6 +299,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     int max_depth;
     int tree_limit;
@@ -270,8 +312,8 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+        args, "OOOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
         &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
     )) return NULL;
 
@@ -282,6 +324,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -293,6 +336,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
+        cat_bitsets_array == NULL ||
         values_array == NULL || X_array == NULL ||
         X_missing_array == NULL || out_pred_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
@@ -301,6 +345,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         Py_XDECREF((PyObject*)base_offset_array);
         Py_XDECREF((PyObject*)X_array);
@@ -329,6 +374,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -340,7 +386,8 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types, cat_bitsets,
+        static_cast<size_t>(PyArray_SIZE(cat_bitsets_array)), values,
         NULL, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );
@@ -355,6 +402,7 @@ static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     Py_XDECREF((PyObject*)base_offset_array);
     Py_XDECREF((PyObject*)X_array);
@@ -377,6 +425,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     int tree_limit;
     PyObject *node_sample_weight_obj;
@@ -385,8 +434,8 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
+        args, "OOOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
     )) return NULL;
 
     /* Interpret the input objects as numpy arrays. */
@@ -396,6 +445,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -404,6 +454,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
+        cat_bitsets_array == NULL ||
         values_array == NULL || node_sample_weight_array == NULL || X_array == NULL ||
         X_missing_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
@@ -412,6 +463,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         //PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
         Py_XDECREF((PyObject*)node_sample_weight_array);
@@ -432,6 +484,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *node_sample_weight = (tfloat*)PyArray_DATA(node_sample_weight_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -440,7 +493,8 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types, cat_bitsets,
+        static_cast<size_t>(PyArray_SIZE(cat_bitsets_array)), values,
         node_sample_weight, 0, tree_limit, 0, max_nodes, 0
     );
     ExplanationDataset data = ExplanationDataset(X, X_missing, NULL, NULL, NULL, num_X, M, 0);
@@ -454,6 +508,7 @@ static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
     Py_XDECREF((PyObject*)node_sample_weight_array);
@@ -474,6 +529,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyObject *features_obj;
     PyObject *thresholds_obj;
     PyObject *threshold_types_obj;
+    PyObject *cat_bitsets_obj;
     PyObject *values_obj;
     int max_depth;
     int tree_limit;
@@ -487,8 +543,8 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
 
     /* Parse the input tuple */
     if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
+        args, "OOOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
+        &features_obj, &thresholds_obj, &threshold_types_obj, &cat_bitsets_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
         &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
     )) return NULL;
 
@@ -499,6 +555,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
+    PyArrayObject *cat_bitsets_array = (PyArrayObject*)PyArray_FROM_OTF(cat_bitsets_obj, NPY_UINT32, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
@@ -510,6 +567,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     /* If that didn't work, throw an exception. Note that R and y are optional. */
     if (children_left_array == NULL || children_right_array == NULL ||
         children_default_array == NULL || features_array == NULL || thresholds_array == NULL ||
+        cat_bitsets_array == NULL ||
         values_array == NULL || X_array == NULL ||
         X_missing_array == NULL || out_pred_array == NULL) {
         Py_XDECREF((PyObject*)children_left_array);
@@ -518,6 +576,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
         Py_XDECREF((PyObject*)features_array);
         Py_XDECREF((PyObject*)thresholds_array);
         Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)cat_bitsets_array);
         Py_XDECREF((PyObject*)values_array);
         Py_XDECREF((PyObject*)base_offset_array);
         Py_XDECREF((PyObject*)X_array);
@@ -540,6 +599,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     int *features = (int*)PyArray_DATA(features_array);
     tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
     int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
+    unsigned int *cat_bitsets = (unsigned int*)PyArray_DATA(cat_bitsets_array);
     tfloat *values = (tfloat*)PyArray_DATA(values_array);
     tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
     tfloat *X = (tfloat*)PyArray_DATA(X_array);
@@ -551,7 +611,8 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     // these are just wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types, cat_bitsets,
+        static_cast<size_t>(PyArray_SIZE(cat_bitsets_array)), values,
         NULL, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );
@@ -566,6 +627,7 @@ static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
     Py_XDECREF((PyObject*)features_array);
     Py_XDECREF((PyObject*)thresholds_array);
     Py_XDECREF((PyObject*)threshold_types_array);
+    Py_XDECREF((PyObject*)cat_bitsets_array);
     Py_XDECREF((PyObject*)values_array);
     Py_XDECREF((PyObject*)base_offset_array);
     Py_XDECREF((PyObject*)X_array);

--- a/shap/cext/_cext_gpu.cc
+++ b/shap/cext/_cext_gpu.cc
@@ -7,6 +7,15 @@
 
 static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args);
 
+static bool has_categorical_splits(PyArrayObject *threshold_types_array) {
+    const int *threshold_types = (const int*)PyArray_DATA(threshold_types_array);
+    const npy_intp size = PyArray_SIZE(threshold_types_array);
+    for (npy_intp i = 0; i < size; ++i) {
+        if (threshold_types[i] == 1) return true;
+    }
+    return false;
+}
+
 static PyMethodDef module_methods[] = {
     {"dense_tree_shap", _cext_dense_tree_shap, METH_VARARGS, "C implementation of Tree SHAP for dense."},
     {NULL, NULL, 0, NULL}
@@ -126,6 +135,26 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
         return NULL;
     }
 
+    if (has_categorical_splits(threshold_types_array)) {
+        PyErr_SetString(PyExc_ValueError, "GPU TreeExplainer does not support categorical splits.");
+        Py_XDECREF((PyObject*)children_left_array);
+        Py_XDECREF((PyObject*)children_right_array);
+        Py_XDECREF((PyObject*)children_default_array);
+        Py_XDECREF((PyObject*)features_array);
+        Py_XDECREF((PyObject*)thresholds_array);
+        Py_XDECREF((PyObject*)threshold_types_array);
+        Py_XDECREF((PyObject*)values_array);
+        Py_XDECREF((PyObject*)node_sample_weights_array);
+        Py_XDECREF((PyObject*)X_array);
+        Py_XDECREF((PyObject*)X_missing_array);
+        Py_XDECREF((PyObject*)y_array);
+        Py_XDECREF((PyObject*)R_array);
+        Py_XDECREF((PyObject*)R_missing_array);
+        Py_XDECREF((PyObject*)out_contribs_array);
+        Py_XDECREF((PyObject*)base_offset_array);
+        return NULL;
+    }
+
     const unsigned num_X = PyArray_DIM(X_array, 0);
     const unsigned M = PyArray_DIM(X_array, 1);
     const unsigned max_nodes = PyArray_DIM(values_array, 1);
@@ -156,7 +185,7 @@ static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
     // these are just a wrapper objects for all the pointers and numbers associated with
     // the ensemble tree model and the dataset we are explaining
     TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
+        children_left, children_right, children_default, features, thresholds, threshold_types, NULL, 0, values,
         node_sample_weights, max_depth, tree_limit, base_offset,
         max_nodes, num_outputs
     );

--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <iostream>
 #include <fstream>
+#include <limits>
 #include <stdio.h>
 #include <cmath>
 #include <ctime>
@@ -36,6 +37,8 @@ struct TreeEnsemble {
     int *features;
     tfloat *thresholds;
     int* threshold_types;
+    unsigned int *cat_bitsets;
+    size_t num_cat_bitsets;
     tfloat *values;
     tfloat *node_sample_weights;
     unsigned max_depth;
@@ -46,12 +49,14 @@ struct TreeEnsemble {
 
     TreeEnsemble() {}
     TreeEnsemble(int *children_left, int *children_right, int *children_default, int *features,
-                 tfloat *thresholds, int *threshold_types, tfloat *values, tfloat *node_sample_weights,
+                 tfloat *thresholds, int *threshold_types, unsigned int *cat_bitsets,
+                 size_t num_cat_bitsets, tfloat *values, tfloat *node_sample_weights,
                  unsigned max_depth, unsigned tree_limit, tfloat *base_offset,
                  unsigned max_nodes, unsigned num_outputs) :
         children_left(children_left), children_right(children_right),
         children_default(children_default), features(features), thresholds(thresholds),
-        threshold_types(threshold_types), values(values), node_sample_weights(node_sample_weights),
+        threshold_types(threshold_types), cat_bitsets(cat_bitsets), num_cat_bitsets(num_cat_bitsets),
+        values(values), node_sample_weights(node_sample_weights),
         max_depth(max_depth), tree_limit(tree_limit),
         base_offset(base_offset), max_nodes(max_nodes), num_outputs(num_outputs) {}
 
@@ -64,6 +69,8 @@ struct TreeEnsemble {
         tree.features = features + d;
         tree.thresholds = thresholds + d;
         tree.threshold_types = threshold_types + d;
+        tree.cat_bitsets = cat_bitsets; // ensemble-global buffer, shared by every per-tree view
+        tree.num_cat_bitsets = num_cat_bitsets;
         tree.values = values + d * num_outputs;
         tree.node_sample_weights = node_sample_weights + d;
         tree.max_depth = max_depth;
@@ -87,6 +94,8 @@ struct TreeEnsemble {
         features = new int[tree_limit * max_nodes];
         thresholds = new tfloat[tree_limit * max_nodes];
         threshold_types = new int[tree_limit * max_nodes];
+        cat_bitsets = NULL;
+        num_cat_bitsets = 0;
         values = new tfloat[tree_limit * max_nodes * num_outputs];
         node_sample_weights = new tfloat[tree_limit * max_nodes];
     }
@@ -178,9 +187,27 @@ inline transform_f get_transform(unsigned model_transform) {
     return transform;
 }
 
-inline bool category_in_threshold(float threshold, float category) {
-    int category_flag = (1 << (int(category) - 1));
-    return (int(threshold) & category_flag) != 0;
+inline bool category_in_threshold(const unsigned int *cat_bitsets, const size_t num_cat_bitsets,
+                                  const tfloat threshold, const tfloat category) {
+    // Invalid model offsets and non-integral category values do not match. In particular,
+    // validate all floating-point values before narrowing them to an array index.
+    if (cat_bitsets == NULL || !std::isfinite(threshold) || threshold < 0 ||
+        std::trunc(threshold) != threshold || threshold >= static_cast<tfloat>(num_cat_bitsets) ||
+        !std::isfinite(category) || category < 0 || std::trunc(category) != category ||
+        category >= static_cast<tfloat>(std::numeric_limits<size_t>::max())) {
+        return false;
+    }
+
+    const size_t start = static_cast<size_t>(threshold);
+    const size_t n_words = cat_bitsets[start];
+    const size_t words_available = num_cat_bitsets - start - 1;
+    if (n_words == 0 || n_words > words_available || category / 32 >= static_cast<tfloat>(n_words)) {
+        return false;
+    }
+
+    const size_t c = static_cast<size_t>(category);
+    const size_t word = c / 32;
+    return (cat_bitsets[start + 1 + word] & (1u << (c % 32))) != 0;
 }
 
 inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat *x, const bool *x_missing) {
@@ -200,7 +227,9 @@ inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat 
             node = trees.children_default[pos];
         } else if (trees.threshold_types[pos] == 0 && x[feature] <= trees.thresholds[pos]) {
             node = trees.children_left[pos];
-        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.thresholds[pos], x[feature])) {
+        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(
+            trees.cat_bitsets, trees.num_cat_bitsets, trees.thresholds[pos], x[feature]
+        )) {
             node = trees.children_left[pos];
         } else {
             node = trees.children_right[pos];
@@ -264,7 +293,9 @@ inline void tree_update_weights(unsigned i, TreeEnsemble &trees, const tfloat *x
             node = trees.children_default[pos];
         } else if (trees.threshold_types[pos] == 0 && x[feature] <= trees.thresholds[pos]) {
             node = trees.children_left[pos];
-        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.thresholds[pos], x[feature])) {
+        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(
+            trees.cat_bitsets, trees.num_cat_bitsets, trees.thresholds[pos], x[feature]
+        )) {
             node = trees.children_left[pos];
         }
          else {
@@ -301,7 +332,11 @@ inline void tree_saabas(tfloat *out, const TreeEnsemble &tree, const Explanation
         const unsigned feature = tree.features[curr_node];
         if (data.X_missing[feature]) {
             next_node = tree.children_default[curr_node];
-        } else if (data.X[feature] <= tree.thresholds[curr_node]) {
+        } else if (tree.threshold_types[curr_node] == 1 && category_in_threshold(
+            tree.cat_bitsets, tree.num_cat_bitsets, tree.thresholds[curr_node], data.X[feature]
+        )) {
+            next_node = tree.children_left[curr_node];
+        } else if (tree.threshold_types[curr_node] == 0 && data.X[feature] <= tree.thresholds[curr_node]) {
             next_node = tree.children_left[curr_node];
         } else {
             next_node = tree.children_right[curr_node];
@@ -411,7 +446,9 @@ inline tfloat unwound_path_sum(const PathElement *unique_path, unsigned unique_d
 inline void tree_shap_recursive(const unsigned num_outputs, const int *children_left,
                                 const int *children_right,
                                 const int *children_default, const int *features,
-                                const tfloat *thresholds, const int *threshold_types, const tfloat *values,
+                                const tfloat *thresholds, const int *threshold_types,
+                                const unsigned int *cat_bitsets, const size_t num_cat_bitsets,
+                                const tfloat *values,
                                 const tfloat *node_sample_weight,
                                 const tfloat *x, const bool *x_missing, tfloat *phi,
                                 unsigned node_index, unsigned unique_depth,
@@ -455,7 +492,9 @@ inline void tree_shap_recursive(const unsigned num_outputs, const int *children_
             hot_index = children_default[node_index];
         } else if (type == 0 && x[split_index] <= thresholds[node_index]) {
             hot_index = children_left[node_index];
-        } else if (type == 1 && category_in_threshold(thresholds[node_index], x[split_index])) {
+        } else if (type == 1 && category_in_threshold(
+            cat_bitsets, num_cat_bitsets, thresholds[node_index], x[split_index]
+        )) {
             hot_index = children_left[node_index];
         }
         else {
@@ -495,14 +534,16 @@ inline void tree_shap_recursive(const unsigned num_outputs, const int *children_
         }
 
         tree_shap_recursive(
-            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types, values,
+            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types,
+            cat_bitsets, num_cat_bitsets, values,
             node_sample_weight, x, x_missing, phi, hot_index, unique_depth + 1, unique_path,
             hot_zero_fraction * incoming_zero_fraction, incoming_one_fraction,
             split_index, condition, condition_feature, hot_condition_fraction
         );
 
         tree_shap_recursive(
-            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types, values,
+            num_outputs, children_left, children_right, children_default, features, thresholds, threshold_types,
+            cat_bitsets, num_cat_bitsets, values,
             node_sample_weight, x, x_missing, phi, cold_index, unique_depth + 1, unique_path,
             cold_zero_fraction * incoming_zero_fraction, 0,
             split_index, condition, condition_feature, cold_condition_fraction
@@ -555,7 +596,8 @@ inline void tree_shap(const TreeEnsemble& tree, const ExplanationDataset &data,
 
     tree_shap_recursive(
         tree.num_outputs, tree.children_left, tree.children_right, tree.children_default,
-        tree.features, tree.thresholds, tree.threshold_types, tree.values, tree.node_sample_weights, data.X,
+        tree.features, tree.thresholds, tree.threshold_types, tree.cat_bitsets, tree.num_cat_bitsets,
+        tree.values, tree.node_sample_weights, data.X,
         data.X_missing, out_contribs, 0, 0, unique_path_data, 1, 1, -1, condition,
         condition_feature, 1
     );
@@ -592,6 +634,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
         out_tree.children_default[pos] = -1;
         out_tree.features[pos] = -1;
         out_tree.thresholds[pos] = 0;
+        out_tree.threshold_types[pos] = -1;
         out_tree.node_sample_weights[pos] = num_background_data_inds;
 
         return pos;
@@ -683,6 +726,7 @@ inline unsigned build_merged_tree_recursive(TreeEnsemble &out_tree, const TreeEn
 
         out_tree.features[pos] = trees.features[row_offset + i];
         out_tree.thresholds[pos] = trees.thresholds[row_offset + i];
+        out_tree.threshold_types[pos] = trees.threshold_types[row_offset + i];
         out_tree.node_sample_weights[pos] = num_background_data_inds;
 
         // build the right subtree
@@ -1420,7 +1464,6 @@ inline void dense_global_path_dependent(const TreeEnsemble& trees, const Explana
     // allocate space for our new merged tree (we save enough room to totally split all samples if need be)
     TreeEnsemble merged_tree;
     merged_tree.allocate(1, (data.num_X + data.num_R) * 2, trees.num_outputs);
-
     // collapse the ensemble of trees into a single tree that has the same behavior
     // for all the X and R samples in the dataset
     build_merged_tree(merged_tree, data, trees);

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -71,6 +71,8 @@ class GPUTreeExplainer(TreeExplainer):
 
         model = self.model
         _xgboost_cat_unsupported(model)
+        if np.any(model.threshold_types == 1):
+            raise ValueError("GPU TreeExplainer does not support categorical splits.")
         transform = model.get_transform()
 
         # run the core algorithm using the C extension
@@ -151,6 +153,8 @@ class GPUTreeExplainer(TreeExplainer):
         transform = "identity"
 
         X, y, X_missing, flat_output, tree_limit, _ = self._validate_inputs(X, y, tree_limit, False)
+        if np.any(self.model.threshold_types == 1):
+            raise ValueError("GPU TreeExplainer does not support categorical splits.")
         # run the core algorithm using the C extension
         assert_import("cext_gpu")
         phi = np.zeros((X.shape[0], X.shape[1] + 1, X.shape[1] + 1, self.model.num_outputs))

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -691,6 +691,7 @@ class TreeExplainer(Explainer):
                 self.model.features,
                 self.model.thresholds,
                 self.model.threshold_types,
+                self.model.cat_bitsets,
                 self.model.values,
                 self.model.node_sample_weight,
                 self.model.max_depth,
@@ -714,6 +715,7 @@ class TreeExplainer(Explainer):
                 self.model.features,
                 self.model.thresholds,
                 self.model.threshold_types,
+                self.model.cat_bitsets,
                 self.model.values,
                 self.model.max_depth,
                 tree_limit,
@@ -859,6 +861,7 @@ class TreeExplainer(Explainer):
             self.model.features,
             self.model.thresholds,
             self.model.threshold_types,
+            self.model.cat_bitsets,
             self.model.values,
             self.model.node_sample_weight,
             self.model.max_depth,
@@ -965,6 +968,7 @@ class TreeEnsemble:
     features: npt.NDArray[np.int32]
     thresholds: npt.NDArray[Any]
     threshold_types: npt.NDArray[np.int32]
+    cat_bitsets: npt.NDArray[np.uint32]
     values: npt.NDArray[Any]
     node_sample_weight: npt.NDArray[Any]
     num_nodes: npt.NDArray[np.int32]
@@ -1555,13 +1559,66 @@ class TreeEnsemble:
             self.values = np.zeros((num_trees, max_nodes, self.num_outputs), dtype=self.internal_dtype)
             self.node_sample_weight = np.zeros((num_trees, max_nodes), dtype=self.internal_dtype)
 
+            cat_bitset_chunks = []
+            cat_bitset_offset = 0
+            # Bitset offsets are stored in floating-point thresholds. Keep every offset in
+            # the range where this model's threshold dtype represents integers exactly.
+            max_exact_bitset_offset = (1 << (np.finfo(self.thresholds.dtype).nmant + 1)) - 1
             for i in range(num_trees):
                 self.children_left[i, : len(self.trees[i].children_left)] = self.trees[i].children_left
                 self.children_right[i, : len(self.trees[i].children_right)] = self.trees[i].children_right
                 self.children_default[i, : len(self.trees[i].children_default)] = self.trees[i].children_default
                 self.features[i, : len(self.trees[i].features)] = self.trees[i].features
-                self.thresholds[i, : len(self.trees[i].thresholds)] = self.trees[i].thresholds
+                tree_thresholds = np.asarray(self.trees[i].thresholds).copy()
+                tree_cat_bitsets = np.asarray(getattr(self.trees[i], "cat_bitsets", []), dtype=np.uint32)
+                cat_node_idx = np.nonzero(self.trees[i].threshold_types == 1)[0]
+
+                if cat_node_idx.size and tree_cat_bitsets.size == 0:
+                    # Before categorical bitsets were introduced, custom SingleTree objects
+                    # stored a packed 32-bit mask in the threshold. Migrate bit k to category
+                    # k + 1, preserving the old behavior for categories 1..32. Category 0 did
+                    # an undefined negative shift in C++; it is deliberately left unset.
+                    legacy_blocks: list[int] = []
+                    for node_idx in cat_node_idx:
+                        legacy_threshold = tree_thresholds[node_idx]
+                        if not np.isfinite(legacy_threshold) or not (
+                            np.iinfo(np.int32).min <= legacy_threshold <= np.iinfo(np.int32).max
+                        ):
+                            raise ValueError(
+                                f"Categorical node {node_idx} in tree {i} has legacy threshold "
+                                f"{legacy_threshold!r}, which cannot be represented as a packed 32-bit mask."
+                            )
+                        legacy_mask = int(legacy_threshold) & 0xFFFFFFFF
+                        tree_thresholds[node_idx] = len(legacy_blocks)
+                        legacy_blocks.extend([2, (legacy_mask << 1) & 0xFFFFFFFF, legacy_mask >> 31])
+                    tree_cat_bitsets = np.asarray(legacy_blocks, dtype=np.uint32)
+
+                if cat_node_idx.size:
+                    local_offsets = tree_thresholds[cat_node_idx]
+                    invalid_offsets = (
+                        ~np.isfinite(local_offsets) | (local_offsets < 0) | (local_offsets != np.trunc(local_offsets))
+                    )
+                    if np.any(invalid_offsets):
+                        node_idx = cat_node_idx[np.flatnonzero(invalid_offsets)[0]]
+                        raise ValueError(
+                            f"Categorical node {node_idx} in tree {i} has an invalid bitset offset "
+                            f"{tree_thresholds[node_idx]!r}."
+                        )
+                    if cat_bitset_offset + int(np.max(local_offsets)) > max_exact_bitset_offset:
+                        raise ValueError(
+                            "Categorical bitset offsets exceed the exact-integer range of the model threshold dtype."
+                        )
+                    tree_thresholds[cat_node_idx] += cat_bitset_offset
+
+                if cat_bitset_offset + tree_cat_bitsets.size > max_exact_bitset_offset:
+                    raise ValueError(
+                        "Categorical bitset buffer exceeds the exact-integer range of the model threshold dtype."
+                    )
+
+                self.thresholds[i, : len(tree_thresholds)] = tree_thresholds
                 self.threshold_types[i, : len(self.trees[i].threshold_types)] = self.trees[i].threshold_types
+                cat_bitset_chunks.append(tree_cat_bitsets)
+                cat_bitset_offset += tree_cat_bitsets.size
 
                 # XGBoost supports boosting forest, which is not compatible with the
                 # current assumption here that the number of stacked models represents
@@ -1581,6 +1638,12 @@ class TreeEnsemble:
                 # ensure that the passed background dataset lands in every leaf
                 if np.min(self.trees[i].node_sample_weight) <= 0:
                     self.fully_defined_weighting = False
+
+            self.cat_bitsets = (
+                np.concatenate(cat_bitset_chunks).astype(np.uint32)
+                if cat_bitset_offset > 0
+                else np.zeros(1, dtype=np.uint32)
+            )
 
             self.num_nodes = np.array([len(t.values) for t in self.trees], dtype=np.int32)
             self.max_depth = np.max([t.max_depth for t in self.trees])
@@ -1735,6 +1798,7 @@ class TreeEnsemble:
             self.features,
             self.thresholds,
             self.threshold_types,
+            self.cat_bitsets,
             self.values,
             self.max_depth,
             tree_limit,
@@ -1811,6 +1875,7 @@ class SingleTree:
     features: npt.NDArray[np.int32]
     thresholds: npt.NDArray[np.float64]
     threshold_types: npt.NDArray[np.int32]
+    cat_bitsets: npt.NDArray[np.uint32]
     values: npt.NDArray[Any]
     node_sample_weight: npt.NDArray[np.float64]
     max_depth: int
@@ -1841,6 +1906,7 @@ class SingleTree:
             self.features = tree.feature.astype(np.int32)
             self.thresholds = tree.threshold.astype(np.float64)
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.cat_bitsets = np.zeros(0, dtype=np.uint32)
             self.values = tree.value.reshape(tree.value.shape[0], tree.value.shape[1] * tree.value.shape[2])
             if normalize:
                 self.values = (self.values.T / self.values.sum(1)).T
@@ -1854,6 +1920,7 @@ class SingleTree:
             self.features = tree["features"].astype(np.int32)
             self.thresholds = tree["thresholds"]
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.cat_bitsets = np.zeros(0, dtype=np.uint32)
             self.values = tree["values"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
@@ -1865,6 +1932,7 @@ class SingleTree:
             self.features = tree["feature"].astype(np.int32)
             self.thresholds = tree["threshold"]
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.cat_bitsets = np.zeros(0, dtype=np.uint32)
             self.values = tree["value"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
@@ -1891,6 +1959,7 @@ class SingleTree:
             self.features = np.full(num_nodes, -2, dtype=np.int32)
             self.thresholds = np.full(num_nodes, -2, dtype=np.float64)
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.cat_bitsets = np.zeros(0, dtype=np.uint32)
             self.values = [-2] * num_nodes  # type: ignore[assignment]
             self.node_sample_weight = np.full(num_nodes, -2, dtype=np.float64)
 
@@ -1947,6 +2016,11 @@ class SingleTree:
             self.values = [-2 for _ in range(num_nodes)]  # type: ignore[assignment]
             self.node_sample_weight = np.empty(num_nodes, dtype=np.float64)
 
+            # flat uint32 buffer of category bitset blocks, one per categorical node:
+            # [n_words, w0, w1, ...] with bit (cat % 32) of word (cat // 32) set for each
+            # category routed left; a node's threshold stores its block's start index.
+            cat_bitset_words: list[int] = []
+
             # BFS traversal through the tree structure
             visited, queue = [], [start]
             while queue:
@@ -1979,11 +2053,15 @@ class SingleTree:
                         self.thresholds[vsplit_idx] = vertex["threshold"]
                         self.threshold_types[vsplit_idx] = 0
                     elif isinstance(vertex["threshold"], str):
-                        threshold = 0.0
                         categories = [int(x) for x in vertex["threshold"].split("||")]
+                        n_words = max(categories) // 32 + 1
+                        words = [0] * n_words
                         for cat in categories:
-                            threshold += 2 ** (cat - 1)
-                        self.thresholds[vsplit_idx] = threshold
+                            words[cat // 32] |= 1 << (cat % 32)
+                        start_idx = len(cat_bitset_words)
+                        cat_bitset_words.append(n_words)
+                        cat_bitset_words.extend(words)
+                        self.thresholds[vsplit_idx] = float(start_idx)
                         self.threshold_types[vsplit_idx] = 1  # Indicates that this is a categorical split
                     else:
                         raise TypeError(f"Threshold type {type(vertex['threshold'])} not supported")
@@ -2013,6 +2091,7 @@ class SingleTree:
                     # currently unavailable in `tree`, so we set to 0 first.
                     # cf. https://github.com/lightgbm-org/LightGBM/issues/5962
                     self.node_sample_weight[vleaf_idx] = vertex.get("leaf_count", 0)
+            self.cat_bitsets = np.array(cat_bitset_words, dtype=np.uint32)
             self.values = np.asarray(self.values)
             self.values = np.multiply(self.values, scaling)
 
@@ -2033,6 +2112,7 @@ class SingleTree:
             self.features = -np.ones(m, dtype=np.int32)
             self.thresholds = np.zeros(m, dtype=np.float64)
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.cat_bitsets = np.zeros(0, dtype=np.uint32)
             self.values = np.zeros((m, 1), dtype=np.float64)
             self.node_sample_weight = np.empty(m, dtype=np.float64)
 
@@ -2107,6 +2187,7 @@ class SingleTree:
             self.features = features
             self.thresholds = thresholds  # type: ignore[assignment]
             self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            self.cat_bitsets = np.zeros(0, dtype=np.uint32)
             self.values = values[:, np.newaxis] * scaling
             self.node_sample_weight = node_sample_weight
         else:
@@ -2122,6 +2203,7 @@ class SingleTree:
                 self.features,
                 self.thresholds,
                 self.threshold_types,
+                self.cat_bitsets,
                 self.values,
                 1,
                 self.node_sample_weight,

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -272,7 +272,7 @@ def test_gpu_tree_explainer_shap_interactions(task, feature_perturbation):
 @pytest.mark.parametrize("use_interactions", [False, True])
 def test_lightgbm_categorical_split(use_interactions):
     # GH 480
-    """Checks that shap interaction values are computed without error when the LightGBM model has categorical splits."""
+    """Checks LightGBM categorical splits: computed correctly on CPU, explicitly rejected on GPU."""
     lightgbm = pytest.importorskip("lightgbm")
     X, y = shap.datasets.california(n_points=10000)
     # Add HouseAgeGroup categorical variable
@@ -289,20 +289,27 @@ def test_lightgbm_categorical_split(use_interactions):
     )  # Set HouseAgeGroup as categorical variable
     preds = model.predict(X, raw_score=True)
 
-    explainer = shap.GPUTreeExplainer(model)
+    cpu_explainer = shap.TreeExplainer(model, feature_perturbation="tree_path_dependent")
+    gpu_explainer = shap.GPUTreeExplainer(model)
 
     if use_interactions:
         # Check SHAP interaction values sum to model output
-        shap_interaction_values = explainer.shap_interaction_values(X.iloc[:10, :])
-        assert np.allclose(shap_interaction_values.sum(axis=(1, 2)) + explainer.expected_value, preds[:10], atol=1e-4)
+        shap_interaction_values = cpu_explainer.shap_interaction_values(X.iloc[:10, :])
+        assert np.allclose(
+            shap_interaction_values.sum(axis=(1, 2)) + cpu_explainer.expected_value, preds[:10], atol=1e-4
+        )
+        with pytest.raises(ValueError, match="GPU TreeExplainer does not support categorical splits"):
+            gpu_explainer.shap_interaction_values(X.iloc[:10, :])
     else:
-        shap_values = explainer.shap_values(X.iloc[:10, :])
-        assert np.allclose(shap_values.sum(axis=1) + explainer.expected_value, preds[:10], atol=1e-4)
+        shap_values = cpu_explainer.shap_values(X.iloc[:10, :])
+        assert np.allclose(shap_values.sum(axis=1) + cpu_explainer.expected_value, preds[:10], atol=1e-4)
+        with pytest.raises(ValueError, match="GPU TreeExplainer does not support categorical splits"):
+            gpu_explainer.shap_values(X.iloc[:10, :])
 
 
-def test_categorical_split_cpu_gpu_equivalence():
+def test_categorical_split_gpu_rejected():
     """
-    Check consistency with a dummy tree that a single categorical split yields the same results on GPU and CPU.
+    Check that legacy custom-tree masks are migrated for CPU and explicitly rejected on GPU.
     """
     tree = {
         "children_left": np.array([1, -1, -1], dtype=np.int32),
@@ -323,8 +330,10 @@ def test_categorical_split_cpu_gpu_equivalence():
     cpu_explainer = shap.TreeExplainer(ensemble, feature_perturbation="tree_path_dependent")
     gpu_explainer = shap.GPUTreeExplainer(ensemble)
     shap_values_cpu = cpu_explainer.shap_values(X, check_additivity=False)
-    shap_values_gpu = gpu_explainer.shap_values(X, check_additivity=False)
-    np.testing.assert_allclose(shap_values_gpu, shap_values_cpu, atol=1e-5)
+    assert shap_values_cpu.shape == X.shape
+    np.testing.assert_array_equal(ensemble.cat_bitsets, np.array([2, 4, 0], dtype=np.uint32))
+    with pytest.raises(ValueError, match="GPU TreeExplainer does not support categorical splits"):
+        gpu_explainer.shap_values(X, check_additivity=False)
 
 
 def test_categorical_split_matches_binary_feature():
@@ -373,13 +382,12 @@ def test_categorical_split_matches_binary_feature():
     cat_cpu = shap.TreeExplainer(cat_ensemble, feature_perturbation="tree_path_dependent").shap_values(
         X_cat, check_additivity=False
     )
-    cat_gpu = shap.GPUTreeExplainer(cat_ensemble).shap_values(X_cat, check_additivity=False)
-    np.testing.assert_allclose(cat_gpu, cat_cpu, atol=1e-5)
+    with pytest.raises(ValueError, match="GPU TreeExplainer does not support categorical splits"):
+        shap.GPUTreeExplainer(cat_ensemble).shap_values(X_cat, check_additivity=False)
 
     bin_cpu = shap.TreeExplainer(bin_ensemble, feature_perturbation="tree_path_dependent").shap_values(
         X_bin, check_additivity=False
     )
     bin_gpu = shap.GPUTreeExplainer(bin_ensemble).shap_values(X_bin, check_additivity=False)
     np.testing.assert_allclose(bin_gpu, bin_cpu, atol=1e-5)
-    np.testing.assert_allclose(cat_gpu, bin_gpu, atol=1e-5)
-    np.testing.assert_allclose(cat_cpu, cat_gpu, atol=1e-5)
+    np.testing.assert_allclose(cat_cpu, bin_gpu, atol=1e-5)

--- a/tests/explainers/test_tree_categorical.py
+++ b/tests/explainers/test_tree_categorical.py
@@ -1,0 +1,238 @@
+"""Tests for categorical splits in the native Tree SHAP implementation."""
+
+import numpy as np
+import pytest
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.tree import DecisionTreeRegressor
+
+import shap
+from shap.explainers._tree import SingleTree, TreeEnsemble
+
+
+def _categorical_training_data(n_categories, *, include_missing=False):
+    categories = np.tile(np.arange(n_categories, dtype=np.float64), 12)
+    continuous = np.linspace(-1.0, 1.0, categories.size)
+    missing = np.zeros(categories.size, dtype=bool)
+    if include_missing:
+        missing[::13] = True
+        categories[missing] = np.nan
+
+    category_codes = np.nan_to_num(categories, nan=0).astype(int)
+    target = 3.0 * np.isin(category_codes % 5, [0, 2]) + 0.2 * continuous
+    target[missing] = 8.0
+    return np.column_stack([categories, continuous]), target
+
+
+def _train_categorical_booster(lightgbm, n_categories=33, *, include_missing=False, num_boost_round=4):
+    X, y = _categorical_training_data(n_categories, include_missing=include_missing)
+    dataset = lightgbm.Dataset(X, label=y, categorical_feature=[0])
+    model = lightgbm.train(
+        {
+            "objective": "regression",
+            "verbosity": -1,
+            "num_threads": 1,
+            "seed": 0,
+            "max_depth": 3,
+            "num_leaves": 8,
+            "min_data_in_leaf": 1,
+            "min_data_per_group": 1,
+            "max_cat_to_onehot": 1,
+            "cat_smooth": 0,
+            "cat_l2": 0,
+            "learning_rate": 0.3,
+            "force_col_wise": True,
+        },
+        dataset,
+        num_boost_round=num_boost_round,
+    )
+    return model, X
+
+
+def _assert_interaction_additivity(model, X):
+    explainer = shap.TreeExplainer(model)
+    interactions = explainer.shap_interaction_values(X)
+    pred_contrib = model.predict(X, pred_contrib=True)
+    predictions = model.predict(X)
+
+    np.testing.assert_allclose(interactions.sum(axis=2), pred_contrib[:, :-1], atol=1e-6, rtol=0)
+    np.testing.assert_allclose(
+        interactions.sum(axis=(1, 2)) + explainer.expected_value,
+        predictions,
+        atol=1e-6,
+        rtol=0,
+    )
+    return explainer
+
+
+def _legacy_categorical_tree(threshold):
+    tree = SingleTree(
+        {
+            "children_left": np.array([1, -1, -1]),
+            "children_right": np.array([2, -1, -1]),
+            "children_default": np.array([2, -1, -1]),
+            "features": np.array([0, -1, -1]),
+            "thresholds": np.array([threshold, -1.0, -1.0]),
+            "values": np.array([[0.0], [1.0], [-1.0]]),
+            "node_sample_weight": np.array([2.0, 1.0, 1.0]),
+        }
+    )
+    tree.threshold_types[0] = 1
+    return tree
+
+
+@pytest.mark.parametrize("n_categories", [8, 33, 300])
+def test_lightgbm_native_categorical_interactions(n_categories):
+    lightgbm = pytest.importorskip("lightgbm")
+    model, X = _train_categorical_booster(lightgbm, n_categories)
+    X_test = X[[0, min(32, n_categories - 1), n_categories - 1]]
+
+    assert X_test[0, 0] == 0
+    assert any(tree["tree_structure"]["decision_type"] == "==" for tree in model.dump_model()["tree_info"])
+    if n_categories == 33:
+        assert any("32" in tree["tree_structure"]["threshold"].split("||") for tree in model.dump_model()["tree_info"])
+
+    _assert_interaction_additivity(model, X_test)
+
+
+def test_lightgbm_native_categorical_missing_routing():
+    lightgbm = pytest.importorskip("lightgbm")
+    model, X = _train_categorical_booster(lightgbm, include_missing=True)
+    X_missing = X[np.isnan(X[:, 0])][:6]
+
+    assert len(X_missing) == 6
+    assert np.isnan(X_missing[:, 0]).all()
+    _assert_interaction_additivity(model, X_missing)
+
+
+def test_lightgbm_mixed_categorical_and_continuous_trees():
+    lightgbm = pytest.importorskip("lightgbm")
+    X, y = _categorical_training_data(33)
+    y = y + 2.0 * (X[:, 1] > 0)
+    dataset = lightgbm.Dataset(X, label=y, categorical_feature=[0])
+    model = lightgbm.train(
+        {
+            "objective": "regression",
+            "verbosity": -1,
+            "num_threads": 1,
+            "seed": 0,
+            "max_depth": 2,
+            "num_leaves": 4,
+            "min_data_in_leaf": 1,
+            "min_data_per_group": 1,
+            "max_cat_to_onehot": 1,
+            "cat_smooth": 0,
+            "cat_l2": 0,
+            "learning_rate": 0.3,
+            "force_col_wise": True,
+        },
+        dataset,
+        num_boost_round=3,
+        callbacks=[lightgbm.reset_parameter(feature_contri=lambda i: [1, 0] if i != 1 else [0, 1])],
+    )
+
+    explainer = _assert_interaction_additivity(model, X[[0, 32, 64]])
+    trees = explainer.model.trees
+    assert trees is not None
+    assert [np.any(tree.threshold_types == 1) for tree in trees] == [True, False, True]
+    bitset_sizes = [tree.cat_bitsets.size for tree in trees]
+    assert bitset_sizes[0] > 0
+    assert bitset_sizes[1] == 0
+    assert bitset_sizes[2] > 0
+
+    second_tree_cat_nodes = np.flatnonzero(trees[2].threshold_types == 1)
+    np.testing.assert_array_equal(
+        explainer.model.thresholds[2, second_tree_cat_nodes],
+        trees[2].thresholds[second_tree_cat_nodes] + trees[0].cat_bitsets.size,
+    )
+
+
+def test_lightgbm_categorical_saabas_reconstructs_prediction():
+    lightgbm = pytest.importorskip("lightgbm")
+    model, X = _train_categorical_booster(lightgbm, n_categories=8)
+    X_test = X[[0, 7, 15, 31]]
+    # Supplying data bypasses LightGBM's native pred_contrib shortcut and exercises
+    # SHAP's categorical-aware dense_tree_saabas implementation.
+    explainer = shap.TreeExplainer(model, data=X)
+
+    shap_values = explainer.shap_values(X_test, approximate=True)
+
+    np.testing.assert_allclose(
+        shap_values.sum(axis=1) + explainer.expected_value,
+        model.predict(X_test),
+        atol=1e-6,
+        rtol=0,
+    )
+
+
+def test_continuous_random_forest_values_and_interactions():
+    rng = np.random.RandomState(0)
+    X = rng.normal(size=(80, 4))
+    y = X[:, 0] ** 2 + X[:, 1] - 0.5 * X[:, 2]
+    model = RandomForestRegressor(n_estimators=6, max_depth=3, random_state=0).fit(X, y)
+    X_test = X[:8]
+    explainer = shap.TreeExplainer(model)
+
+    shap_values = explainer.shap_values(X_test)
+    interactions = explainer.shap_interaction_values(X_test)
+
+    assert not np.any(explainer.model.threshold_types == 1)
+    np.testing.assert_allclose(interactions.sum(axis=2), shap_values, atol=1e-6, rtol=0)
+    np.testing.assert_allclose(
+        interactions.sum(axis=(1, 2)) + explainer.expected_value,
+        model.predict(X_test),
+        atol=1e-6,
+        rtol=0,
+    )
+
+
+def test_legacy_packed_categorical_mask_migration():
+    ensemble = TreeEnsemble([_legacy_categorical_tree(np.int32(-1))], model_output="raw")
+    categories = np.arange(34, dtype=np.float64).reshape(-1, 1)
+
+    predictions = ensemble.predict(categories)
+
+    np.testing.assert_array_equal(ensemble.cat_bitsets, np.array([2, 0xFFFFFFFE, 1], dtype=np.uint32))
+    np.testing.assert_array_equal(predictions[1:33], np.ones(32))
+    np.testing.assert_array_equal(predictions[[0, 33]], -np.ones(2))
+
+
+def test_invalid_legacy_packed_categorical_mask_raises():
+    with pytest.raises(ValueError, match="cannot be represented as a packed 32-bit mask"):
+        TreeEnsemble([_legacy_categorical_tree(np.nan)], model_output="raw")
+
+
+def test_global_path_dependent_rejects_categorical_splits():
+    lightgbm = pytest.importorskip("lightgbm")
+    model, X = _train_categorical_booster(lightgbm, n_categories=8, num_boost_round=2)
+    categorical_explainer = shap.TreeExplainer(model, data=X[:40])
+    categorical_explainer.feature_perturbation = "global_path_dependent"
+
+    with pytest.raises(ValueError, match="global_path_dependent.*does not support categorical splits"):
+        categorical_explainer.shap_values(X[:2])
+
+    continuous_model = DecisionTreeRegressor(max_depth=1, random_state=0).fit(X[:, 1:], X[:, 1] > 0)
+    continuous_explainer = shap.TreeExplainer(continuous_model, data=X[:40, 1:])
+    continuous_explainer.feature_perturbation = "global_path_dependent"
+    # The constructor no longer exposes this legacy mode, so discard the expected value
+    # computed for its initial interventional mode and let the native call set the right one.
+    continuous_explainer.expected_value = None
+
+    shap_values = continuous_explainer.shap_values(X[:4, 1:])
+    np.testing.assert_allclose(
+        shap_values.sum(axis=1) + continuous_explainer.expected_value,
+        continuous_model.predict(X[:4, 1:]),
+        atol=1e-6,
+        rtol=0,
+    )
+
+
+def test_malformed_categorical_bitset_offset_routes_right():
+    ensemble = TreeEnsemble([_legacy_categorical_tree(1)], model_output="raw")
+    ensemble.thresholds[0, 0] = ensemble.cat_bitsets.size + 10
+    X = np.array([[1.0]])
+
+    np.testing.assert_array_equal(ensemble.predict(X), np.array([-1.0]))
+
+    explainer = shap.TreeExplainer(ensemble)
+    shap_values = explainer.shap_values(X)
+    np.testing.assert_allclose(shap_values.sum() + explainer.expected_value, -1.0, atol=1e-6, rtol=0)


### PR DESCRIPTION
Fixes #1644

Hello! Human here. I do not write C but hit an issue when trying to run SHAP on a LGBM model with categorical features. Claude and Codex did the real lifting, and their summary is below. You might think of this in a TDD mindset, the test here was getting reasonable results from SHAP on a real categorical model, and then the fix was made compliant for contribution.

## Overview

`shap_interaction_values` (and `approximate=True` Saabas attributions) are silently incorrect for LightGBM models trained with native categorical features. Two compounding defects:

1. A matched pair of off-by-ones (`category_in_threshold` checks `1 << (cat - 1)`; the parser packs `2 ** (cat - 1)`) that corrupts attributions whenever category 0 appears in the data (fractional bit + `1 << -1` UB). This is the bug #4274 targets.
2. Structural: the packed-double mask representation caps at ~31 category codes (float64 mantissa → 32-bit int cast). Any real-world high-cardinality categorical (city, zip code) overflows silently — on a 300-category toy the interaction row-sums disagree with LightGBM's own `pred_contrib` by ~460 where correct values agree to 1e-14. No error is raised.

This PR supersedes the mask arithmetic entirely rather than patching it.

### What this does

- **New representation**: per-tree flat uint32 bitset buffers (`[n_words, w0, ...]` blocks; categorical node thresholds store block offsets), stacked into one ensemble-global buffer with rebased offsets — the same shape LightGBM itself uses (cat_boundaries/cat_threshold). Removes the category-count cap entirely.
- **Validated native lookup**: `category_in_threshold` bounds-checks the offset, block length, and category before any narrowing; malformed inputs follow the right (no-match) branch instead of reading out of bounds. Used consistently by the TreeSHAP recursion, prediction, background weight updates, and Saabas.
- **Backwards compatibility**: manually constructed `SingleTree` objects using the legacy packed int32 mask are auto-migrated (categories 1..32, including the sign-bit category-32 case); masks that cannot be represented raise a clear error instead of silently misrouting.
- **Explicit rejection where categorical splits are not implemented**: `GPUTreeExplainer` and the legacy `global_path_dependent` mode raise a clear `ValueError` on categorical models instead of producing wrong values. Continuous models are unaffected in both paths (covered by tests). Full categorical support there is left as future work.

### What this deliberately does not do

- No interventional-path categorical support beyond what already exists.
- No CUDA bitset kernels (rejection instead — see above).
- No public API changes; the C-extension signatures gained one buffer argument (internal ABI, all callers updated in this PR).

### Validation

- New test module `tests/explainers/test_tree_categorical.py` (11 tests, <1s): interaction row-sum vs LightGBM `pred_contrib` and additivity at 1e-6 across 8/33/300 categories with category 0 present; NaN-only rows (missing routing); mixed categorical/continuous ensembles (bitset stacking incl. empty buffers); Saabas reconstruction; continuous-only regression; legacy-mask migration + invalid-mask error; global_path_dependent rejection + continuous control; malformed-offset robustness.
- Real-model gate: an 18-fold production LightGBM ensemble (50 features, 6 native categoricals up to ~5.3k categories), 1000 rows/fold — interaction row-sums vs `pred_contrib` ≤ 9.3e-15, additivity ≤ 2.9e-14, main effects vs pred_contrib ≤ 2.9e-14.
- GPU: `_cext_gpu` builds on real CUDA hardware (NVIDIA L4, CUDA 12.6) and the categorical portions of `tests/explainers/test_gpu_tree.py` pass there: the rejection tests, legacy-mask migration, and the updated GH 480 test (CPU path-dependent computes correct values on the categorical model; GPU raises). A live probe confirms both `shap_values` and `shap_interaction_values` refuse categorical models while a continuous model computes on GPU with additivity error ~2e-7. Collect-only passes without a GPU.
- Build fix included: `CMakeLists.txt` used `if(ENV{SHAP_ENABLE_CUDA})` — the bare form is a literal string and always false in CMake `if()`, so the documented `SHAP_ENABLE_CUDA=1` opt-in could never build the GPU extension. Fixed to `$ENV{...}` (verified against unpatched master: the GPU extension cannot be built there at all, so the GPU test module has been silently skipping).
- Known-unrelated failures on the GPU box: 6 `xgboost.sklearn.*` parametrizations of `test_gpu_tree_explainer_shap` fail with xgboost 3.3.0 — that version defaults `enable_categorical=True` on its sklearn wrappers, which trips the pre-existing `_xgboost_cat_unsupported` check CPU-side (code this PR does not touch) whenever background data is passed. Reproduced verbatim against unpatched master on the same hardware; with xgboost 3.0.0 the same fixtures pass.

Relationship to #4274: that PR fixes defect (1) for the interventional path; this PR addresses the path-dependent path and removes the structural cap (2), which #4274's representation cannot.

### AI usage disclosure

This section is written by the LLM that did the implementation (Claude, via Claude Code), at the author's request.

The author hit this bug using shap on a production LightGBM model with high-cardinality native categoricals. He diagnosed the two defects above and set the acceptance criteria, but does not write C — so the work was test-driven, with me doing all of the final "D". He specified the gates up front: interaction row-sums must match LightGBM's own `pred_contrib` and totals must reconstruct predictions, both at 1e-6, on toy models at 8/33/300 categories (category 0 present, NaN rows included) and on an 18-fold production ensemble. I wrote the C++ and Python to make those gates pass, and the test suite in this PR.

Where the lines were: design decisions — the bitset representation mirroring LightGBM's cat_boundaries/cat_threshold, migrating rather than rejecting legacy packed masks, failing loudly in the GPU and global-path modes — were discussed and decided by the author. The implementation within those decisions was autonomous. A second, independent LLM reviewed the full diff adversarially and found three real bugs (an out-of-bounds read, a CUDA compile break, and a Saabas misrouting); I fixed all three, and each is now pinned by a test.

None of this asks you to trust a model's opinion of its own code: every numerical claim is checked against LightGBM's own TreeSHAP implementation (`pred_contrib`) as the external oracle, and the tests in this PR encode those checks permanently.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [x] Unit tests added (if fixing a bug or adding a new feature)
