### PR TITLE
Distribute shap-gpu CUDA wheels via cibuildwheel

### DIFF
--- a/.github/workflows/build_gpu.yml
+++ b/.github/workflows/build_gpu.yml
@@ -1,51 +1,104 @@
-# Dummy release workflow to reserve the "shap-gpu" name on PyPI and TestPyPI.
-# Each job builds an sdist (no CUDA/C compilation) with the name overridden to
-# "shap-gpu" and a placeholder version, then publishes via trusted publishing.
-name: release
+# Build and optionally publish shap-gpu wheels (CUDA-enabled TreeExplainer).
+#
+# Tracks https://github.com/shap/shap/issues/4182 — distribute GPUTreeExplainer on PyPI.
+# The PyPI package name is shap-gpu; import name remains `shap` (same codebase + _cext_gpu).
+#
+# Builds Linux x86_64 manylinux wheels with the CUDA toolkit inside cibuildwheel's
+# manylinux_cuda image. GPU runtime tests are not run in CI (no GPU device); we only
+# verify that _cext_gpu imports after install.
+name: Build shap-gpu wheels
+
 on:
   workflow_dispatch:
+    inputs:
+      publish_testpypi:
+        description: Publish built wheels to TestPyPI
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - ".github/workflows/build_gpu.yml"
+      - "CMakeLists.txt"
+      - "pyproject.toml"
+      - "shap/cext/**"
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  publish-pypi:
+  build_wheels:
+    name: Build CUDA manylinux wheels
     runs-on: ubuntu-latest
-    # Only publish tagged releases to PyPI
-    if: startsWith(github.ref, 'refs/tags')
-    environment: pypi
-    permissions:
-      id-token: write   # for PyPI trusted publishing
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # setuptools_scm needs full history/tags
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Override package name to shap-gpu
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags
+
+      - name: Override PyPI distribution name to shap-gpu
         run: sed -i 's/^name = "shap"/name = "shap-gpu"/' pyproject.toml
-      - name: Build sdist
+
+      - name: Build wheels with cibuildwheel
+        uses: pypa/cibuildwheel@v3.2.1
         env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.1.dev0"
