### PR TITLE
FIX: sync model_output when TreeExplainer is given a pre-built TreeEnsemble

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import copy
 import io
 import json
 import os
@@ -315,11 +316,17 @@ class TreeExplainer(Explainer):
             # to construct trees by hand (e.g. with categorical splits, which the
             # third-party model parsers are needed for otherwise) and explain them
             # without round-tripping through an external model object.
-            self.model = model
+            # Copy first so that setting model_output below doesn't mutate an
+            # instance the caller might reuse elsewhere (e.g. passing the same
+            # hand-built TreeEnsemble to both TreeExplainer and GPUTreeExplainer).
+            self.model = copy.copy(model)
+            self.model.model_output = model_output
         else:
             self.model = TreeEnsemble(model, self.data, self.data_missing, model_output)
-        self.model_output = model_output
-        # self.model_output = self.model.model_output # this allows the TreeEnsemble to translate model outputs types by how it loads the model
+        # self.model.model_output may differ from the model_output argument above
+        # (e.g. TreeEnsemble translates "predict_proba" to "probability" for some
+        # model types), so mirror the resolved value rather than the raw argument.
+        self.model_output = self.model.model_output
 
         # check for unsupported combinations of feature_perturbation and model_outputs
         if feature_perturbation == "tree_path_dependent":

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -90,6 +90,73 @@ def test_xgboost_predictions():
     assert np.allclose(y_pred, y_pred_tree_ensemble, atol=1e-7)
 
 
+def _hand_built_tree_ensemble(model_output=None):
+    """A minimal hand-built TreeEnsemble, matching the "construct trees by hand"
+    use case TreeExplainer's isinstance(model, TreeEnsemble) branch exists for."""
+    from shap.explainers._tree import TreeEnsemble
+
+    tree_dict = {
+        "objective": "binary_crossentropy",
+        "tree_output": "log_odds",
+        "trees": [
+            {
+                "children_left": np.array([1, -1, -1], dtype=np.int32),
+                "children_right": np.array([2, -1, -1], dtype=np.int32),
+                "children_default": np.array([1, -1, -1], dtype=np.int32),
+                "features": np.array([0, -2, -2], dtype=np.int32),
+                "thresholds": np.array([0.5, -2, -2], dtype=np.float64),
+                "values": np.array([[0.0], [0.2], [0.8]], dtype=np.float64),
+                "node_sample_weight": np.array([100.0, 40.0, 60.0], dtype=np.float64),
+            }
+        ],
+    }
+    ensemble = TreeEnsemble(tree_dict)
+    if model_output is not None:
+        ensemble.model_output = model_output
+    return ensemble
+
+
+def test_treeexplainer_syncs_model_output_for_prebuilt_treeensemble():
+    """Regression test: TreeExplainer(model=<TreeEnsemble>, model_output=...) used to
+    leave self.model.model_output (what computation actually reads) out of sync with
+    self.model_output (the attribute set from the argument), because the
+    isinstance(model, TreeEnsemble) fast path skipped the sync that a freshly
+    constructed TreeEnsemble gets. See GH issue for the three failure modes this
+    caused."""
+    background = np.array([[0.2], [0.7], [0.4]])
+    explainer = shap.TreeExplainer(
+        model=_hand_built_tree_ensemble(),
+        data=background,
+        model_output="probability",
+        feature_perturbation="interventional",
+    )
+    assert explainer.model_output == "probability"
+    assert explainer.model.model_output == "probability"
+
+
+def test_treeexplainer_tree_path_dependent_default_works_for_prebuilt_treeensemble():
+    """The plain default case (model_output="raw", the TreeExplainer default) should
+    just work for a hand-built TreeEnsemble the same as it does for any other model,
+    instead of raising because the pre-built ensemble's model_output was never
+    reconciled with the default."""
+    explainer = shap.TreeExplainer(model=_hand_built_tree_ensemble(), feature_perturbation="tree_path_dependent")
+    assert explainer.model_output == "raw"
+    assert explainer.model.model_output == "raw"
+
+
+def test_treeexplainer_does_not_mutate_shared_prebuilt_treeensemble():
+    """Constructing a TreeExplainer around a pre-built TreeEnsemble must not mutate
+    that TreeEnsemble in place, since callers may reuse the same instance elsewhere
+    (e.g. shap's own GPU/CPU equivalence tests construct both a TreeExplainer and a
+    GPUTreeExplainer from one shared TreeEnsemble)."""
+    shared = _hand_built_tree_ensemble(model_output="raw")
+    background = np.array([[0.2], [0.7], [0.4]])
+
+    shap.TreeExplainer(model=shared, data=background, model_output="probability", feature_perturbation="interventional")
+
+    assert shared.model_output == "raw"
+
+
 def test_front_page_sklearn():
     # load JS visualization code to notebook
     shap.initjs()


### PR DESCRIPTION
Fixes #5098.

## What this fixes

`TreeExplainer(model=<pre-built TreeEnsemble>, model_output=...)` silently ignored the `model_output` argument. The `isinstance(model, TreeEnsemble)` fast path added in #5026 skips the logic a freshly-constructed `TreeEnsemble` gets, so `self.model_output` (set from the argument) and `self.model.model_output` (what every validation and computation call site in `_tree.py` actually reads) could permanently disagree. Depending on what the pre-built `TreeEnsemble` already had, this either raised a misleading `ValueError`/`Exception` unrelated to the real cause, or silently computed with the wrong output type with no error at all. Three concrete repro cases and the full analysis are in #5098.

## Fix

- Copy the passed-in `TreeEnsemble` before mutating it, so constructing a `TreeExplainer` doesn't affect an instance the caller might reuse elsewhere (e.g. shap's own GPU/CPU equivalence tests pass one `TreeEnsemble` to both `TreeExplainer` and `GPUTreeExplainer`).
- Set `model_output` on that copy from the argument, then in both branches (fresh construction and passthrough) set `self.model_output = self.model.model_output`, mirroring the *resolved* value rather than the raw argument. This completes what the commented-out line right above this code already gestured at, since `TreeEnsemble.__init__` can itself translate `model_output` for some model types (e.g. `predict_proba` -> `probability`), and that translation wasn't being reflected back either.

## Tests

Added three tests to `tests/explainers/test_tree.py`, all against a hand-built `TreeEnsemble` (the exact use case the `isinstance` branch's docstring describes):
- `test_treeexplainer_syncs_model_output_for_prebuilt_treeensemble` - the core regression case
- `test_treeexplainer_tree_path_dependent_default_works_for_prebuilt_treeensemble` - the default (`model_output="raw"`) case should just work, which it didn't before
- `test_treeexplainer_does_not_mutate_shared_prebuilt_treeensemble` - the aliasing case the `copy.copy` call exists to prevent

## Testing notes

I don't have a C++ toolchain configured to build shap's compiled extension locally, so I validated construction-time behavior (where this fix lives) against the real source with the two `_cext` functions used during `TreeEnsemble`/`TreeExplainer` construction stubbed out, then ran the full existing `tests/explainers/test_tree.py` suite against the fix. All 65 failures there trace to the same three environment gaps (missing `_cext.dense_tree_shap`, missing `_cext.dense_tree_update_weights`, and `lightgbm` not installed) - every one of them fails *after* `TreeExplainer.__init__` completes successfully, at the point of calling `.shap_values()`/`.predict()`, so none are affected by this change. Happy to have CI confirm on a real build.

## Related

@adityaanikam independently diagnosed this same root cause on the issue with a very thorough writeup, thank you for confirming the mechanism.
