### PR TITLE
Fix XGBoost categorical splits for CPU TreeExplainer with background

### DIFF
--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -178,9 +178,36 @@ inline transform_f get_transform(unsigned model_transform) {
     return transform;
 }
 
-inline bool category_in_threshold(float threshold, float category) {
+// LightGBM-style categorical splits (threshold_types == 1): 1-based category levels.
+inline bool category_in_threshold(tfloat threshold, tfloat category) {
     int category_flag = (1 << (int(category) - 1));
     return (int(threshold) & category_flag) != 0;
+}
+
+// XGBoost-style categorical splits (threshold_types == 2): 0-based category codes.
+inline bool category_in_threshold_xgb(tfloat threshold, tfloat category) {
+    const int category_int = static_cast<int>(category);
+    if (category_int < 0) {
+        return false;
+    }
+    const int category_flag = 1 << category_int;
+    return (static_cast<int>(threshold) & category_flag) != 0;
+}
+
+inline unsigned tree_split_child(
+    int split_type, tfloat threshold, tfloat feature_value, unsigned left_child, unsigned right_child
+) {
+    if (split_type == 0) {
+        return feature_value <= threshold ? left_child : right_child;
+    }
+    if (split_type == 1) {
+        return category_in_threshold(threshold, feature_value) ? left_child : right_child;
+    }
+    if (split_type == 2) {
+        // XGBoost: categories in the bitmask go right; missing/other categories go left.
+        return category_in_threshold_xgb(threshold, feature_value) ? right_child : left_child;
+    }
+    return right_child;
 }
 
 inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat *x, const bool *x_missing) {
@@ -198,12 +225,11 @@ inline tfloat *tree_predict(unsigned i, const TreeEnsemble &trees, const tfloat 
         // otherwise we are at an internal node and need to recurse
         if (x_missing[feature]) {
             node = trees.children_default[pos];
-        } else if (trees.threshold_types[pos] == 0 && x[feature] <= trees.thresholds[pos]) {
-            node = trees.children_left[pos];
-        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.thresholds[pos], x[feature])) {
-            node = trees.children_left[pos];
         } else {
-            node = trees.children_right[pos];
+            node = tree_split_child(
+                trees.threshold_types[pos], trees.thresholds[pos], x[feature],
+                trees.children_left[pos], trees.children_right[pos]
+            );
         }
     }
 }
@@ -262,13 +288,11 @@ inline void tree_update_weights(unsigned i, TreeEnsemble &trees, const tfloat *x
         // otherwise we are at an internal node and need to recurse
         if (x_missing[feature]) {
             node = trees.children_default[pos];
-        } else if (trees.threshold_types[pos] == 0 && x[feature] <= trees.thresholds[pos]) {
-            node = trees.children_left[pos];
-        } else if (trees.threshold_types[pos] == 1 && category_in_threshold(trees.thresholds[pos], x[feature])) {
-            node = trees.children_left[pos];
-        }
-         else {
-            node = trees.children_right[pos];
+        } else {
+            node = tree_split_child(
+                trees.threshold_types[pos], trees.thresholds[pos], x[feature],
+                trees.children_left[pos], trees.children_right[pos]
+            );
         }
     }
 }
