### PR TITLE
fix: preserve global NumPy RNG state in corrgroups60/independentlinear60

### DIFF
--- a/shap/datasets.py
+++ b/shap/datasets.py
@@ -527,8 +527,8 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
         data, target = shap.datasets.corrgroups60()
 
     """
-    # set a constant seed
-    old_seed = np.random.seed()
+    # save and restore the global RNG state so callers are unaffected
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -563,8 +563,8 @@ def corrgroups60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray]:
     X = X_final
     y = f(X) + np.random.randn(N) * 1e-2
 
-    # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    # restore the previous numpy random state
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 
@@ -598,8 +598,8 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
         features, labels = shap.datasets.independentlinear60()
 
     """
-    # set a constant seed
-    old_seed = np.random.seed()
+    # save and restore the global RNG state so callers are unaffected
+    old_state = np.random.get_state()
     np.random.seed(0)
 
     # generate dataset with known correlation
@@ -617,8 +617,8 @@ def independentlinear60(n_points: int = 1_000) -> tuple[pd.DataFrame, np.ndarray
     X = X_start - X_start.mean(0)
     y = f(X) + np.random.randn(N) * 1e-2
 
-    # restore the previous numpy random seed
-    np.random.seed(old_seed)
+    # restore the previous numpy random state
+    np.random.set_state(old_state)
 
     return pd.DataFrame(X), y
 

--- a/tests/test_rng_state.py
+++ b/tests/test_rng_state.py
@@ -1,0 +1,88 @@
+"""Regression tests for GitHub issue #4988.
+
+corrgroups60() and independentlinear60() must not corrupt the global
+NumPy RNG state.  Before the fix, both functions stored the None return
+value of np.random.seed() and later called np.random.seed(None), which
+re-seeds from OS entropy instead of restoring the original state.
+"""
+
+import numpy as np
+
+import shap
+
+
+def test_corrgroups60_preserves_rng_state():
+    """Calling corrgroups60 must leave the global RNG state unchanged."""
+    np.random.seed(12345)
+    state_before = np.random.get_state()
+
+    shap.datasets.corrgroups60()
+
+    state_after = np.random.get_state()
+
+    # The state tuple is ('MT19937', array_of_624_uint32, pos, has_gauss, cached_gaussian).
+    # Compare every element.
+    assert state_before[0] == state_after[0], "RNG algorithm name changed"
+    np.testing.assert_array_equal(state_before[1], state_after[1])
+    assert state_before[2] == state_after[2], "RNG position changed"
+    assert state_before[3] == state_after[3], "has_gauss flag changed"
+    assert state_before[4] == state_after[4], "cached_gaussian changed"
+
+
+def test_independentlinear60_preserves_rng_state():
+    """Calling independentlinear60 must leave the global RNG state unchanged."""
+    np.random.seed(12345)
+    state_before = np.random.get_state()
+
+    shap.datasets.independentlinear60()
+
+    state_after = np.random.get_state()
+
+    assert state_before[0] == state_after[0], "RNG algorithm name changed"
+    np.testing.assert_array_equal(state_before[1], state_after[1])
+    assert state_before[2] == state_after[2], "RNG position changed"
+    assert state_before[3] == state_after[3], "has_gauss flag changed"
+    assert state_before[4] == state_after[4], "cached_gaussian changed"
+
+
+def test_corrgroups60_deterministic_output():
+    """The data returned by corrgroups60 must still be reproducible."""
+    X1, y1 = shap.datasets.corrgroups60(n_points=100)
+    X2, y2 = shap.datasets.corrgroups60(n_points=100)
+    np.testing.assert_array_equal(X1.values, X2.values)
+    np.testing.assert_array_equal(y1, y2)
+
+
+def test_independentlinear60_deterministic_output():
+    """The data returned by independentlinear60 must still be reproducible."""
+    X1, y1 = shap.datasets.independentlinear60(n_points=100)
+    X2, y2 = shap.datasets.independentlinear60(n_points=100)
+    np.testing.assert_array_equal(X1.values, X2.values)
+    np.testing.assert_array_equal(y1, y2)
+
+
+def test_rng_sequence_continues_after_corrgroups60():
+    """Random numbers generated after corrgroups60 must follow the
+    pre-call sequence, proving the state was truly restored (not just
+    re-seeded to a different fixed value)."""
+    np.random.seed(42)
+    expected = np.random.randn(5)
+
+    np.random.seed(42)
+    shap.datasets.corrgroups60()
+    actual = np.random.randn(5)
+
+    np.testing.assert_array_equal(expected, actual)
+
+
+def test_rng_sequence_continues_after_independentlinear60():
+    """Random numbers generated after independentlinear60 must follow the
+    pre-call sequence, proving the state was truly restored."""
+    np.random.seed(42)
+    expected = np.random.randn(5)
+
+    np.random.seed(42)
+    shap.datasets.independentlinear60()
+    actual = np.random.randn(5)
+
+    np.testing.assert_array_equal(expected, actual)


### PR DESCRIPTION
## Summary

Fixes silent global RNG state corruption in `corrgroups60()` and `independentlinear60()`.

## Problem

Both functions saved the RNG state with:
```python
old_seed = np.random.seed(0)  # returns None
```
Then restored with:
```python
np.random.seed(old_seed)  # np.random.seed(None) → re-seeds from OS entropy
```

This silently re-randomizes the global RNG instead of restoring the caller's state, breaking reproducibility for any code that calls these functions mid-sequence.

## Fix

Replace `np.random.seed()` save/restore with `np.random.get_state()` / `np.random.set_state()`:
```python
old_state = np.random.get_state()
np.random.seed(0)
# ... generate data ...
np.random.set_state(old_state)
```

The functions still use seed 0 internally for deterministic output — only the global state restoration is changed.

## Tests

6 regression tests in `tests/test_rng_state.py`:
- State preservation after `corrgroups60()` and `independentlinear60()`
- Deterministic output (same data on repeated calls)
- Sequence continuity (random numbers after the call match what they would be without it)

Closes #4988

## Files Changed

- `shap/datasets.py` — fixed both functions
- `tests/test_rng_state.py` — 6 regression tests (new)

Developed with Claude Code as a coding partner