### PR TITLE
FIX: convert list input to numpy array in TreeExplainer (closes #4473)

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -456,6 +456,10 @@ class TreeExplainer(Explainer):
         tree_limit: int | None,
         check_additivity: bool,
     ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | pd.Series | None, npt.NDArray[np.bool_], bool, int, bool]:
+        # convert plain Python lists to numpy arrays
+        if isinstance(X, list):
+            X = np.array(X, dtype=self.model.input_dtype)
+
         # see if we have a default tree_limit in place.
         if tree_limit is None:
             tree_limit = -1 if self.model.tree_limit is None else self.model.tree_limit


### PR DESCRIPTION
## Summary
TreeExplainer crashes with AttributeError when input is a plain Python list because `_validate_inputs` assumes the input has a .shape attribute.

## Changes
- Added isinstance(X, list) check in `_validate_inputs` to convert lists to numpy arrays

## Testing
- Confirmed list input, list-of-lists, and numpy array inputs all work correctly
- All existing tree tests pass

Fixes #4473