### PR TITLE
PERF: Migrate TreeExplainer bindings to nanobind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,11 +74,6 @@ install(TARGETS _cutils LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 # Build the Tree Logic extension module (cext)
 # ==============================================================================
 
-# Check if the SABI version is being requested
-if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
-  set(USE_SABI USE_SABI ${SKBUILD_SABI_VERSION})
-endif()
-
 # Build the CPU Tree SHAP module using nanobind.
 nanobind_add_module(
   _cext
@@ -104,15 +99,6 @@ nanobind_add_stub(
   DEPENDS _cext
 )
 
-# Get the include directory for NumPy. The optional legacy GPU extension below
-# still uses the NumPy C API.
-execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}"
-    -c "import numpy; print(numpy.get_include())"
-    OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
 add_custom_command(
   TARGET _cext_stub POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -127,6 +113,19 @@ install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 # Optional: Build the GPU Tree SHAP extension module (cext_gpu)
 # Enabled via: SHAP_ENABLE_CUDA=1 pip install .
 # ==============================================================================
+
+# Check if the SABI version is being requested
+if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
+  set(USE_SABI USE_SABI ${SKBUILD_SABI_VERSION})
+endif()
+
+# Get the include directory for NumPy. The GPU extension still uses the NumPy C API.
+execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}"
+    -c "import numpy; print(numpy.get_include())"
+    OUTPUT_VARIABLE NUMPY_INCLUDE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 if(ENV{SHAP_ENABLE_CUDA})
   message(MESSAGE "SHAP_ENABLE_CUDA is set, attempting to build the GPU extension...")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,17 +79,33 @@ if(NOT "${SKBUILD_SABI_VERSION}" STREQUAL "")
   set(USE_SABI USE_SABI ${SKBUILD_SABI_VERSION})
 endif()
 
-python_add_library(
-  _cext MODULE
+# Build the CPU Tree SHAP module using nanobind.
+nanobind_add_module(
+  _cext
+
+  # This extension is free-threaded
+  FREE_THREADED
 
   # Target the stable ABI of Python 3.12+, reducing the number of binary wheels
-  ${USE_SABI} WITH_SOABI
+  STABLE_ABI
+
+  # Build libnanobind as a static library and link it into the module
+  NB_STATIC
 
   # Sources for the cext module
   shap/cext/_cext.cc
 )
 
-# Get the include directory for NumPy and add it to the include path
+nanobind_add_stub(
+  _cext_stub
+  MODULE _cext
+  OUTPUT _cext.pyi
+  PYTHON_PATH $<TARGET_FILE_DIR:_cext>
+  DEPENDS _cext
+)
+
+# Get the include directory for NumPy. The optional legacy GPU extension below
+# still uses the NumPy C API.
 execute_process(
     COMMAND "${PYTHON_EXECUTABLE}"
     -c "import numpy; print(numpy.get_include())"
@@ -97,7 +113,12 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-target_include_directories(_cext PUBLIC ${NUMPY_INCLUDE_DIR})
+add_custom_command(
+  TARGET _cext_stub POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_CURRENT_BINARY_DIR}/_cext.pyi
+    ${CMAKE_CURRENT_SOURCE_DIR}/shap/_cext.pyi
+)
 
 # Install directive for scikit-build-core
 install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})

--- a/monitoring/tree_explainer.py
+++ b/monitoring/tree_explainer.py
@@ -1,0 +1,43 @@
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from xgboost import XGBClassifier
+
+from shap.datasets import adult
+from shap.explainers import TreeExplainer
+
+
+class TreeSuite:
+    # Adapted from tests/explainers/test_tree.py
+    max_samples = 100
+
+    def setup(self):
+        self.X, self.y = adult(n_points=self.max_samples)
+        self.X = self.X.values
+
+        self.regressor = RandomForestRegressor(random_state=0)
+        self.regressor.fit(self.X, self.y)
+
+        self.classifier = RandomForestClassifier(random_state=0)
+        self.classifier.fit(self.X, self.y)
+
+        self.xgboost = XGBClassifier(tree_method="exact", base_score=0.5)
+        self.xgboost.fit(self.X, self.y)
+
+    def time_single_output(self):
+        ex = TreeExplainer(self.regressor)
+        _ = ex(self.X)
+
+    def time_multi_output(self):
+        ex = TreeExplainer(self.classifier)
+        _ = ex(self.X)
+
+    def time_interactions(self):
+        ex = TreeExplainer(self.regressor)
+        _ = ex(self.X, interactions=True)
+
+    def time_xgboost(self):
+        ex = TreeExplainer(self.xgboost)
+        _ = ex(self.X)
+
+    def time_xgboost_interactions(self):
+        ex = TreeExplainer(self.xgboost)
+        _ = ex(self.X, interactions=True)

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -11,19 +11,19 @@ namespace nb = nanobind;
 using namespace nb::literals;
 
 template <typename T, typename... Args>
-using Array = nb::ndarray<T, nb::numpy, nb::c_contig, nb::device::cpu, Args...>;
+using Array = nb::ndarray<T, nb::c_contig, Args...>;
 
 using IntArray = Array<const int>;
 using DoubleArray = Array<const double>;
 using BoolArray = Array<const bool>;
 using MutableDoubleArray = Array<double>;
 