-        run: uv build --sdist
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          # Linux CUDA manylinux image (see cibuildwheel CUDA FAQ)
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/manylinux_cuda/manylinux_2_28_x86_64_cuda12_9:latest
+          # Start with cp312/cp313 x86_64 only; expand matrix once pipeline is stable
+          CIBW_BUILD: cp312-manylinux_x86_64 cp313-manylinux_x86_64
+          CIBW_SKIP: "cp*-musllinux_* cp*-macosx_* cp*-win_* cp*-manylinux_aarch64"
+          CIBW_BUILD_VERBOSITY: 1
+          # Compile _cext_gpu during wheel build (see CMakeLists.txt)
+          CIBW_ENVIRONMENT: SHAP_ENABLE_CUDA=1
+          CIBW_ENVIRONMENT_LINUX: SHAP_ENABLE_CUDA=1 SHAP_CUDA_ARCHITECTURES="60;70;75;80"
+          # No GPU device in CI — verify extension is present, skip full pytest suite
+          CIBW_TEST_COMMAND: >-
+            python -c "import shap; from shap.utils import assert_import; assert_import('cext_gpu'); print('shap-gpu: _cext_gpu OK')"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shap-gpu-wheels
+          path: ./wheelhouse/*.whl
+          retention-days: 14
 
   publish-testpypi:
+    name: Publish wheels to TestPyPI
+    needs: build_wheels
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish_testpypi
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
-      id-token: write   # for TestPyPI trusted publishing
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0          # setuptools_scm needs full history/tags
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Override package name to shap-gpu
-        run: sed -i 's/^name = "shap"/name = "shap-gpu"/' pyproject.toml
-      - name: Build sdist
-        env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.1.dev0"
-        run: uv build --sdist
+          name: shap-gpu-wheels
+          path: dist
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist
+
+  publish-pypi:
+    name: Publish wheels to PyPI
+    needs: build_wheels
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: shap-gpu-wheels
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,10 +107,16 @@ install(TARGETS _cext LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 # Enabled via: SHAP_ENABLE_CUDA=1 pip install .
 # ==============================================================================
 
-if(ENV{SHAP_ENABLE_CUDA})
-  message(MESSAGE "SHAP_ENABLE_CUDA is set, attempting to build the GPU extension...")
+if(DEFINED ENV{SHAP_ENABLE_CUDA} AND NOT "$ENV{SHAP_ENABLE_CUDA}" STREQUAL "")
+  message(STATUS "SHAP_ENABLE_CUDA is set. Building the GPU extension module (_cext_gpu).")
   enable_language(CUDA)
   find_package(CUDAToolkit REQUIRED)
+
+  if(DEFINED ENV{SHAP_CUDA_ARCHITECTURES} AND NOT "$ENV{SHAP_CUDA_ARCHITECTURES}" STREQUAL "")
+    set(SHAP_GPU_CUDA_ARCHITECTURES "$ENV{SHAP_CUDA_ARCHITECTURES}")
+  else()
+    set(SHAP_GPU_CUDA_ARCHITECTURES "60;70;75;80")
+  endif()
 
   python_add_library(
     _cext_gpu MODULE
@@ -126,7 +132,7 @@ if(ENV{SHAP_ENABLE_CUDA})
   target_link_libraries(_cext_gpu PRIVATE CUDA::cudart)
 
   set_target_properties(_cext_gpu PROPERTIES
-    CUDA_ARCHITECTURES "60;70;75;80"
+    CUDA_ARCHITECTURES "${SHAP_GPU_CUDA_ARCHITECTURES}"
     CUDA_STANDARD 14
     CUDA_EXTENSIONS ON
   )
@@ -141,5 +147,5 @@ if(ENV{SHAP_ENABLE_CUDA})
 
   install(TARGETS _cext_gpu LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME})
 else()
-  message(MESSAGE "SHAP_ENABLE_CUDA is not set, skipping the GPU extension.")
+  message(STATUS "SHAP_ENABLE_CUDA is not set. Skipping the GPU extension module.")
 endif()

--- a/shap/explainers/_gpu_tree.py
+++ b/shap/explainers/_gpu_tree.py
@@ -26,6 +26,17 @@ class GPUTreeExplainer(TreeExplainer):
 
     """
 
+    _UNSUPPORTED_MODEL_OUTPUTS = frozenset({"probability", "probability_doubled", "log_loss"})
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.model.model_output in self._UNSUPPORTED_MODEL_OUTPUTS:
+            raise NotImplementedError(
+                f'GPUTreeExplainer does not yet support model_output="{self.model.model_output}". '
+                'Use model_output="raw" or TreeExplainer on CPU for probability/log_loss explanations. '
+                "See https://github.com/shap/shap/issues/3655"
+            )
+
     def shap_values(self, X, y=None, tree_limit=None, approximate=False, check_additivity=True, from_call=False):
         """Estimate the SHAP values for a set of samples.
 

--- a/tests/explainers/test_gpu_tree.py
+++ b/tests/explainers/test_gpu_tree.py
@@ -43,6 +43,21 @@ def test_front_page_xgboost():
     shap.summary_plot(shap_values, X, show=False)
 
 
+def test_gpu_unsupported_model_output_raises():
+    xgboost = pytest.importorskip("xgboost")
+
+    X, y = shap.datasets.california(n_points=100)
+    model = xgboost.train({"learning_rate": 0.01}, xgboost.DMatrix(X, label=y), 10)
+
+    with pytest.raises(NotImplementedError, match='model_output="probability"'):
+        shap.GPUTreeExplainer(
+            model,
+            X,
+            feature_perturbation="interventional",
+            model_output="probability",
+        )
+
+
 rs = np.random.RandomState(15921)
 n = 100
 m = 4


### PR DESCRIPTION
## Summary
- Replace the placeholder `build_gpu.yml` sdist workflow with a real **cibuildwheel** pipeline that builds Linux x86_64 CUDA wheels (`cp312`, `cp313`) as **`shap-gpu`**
- CI verifies `_cext_gpu` imports after install (no GPU device on GitHub runners)
- Add `SHAP_CUDA_ARCHITECTURES` env var to `CMakeLists.txt` for wheel builds
- Raise `NotImplementedError` for GPU `model_output` in `probability` / `log_loss` (#3655) — interim guard per @RAMitchell on #4270

Tracks #4182. Design follows the separate-`shap-gpu` distribution from #5058 (not bundling CUDA into main `shap` wheels, cf. closed #4543).

## Test plan
- [x] Fork `workflow_dispatch` on `build_gpu.yml` (see Actions on 04pallav/shap)
- [ ] Download wheel artifact; `pip install` on CUDA host + run `tests/gpu_tree_tests.ipynb` or `test_gpu_tree.py`
- [ ] Maintainer review: CUDA version (12.9), arch list, Python matrix

## CI limitations (v1)
- Import-only test in CI — full GPU correctness via Colab notebook (`tests/gpu_tree_tests.ipynb`) as in #4543 discussion
- Linux x86_64 only; Windows (#3646) deferred


Made with [Cursor](https://cursor.com)