### PR TITLE
remove numba and llvmlite from dependencies, support free-threaded python

### DIFF
--- a/.github/workflows/build_gpu_wheels.yml
+++ b/.github/workflows/build_gpu_wheels.yml
@@ -75,7 +75,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Build CUDA wheel
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v4.2.0
         env:
           # Only manylinux x86_64 - CUDA has no aarch64/macOS/Windows target here.
           CIBW_BUILD: "cp3*-manylinux_x86_64"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -79,7 +79,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS_LINUX: ${{ contains(matrix.os, '-arm') && 'aarch64' || 'x86_64' }}
           CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-14' && 'arm64' || 'x86_64' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ dependencies = [
   'tqdm>=4.27.0',
   'packaging>20.9',
   'slicer==0.0.8',
-  'numba',
-  'llvmlite',
   'cloudpickle',
 ]
 classifiers = [
@@ -192,7 +190,6 @@ module = [
   "IPython.*",
   "lightgbm.*",
   "lime.*",
-  "numba",
   "pandas",
   "pyod.*",
   "pyspark.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,6 +339,13 @@ build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
 test-groups = ["test-core", "plots"]
+# scikit-learn ships no cp315 or musllinux wheels yet; its sdist build pins
+# scipy<1.18, which has no wheels there either and needs Fortran+OpenBLAS.
+# Un-skip when the upstream wheels ship:
+#   https://github.com/scikit-learn/scikit-learn/issues/34652 (Python 3.15 support)
+#   https://github.com/pandas-dev/pandas/issues/66740 (Python 3.15 tracker)
+#   https://github.com/scikit-learn/scikit-learn/issues/27004 (musllinux wheels)
+test-skip = "cp315* *-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,8 +335,6 @@ omit = ["shap/benchmark/*"]
 combine = ["shap", "*/site-packages/shap"]
 
 [tool.cibuildwheel]
-enable = ["cpython-freethreading"]
-
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-  'numpy>=2,<2.5',  # numba does not yet support numpy>=2.5, see numba/numba#10689
+  'numpy>=2',
   'scipy',
   'scikit-learn',
   'pandas',
@@ -128,6 +128,8 @@ cache-keys = [
   { file = "shap/cutils/*.h" },
   { file = "CMakeLists.txt" },
 ]
+
+
 
 [tool.mypy]
 check_untyped_defs = true
@@ -292,7 +294,6 @@ ignore = [
   "E117",
   "E501",
   "W191",
-
   # pydocstyle issues not yet fixed
   "D100",  # Missing docstring in public module
   "D101",  # Missing docstring in public class
@@ -334,24 +335,12 @@ omit = ["shap/benchmark/*"]
 combine = ["shap", "*/site-packages/shap"]
 
 [tool.cibuildwheel]
-# TODO: Should we use uv as build frontend for faster builds?
-# build-frontend = "uv"
+enable = ["cpython-freethreading"]
 
-# Restrict the set of builds to mirror the wheels available in scipy. See #3028
-# skip cp314-macosx_x86_64 due to lack of numba and llvmlite support
-# skip *t (free-threaded builds) since dependencies like llvmlite don't support it yet
-skip = [
-  "cp314-macosx_x86_64",
-  "cp314t-manylinux_x86_64",
-  "cp314t-macosx_x86_64",
-  "cp314t-win_amd64",
-]
 build-verbosity = 2
 # Change import-mode to ensure we test against installed package, not local project
 test-command = "pytest -v {project}/tests --import-mode=append"
 test-groups = ["test-core", "plots"]
-# skip tests on *-musllinux*" since llvmlite and numba do not provide musllinux wheels
-test-skip = "*-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/shap/explainers/_additive.py
+++ b/shap/explainers/_additive.py
@@ -15,7 +15,7 @@ class AdditiveExplainer(Explainer):
     you will get incorrect answers that fail additivity).
     """
 
-    _expected_value: float | npt.NDArray[np.floating[Any]]
+    _expected_value: float | np.floating[Any] | npt.NDArray[np.floating[Any]]
     _zero_offset: float | npt.NDArray[np.floating[Any]]
     _input_offsets: npt.NDArray[np.floating[Any]]
 

--- a/shap/explainers/_gradient.py
+++ b/shap/explainers/_gradient.py
@@ -537,7 +537,8 @@ class _PyTorchGradient(Explainer):
         else:
             self.gradients = [None for _ in range(outputs.shape[1])]
 
-    def gradient(self, idx: int, inputs: list[Any]) -> list[npt.NDArray[Any]]:
+    # todo: idx could also be tensor but we haven't imported this globally
+    def gradient(self, idx: int | Any, inputs: list[Any]) -> list[npt.NDArray[Any]]:
         import torch
 
         self.model.zero_grad()

--- a/shap/plots/colors/_colors.py
+++ b/shap/plots/colors/_colors.py
@@ -1,12 +1,14 @@
 """This defines some common colors."""
 
+from collections.abc import Sequence
+
 import numpy as np
 from matplotlib.colors import LinearSegmentedColormap
 
 from ._colorconv import lab2rgb, lch2lab
 
 
-def lch2rgb(x: list[float]) -> np.ndarray:
+def lch2rgb(x: Sequence[float]) -> np.ndarray:
     return lab2rgb(lch2lab([[x]]))[0][0]
 
 
@@ -36,7 +38,7 @@ l_vals = list(np.linspace(blue_lch[0], l_mid, nsteps // 2)) + list(np.linspace(l
 c_vals = np.linspace(blue_lch[1], red_lch[1], nsteps)
 h_vals = np.linspace(blue_lch[2], red_lch[2], nsteps)
 for pos, l, c, h in zip(np.linspace(0, 1, nsteps), l_vals, c_vals, h_vals):  # noqa: E741
-    lch = [l, c, h]
+    lch: list[float] = [l, c, h]
     rgb = lch2rgb(lch)
     reds.append((pos, rgb[0], rgb[0]))
     greens.append((pos, rgb[1], rgb[1]))
@@ -105,14 +107,12 @@ transparent_red = LinearSegmentedColormap.from_list("transparent_red", colors)
 old_blue_rgb = np.array([30, 136, 229]) / 255
 old_red_rgb = np.array([255, 13, 87]) / 255
 
-colors = []
+rgb_colors: list[np.ndarray] = []
 for alpha in np.linspace(1, 0, 100):
-    c = blue_rgb * alpha + (1 - alpha) * white_rgb
-    colors.append(c)
+    rgb_colors.append(blue_rgb * alpha + (1 - alpha) * white_rgb)
 for alpha in np.linspace(0, 1, 100):
-    c = red_rgb * alpha + (1 - alpha) * white_rgb
-    colors.append(c)
-red_white_blue = LinearSegmentedColormap.from_list("red_white_blue", colors)
+    rgb_colors.append(red_rgb * alpha + (1 - alpha) * white_rgb)
+red_white_blue = LinearSegmentedColormap.from_list("red_white_blue", rgb_colors)
 
 
 # default_colors = ["#1E88E5", "#ff0d57", "#13B755", "#7C52FF", "#FFC000", "#00AEEF"]


### PR DESCRIPTION
## Overview

Thanks to these PRs we can finally remove numba and llvmlite from dependencies:

## Merged migrations

- [#4366](https://github.com/shap/shap/pull/4366) — Move to nanobind (2026-04-17)
- [#5081](https://github.com/shap/shap/pull/5081) — PERF: Migrate lower_credit to nanobind (2026-08-30)
- [#5082](https://github.com/shap/shap/pull/5082) — PERF: Migrate mask construction to nanobind (2026-08-30)
- [#5088](https://github.com/shap/shap/pull/5088) — PERF: Migrate clustering utilities to nanobind (2026-08-09)
- [#5089](https://github.com/shap/shap/pull/5089) — PERF: Remove Numba from image masker (2026-08-03)
- [#5090](https://github.com/shap/shap/pull/5090) — PERF: Migrate tabular masking utilities to nanobind (2026-08-10)
- [#5091](https://github.com/shap/shap/pull/5091) — PERF: Migrate ExactExplainer interaction utility to nanobind (2026-08-11)
- [#5092](https://github.com/shap/shap/pull/5092) — PERF: Migrate masked-model output utilities to nanobind (2026-08-31)

## Merged infrastructure

- [#4452](https://github.com/shap/shap/pull/4452) — Establish scikit-build-core as sole backend (2026-04-13)
- [#4539](https://github.com/shap/shap/pull/4539) — Add nanobind stub (2026-04-13)
- [#4541](https://github.com/shap/shap/pull/4541) — Fix import for nanobind cutils (2026-04-13)


This also adds builds for free-threaded python.

## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- ~[ ] Unit tests added (if fixing a bug or adding a new feature)~
