### PR TITLE
TYP: add type hints for plots._benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ module = [
   # "shap.maskers._masker",     # NOW TYPE CHECKED - type hints added
   "shap.maskers._tabular",
   "shap.maskers._text",
-  "shap.plots._benchmark",
+  # "shap.plots._benchmark",  # NOW TYPE CHECKED - type hints added
   "shap.plots._force_matplotlib",
   "shap.plots._force",
   "shap.plots._text",

--- a/shap/plots/_benchmark.py
+++ b/shap/plots/_benchmark.py
@@ -23,7 +23,7 @@ def benchmark(benchmark, show=True):
 
         # see if we have multiple metrics or just a single metric
         single_metric = True
-        metric_name = None
+        metric_name: str | None = None
         has_curves = True
         for b in benchmark:
             if metric_name is None:
@@ -33,6 +33,8 @@ def benchmark(benchmark, show=True):
 
             if b.curve_x is None or b.curve_y is None:
                 has_curves = False
+        if metric_name is None:
+            raise ValueError("The benchmark list must not be empty.")
 
         methods = list({b.method for b in benchmark})
         methods.sort()
@@ -155,15 +157,15 @@ def benchmark(benchmark, show=True):
             xs = [-0.03 * (len(methods) - 1)] + list(range(len(metrics) + 1))
             for i, method in enumerate(methods):
                 scores = [1 - i / (len(methods) - 1), 1 - i / (len(methods) - 1)]
-                values = [None, None]
+                metric_values = [None, None]
                 for metric in metrics:
                     for b in benchmark:
                         if b.method == method and b.metric == metric:
                             scores.append(norm_values[b.full_name])
-                            values.append(b.value)
+                            metric_values.append(b.value)
                 plt.plot(xs, scores, color=method_color[method], label=method)
 
-                for x, y, value in zip(xs, scores, values):
+                for x, y, value in zip(xs, scores, metric_values):
                     if value is None:
                         continue
                     label = f"{value:.2f}"

--- a/tests/plots/test_benchmark.py
+++ b/tests/plots/test_benchmark.py
@@ -1,0 +1,11 @@
+"""This file contains tests for the benchmark plot."""
+
+import pytest
+
+import shap
+
+
+def test_benchmark_empty_list_raises():
+    """Check that a ValueError is raised when the list of benchmark results is empty."""
+    with pytest.raises(ValueError, match="must not be empty"):
+        shap.plots.benchmark([], show=False)


### PR DESCRIPTION
## Overview

Fixes the type issues in `shap/plots/_benchmark.py` so that mypy passes with `check_untyped_defs`, and removes the module from the exclusion list in `pyproject.toml`. Part of #3730.

Changes:

- Annotate `metric_name` as `str | None` and add a guard after the metric-detection loop that raises `ValueError` on an empty list of benchmark results. This narrows the type for the `xlabel_names[metric_name]` / `metric_name.capitalize()` call sites.
- Rename the `values` list in the multi-metric branch to `metric_values`, since the name was reused for an ndarray in a sibling branch and mypy inferred the array type for both.

## Behavior change

Calling `benchmark([])` previously crashed with `UnboundLocalError` (the plotting loop never ran, so `ax` was unbound). It now raises `ValueError("The benchmark list must not be empty.")` at the top of the function. Added a test for this in `tests/plots/test_benchmark.py`; happy to adjust the message or drop the test if preferred.

## Verification

- `mypy shap/plots/_benchmark.py` passes with the exclusion removed; full `mypy shap` output matches master's baseline (no new errors).
- `pytest tests/plots/test_benchmark.py` passes, and fails with the old `UnboundLocalError` if the guard is removed.
- `pre-commit run --all-files` passes.

## AI Disclosure

Developed with Claude assistance:
- **Autonomous**: wrote the regression test in `tests/plots/test_benchmark.py`; authored the commit message and PR text; fixed `pyproject.toml` comment formatting
- **Assisted**: branch/commit/push/PR mechanics performed by Claude at my direction
- **Advised**: scoped the issue against the current repo state; explained mypy inference and narrowing, guard placement, and repo conventions — I wrote all changes to `shap/plots/_benchmark.py` myself and understand each line of the diff

Details: `.claude/disclosures/typ-3730-plots-benchmark.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)