### PR TITLE
Expose plot functions to static analysis tools

### DIFF
--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TYPE_CHECKING
 
 from ._explanation import Cohorts, Explanation
 
@@ -48,7 +48,7 @@ try:
     have_matplotlib = True
 except ImportError:
     have_matplotlib = False
-if have_matplotlib:
+if have_matplotlib or TYPE_CHECKING:
     from . import plots
     from .plots._bar import bar_legacy as bar_plot
     from .plots._beeswarm import summary_legacy as summary_plot

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from ._explanation import Cohorts, Explanation
 


### PR DESCRIPTION
## Context
Static analysis tools (such as type-checkers) cannot resolve `shap.bar_plot()` and similar matplotlib-based functions exported in `shap/__init__.py`, because they're guarded behind an expression which those tools cannot evaluate (`if have_matplotlib`).

As a result, type-checking any code which utilises these methods is rather painful, since the type-checker flags the functions as missing.

## Changes
Use the `TYPE_CHECKING` constant to expose these functions to type-checkers without changing runtime semantics.
