### PR TITLE
DOCS: Document categorical split limitation in TreeExplainer

### DIFF
--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -354,6 +354,12 @@ class TreeExplainer(Explainer):
 
         # compute the expected value if we have a parsed tree for the cext
         if self.model.model_output == "log_loss":
+            if self.model.trees is None:
+                raise ExplainerError(
+                    "Currently TreeExplainer can only handle models with categorical splits when "
+                    'feature_perturbation="tree_path_dependent" and no background data is passed. Please try again using '
+                    'shap.TreeExplainer(model, feature_perturbation="tree_path_dependent").'
+                )
             self.expected_value = self.__dynamic_expected_value
         elif data is not None:
             try:

--- a/shap/explainers/_tree.py
+++ b/shap/explainers/_tree.py
@@ -179,7 +179,10 @@ class TreeExplainer(Explainer):
         model : model object
             The tree based machine learning model that we want to explain.
             XGBoost, LightGBM, CatBoost, Pyspark and most tree-based
-            scikit-learn models are supported.
+            scikit-learn models are supported. Notably, models with native categorical splits
+            only work with ``feature_perturbation="tree_path_dependent"`` and no background data.
+            Therefore, such models cannot be used with ``model_output="log_loss"``, which requires
+            ``feature_perturbation="interventional"`` and therefore a background dataset.
 
         data : numpy.array or pandas.DataFrame
             The background dataset to use for integrating out features.
@@ -207,6 +210,10 @@ class TreeExplainer(Explainer):
             - if ``"auto"``, the "interventional" approach will be used when a
               background is provided, otherwise the "tree_path_dependent" approach will
               be used.
+
+            Models with native categorical splits (e.g. LightGBM trained on pandas ``category`` dtype columns)
+            are only supported with ``feature_perturbation="tree_path_dependent"``. Passing a background dataset
+            with such a model is not currently supported.
 
             .. versionadded:: 0.47
                The `"auto"` option was added.


### PR DESCRIPTION
## Overview

Closes #5132 

Description of the changes proposed in this pull request:

Added documentation regarding the use of models with native categorical splits and how they only work with feature_perturbation="tree_path_dependent" and no background data. Also noted that this caveat extends to model_output="log_loss", which requires feature_perturbation="interventional" and therefore a background dataset, making it incompatible with models that have native categorical splits.

I also added similar documentation in the feature_perturbation section of the docstring, since that's probably where a user debugging this specific issue would look.

Regarding the bug fix, if you used a LightGBM model with categorical splits and passed background data with model_output="log_loss", TreeExplainer would build fine but then crash later with a confusing AttributeError. The same setup without log_loss already gave a clear error, but this path just wasn't checked. Therefore, added the same check to the log_loss path, so it now raises the same clear error right away instead of failing later.


## Checklist

- [x] All [pre-commit checks](https://pre-commit.com/#install) pass.
- [ ] Unit tests added (if fixing a bug or adding a new feature)