@@ -453,13 +477,11 @@ inline void tree_shap_recursive(const unsigned num_outputs, const int *children_
         int type = threshold_types[node_index];
         if (x_missing[split_index]) {
             hot_index = children_default[node_index];
-        } else if (type == 0 && x[split_index] <= thresholds[node_index]) {
-            hot_index = children_left[node_index];
-        } else if (type == 1 && category_in_threshold(thresholds[node_index], x[split_index])) {
-            hot_index = children_left[node_index];
-        }
-        else {
-            hot_index = children_right[node_index];
+        } else {
+            hot_index = tree_split_child(
+                type, thresholds[node_index], x[split_index],
+                children_left[node_index], children_right[node_index]
+            );
         }
         const unsigned cold_index = (static_cast<int>(hot_index) == children_left[node_index] ?
                                         children_right[node_index] : children_left[node_index]);

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -6,6 +6,8 @@ import json
 import os
 import time
 import warnings
+from collections.abc import Callable
+from functools import partial
 from typing import Any, Literal
 
 import numpy as np
@@ -107,7 +109,7 @@ def _xgboost_n_iterations(tree_limit: int, num_stacked_models: int) -> int:
 _XGBOOST_ENABLE_CATEGORICAL_DEFAULT_TRUE_VERSION = "3.3"
 
 
-def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
+def _xgboost_cat_unsupported(model: TreeEnsemble, feature_perturbation: str | None = None) -> None:
     # XGBoost's own internal SHAP calculation (used for feature_perturbation=
     # "tree_path_dependent") has natively supported categorical splits since
     # XGBoost 1.5.0, so no guard is needed there. This guard only applies to
@@ -131,7 +133,17 @@ def _xgboost_cat_unsupported(model: TreeEnsemble) -> None:
         if version.parse(xgboost.__version__) < version.parse(_XGBOOST_ENABLE_CATEGORICAL_DEFAULT_TRUE_VERSION):
             has_cat_columns = True
 
-    if has_cat_columns:
+    if not has_cat_columns:
+        return
+
+    if feature_perturbation == "interventional":
+        raise NotImplementedError(
+            "Categorical split is not yet supported with feature_perturbation="
+            '"interventional". You can use feature_perturbation="tree_path_dependent".'
+        )
+
+    threshold_types = getattr(model, "threshold_types", None)
+    if threshold_types is None or not np.any(threshold_types == 2):
         raise NotImplementedError(
             "Categorical split is not yet supported. You can still use"
             " TreeExplainer with `feature_perturbation=tree_path_dependent`."
@@ -274,9 +286,7 @@ class TreeExplainer(Explainer):
                 "TreeExplainer does not support clustered data inputs! Please use shap.Explainer or pass an unclustered masker!"
             )
 
-        if isinstance(data, pd.DataFrame):
-            self.data = data.values
-        elif isinstance(data, DenseData):
+        if isinstance(data, DenseData):
             self.data = data.data
         else:
             self.data = data
@@ -318,6 +328,8 @@ class TreeExplainer(Explainer):
             self.model = model
         else:
             self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
+            self.data = self.model.data
+            self.data_missing = self.model.data_missing
         self.model_output = model_output
         # self.model_output = self.model.model_output # this allows the TreeEnsemble to translate model outputs types by how it loads the model
 
@@ -486,9 +498,7 @@ class TreeExplainer(Explainer):
 
         if tree_limit < 0 or tree_limit > self.model.values.shape[0]:
             tree_limit = self.model.values.shape[0]
-        # convert dataframes (use to_numpy to handle pandas nullable dtypes like Int64/Float64)
-        if isinstance(X, (pd.Series, pd.DataFrame)):
-            X = X.to_numpy(dtype=self.model.input_dtype, na_value=np.nan)
+        X = self.model._to_input_array(X)
         flat_output = False
         if len(X.shape) == 1:
             flat_output = True
@@ -717,7 +727,7 @@ class TreeExplainer(Explainer):
             X, y, tree_limit, check_additivity
         )
         transform = self.model.get_transform()
-        _xgboost_cat_unsupported(self.model)
+        _xgboost_cat_unsupported(self.model, self.feature_perturbation)
 
         # run the core algorithm using the C extension
         assert_import("cext")
@@ -1037,6 +1047,7 @@ class TreeEnsemble:
         self.tree_limit = None  # used for limiting the number of trees we use by default (like from early stopping)
         self.num_stacked_models = 1  # If this is greater than 1 it means we have multiple stacked models with the same number of trees in each model (XGBoost multi-output style)
         self.cat_feature_indices = None  # If this is set it tells us which features are treated categorically
