### PR TITLE
ENH: Interventional (marginal) SHAP interaction values for tree models

### DIFF
--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -1448,6 +1448,269 @@ inline void dense_global_path_dependent(const TreeEnsemble& trees, const Explana
 }
 
 
+// ===========================================================================
+// INTERVENTIONAL (marginal) order-2 tree interaction values.
+//
+// This is the previously-missing path: FEATURE_DEPENDENCE::independent with
+// interactions == true.  It is a direct C++ port of the Zern, Broelemann &
+// Kasneci (2023, AAAI) algorithm that shapiq implements — a paired E/R
+// depth-first traversal of the explained point x and each background reference
+// r, with a closed-form per-leaf Shapley-interaction weight.  No 2^n coalition
+// enumeration; polynomial and linear in |R|.
+//
+// For each explained point x and reference r, one DFS of each tree splits the
+// features that route x and r to different children into two disjoint sets:
+//   E = features whose divergent split followed x's branch,
+//   R = features whose divergent split followed r's branch.
+// A reached leaf with value v contributes to the interaction of feature set U
+// (|U cap E| = s_cap_e, |U cap R| = s_cap_r) the amount v * lambda(...) iff
+// U subset (E cup R).  Summing over all reached leaves / references / trees and
+// dividing by |R| yields the exact interventional Shapley Interaction (SII)
+// values.  For order 2 that is: n main effects phi_i (= interventional single
+// SHAP) and C(n,2) pair values SII_ij.
+//
+// We then assemble shap's CLASSIC interaction matrix convention (Lundberg 2020,
+// the same one dense_tree_interactions_path_dependent produces):
+//   off-diagonal  Phi_ij = Phi_ji = SII_ij / 2
+//   diagonal      Phi_ii = phi_i - sum_{j!=i} Phi_ij
+//   bias cell     Phi[M][M] = baseline = E_{r~R}[f(r)]
+// so that every row sums to the interventional single SHAP value phi_i, the
+// whole M x M block sums to f(x) - E_R[f], and the full (M+1)x(M+1) sums to f(x).
+//
+// Scope: model_output == "raw" (transform == NULL) only, which is what
+// shap_interaction_values already asserts.
+// ===========================================================================
+
+// C(n, k) as a double (n bounded by tree depth, so this is exact and cheap).
+inline tfloat interv_binom(int n, int k) {
+    if (k < 0 || k > n) return 0.0;
+    if (k == 0 || k == n) return 1.0;
+    if (k > n - k) k = n - k;
+    tfloat result = 1.0;
+    for (int i = 0; i < k; ++i) {
+        result = result * static_cast<tfloat>(n - i) / static_cast<tfloat>(i + 1);
+    }
+    return result;
+}
+
+// SII leaf weight  lambda(e, r, s_cap_e, s_cap_r)
+//   w1 = e - s_cap_e; w2 = r - s_cap_r
+//   sign = (-1)^{s_cap_r}
+//   lambda = sign / ((w1 + w2 + 1) * C(w1 + w2, w1))
+// (Zern et al. 2023, Prop.1 / Cor.1; == shapiq weights.cpp shapley_weight.)
+inline tfloat interv_sii_weight(int e, int r, int s_cap_e, int s_cap_r) {
+    const int w1 = e - s_cap_e;
+    const int w2 = r - s_cap_r;
+    const tfloat sign = (s_cap_r % 2 == 0) ? 1.0 : -1.0;
+    return sign / (static_cast<tfloat>(w1 + w2 + 1) * interv_binom(w1 + w2, w1));
+}
+
+// Accumulate one reached leaf's contribution into the (order-1) phi_single and
+// (order-2, canonical upper-triangle a<b) phi_pair buffers.
+inline void interv_second_order_leaf_update(
+        const int *Elist, int e, const int *Rlist, int r,
+        const tfloat *leaf_values, unsigned num_outputs, unsigned M,
+        tfloat *phi_single, tfloat *phi_pair) {
+
+    // weights are independent of which specific features are in E/R, so compute
+    // them once per leaf (guarded so we never evaluate an unused degenerate one).
+    const tfloat wE  = (e >= 1)            ? interv_sii_weight(e, r, 1, 0) : 0.0;
+    const tfloat wR  = (r >= 1)            ? interv_sii_weight(e, r, 0, 1) : 0.0;
+    const tfloat wEE = (e >= 2)            ? interv_sii_weight(e, r, 2, 0) : 0.0;
+    const tfloat wRR = (r >= 2)            ? interv_sii_weight(e, r, 0, 2) : 0.0;
+    const tfloat wER = (e >= 1 && r >= 1)  ? interv_sii_weight(e, r, 1, 1) : 0.0;
+
+    for (unsigned o = 0; o < num_outputs; ++o) {
+        const tfloat v = leaf_values[o];
+        if (v == 0.0) continue;
+
+        // main effects (diagonal of SII == interventional single SHAP)
+        for (int a = 0; a < e; ++a) phi_single[Elist[a] * num_outputs + o] += v * wE;
+        for (int a = 0; a < r; ++a) phi_single[Rlist[a] * num_outputs + o] += v * wR;
+
+        // pairwise, both endpoints in E
+        for (int a = 0; a < e; ++a) {
+            for (int b = a + 1; b < e; ++b) {
+                int i = Elist[a], j = Elist[b];
+                if (i > j) { int t = i; i = j; j = t; }
+                phi_pair[(static_cast<unsigned>(i) * M + j) * num_outputs + o] += v * wEE;
+            }
+        }
+        // pairwise, both endpoints in R
+        for (int a = 0; a < r; ++a) {
+            for (int b = a + 1; b < r; ++b) {
+                int i = Rlist[a], j = Rlist[b];
+                if (i > j) { int t = i; i = j; j = t; }
+                phi_pair[(static_cast<unsigned>(i) * M + j) * num_outputs + o] += v * wRR;
+            }
+        }
+        // pairwise, one endpoint in E and one in R (E and R are disjoint by
+        // construction; the i==j guard is defensive)
+        for (int a = 0; a < e; ++a) {
+            for (int b = 0; b < r; ++b) {
+                int i = Elist[a], j = Rlist[b];
+                if (i == j) continue;
+                if (i > j) { int t = i; i = j; j = t; }
+                phi_pair[(static_cast<unsigned>(i) * M + j) * num_outputs + o] += v * wER;
+            }
+        }
+    }
+}
+
+// Paired DFS of x and r through a single tree, collecting per-leaf (E, R, value)
+// and folding them into phi_single / phi_pair via the order-2 update above.
+// Elist/Rlist are shared scratch buffers (sized >= max_depth+1); the standard
+// "write at index count, recurse with count+1" pattern keeps sibling branches
+// independent.
+inline void interv_er_dfs(
+        const TreeEnsemble &tree,
+        const tfloat *x, const bool *x_missing,
+        const tfloat *r, const bool *r_missing,
+        unsigned node, int *Elist, int en, int *Rlist, int rn,
+        unsigned M, unsigned num_outputs,
+        tfloat *phi_single, tfloat *phi_pair) {
+
+    // leaf
+    if (tree.children_right[node] < 0) {
+        interv_second_order_leaf_update(Elist, en, Rlist, rn,
+                                        tree.values + node * num_outputs,
+                                        num_outputs, M, phi_single, phi_pair);
+        return;
+    }
+
+    const unsigned feat = tree.features[node];
+    const int type = tree.threshold_types[node];
+    const tfloat thr = tree.thresholds[node];
+
+    // branch x would take
+    unsigned child_x;
+    if (x_missing[feat]) child_x = tree.children_default[node];
+    else if (type == 0 && x[feat] <= thr) child_x = tree.children_left[node];
+    else if (type == 1 && category_in_threshold(thr, x[feat])) child_x = tree.children_left[node];
+    else child_x = tree.children_right[node];
+
+    // branch r would take
+    unsigned child_r;
+    if (r_missing[feat]) child_r = tree.children_default[node];
+    else if (type == 0 && r[feat] <= thr) child_r = tree.children_left[node];
+    else if (type == 1 && category_in_threshold(thr, r[feat])) child_r = tree.children_left[node];
+    else child_r = tree.children_right[node];
+
+    if (child_x == child_r) {
+        // split does not separate x and r: sets unchanged, single continuation
+        interv_er_dfs(tree, x, x_missing, r, r_missing, child_x,
+                      Elist, en, Rlist, rn, M, num_outputs, phi_single, phi_pair);
+    } else {
+        // Divergent split. E and R are treated as SETS (shapiq uses
+        // e_set | {feature}); a feature split multiple times along the path must
+        // be counted ONCE. Descend x's branch iff the feature isn't already
+        // committed to R; grow E only if the feature isn't already in E.
+        // Symmetrically for r's branch. (A feature already committed to one side
+        // can't be claimed by the other -> Zern et al. guards i in B / i not in A.)
+        bool in_R = false;
+        for (int i = 0; i < rn; ++i) { if (Rlist[i] == static_cast<int>(feat)) { in_R = true; break; } }
+        bool in_E = false;
+        for (int i = 0; i < en; ++i) { if (Elist[i] == static_cast<int>(feat)) { in_E = true; break; } }
+
+        if (!in_R) {  // follow x -> feature belongs to E
+            int next_en = en;
+            if (!in_E) { Elist[en] = static_cast<int>(feat); next_en = en + 1; }
+            interv_er_dfs(tree, x, x_missing, r, r_missing, child_x,
+                          Elist, next_en, Rlist, rn, M, num_outputs, phi_single, phi_pair);
+        }
+        if (!in_E) {  // follow r -> feature belongs to R
+            int next_rn = rn;
+            if (!in_R) { Rlist[rn] = static_cast<int>(feat); next_rn = rn + 1; }
+            interv_er_dfs(tree, x, x_missing, r, r_missing, child_r,
+                          Elist, en, Rlist, next_rn, M, num_outputs, phi_single, phi_pair);
+        }
+    }
+}
+
+inline void dense_tree_interactions_independent(const TreeEnsemble& trees, const ExplanationDataset &data,
+                                                tfloat *out_contribs, transform_f transform) {
+    if (transform != NULL) {
+        // Non-raw model_output would need the per-reference rescale that
+        // dense_independent applies; shap_interaction_values asserts raw, so we
+        // never expect to get here. Warn and proceed with the raw computation.
+        std::cerr << "dense_tree_interactions_independent: only model_output=\"raw\" is supported; "
+                     "computing raw interaction values.\n";
+    }
+
+    const unsigned M  = data.M;
+    const unsigned no = trees.num_outputs;
+    const unsigned long long matrix_stride =
+        static_cast<unsigned long long>(M + 1) * (M + 1) * no;
+    const unsigned row_stride = (M + 1) * no;  // = contrib_row_size
+
+    tfloat *phi_single = new tfloat[static_cast<size_t>(M) * no];
+    tfloat *phi_pair   = new tfloat[static_cast<size_t>(M) * M * no];
+    tfloat *baseline   = new tfloat[no];
+    int *Elist = new int[trees.max_depth + 2];
+    int *Rlist = new int[trees.max_depth + 2];
+
+    for (unsigned i = 0; i < data.num_X; ++i) {
+        const tfloat *x = data.X + static_cast<size_t>(i) * M;
+        const bool  *x_missing = data.X_missing + static_cast<size_t>(i) * M;
+        tfloat *inst = out_contribs + static_cast<unsigned long long>(i) * matrix_stride;
+
+        std::fill(inst, inst + matrix_stride, static_cast<tfloat>(0));
+        std::fill(phi_single, phi_single + static_cast<size_t>(M) * no, static_cast<tfloat>(0));
+        std::fill(phi_pair, phi_pair + static_cast<size_t>(M) * M * no, static_cast<tfloat>(0));
+        std::fill(baseline, baseline + no, static_cast<tfloat>(0));
+
+        for (unsigned j = 0; j < data.num_R; ++j) {
+            const tfloat *r = data.R + static_cast<size_t>(j) * M;
+            const bool  *r_missing = data.R_missing + static_cast<size_t>(j) * M;
+            for (unsigned t = 0; t < trees.tree_limit; ++t) {
+                TreeEnsemble tree;
+                trees.get_tree(tree, t);
+                // baseline contribution: this tree's prediction for r
+                const tfloat *rleaf = tree_predict(0, tree, r, r_missing);
+                for (unsigned o = 0; o < no; ++o) baseline[o] += rleaf[o];
+                // interaction contribution
+                interv_er_dfs(tree, x, x_missing, r, r_missing, 0,
+                              Elist, 0, Rlist, 0, M, no, phi_single, phi_pair);
+            }
+        }
+
+        const tfloat invR = static_cast<tfloat>(1) / static_cast<tfloat>(data.num_R);
+        for (size_t k = 0; k < static_cast<size_t>(M) * no; ++k) phi_single[k] *= invR;
+        for (size_t k = 0; k < static_cast<size_t>(M) * M * no; ++k) phi_pair[k] *= invR;
+        for (unsigned o = 0; o < no; ++o) baseline[o] = baseline[o] * invR + trees.base_offset[o];
+
+        // assemble shap's classic (M+1)x(M+1) interaction matrix
+        for (unsigned o = 0; o < no; ++o) {
+            // off-diagonals = SII_pair / 2, written symmetrically
+            for (unsigned a = 0; a < M; ++a) {
+                for (unsigned b = a + 1; b < M; ++b) {
+                    const tfloat half = phi_pair[(static_cast<size_t>(a) * M + b) * no + o] * static_cast<tfloat>(0.5);
+                    inst[(static_cast<size_t>(a) * (M + 1) + b) * no + o] = half;
+                    inst[(static_cast<size_t>(b) * (M + 1) + a) * no + o] = half;
+                }
+            }
+            // diagonal = phi_i - sum_{j!=i} Phi_ij (so each row sums to phi_i)
+            for (unsigned a = 0; a < M; ++a) {
+                tfloat off_sum = 0.0;
+                for (unsigned b = 0; b < M; ++b) {
+                    if (b != a) off_sum += inst[(static_cast<size_t>(a) * (M + 1) + b) * no + o];
+                }
+                inst[(static_cast<size_t>(a) * (M + 1) + a) * no + o] = phi_single[a * no + o] - off_sum;
+            }
+            // bias cell [M][M] = baseline (bias row/col already zeroed above)
+            inst[(static_cast<size_t>(M) * (M + 1) + M) * no + o] = baseline[o];
+        }
+    }
+
+    delete[] phi_single;
+    delete[] phi_pair;
+    delete[] baseline;
+    delete[] Elist;
+    delete[] Rlist;
+    (void)row_stride;
+}
+
+
 /**
  * The main method for computing Tree SHAP on models using dense data.
  */
