### PR TITLE
FIX: raise TypeError for list input in TreeExplainer

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -465,6 +465,8 @@ class TreeExplainer(Explainer):
         # convert dataframes (use to_numpy to handle pandas nullable dtypes like Int64/Float64)
         if isinstance(X, (pd.Series, pd.DataFrame)):
             X = X.to_numpy(dtype=self.model.input_dtype, na_value=np.nan)
+        if not isinstance(X, np.ndarray):
+            raise TypeError(f"X must be a numpy array (or pandas DataFrame/Series), not {type(X).__name__}")
         flat_output = False
         if len(X.shape) == 1:
             flat_output = True

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -44,6 +44,20 @@ def test_large_background_dataset_warning():
         shap.TreeExplainer(model, background, feature_perturbation="interventional")
 
 
+def test_list_input_raises_type_error():
+    """Passing a plain Python list to shap_values should raise TypeError (not AttributeError)."""
+    X, y = shap.datasets.california(n_points=100)
+    model = DecisionTreeRegressor(max_depth=3, random_state=0)
+    model.fit(X, y)
+    explainer = shap.TreeExplainer(model)
+
+    with pytest.raises(TypeError, match="must be a numpy array"):
+        explainer.shap_values(list(X.iloc[0]))
+
+    with pytest.raises(TypeError, match="must be a numpy array"):
+        explainer.shap_values(X.values.tolist())
+
+
 def test_front_page_xgboost():
     xgboost = pytest.importorskip("xgboost")
 


### PR DESCRIPTION
TreeExplainer crashes with `AttributeError` when a plain Python list is passed to `shap_values()`, because `_validate_inputs` assumes the input has a `.shape` attribute.

This fix adds an `isinstance` check after the pandas conversion to raise a clear `TypeError` for unsupported input types (e.g., lists), instead of crashing with `AttributeError`.

Fixes #4473