+        self.input_transform: Callable[..., npt.NDArray[Any]] | None = None
         self._xgb_enable_categorical = False
 
         # we use names like keras
@@ -1631,15 +1642,37 @@ class TreeEnsemble:
             self.base_offset = self.base_offset.flatten()
             assert len(self.base_offset) == self.num_outputs
 
+    def _to_input_array(self, X: npt.NDArray[Any] | pd.Series | pd.DataFrame) -> npt.NDArray[Any]:
+        """Convert user input to the ndarray format expected by the C extension."""
+        if isinstance(X, pd.Series):
+            if self.input_transform is not None:
+                return self.input_transform(X.to_frame().T, dtype=self.input_dtype).reshape(-1)
+            return X.to_numpy(dtype=self.input_dtype, na_value=np.nan)
+        if isinstance(X, pd.DataFrame):
+            if self.input_transform is not None:
+                return self.input_transform(X, dtype=self.input_dtype)
+            return X.to_numpy(dtype=self.input_dtype, na_value=np.nan)
+        return X
+
     def _set_xgboost_model_attributes(
         self,
-        data: npt.NDArray[Any] | None,
+        data: npt.NDArray[Any] | pd.Series | pd.DataFrame | None,
         data_missing: npt.NDArray[np.bool_] | None,
         objective_name_map: dict[str, str],
         tree_output_name_map: dict[str, str],
     ) -> None:
         self.model_type = "xgboost"
         loader = XGBTreeModelLoader(self.original_model)
+        if loader.cat_feature_indices is not None:
+            self.input_transform = partial(
+                XGBTreeModelLoader.transform_input,
+                cat_feature_indices=loader.cat_feature_indices,
+            )
+        if data is not None and isinstance(data, (pd.Series, pd.DataFrame)):
+            data = self._to_input_array(data)
+            data_missing = np.isnan(data, dtype=bool)
+            self.data = data
+            self.data_missing = data_missing
 
         self.trees = loader.get_trees(data=data, data_missing=data_missing)
         self.base_offset = loader.base_score
@@ -1738,9 +1771,7 @@ class TreeEnsemble:
         if tree_limit is None:
             tree_limit = -1 if self.tree_limit is None else self.tree_limit
 
-        # convert dataframes (use to_numpy to handle pandas nullable dtypes like Int64/Float64)
-        if isinstance(X, (pd.Series, pd.DataFrame)):
-            X = X.to_numpy(dtype=self.input_dtype, na_value=np.nan)
+        X = self._to_input_array(X)
         flat_output = False
         if len(X.shape) == 1:
             flat_output = True
@@ -1904,7 +1935,10 @@ class SingleTree:
             self.children_default = tree["children_default"].astype(np.int32)
             self.features = tree["feature"].astype(np.int32)
             self.thresholds = tree["threshold"]
-            self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
+            if "threshold_type" in tree:
+                self.threshold_types = np.asarray(tree["threshold_type"], dtype=np.int32)
+            else:
+                self.threshold_types = np.zeros_like(self.thresholds, dtype=np.int32)
             self.values = tree["value"] * scaling
             self.node_sample_weight = tree["node_sample_weight"]
 
@@ -2273,6 +2307,30 @@ class XGBTreeModelLoader:
     categories: list[list[list[int]]]
     cat_feature_indices: npt.NDArray[Any] | None
 
