### PR TITLE
Remove outdated TensorFlow version warnings from DeepExplainer

### DIFF
--- a/shap/explainers/_deep/deep_tf.py
+++ b/shap/explainers/_deep/deep_tf.py
@@ -87,14 +87,6 @@ class TFDeep(Explainer):
             have a value of False during predictions (and hence explanations).
 
         """
-        if version.parse(tf.__version__) < version.parse("1.4.0"):
-            warnings.warn("Your TensorFlow version is older than 1.4.0 and not supported.")
-
-        if version.parse(tf.__version__) >= version.parse("2.4.0"):
-            warnings.warn(
-                "Your TensorFlow version is newer than 2.4.0 and so graph support has been removed in eager mode and some static graphs may not be supported. See PR #1483 for discussion."
-            )
-
         # determine the model inputs and outputs
         self.model_inputs = _get_model_inputs(model)
         self.model_output = _get_model_output(model)


### PR DESCRIPTION
## Summary

Addresses #3066 / #3970.

Removes two outdated `warnings.warn()` calls from `DeepExplainer.__init__()` in `shap/explainers/_deep/deep_tf.py`:

1. **TF < 1.4.0 warning** — TensorFlow 1.4 was released November 2017. This is dead code that will never trigger on any supported Python/TF combination.

2. **TF >= 2.4.0 warning** ("not able to use graph-based TF in eager mode") — TF 2.4 was released December 2020. This warning has been firing for every user for 5+ years. It's informational noise: the code already handles eager mode properly (lines 107-114), and users cannot meaningfully act on it (downgrading to TF 2.3 is not viable in 2026).

## Changes

- Deleted 8 lines (two `if`/`warnings.warn()` blocks) from `deep_tf.py`
- No replacement needed — the version checks were purely informational

## Test plan

- All existing tests pass
- The eager-mode handling code (lines 107-114) is unchanged and continues to work correctly