### PR TITLE
remove llvmlite and numba restrictions on macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,8 @@ dependencies = [
   'tqdm>=4.27.0',
   'packaging>20.9',
   'slicer==0.0.8',
-  'numba<0.63; sys_platform == "darwin" and platform_machine == "x86_64"',  # numba 0.63+ dropped macOS x86_64 wheels, see numba/numba#10187
-  'numba; sys_platform != "darwin" or platform_machine != "x86_64"',
-  'llvmlite<0.46; sys_platform == "darwin" and platform_machine == "x86_64"',  # llvmlite 0.46+ dropped macOS x86_64 wheels, see numba/numba#10187
-  'llvmlite; sys_platform != "darwin" or platform_machine != "x86_64"',
+  'numba',
+  'llvmlite',
   'cloudpickle',
 ]
 classifiers = [


### PR DESCRIPTION
## Overview

Closes #5113  <!--Add issue number here, or delete as appropriate-->

Description of the changes proposed in this pull request:
- remove the dependency restrictions on numba and llvmlite for macos


## Checklist

- [ ] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