+    @staticmethod
+    def transform_input(
+        X: npt.NDArray[Any] | pd.Series | pd.DataFrame,
+        *,
+        cat_feature_indices: npt.NDArray[np.intp] | None,
+        dtype: npt.DTypeLike = np.float64,
+    ) -> npt.NDArray[Any]:
+        """Convert pandas categorical columns to integer codes for XGBoost tree traversal."""
+        if isinstance(X, pd.Series):
+            X = X.to_frame().T
+
+        if isinstance(X, pd.DataFrame):
+            arr = X.to_numpy(dtype=dtype, na_value=np.nan).copy()
+            if cat_feature_indices is not None:
+                for idx in cat_feature_indices:
+                    col = X.iloc[:, int(idx)]
+                    if isinstance(col.dtype, pd.CategoricalDtype):
+                        codes = col.cat.codes.to_numpy(dtype=arr.dtype, copy=True)
+                        codes[codes < 0] = np.nan
+                        arr[:, int(idx)] = codes
+            return arr
+
+        return X
+
     def __init__(self, xgb_model: Any) -> None:
         import xgboost as xgb
 
@@ -2434,6 +2492,13 @@ class XGBTreeModelLoader:
 
             tree_categories = self.parse_categories(cat_nodes, cat_segments, cat_sizes, cats, self.node_cleft[-1])
             self.categories.append(tree_categories)