-using IntArray1D = Array<const int, nb::shape<-1>>;
-using DoubleArray1D = Array<const double, nb::shape<-1>>;
-using MutableDoubleArray1D = Array<double, nb::shape<-1>>;
-using DoubleArray2D = Array<const double, nb::shape<-1, -1>>;
-using MutableDoubleArray2D = Array<double, nb::shape<-1, -1>>;
-using DoubleArray3D = Array<const double, nb::shape<-1, -1, -1>>;
+using IntArray1D = Array<const int, nb::ndim<1>>;
+using DoubleArray1D = Array<const double, nb::ndim<1>>;
+using MutableDoubleArray1D = Array<double, nb::ndim<1>>;
+using DoubleArray2D = Array<const double, nb::ndim<2>>;
+using MutableDoubleArray2D = Array<double, nb::ndim<2>>;
+using DoubleArray3D = Array<const double, nb::ndim<3>>;
 
 int compute_expectations_wrapper(
     const IntArray1D &children_left,

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -1,567 +1,359 @@
-#define NPY_NO_DEPRECATED_API NPY_2_0_API_VERSION
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/optional.h>
 
-#include <Python.h>
-#include <numpy/arrayobject.h>
+#include <optional>
+#include <string>
+
 #include "tree_shap.h"
-#include <iostream>
 
-static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args);
-static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args);
-static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args);
-static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args);
-static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args);
+namespace nb = nanobind;
+using namespace nb::literals;
 
-static PyMethodDef module_methods[] = {
-    {"dense_tree_shap", _cext_dense_tree_shap, METH_VARARGS, "C implementation of Tree SHAP for dense."},
-    {"dense_tree_predict", _cext_dense_tree_predict, METH_VARARGS, "C implementation of tree predictions."},
-    {"dense_tree_update_weights", _cext_dense_tree_update_weights, METH_VARARGS, "C implementation of tree node weight compuatations."},
-    {"dense_tree_saabas", _cext_dense_tree_saabas, METH_VARARGS, "C implementation of Saabas (rough fast approximation to Tree SHAP)."},
-    {"compute_expectations", _cext_compute_expectations, METH_VARARGS, "Compute expectations of internal nodes."},
-    {NULL, NULL, 0, NULL}
-};
+template <typename T, typename... Args>
+using Array = nb::ndarray<T, nb::numpy, nb::c_contig, nb::device::cpu, Args...>;
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_cext",
-    "This module provides an interface for a fast Tree SHAP implementation.",
-    -1,
-    module_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
+using IntArray = Array<const int>;
+using DoubleArray = Array<const double>;
+using BoolArray = Array<const bool>;
+using MutableDoubleArray = Array<double>;
 
-PyMODINIT_FUNC PyInit__cext(void)
-{
-    PyObject *module = PyModule_Create(&moduledef);
-    if (!module) return NULL;
+using IntArray1D = Array<const int, nb::shape<-1>>;
+using DoubleArray1D = Array<const double, nb::shape<-1>>;
+using MutableDoubleArray1D = Array<double, nb::shape<-1>>;
+using DoubleArray2D = Array<const double, nb::shape<-1, -1>>;
+using MutableDoubleArray2D = Array<double, nb::shape<-1, -1>>;
+using DoubleArray3D = Array<const double, nb::shape<-1, -1, -1>>;
 
-    /* Load `numpy` functionality. */
-    import_array();
-
-    return module;
-}
-
-static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)
-{
-    PyObject *children_left_obj;
-    PyObject *children_right_obj;
-    PyObject *node_sample_weight_obj;
-    PyObject *values_obj;
-
-    /* Parse the input tuple */
-    if (!PyArg_ParseTuple(
-        args, "OOOO", &children_left_obj, &children_right_obj, &node_sample_weight_obj, &values_obj
-    )) return NULL;
-
-    /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-
-    /* If that didn't work, throw an exception. */
-    if (children_left_array == NULL || children_right_array == NULL ||
-        values_array == NULL || node_sample_weight_array == NULL) {
-        Py_XDECREF((PyObject*)children_left_array);
-        Py_XDECREF((PyObject*)children_right_array);
-        //PyArray_ResolveWritebackIfCopy(values_array);
-        Py_XDECREF((PyObject*)values_array);
-        Py_XDECREF((PyObject*)node_sample_weight_array);
-        return NULL;
-    }
-
+int compute_expectations_wrapper(
+    const IntArray1D &children_left,
+    const IntArray1D &children_right,
+    const DoubleArray1D &node_sample_weight,
+    MutableDoubleArray2D &values
+) {
     TreeEnsemble tree;
+    tree.num_outputs = values.shape(1);
+    tree.children_left = const_cast<int *>(children_left.data());
+    tree.children_right = const_cast<int *>(children_right.data());
+    tree.values = values.data();
+    tree.node_sample_weights = const_cast<double *>(node_sample_weight.data());
 
-    // number of outputs
-    tree.num_outputs = PyArray_DIM(values_array, 1);
-
-    /* Get pointers to the data as C-types. */
-    tree.children_left = (int*)PyArray_DATA(children_left_array);
-    tree.children_right = (int*)PyArray_DATA(children_right_array);
-    tree.values = (tfloat*)PyArray_DATA(values_array);
-    tree.node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weight_array);
-
-    const int max_depth = compute_expectations(tree);
-
-    // clean up the created python objects
-    Py_XDECREF((PyObject*)children_left_array);
-    Py_XDECREF((PyObject*)children_right_array);
-    //PyArray_ResolveWritebackIfCopy(values_array);
-    Py_XDECREF((PyObject*)values_array);
-    Py_XDECREF((PyObject*)node_sample_weight_array);
-
-    PyObject *ret = Py_BuildValue("i", max_depth);
-    return ret;
+    return compute_expectations(tree);
 }
 
