### PR TITLE
Fix partial_dependence_plot ignoring custom ax argument

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -102,8 +102,9 @@ def partial_dependence(
             fig = plt.figure()
             ax1 = plt.gca()
         else:
-            fig = plt.gcf()
-            ax1 = plt.gca()
+            ax1 = ax
+            fig = ax1.figure
+            plt.sca(ax1)
 
         # fig, ax1 = plt.subplots(figsize)
         ax2 = ax1.twinx()
@@ -236,8 +237,11 @@ def partial_dependence(
                 x1[i, j] = xs1[j]
                 vals[i, j] = model(features_tmp).mean()
 
-        fig = plt.figure()
-        ax = fig.add_subplot(111, projection="3d")
+        if ax is None:
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection="3d")
+        else:
+            fig = ax.figure
 
         #         x = y = np.arange(-3.0, 3.0, 0.05)
         #         X, Y = np.meshgrid(x, y)

--- a/tests/plots/test_dependence.py
+++ b/tests/plots/test_dependence.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -41,3 +42,47 @@ def test_dependence_use_line_collection_bug():
         shap_values=shap_values[:1, :],  # type: ignore[call-overload]
         show=False,
     )
+
+
+def test_partial_dependence_custom_ax():
+    """Passing a custom ax should plot on that axes, not create a new one.
+
+    Regression test for GH #3206.
+    """
+    sklearn = pytest.importorskip("sklearn")
+
+    X, y = shap.datasets.california(n_points=20)
+    model = sklearn.linear_model.LinearRegression()
+    model.fit(X, y)
+
+    fig, axes = plt.subplots(1, 2)
+
+    # Plot on the first axes
+    shap.partial_dependence_plot(
+        "MedInc",
+        model.predict,
+        X,
+        ice=False,
+        show=False,
+        ax=axes[0],
+    )
+
+    # Plot on the second axes
+    shap.partial_dependence_plot(
+        "HouseAge",
+        model.predict,
+        X,
+        ice=False,
+        show=False,
+        ax=axes[1],
+    )
+
+    # Verify that each axes received its own plot (has lines drawn on it)
+    assert len(axes[0].lines) > 0, "First axes should have plot lines"
+    assert len(axes[1].lines) > 0, "Second axes should have plot lines"
+
+    # Verify that the axes labels are different (each feature plotted separately)
+    assert axes[0].get_xlabel() == "MedInc"
+    assert axes[1].get_xlabel() == "HouseAge"
+
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Fixes #3206.

`partial_dependence_plot()` accepts an `ax` parameter but ignores it in both the 1D and 2D code paths — all plots land on whichever axes matplotlib considers "current" instead of the user-supplied target.

## Changes

**1D case** (`shap/plots/_partial_dependence.py`, ~line 104):
- Was: `fig = plt.gcf(); ax1 = plt.gca()` — ignores the passed `ax`
- Now: `ax1 = ax; fig = ax1.figure; plt.sca(ax1)` — uses the user-supplied axes and sets it as current so `twinx()` operates correctly

**2D case** (~line 240):
- Was: `fig = plt.figure()` — unconditionally creates a new figure
- Now: wrapped in `if ax is None:` guard so user-supplied axes are respected

## Test plan

- Added `test_partial_dependence_custom_ax` in `tests/plots/test_dependence.py`
- Creates a 1x2 subplot grid, plots two different features onto separate axes
- Asserts each axes has lines and the correct xlabel (verifying plots went to different subplots)
- All existing tests pass