@@ -1461,7 +1724,7 @@ inline void dense_tree_shap(const TreeEnsemble& trees, const ExplanationDataset 
     switch (feature_dependence) {
         case FEATURE_DEPENDENCE::independent:
             if (interactions) {
-                std::cerr << "FEATURE_DEPENDENCE::independent does not support interactions!\n";
+                dense_tree_interactions_independent(trees, data, out_contribs, transform);
             } else dense_independent(trees, data, out_contribs, transform);
             return;
 

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -841,7 +841,19 @@ class TreeExplainer(Explainer):
         assert self.model.model_output == "raw", (
             'Only model_output = "raw" is supported for SHAP interaction values right now!'
         )
-        # assert self.feature_perturbation == "tree_path_dependent", "Only feature_perturbation = \"tree_path_dependent\" is supported for SHAP interaction values right now!"
+        # Interaction values are supported for "tree_path_dependent" (conditional
+        # expectation) and, since the interventional-interaction C++ path was
+        # added, for "interventional" (marginal) as well -- but the latter needs
+        # a background dataset to marginalize against.
+        assert self.feature_perturbation in ("tree_path_dependent", "interventional"), (
+            'Only feature_perturbation in {"tree_path_dependent", "interventional"} is '
+            "supported for SHAP interaction values right now!"
+        )
+        if self.feature_perturbation == "interventional" and self.data is None:
+            raise ValueError(
+                'feature_perturbation="interventional" interaction values require a '
+                "background dataset; pass data=... to shap.TreeExplainer(...)."
+            )
         transform = "identity"
 
         # see if we have a default tree_limit in place.

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -3016,3 +3016,171 @@ def test_nullable_pandas_dtype():
     explainer = shap.TreeExplainer(model)
     sv = explainer.shap_values(X_test)
     assert not np.any(np.isnan(sv[~np.isnan(X_test.to_numpy(dtype=float, na_value=np.nan)).any(axis=1)]))
+
+
+# ---------------------------------------------------------------------------
+# Interventional (marginal) SHAP interaction values -- GH#1824
+#
+# Before this path existed, ``TreeExplainer(model, background,
+# feature_perturbation="interventional").shap_interaction_values(...)`` hit the
+# ``independent + interactions`` branch of the C extension, which printed a note
+# to stderr and returned an all-zero tensor. These tests cover the new marginal
+# interaction path (order 2, ``model_output="raw"``).
+# ---------------------------------------------------------------------------
+
+
+def _interv_marginal_predict(model, S, x, r):
+    """model.predict on the reference r with the features in S taken from x."""
+    z = r.copy()
+    for i in S:
+        z[i] = x[i]
+    return model.predict(z.reshape(1, -1))[0]
+
+
+def _interv_brute_shapley(model, x, bg, M):
+    """Exact marginal (interventional) Shapley values by coalition enumeration."""
+    phi = np.zeros(M)
+    for r in bg:
+        for i in range(M):
+            others = [f for f in range(M) if f != i]
+            for k in range(len(others) + 1):
+                for S in itertools.combinations(others, k):
+                    S = list(S)
+                    w = math.factorial(len(S)) * math.factorial(M - len(S) - 1) / math.factorial(M)
+                    phi[i] += w * (
+                        _interv_marginal_predict(model, S + [i], x, r) - _interv_marginal_predict(model, S, x, r)
+                    )
+    return phi / len(bg)
+
+
+def _interv_brute_sii_pair(model, x, bg, M):
+    """Exact marginal Shapley-interaction (SII) pair values by enumeration."""
+    inter = np.zeros((M, M))
+    for r in bg:
+        for i in range(M):
+            for j in range(i + 1, M):
+                others = [f for f in range(M) if f not in (i, j)]
+                for k in range(len(others) + 1):
+                    for S in itertools.combinations(others, k):
+                        S = list(S)
+                        s = len(S)
+                        w = math.factorial(s) * math.factorial(M - s - 2) / math.factorial(M - 1)
+                        d = (
+                            _interv_marginal_predict(model, S + [i, j], x, r)
+                            - _interv_marginal_predict(model, S + [i], x, r)
+                            - _interv_marginal_predict(model, S + [j], x, r)
+                            + _interv_marginal_predict(model, S, x, r)
+                        )
+                        inter[i, j] += w * d
+                inter[j, i] = inter[i, j]
+    return inter / len(bg)
+
+
+def _interv_classic_matrix(single, pair, M):
+    """Assemble shap's classic interaction matrix from SII single/pair values:
+    off-diagonal = SII_pair / 2, diagonal absorbs the remainder so each row sums
+    to the single SHAP value."""
+    Phi = np.zeros((M, M))
+    for i in range(M):
+        for j in range(i + 1, M):
+            Phi[i, j] = Phi[j, i] = pair[i, j] / 2.0
+    for i in range(M):
+        Phi[i, i] = single[i] - (Phi[i].sum() - Phi[i, i])
+    return Phi
+
+
+def _interv_small_rf():
+    from sklearn.ensemble import RandomForestRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.rand(200, 4)
+    y = X[:, 0] * X[:, 1] + X[:, 2] - 0.5 * X[:, 0] * X[:, 3] + 0.1 * rng.rand(200)
+    model = RandomForestRegressor(n_estimators=6, max_depth=4, random_state=0).fit(X, y)
+    return model, X[:20], X[:3]
+
+
+def test_interventional_interaction_values_nonzero():
+    """Regression test for GH#1824: interventional interaction values were
+    silently returned as all zeros."""
+    model, bg, x = _interv_small_rf()
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    iv = np.asarray(explainer.shap_interaction_values(x))
+    assert np.abs(iv).sum() > 0
+
+
+def test_interventional_interaction_values_symmetric():
+    model, bg, x = _interv_small_rf()
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    iv = np.asarray(explainer.shap_interaction_values(x))
+    assert np.allclose(iv, np.swapaxes(iv, 1, 2), atol=1e-12)
+
+
+def test_interventional_interaction_values_reconcile():
+    model, bg, x = _interv_small_rf()
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    iv = np.asarray(explainer.shap_interaction_values(x))
+    sv = np.asarray(explainer.shap_values(x))
+    # each row sums to the interventional single SHAP value
+    assert np.allclose(iv.sum(axis=2), sv, atol=1e-6)
+    # the full matrix plus the expected value reconstructs the prediction
+    assert np.allclose(iv.sum(axis=(1, 2)) + explainer.expected_value, model.predict(x), atol=1e-4)
+
+
+def test_interventional_interaction_values_match_brute_force():
+    """The classic interaction matrix must equal an exact brute-force marginal
+    Shapley-interaction computation built only from model.predict."""
+    model, bg, x = _interv_small_rf()
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    iv = np.asarray(explainer.shap_interaction_values(x))
+    M = x.shape[1]
+    for k in range(len(x)):
+        single = _interv_brute_shapley(model, x[k], bg, M)
+        pair = _interv_brute_sii_pair(model, x[k], bg, M)
+        expected = _interv_classic_matrix(single, pair, M)
+        assert np.allclose(iv[k], expected, atol=1e-4)
+
+
+def test_interventional_interaction_values_requires_background():
+    """Interventional interactions need a background dataset to marginalize
+    against; asking for them without one must error rather than return zeros."""
+    from sklearn.ensemble import RandomForestRegressor
+
+    rng = np.random.RandomState(0)
+    X = rng.rand(80, 4)
+    y = X[:, 0] * X[:, 1] + X[:, 2]
+    model = RandomForestRegressor(n_estimators=5, max_depth=3, random_state=0).fit(X, y)
+    explainer = shap.TreeExplainer(model, X[:16], feature_perturbation="interventional")
+    explainer.data = None  # simulate a missing background on an interventional explainer
+    with pytest.raises(ValueError, match="background dataset"):
+        explainer.shap_interaction_values(X[:2])
+
+
+@pytest.mark.parametrize("model_name", ["random_forest", "gradient_boosting", "lightgbm", "xgboost"])
+def test_interventional_interaction_values_additivity_across_models(model_name):
+    rng = np.random.RandomState(1)
+    X = rng.rand(300, 5).astype(np.float64)
+    y = X[:, 0] * X[:, 3] + np.sin(3 * X[:, 1]) + X[:, 2] - X[:, 0] * X[:, 4]
+
+    if model_name == "random_forest":
+        from sklearn.ensemble import RandomForestRegressor
+
+        model = RandomForestRegressor(n_estimators=10, max_depth=4, random_state=0).fit(X, y)
+    elif model_name == "gradient_boosting":
+        model = GradientBoostingRegressor(n_estimators=20, max_depth=3, random_state=0).fit(X, y)
+    elif model_name == "lightgbm":
+        lightgbm = pytest.importorskip("lightgbm")
+        model = lightgbm.LGBMRegressor(n_estimators=20, max_depth=3, random_state=0, verbose=-1).fit(X, y)
+    else:
+        xgboost = pytest.importorskip("xgboost")
+        model = xgboost.XGBRegressor(n_estimators=20, max_depth=3, random_state=0).fit(X, y)
+
+    bg = X[:32]
+    x = X[:5]
+    explainer = shap.TreeExplainer(model, bg, feature_perturbation="interventional")
+    iv = np.asarray(explainer.shap_interaction_values(x))
+    sv = np.asarray(explainer.shap_values(x))
+
+    assert np.abs(iv).sum() > 0
+    assert np.allclose(iv, np.swapaxes(iv, 1, 2), atol=1e-6)
+    assert np.allclose(iv.sum(axis=2), sv, atol=1e-4)
+    assert np.allclose(iv.sum(axis=(1, 2)) + explainer.expected_value, model.predict(x), atol=1e-4)


### PR DESCRIPTION
## Overview

Closes #1824.

Interventional `TreeExplainer.shap_interaction_values` silently returned all
zeros: with a background dataset, the C extension hit the
`independent + interactions` branch, printed a stderr note, and returned a zero
tensor. This implements the missing marginal interaction path, so

```python
shap.TreeExplainer(model, background, feature_perturbation="interventional").shap_interaction_values(X)
```

returns correct values in the usual `(n, M, M)` convention.

Algorithm follows Zern et al. (AAAI 2023). CPU, order 2, `model_output="raw"` —
the scope the interaction API already asserts. #4274 targets the same issue more
broadly (GPU, transforms); this is a minimal, independent CPU path.

### Changed
- `shap/cext/tree_shap.h` — new `dense_tree_interactions_independent`, wired into the dispatcher in place of the stderr/zero stub.
- `shap/explainers/_tree.py` — allow `feature_perturbation="interventional"` (needs a background), else raise instead of returning zeros.
- `tests/explainers/test_tree.py` — tests for the new path.

### Validation
Nonzero output, symmetry, row-sum equals the interventional single SHAP values,
matrix + `expected_value` reconstructs the prediction, and a match to a
brute-force marginal Shapley-interaction reference (RF/GBR/LightGBM/XGBoost).

## AI Disclosure

Developed with AI assistance (Claude) per the repository's AI policy. The author
directed the work and validated every change against a brute-force reference and
an independent library (shapiq).

## Checklist

- [x] All pre-commit checks pass.
- [x] Unit tests added.