+double dense_tree_shap_wrapper(
+    const IntArray &children_left,
+    const IntArray &children_right,
+    const IntArray &children_default,
+    const IntArray &features,
+    const DoubleArray &thresholds,
+    const IntArray &threshold_types,
+    const DoubleArray3D &values,
+    const DoubleArray &node_sample_weights,
+    int max_depth,
+    const DoubleArray2D &X,
+    const BoolArray &X_missing,
+    const std::optional<DoubleArray> &y,
+    const std::optional<DoubleArray2D> &R,
+    const std::optional<BoolArray> &R_missing,
+    int tree_limit,
+    const DoubleArray1D &base_offset,
+    MutableDoubleArray &out_contribs,
+    int feature_dependence,
+    int model_output,
+    bool interactions
+) {
+    const unsigned num_X = X.shape(0);
+    const unsigned M = X.shape(1);
+    const unsigned max_nodes = values.shape(1);
+    const unsigned num_outputs = values.shape(2);
+    const unsigned num_R = R ? R->shape(0) : 0;
 
-static PyObject *_cext_dense_tree_shap(PyObject *self, PyObject *args)
-{
-    PyObject *children_left_obj;
-    PyObject *children_right_obj;
-    PyObject *children_default_obj;
-    PyObject *features_obj;
-    PyObject *thresholds_obj;
-    PyObject *threshold_types_obj;
-    PyObject *values_obj;
-    PyObject *node_sample_weights_obj;
-    int max_depth;
-    PyObject *X_obj;
-    PyObject *X_missing_obj;
-    PyObject *y_obj;
-    PyObject *R_obj;
-    PyObject *R_missing_obj;
-    int tree_limit;
-    PyObject *out_contribs_obj;
-    int feature_dependence;
-    int model_output;
-    PyObject *base_offset_obj;
-    bool interactions;
-
-    /* Parse the input tuple */
-    if (!PyArg_ParseTuple(
-        args, "OOOOOOOOiOOOOOiOOiib", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &node_sample_weights_obj,
-        &max_depth, &X_obj, &X_missing_obj, &y_obj, &R_obj, &R_missing_obj, &tree_limit, &base_offset_obj,
-        &out_contribs_obj, &feature_dependence, &model_output, &interactions
-    )) return NULL;
-
-    /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weights_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weights_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *R_array = NULL;
-    if (R_obj != Py_None) R_array = (PyArrayObject*)PyArray_FROM_OTF(R_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *R_missing_array = NULL;
-    if (R_missing_obj != Py_None) R_missing_array = (PyArrayObject*)PyArray_FROM_OTF(R_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_contribs_array = (PyArrayObject*)PyArray_FROM_OTF(out_contribs_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-
-    /* If that didn't work, throw an exception. Note that R and y are optional. */
-    if (children_left_array == NULL || children_right_array == NULL ||
-        children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
-        values_array == NULL || node_sample_weights_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_contribs_array == NULL) {
-        Py_XDECREF((PyObject*)children_left_array);
-        Py_XDECREF((PyObject*)children_right_array);
-        Py_XDECREF((PyObject*)children_default_array);
-        Py_XDECREF((PyObject*)features_array);
-        Py_XDECREF((PyObject*)thresholds_array);
-        Py_XDECREF((PyObject*)threshold_types_array);
-        Py_XDECREF((PyObject*)values_array);
-        Py_XDECREF((PyObject*)node_sample_weights_array);
-        Py_XDECREF((PyObject*)X_array);
-        Py_XDECREF((PyObject*)X_missing_array);
-        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
-        if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
-        if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
-        //PyArray_ResolveWritebackIfCopy(out_contribs_array);
-        Py_XDECREF((PyObject*)out_contribs_array);
-        Py_XDECREF((PyObject*)base_offset_array);
-        return NULL;
-    }
-
-    const unsigned num_X = PyArray_DIM(X_array, 0);
-    const unsigned M = PyArray_DIM(X_array, 1);
-    const unsigned max_nodes = PyArray_DIM(values_array, 1);
-    const unsigned num_outputs = PyArray_DIM(values_array, 2);
-    unsigned num_R = 0;
-    if (R_array != NULL) num_R = PyArray_DIM(R_array, 0);
-
-    // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *node_sample_weights = (tfloat*)PyArray_DATA(node_sample_weights_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
-    tfloat *y = NULL;
-    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
-    tfloat *R = NULL;
-    if (R_array != NULL) R = (tfloat*)PyArray_DATA(R_array);
-    bool *R_missing = NULL;
-    if (R_missing_array != NULL) R_missing = (bool*)PyArray_DATA(R_missing_array);
-    tfloat *out_contribs = (tfloat*)PyArray_DATA(out_contribs_array);
-    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
-
-    // these are just a wrapper objects for all the pointers and numbers associated with
-    // the ensemble tree model and the dataset we are explaining
-    TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
-        node_sample_weights, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs
+    TreeEnsemble trees(
+        const_cast<int *>(children_left.data()),
+        const_cast<int *>(children_right.data()),
+        const_cast<int *>(children_default.data()),
+        const_cast<int *>(features.data()),
+        const_cast<double *>(thresholds.data()),
+        const_cast<int *>(threshold_types.data()),
+        const_cast<double *>(values.data()),
+        const_cast<double *>(node_sample_weights.data()),
+        max_depth,
+        tree_limit,
+        const_cast<double *>(base_offset.data()),
+        max_nodes,
+        num_outputs
     );
-    ExplanationDataset data = ExplanationDataset(X, X_missing, y, R, R_missing, num_X, M, num_R);
+    ExplanationDataset data(
+        const_cast<double *>(X.data()),
+        const_cast<bool *>(X_missing.data()),
+        y ? const_cast<double *>(y->data()) : nullptr,
+        R ? const_cast<double *>(R->data()) : nullptr,
+        R_missing ? const_cast<bool *>(R_missing->data()) : nullptr,
+        num_X,
+        M,
+        num_R
+    );
 
-    dense_tree_shap(trees, data, out_contribs, feature_dependence, model_output, interactions);
-
-    // retrieve return value before python cleanup of objects
-    tfloat ret_value = (double)values[0];
-
-    // clean up the created python objects
-    Py_XDECREF((PyObject*)children_left_array);
-    Py_XDECREF((PyObject*)children_right_array);
-    Py_XDECREF((PyObject*)children_default_array);
-    Py_XDECREF((PyObject*)features_array);
-    Py_XDECREF((PyObject*)thresholds_array);
-    Py_XDECREF((PyObject*)threshold_types_array);
-    Py_XDECREF((PyObject*)values_array);
-    Py_XDECREF((PyObject*)node_sample_weights_array);
-    Py_XDECREF((PyObject*)X_array);
-    Py_XDECREF((PyObject*)X_missing_array);
-    if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
-    if (R_array != NULL) Py_XDECREF((PyObject*)R_array);
-    if (R_missing_array != NULL) Py_XDECREF((PyObject*)R_missing_array);
-    //PyArray_ResolveWritebackIfCopy(out_contribs_array);
-    Py_XDECREF((PyObject*)out_contribs_array);
-    Py_XDECREF((PyObject*)base_offset_array);
-
-    /* Build the output tuple */
-    PyObject *ret = Py_BuildValue("d", ret_value);
-    return ret;
+    dense_tree_shap(
+        trees, data, out_contribs.data(), feature_dependence, model_output, interactions
+    );
+    return values.data()[0];
 }
 
+double dense_tree_predict_wrapper(
+    const IntArray &children_left,
+    const IntArray &children_right,
+    const IntArray &children_default,
+    const IntArray &features,
+    const DoubleArray &thresholds,
+    const IntArray &threshold_types,
+    const DoubleArray3D &values,
+    int max_depth,
+    int tree_limit,
+    const DoubleArray1D &base_offset,
+    int model_output,
+    const DoubleArray2D &X,
+    const BoolArray &X_missing,
+    const std::optional<DoubleArray> &y,
+    MutableDoubleArray &out_pred
+) {
+    const unsigned num_X = X.shape(0);
+    const unsigned M = X.shape(1);
+    const unsigned max_nodes = values.shape(1);
+    const unsigned num_outputs = values.shape(2);
 
-static PyObject *_cext_dense_tree_predict(PyObject *self, PyObject *args)
-{
-    PyObject *children_left_obj;
-    PyObject *children_right_obj;
-    PyObject *children_default_obj;
-    PyObject *features_obj;
-    PyObject *thresholds_obj;
-    PyObject *threshold_types_obj;
-    PyObject *values_obj;
-    int max_depth;
-    int tree_limit;
-    PyObject *base_offset_obj;
-    int model_output;
-    PyObject *X_obj;
-    PyObject *X_missing_obj;
-    PyObject *y_obj;
-    PyObject *out_pred_obj;
-
-    /* Parse the input tuple */
-    if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
-        &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
-    )) return NULL;
-
-    /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_pred_array = (PyArrayObject*)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-
-    /* If that didn't work, throw an exception. Note that R and y are optional. */
-    if (children_left_array == NULL || children_right_array == NULL ||
-        children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
-        values_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_pred_array == NULL) {
-        Py_XDECREF((PyObject*)children_left_array);
-        Py_XDECREF((PyObject*)children_right_array);
-        Py_XDECREF((PyObject*)children_default_array);
-        Py_XDECREF((PyObject*)features_array);
-        Py_XDECREF((PyObject*)thresholds_array);
-        Py_XDECREF((PyObject*)threshold_types_array);
-        Py_XDECREF((PyObject*)values_array);
-        Py_XDECREF((PyObject*)base_offset_array);
-        Py_XDECREF((PyObject*)X_array);
-        Py_XDECREF((PyObject*)X_missing_array);
-        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
-        //PyArray_ResolveWritebackIfCopy(out_pred_array);
-        Py_XDECREF((PyObject*)out_pred_array);
-        return NULL;
+    if (base_offset.shape(0) != num_outputs) {
+        throw nb::value_error(
+            (
+                "The passed base_offset array does not have the same number of outputs "
+                "as the values array: " +
+                std::to_string(base_offset.shape(0)) + " vs. " +
+                std::to_string(num_outputs)
+            ).c_str()
+        );
     }
 
-    const unsigned num_X = PyArray_DIM(X_array, 0);
-    const unsigned M = PyArray_DIM(X_array, 1);
-    const unsigned max_nodes = PyArray_DIM(values_array, 1);
-    const unsigned num_outputs = PyArray_DIM(values_array, 2);
-
-    const unsigned num_offsets = PyArray_DIM(base_offset_array, 0);
-    if (num_offsets != num_outputs) {
-        std::cerr << "The passed base_offset array does that have the same number of outputs as the values array: " << num_offsets << " vs. " << num_outputs << std::endl;
-        return NULL;
-    }
-
-    // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
-    tfloat *y = NULL;
-    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
-    tfloat *out_pred = (tfloat*)PyArray_DATA(out_pred_array);
-
-    // these are just wrapper objects for all the pointers and numbers associated with
-    // the ensemble tree model and the dataset we are explaining
-    TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
-        NULL, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs
+    TreeEnsemble trees(
+        const_cast<int *>(children_left.data()),
+        const_cast<int *>(children_right.data()),
+        const_cast<int *>(children_default.data()),
+        const_cast<int *>(features.data()),
+        const_cast<double *>(thresholds.data()),
+        const_cast<int *>(threshold_types.data()),
+        const_cast<double *>(values.data()),
+        nullptr,
+        max_depth,
+        tree_limit,
+        const_cast<double *>(base_offset.data()),
+        max_nodes,
+        num_outputs
     );
-    ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
+    ExplanationDataset data(
+        const_cast<double *>(X.data()),
+        const_cast<bool *>(X_missing.data()),
+        y ? const_cast<double *>(y->data()) : nullptr,
+        nullptr,
+        nullptr,
+        num_X,
+        M,
+        0
+    );
 
-    dense_tree_predict(out_pred, trees, data, model_output);
-
-    // clean up the created python objects
-    Py_XDECREF((PyObject*)children_left_array);
-    Py_XDECREF((PyObject*)children_right_array);
-    Py_XDECREF((PyObject*)children_default_array);
-    Py_XDECREF((PyObject*)features_array);
-    Py_XDECREF((PyObject*)thresholds_array);
-    Py_XDECREF((PyObject*)threshold_types_array);
-    Py_XDECREF((PyObject*)values_array);
-    Py_XDECREF((PyObject*)base_offset_array);
-    Py_XDECREF((PyObject*)X_array);
-    Py_XDECREF((PyObject*)X_missing_array);
-    if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
-    //PyArray_ResolveWritebackIfCopy(out_pred_array);
-    Py_XDECREF((PyObject*)out_pred_array);
-
-    /* Build the output tuple */
-    PyObject *ret = Py_BuildValue("d", (double)values[0]);
-    return ret;
+    dense_tree_predict(out_pred.data(), trees, data, model_output);
+    return values.data()[0];
 }
 
+double dense_tree_update_weights_wrapper(
+    const IntArray1D &children_left,
+    const IntArray1D &children_right,
+    const IntArray1D &children_default,
+    const IntArray1D &features,
+    const DoubleArray1D &thresholds,
+    const IntArray1D &threshold_types,
+    const DoubleArray2D &values,
+    int tree_limit,
+    MutableDoubleArray1D &node_sample_weight,
+    const DoubleArray2D &X,
+    const BoolArray &X_missing
+) {
+    const unsigned num_X = X.shape(0);
+    const unsigned M = X.shape(1);
+    const unsigned max_nodes = values.shape(0);
 
-static PyObject *_cext_dense_tree_update_weights(PyObject *self, PyObject *args)
-{
-    PyObject *children_left_obj;
-    PyObject *children_right_obj;
-    PyObject *children_default_obj;
-    PyObject *features_obj;
-    PyObject *thresholds_obj;
-    PyObject *threshold_types_obj;
-    PyObject *values_obj;
-    int tree_limit;
-    PyObject *node_sample_weight_obj;
-    PyObject *X_obj;
-    PyObject *X_missing_obj;
-
-    /* Parse the input tuple */
-    if (!PyArg_ParseTuple(
-        args, "OOOOOOOiOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &tree_limit, &node_sample_weight_obj, &X_obj, &X_missing_obj
-    )) return NULL;
-
-    /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *node_sample_weight_array = (PyArrayObject*)PyArray_FROM_OTF(node_sample_weight_obj, NPY_DOUBLE, NPY_ARRAY_INOUT_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-
-    /* If that didn't work, throw an exception. */
-    if (children_left_array == NULL || children_right_array == NULL ||
-        children_default_array == NULL || features_array == NULL || thresholds_array == NULL || threshold_types_array == NULL ||
-        values_array == NULL || node_sample_weight_array == NULL || X_array == NULL ||
-        X_missing_array == NULL) {
-        Py_XDECREF((PyObject*)children_left_array);
-        Py_XDECREF((PyObject*)children_right_array);
-        Py_XDECREF((PyObject*)children_default_array);
-        Py_XDECREF((PyObject*)features_array);
-        Py_XDECREF((PyObject*)thresholds_array);
-        Py_XDECREF((PyObject*)threshold_types_array);
-        Py_XDECREF((PyObject*)values_array);
-        //PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
-        Py_XDECREF((PyObject*)node_sample_weight_array);
-        Py_XDECREF((PyObject*)X_array);
-        Py_XDECREF((PyObject*)X_missing_array);
-        std::cerr << "Found a NULL input array in _cext_dense_tree_update_weights!\n";
-        return NULL;
-    }
-
-    const unsigned num_X = PyArray_DIM(X_array, 0);
-    const unsigned M = PyArray_DIM(X_array, 1);
-    const unsigned max_nodes = PyArray_DIM(values_array, 1);
-
-    // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *node_sample_weight = (tfloat*)PyArray_DATA(node_sample_weight_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
-
-    // these are just wrapper objects for all the pointers and numbers associated with
-    // the ensemble tree model and the dataset we are explaining
-    TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
-        node_sample_weight, 0, tree_limit, 0, max_nodes, 0
+    TreeEnsemble trees(
+        const_cast<int *>(children_left.data()),
+        const_cast<int *>(children_right.data()),
+        const_cast<int *>(children_default.data()),
+        const_cast<int *>(features.data()),
+        const_cast<double *>(thresholds.data()),
+        const_cast<int *>(threshold_types.data()),
+        const_cast<double *>(values.data()),
+        node_sample_weight.data(),
+        0,
+        tree_limit,
+        nullptr,
+        max_nodes,
+        0
     );
-    ExplanationDataset data = ExplanationDataset(X, X_missing, NULL, NULL, NULL, num_X, M, 0);
+    ExplanationDataset data(
+        const_cast<double *>(X.data()),
+        const_cast<bool *>(X_missing.data()),
+        nullptr,
+        nullptr,
+        nullptr,
+        num_X,
+        M,
+        0
+    );
 
     dense_tree_update_weights(trees, data);
-
-    // clean up the created python objects
-    Py_XDECREF((PyObject*)children_left_array);
-    Py_XDECREF((PyObject*)children_right_array);
-    Py_XDECREF((PyObject*)children_default_array);
-    Py_XDECREF((PyObject*)features_array);
-    Py_XDECREF((PyObject*)thresholds_array);
-    Py_XDECREF((PyObject*)threshold_types_array);
-    Py_XDECREF((PyObject*)values_array);
-    // PyArray_ResolveWritebackIfCopy(node_sample_weight_array);
-    Py_XDECREF((PyObject*)node_sample_weight_array);
-    Py_XDECREF((PyObject*)X_array);
-    Py_XDECREF((PyObject*)X_missing_array);
-
-    /* Build the output tuple */
-    PyObject *ret = Py_BuildValue("d", 1);
-    return ret;
+    return 1.0;
 }
 
+double dense_tree_saabas_wrapper(
+    const IntArray &children_left,
+    const IntArray &children_right,
+    const IntArray &children_default,
+    const IntArray &features,
+    const DoubleArray &thresholds,
+    const IntArray &threshold_types,
+    const DoubleArray3D &values,
+    int max_depth,
+    int tree_limit,
+    const DoubleArray1D &base_offset,
+    int model_output,
+    const DoubleArray2D &X,
+    const BoolArray &X_missing,
+    const std::optional<DoubleArray> &y,
+    MutableDoubleArray &out_pred
+) {
+    const unsigned num_X = X.shape(0);
+    const unsigned M = X.shape(1);
+    const unsigned max_nodes = values.shape(1);
+    const unsigned num_outputs = values.shape(2);
 
-static PyObject *_cext_dense_tree_saabas(PyObject *self, PyObject *args)
-{
-    PyObject *children_left_obj;
-    PyObject *children_right_obj;
-    PyObject *children_default_obj;
-    PyObject *features_obj;
-    PyObject *thresholds_obj;
-    PyObject *threshold_types_obj;
-    PyObject *values_obj;
-    int max_depth;
-    int tree_limit;
-    PyObject *base_offset_obj;
-    int model_output;
-    PyObject *X_obj;
-    PyObject *X_missing_obj;
-    PyObject *y_obj;
-    PyObject *out_pred_obj;
-
-
-    /* Parse the input tuple */
-    if (!PyArg_ParseTuple(
-        args, "OOOOOOOiiOiOOOO", &children_left_obj, &children_right_obj, &children_default_obj,
-        &features_obj, &thresholds_obj, &threshold_types_obj, &values_obj, &max_depth, &tree_limit, &base_offset_obj, &model_output,
-        &X_obj, &X_missing_obj, &y_obj, &out_pred_obj
-    )) return NULL;
-
-    /* Interpret the input objects as numpy arrays. */
-    PyArrayObject *children_left_array = (PyArrayObject*)PyArray_FROM_OTF(children_left_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_right_array = (PyArrayObject*)PyArray_FROM_OTF(children_right_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *children_default_array = (PyArrayObject*)PyArray_FROM_OTF(children_default_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *features_array = (PyArrayObject*)PyArray_FROM_OTF(features_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *thresholds_array = (PyArrayObject*)PyArray_FROM_OTF(thresholds_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *threshold_types_array = (PyArrayObject*)PyArray_FROM_OTF(threshold_types_obj, NPY_INT, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *values_array = (PyArrayObject*)PyArray_FROM_OTF(values_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *base_offset_array = (PyArrayObject*)PyArray_FROM_OTF(base_offset_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_array = (PyArrayObject*)PyArray_FROM_OTF(X_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *X_missing_array = (PyArrayObject*)PyArray_FROM_OTF(X_missing_obj, NPY_BOOL, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *y_array = NULL;
-    if (y_obj != Py_None) y_array = (PyArrayObject*)PyArray_FROM_OTF(y_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-    PyArrayObject *out_pred_array = (PyArrayObject*)PyArray_FROM_OTF(out_pred_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
-
-    /* If that didn't work, throw an exception. Note that R and y are optional. */
-    if (children_left_array == NULL || children_right_array == NULL ||
-        children_default_array == NULL || features_array == NULL || thresholds_array == NULL ||
-        values_array == NULL || X_array == NULL ||
-        X_missing_array == NULL || out_pred_array == NULL) {
-        Py_XDECREF((PyObject*)children_left_array);
-        Py_XDECREF((PyObject*)children_right_array);
-        Py_XDECREF((PyObject*)children_default_array);
-        Py_XDECREF((PyObject*)features_array);
-        Py_XDECREF((PyObject*)thresholds_array);
-        Py_XDECREF((PyObject*)threshold_types_array);
-        Py_XDECREF((PyObject*)values_array);
-        Py_XDECREF((PyObject*)base_offset_array);
-        Py_XDECREF((PyObject*)X_array);
-        Py_XDECREF((PyObject*)X_missing_array);
-        if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
-        //PyArray_ResolveWritebackIfCopy(out_pred_array);
-        Py_XDECREF((PyObject*)out_pred_array);
-        return NULL;
-    }
-
-    const unsigned num_X = PyArray_DIM(X_array, 0);
-    const unsigned M = PyArray_DIM(X_array, 1);
-    const unsigned max_nodes = PyArray_DIM(values_array, 1);
-    const unsigned num_outputs = PyArray_DIM(values_array, 2);
-
-    // Get pointers to the data as C-types
-    int *children_left = (int*)PyArray_DATA(children_left_array);
-    int *children_right = (int*)PyArray_DATA(children_right_array);
-    int *children_default = (int*)PyArray_DATA(children_default_array);
-    int *features = (int*)PyArray_DATA(features_array);
-    tfloat *thresholds = (tfloat*)PyArray_DATA(thresholds_array);
-    int *threshold_types = (int*)PyArray_DATA(threshold_types_array);
-    tfloat *values = (tfloat*)PyArray_DATA(values_array);
-    tfloat *base_offset = (tfloat*)PyArray_DATA(base_offset_array);
-    tfloat *X = (tfloat*)PyArray_DATA(X_array);
-    bool *X_missing = (bool*)PyArray_DATA(X_missing_array);
-    tfloat *y = NULL;
-    if (y_array != NULL) y = (tfloat*)PyArray_DATA(y_array);
-    tfloat *out_pred = (tfloat*)PyArray_DATA(out_pred_array);
-
-    // these are just wrapper objects for all the pointers and numbers associated with
-    // the ensemble tree model and the dataset we are explaining
-    TreeEnsemble trees = TreeEnsemble(
-        children_left, children_right, children_default, features, thresholds, threshold_types, values,
-        NULL, max_depth, tree_limit, base_offset,
-        max_nodes, num_outputs
+    TreeEnsemble trees(
+        const_cast<int *>(children_left.data()),
+        const_cast<int *>(children_right.data()),
+        const_cast<int *>(children_default.data()),
+        const_cast<int *>(features.data()),
+        const_cast<double *>(thresholds.data()),
+        const_cast<int *>(threshold_types.data()),
+        const_cast<double *>(values.data()),
+        nullptr,
+        max_depth,
+        tree_limit,
+        const_cast<double *>(base_offset.data()),
+        max_nodes,
+        num_outputs
     );
-    ExplanationDataset data = ExplanationDataset(X, X_missing, y, NULL, NULL, num_X, M, 0);
+    ExplanationDataset data(
+        const_cast<double *>(X.data()),
+        const_cast<bool *>(X_missing.data()),
+        y ? const_cast<double *>(y->data()) : nullptr,
+        nullptr,
+        nullptr,
+        num_X,
+        M,
+        0
+    );
 
-    dense_tree_saabas(out_pred, trees, data);
+    dense_tree_saabas(out_pred.data(), trees, data);
+    return values.data()[0];
+}
 
-    // clean up the created python objects
-    Py_XDECREF((PyObject*)children_left_array);
-    Py_XDECREF((PyObject*)children_right_array);
-    Py_XDECREF((PyObject*)children_default_array);
-    Py_XDECREF((PyObject*)features_array);
-    Py_XDECREF((PyObject*)thresholds_array);
-    Py_XDECREF((PyObject*)threshold_types_array);
-    Py_XDECREF((PyObject*)values_array);
-    Py_XDECREF((PyObject*)base_offset_array);
-    Py_XDECREF((PyObject*)X_array);
-    Py_XDECREF((PyObject*)X_missing_array);
-    if (y_array != NULL) Py_XDECREF((PyObject*)y_array);
-    //PyArray_ResolveWritebackIfCopy(out_pred_array);
-    Py_XDECREF((PyObject*)out_pred_array);
+NB_MODULE(_cext, m) {
+    m.doc() = "Fast Tree SHAP implementation.";
 
-    /* Build the output tuple */
-    PyObject *ret = Py_BuildValue("d", (double)values[0]);
-    return ret;
+    m.def(
+        "dense_tree_shap",
+        &dense_tree_shap_wrapper,
+        "children_left"_a,
+        "children_right"_a,
+        "children_default"_a,
+        "features"_a,
+        "thresholds"_a,
+        "threshold_types"_a,
+        "values"_a,
+        "node_sample_weights"_a,
+        "max_depth"_a,
+        "X"_a,
+        "X_missing"_a,
+        "y"_a,
+        "R"_a,
+        "R_missing"_a,
+        "tree_limit"_a,
+        "base_offset"_a,
+        "out_contribs"_a,
+        "feature_dependence"_a,
+        "model_output"_a,
+        "interactions"_a,
+        "C implementation of Tree SHAP for dense trees."
+    );
+    m.def(
+        "dense_tree_predict",
+        &dense_tree_predict_wrapper,
+        "children_left"_a,
+        "children_right"_a,
+        "children_default"_a,
+        "features"_a,
+        "thresholds"_a,
+        "threshold_types"_a,
+        "values"_a,
+        "max_depth"_a,
+        "tree_limit"_a,
+        "base_offset"_a,
+        "model_output"_a,
+        "X"_a,
+        "X_missing"_a,
+        "y"_a,
+        "out_pred"_a,
+        "C implementation of tree predictions."
+    );
+    m.def(
+        "dense_tree_update_weights",
+        &dense_tree_update_weights_wrapper,
+        "children_left"_a,
+        "children_right"_a,
+        "children_default"_a,
+        "features"_a,
+        "thresholds"_a,
+        "threshold_types"_a,
+        "values"_a,
+        "tree_limit"_a,
+        "node_sample_weight"_a,
+        "X"_a,
+        "X_missing"_a,
+        "C implementation of tree node weight computations."
+    );
+    m.def(
+        "dense_tree_saabas",
+        &dense_tree_saabas_wrapper,
+        "children_left"_a,
+        "children_right"_a,
+        "children_default"_a,
+        "features"_a,
+        "thresholds"_a,
+        "threshold_types"_a,
+        "values"_a,
+        "max_depth"_a,
+        "tree_limit"_a,
+        "base_offset"_a,
+        "model_output"_a,
+        "X"_a,
+        "X_missing"_a,
+        "y"_a,
+        "out_pred"_a,
+        "C implementation of Saabas (rough fast approximation to Tree SHAP)."
+    );
+    m.def(
+        "compute_expectations",
+        &compute_expectations_wrapper,
+        "children_left"_a,
+        "children_right"_a,
+        "node_sample_weight"_a,
+        "values"_a,
+        "Compute expectations of internal nodes."
+    );
 }

--- a/shap/cext/_cext.cc
+++ b/shap/cext/_cext.cc
@@ -20,7 +20,6 @@ static PyMethodDef module_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_cext",
@@ -32,28 +31,16 @@ static struct PyModuleDef moduledef = {
     NULL,
     NULL
 };
-#endif
 
-#if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC PyInit__cext(void)
-#else
-PyMODINIT_FUNC init_cext(void)
-#endif
 {
-    #if PY_MAJOR_VERSION >= 3
-        PyObject *module = PyModule_Create(&moduledef);
-        if (!module) return NULL;
-    #else
-        PyObject *module = Py_InitModule("_cext", module_methods);
-        if (!module) return;
-    #endif
+    PyObject *module = PyModule_Create(&moduledef);
+    if (!module) return NULL;
 
     /* Load `numpy` functionality. */
     import_array();
 
-    #if PY_MAJOR_VERSION >= 3
-        return module;
-    #endif
+    return module;
 }
 
 static PyObject *_cext_compute_expectations(PyObject *self, PyObject *args)


### PR DESCRIPTION
## Overview

Migrates the CPU bindings used by `TreeExplainer` from the Python/NumPy C APIs to the nanobind C++ interface.

The change:

- replaces `PyArg_ParseTuple`, manual reference counting, and NumPy C-API conversions with typed nanobind ndarray arguments;
- migrates `dense_tree_shap`, `dense_tree_predict`, `dense_tree_update_weights`, `dense_tree_saabas`, and `compute_expectations`;
- preserves nullable labels and background arrays along with writable contribution, prediction, weight, and expectation buffers;
- builds `_cext` with nanobind using the stable ABI and free-threaded module support;
- generates `_cext` typing stubs during the CMake build;
- removes the obsolete Python 2 module initialization path;
- leaves `GPUTreeExplainer` and its legacy CUDA binding unchanged;
- adds a `TreeSuite` ASV suite covering scikit-learn single-output, multi-output, and interaction workloads plus XGBoost values and interactions.

This modernizes the TreeExplainer extension boundary while preserving its Python API and native Tree SHAP implementation.

## Performance monitoring

Comparison command:

```console
uv run asv continuous upstream/master HEAD --bench 'tree_explainer.TreeSuite' --split
```

ASV reported no statistically significant changes across the suite.

| Change | Before [c7315f10] <master> | After [fe33dec7] <feature/nanobind-tree> | Ratio | Benchmark |
|---|---:|---:|---:|---|
| - | 88.9±0.6ms | 84.5±0.4ms | 0.95 | tree_explainer.TreeSuite.time_interactions |
| - | 14.3±0.2ms | 14.2±0.2ms | 0.99 | tree_explainer.TreeSuite.time_multi_output |
| - | 7.60±0.07ms | 7.48±0.1ms | 0.98 | tree_explainer.TreeSuite.time_single_output |
| - | 4.31±0.08ms | 4.61±0.04ms | 1.07 | tree_explainer.TreeSuite.time_xgboost |
| - | 4.82±0.06ms | 5.14±0.08ms | 1.07 | tree_explainer.TreeSuite.time_xgboost_interactions |

## Validation

- [x] Package build and `_cext` import
- [x] `pytest tests/explainers/test_tree.py -q --disable-warnings --maxfail=1 -k 'not front_page'` — 110 passed, 3 skipped, 3 deselected
- [x] `asv check -E existing:.venv/bin/python` — no problems found
- [x] `asv continuous upstream/master HEAD --bench 'tree_explainer.TreeSuite' --split` — no significant changes
- [x] Repository pre-commit hooks

## AI usage disclosure

Codex assisted with the migration and PR preparation. It inspected the existing TreeExplainer and nanobind patterns, implemented and tested the typed CPU bindings, preserved the separate GPU implementation, added and ran the ASV monitoring suite, pushed the prepared branch, and drafted/opened this PR. The contributor remains responsible for, and has reviewed, the submitted code and description.
