### PR TITLE
FIX: allow oversampling in Explanation.sample when replace=True

### DIFF
--- a/shap/_explanation.py
+++ b/shap/_explanation.py
@@ -621,7 +621,11 @@ class Explanation(metaclass=MetaExplanation):
         rng = np.random.RandomState(random_state)
         length = self.shape[0]
         assert length is not None
-        inds = rng.choice(length, size=min(max_samples, length), replace=replace)
+        # Without replacement we cannot draw more rows than exist, so cap the
+        # count. With replacement, oversampling beyond the row count is valid
+        # (e.g. bootstrapping) and must return the requested number of rows.
+        size = max_samples if replace else min(max_samples, length)
+        inds = rng.choice(length, size=size, replace=replace)
         prev_shape = self.shape
         new_self = self[list(inds)]
         # Replace the __getitem__ entry with "sample" so op_history

--- a/tests/test_explanation.py
+++ b/tests/test_explanation.py
@@ -245,3 +245,17 @@ def test_cohorts_generation_with_one_feature():
     cohorts = exp.cohorts(3)
     assert isinstance(cohorts, shap.Cohorts)
     assert len(cohorts.cohorts) == 3
+
+
+def test_sample_with_replacement_allows_oversampling():
+    # With replacement, requesting more rows than exist is valid (e.g.
+    # bootstrapping) and must return the requested number of rows. Without
+    # replacement, the count stays capped at the number of rows, as documented.
+    exp = shap.Explanation(
+        values=np.arange(10).reshape(10, 1).astype(float),
+        base_values=np.zeros(10),
+        data=np.arange(10).reshape(10, 1).astype(float),
+    )
+    assert exp.sample(25, replace=True).shape[0] == 25
+    assert exp.sample(25, replace=False).shape[0] == 10
+    assert exp.sample(4, replace=False).shape[0] == 4


### PR DESCRIPTION
## Overview

`Explanation.sample(max_samples, replace=True)` returns fewer rows than asked for when `max_samples` is bigger than the number of rows:

```python
e = shap.Explanation(values=np.arange(10).reshape(10, 1).astype(float), base_values=np.zeros(10))
e.sample(25, replace=True).shape  # (10, 1) on master, expected (25, 1)
```

The cap in `rng.choice(length, size=min(max_samples, length), replace=replace)` is only needed for `replace=False`, since NumPy can't draw more items than exist without replacement. With `replace=True` oversampling is fine — that's what the flag is for — so the cap just truncates the result. The docstring already says the shortfall only applies when `replace=False`.

Fix guards the cap with the `replace` flag; `replace=False` behaviour is unchanged. Test covers both.

## Checklist

- [x] All pre-commit checks pass.
- [x] Unit tests added.

## AI Disclosure

I used Claude to help find this bug and draft the fix and test, per the repo's AI policy. I ran it all locally against both the released package and the fix, understand the change, and take responsibility for it.