+            for node_id, node_cats in enumerate(tree_categories):
+                if node_cats:
+                    threshold_types[node_id] = 2
+                    threshold = 0.0
+                    for cat in node_cats:
+                        threshold += 2 ** int(cat)
+                    thresholds[node_id] = threshold
 
     @staticmethod
     def parse_categories(

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -1612,6 +1612,48 @@ class TestExplainerXGBoost:
         assert explainer.model.tree_limit == ltr.n_estimators * 3
 
 
+def _fit_xgboost_categorical_classifier():
+    """Small adult model with one pandas categorical column (enable_categorical=True)."""
+    xgboost = pytest.importorskip("xgboost")
+    X, y = shap.datasets.adult(n_points=300)
+    X = X.copy()
+    X["Workclass"] = X["Workclass"].astype("category")
+    clf = xgboost.XGBClassifier(
+        n_estimators=8,
+        enable_categorical=True,
+        max_depth=4,
+        tree_method="hist",
+        random_state=0,
+    )
+    clf.fit(X, y)
+    return clf, X.iloc[:20], X.iloc[20:120]
+
+
+class TestExplainerXGBoostCategorical:
+    """TreeExplainer with XGBoost sklearn enable_categorical models."""
+
+    def test_tree_path_dependent_background_additivity(self):
+        """Background forces _cext; categorical splits must satisfy SHAP additivity."""
+        clf, X_explain, X_bg = _fit_xgboost_categorical_classifier()
+        explainer = shap.TreeExplainer(clf, X_bg, feature_perturbation="tree_path_dependent")
+        assert np.any(explainer.model.threshold_types == 2)
+        shap_values = explainer.shap_values(X_explain, check_additivity=True)
+        margin = clf.predict(X_explain, output_margin=True)
+        np.testing.assert_allclose(
+            shap_values.sum(1) + explainer.expected_value,
+            margin,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+    def test_interventional_raises(self):
+        """Interventional feature perturbation is not supported for XGBoost categorical splits."""
+        clf, X_explain, X_bg = _fit_xgboost_categorical_classifier()
+        explainer = shap.TreeExplainer(clf, X_bg, feature_perturbation="interventional")
+        with pytest.raises(NotImplementedError, match="interventional"):
+            explainer.shap_values(X_explain)
+
+
 class TestExplainerLightGBM:
     """Tests for the TreeExplainer when the model passed in is a LightGBM instance.
 


### PR DESCRIPTION
> **Status:** Work in progress — I am still finalizing this PR; it is not fully ready for review yet.

Related issues: #2662, #5068

## Summary

`TreeExplainer` on an XGBoost model with native categoricals (`enable_categorical=True`) works today **without** a background dataset: SHAP delegates to XGBoost’s own `pred_contribs` path. It breaks when you pass **background data** with `feature_perturbation="tree_path_dependent"` — that configuration forces SHAP’s CPU `_cext` implementation, which did not support XGB categorical trees end-to-end.

On master, that `_cext` path either raises `NotImplementedError` for categorical XGB models, or (if reached) cannot traverse the trees correctly: the loader never marks categorical nodes or builds their bitmask thresholds, the C++ core has no XGB split type (only numeric and LightGBM), and pandas `category` columns are passed through `to_numpy()` as labels instead of the integer codes the booster trained on.

This PR connects the full pipeline for that path:

- **Loader (`XGBTreeModelLoader`):** mark categorical split nodes as `threshold_types=2` and set threshold bitmasks from category codes.
- **C++ (`tree_shap.h`):** add XGB routing (in-set → right, `2^code` bitmask) via a shared split dispatcher used in predict, weight update, and SHAP recursion.
- **Python (`_tree.py`):** convert categorical columns to codes through `transform_input` / `_to_input_array`; allow `_cext` when type-2 nodes are present; keep background and explain rows in sync (`TreeExplainer.data` ← encoded `TreeEnsemble.data`).

## Why `threshold_types=2` instead of reusing LightGBM (`type=1`)?

`threshold_types` is not a per-library enum in C++; it encodes a **routing contract**. Today only LightGBM’s loader sets `type=1` (PR #4171, parsing `.dump_model()` cat thresholds like `"1||3"`).

We cannot reuse `type=1` for XGBoost categoricals because the booster semantics differ in two ways:

| | LightGBM (`type=1`) | XGBoost (`type=2`) |
|---|---|---|
| Bitmask | `2^(cat−1)` — **1-based** category levels from the dump | `2^cat` — **0-based** pandas/XGB category codes |
| Routing | category **in** split set → **left** child | category **in** split set → **right** child |

`children_left` / `children_right` come from each library’s tree dump unchanged. SHAP must mirror whichever child the model actually follows. Using LightGBM routing on XGB arrays would walk the **wrong branch** (wrong leaf, wrong SHAP values) even if the bitmask were remapped.

**Why not swap left/right in the loader instead of `type=2`?** Possible in theory, but fragile (easy to get `children_default` / missing-value routing wrong) and hides which convention is in use. A separate type keeps LGBM behavior untouched and makes XGB trees detectable in Python (`threshold_types == 2`).

**Numeric splits are not affected:** for `type=0`, both libraries use the same low/high meaning (`x ≤ threshold` → left). XGB’s `<` vs SHAP’s `≤` is already handled in `XGBTreeModelLoader` via `np.nextafter` — a boundary tweak, not a left/right flip. The left/right disagreement only appears for categorical set-membership splits.

## Testing

**Success criterion:** with background + `tree_path_dependent`, row-level SHAP values satisfy additivity — `sum(shap_values) + expected_value ≈ predict(..., output_margin=True)`.

**Automated (`TestExplainerXGBoostCategorical`):**
- Fixture: adult dataset (300 rows), `Workclass` as pandas `category`, `XGBClassifier(enable_categorical=True, tree_method="hist")`, 100-row background + 20 explain rows.
- `test_tree_path_dependent_background_additivity`: background forces `_cext` (not `pred_contribs`); asserts `threshold_types == 2` nodes exist; runs `shap_values(..., check_additivity=True)`; explicitly checks `shap.sum(1) + expected_value` vs `output_margin` (`rtol=atol=1e-5`).
- `test_interventional_raises`: same model/background with `feature_perturbation="interventional"` raises `NotImplementedError` (expected gap).

**CI:** full upstream `tests` workflow green on this branch (all OS/Python matrix jobs, including `oldest supported numpy`).

**Not tested:** per-feature agreement with XGB `pred_contribs` on the no-background shortcut path.

## Not in this PR

| Item | Status |
|------|--------|
| **Interventional + categoricals** | Still `NotImplementedError` |
| **GPU (`_cext_gpu`)** | Deferred |
| **Per-feature vs `pred_contribs`** | Not tested — row-level additivity only |