### PR TITLE
FIX: Preserve float64 thresholds in interventional TreeExplainer

### DIFF
--- a/shap/cext/tree_shap.h
+++ b/shap/cext/tree_shap.h
@@ -728,7 +728,8 @@ inline void build_merged_tree(TreeEnsemble &out_tree, const ExplanationDataset &
 struct Node {
     short cl, cr, cd, pnode; // uint_16
     long feat, pfeat;
-    float thres, value;
+    tfloat thres;
+    float value;
     char from_flag;
 };
 
@@ -768,7 +769,8 @@ inline void tree_shap_indep(const unsigned max_depth, const unsigned num_feats,
     long feat, pfeat = -1;
     short next_xnode = -1, next_rnode = -1;
     short next_node = -1, from_child = -1;
-    float thres, pos_x = 0, neg_x = 0, pos_r = 0, neg_r = 0;
+    tfloat thres;
+    float pos_x = 0, neg_x = 0, pos_r = 0, neg_r = 0;
     char from_flag;
     unsigned M = 0, N = 0;
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -44,6 +44,26 @@ def test_large_background_dataset_warning():
         shap.TreeExplainer(model, background, feature_perturbation="interventional")
 
 
+def test_interventional_preserves_float64_threshold():
+    stump = {
+        "children_left": np.array([1, -1, -1], dtype=np.int32),
+        "children_right": np.array([2, -1, -1], dtype=np.int32),
+        "children_default": np.array([1, -1, -1], dtype=np.int32),
+        "feature": np.array([0, -2, -2], dtype=np.int32),
+        "threshold": np.array([0.3, -2.0, -2.0]),
+        "value": np.array([[0.0], [1.0], [2.0]]),
+        "node_sample_weight": np.array([2.0, 1.0, 1.0]),
+    }
+    x = np.array([[0.3000000059604645]])
+    explainer = shap.TreeExplainer(
+        {"trees": [stump]}, data=np.array([[1.0]]), feature_perturbation="interventional"
+    )
+
+    shap_values = explainer.shap_values(x, check_additivity=False)
+
+    assert np.allclose(shap_values[0, 0] + explainer.expected_value, explainer.model.predict(x)[0])
+
+
 def test_front_page_xgboost():
     xgboost = pytest.importorskip("xgboost")
 

--- a/tests/explainers/test_tree.py
+++ b/tests/explainers/test_tree.py
@@ -55,9 +55,7 @@ def test_interventional_preserves_float64_threshold():
         "node_sample_weight": np.array([2.0, 1.0, 1.0]),
     }
     x = np.array([[0.3000000059604645]])
-    explainer = shap.TreeExplainer(
-        {"trees": [stump]}, data=np.array([[1.0]]), feature_perturbation="interventional"
-    )
+    explainer = shap.TreeExplainer({"trees": [stump]}, data=np.array([[1.0]]), feature_perturbation="interventional")
 
     shap_values = explainer.shap_values(x, check_additivity=False)
 


### PR DESCRIPTION
Title: FIX: Preserve float64 thresholds in interventional TreeExplainer

## Summary

- Keep independent TreeSHAP split thresholds as the existing double-precision `tfloat` instead of narrowing them to `float`.
- Add a regression test at the float64/float32 boundary that checks SHAP additivity against model prediction.
- Duplicate-work check: the supplied issue snapshot shows no related PR or duplicate marker.

Fixes #5116

## Test evidence

- `c++ -std=c++11 $(python3-config --includes) -I. -x c++ -o /tmp/builder_tree_threshold -` with an inline one-stump harness, then `/tmp/builder_tree_threshold` (passed)
- `python3 -m py_compile tests/explainers/test_tree.py` (passed)
- `git diff --check` (passed)
- Focused pytest could not start because pytest is not installed in the restricted environment; full pytest and pre-commit remain for CI.

## Risks or notes for maintainers

- The internal independent-algorithm `Node` may be slightly larger because its threshold is now double precision.
- The change is limited to threshold storage/comparison and the boundary regression; no public API or dependency changes.

## AI usage disclosure

An AI coding agent autonomously traced the precision loss, prepared the two-file patch, and ran the compiled boundary, syntax, and diff checks. It assisted with the regression and PR wording and did not make a product or design decision. I reviewed and understand every changed line and the rationale: the extension receives thresholds and inputs as double-precision `tfloat`, so the independent TreeSHAP node and comparison must retain that precision to match model routing.

## Checklist

- [ ] All pre-commit checks pass (deferred to CI because pre-commit is unavailable locally).
- [x] Unit test added for the bug fix.
