### PR TITLE
FIX: Honor Explanation values in partial dependence rank indexing

### DIFF
--- a/shap/plots/_partial_dependence.py
+++ b/shap/plots/_partial_dependence.py
@@ -67,9 +67,11 @@ def partial_dependence(
     if feature_names is None:
         feature_names = [f"Feature {i}" for i in range(features.shape[1])]
 
+    shap_values_array = shap_values.values if isinstance(shap_values, Explanation) else None
+
     # this is for a 1D partial dependence plot
     if not isinstance(ind, tuple):
-        ind = convert_name(ind, None, feature_names)
+        ind = convert_name(ind, shap_values_array, feature_names)
         xv = features[:, ind]
         xmin, xmax = compute_bounds(xmin, xmax, xv)
         npoints = 100 if npoints is None else npoints
@@ -208,8 +210,8 @@ def partial_dependence(
 
     # this is for a 2D partial dependence plot
     else:
-        ind0 = convert_name(ind[0], None, feature_names)
-        ind1 = convert_name(ind[1], None, feature_names)
+        ind0 = convert_name(ind[0], shap_values_array, feature_names)
+        ind1 = convert_name(ind[1], shap_values_array, feature_names)
         xv0 = features[:, ind0]
         xv1 = features[:, ind1]
 

--- a/tests/plots/test_dependence.py
+++ b/tests/plots/test_dependence.py
@@ -41,3 +41,86 @@ def test_dependence_use_line_collection_bug():
         shap_values=shap_values[:1, :],  # type: ignore[call-overload]
         show=False,
     )
+
+
+@pytest.fixture
+def partial_dependence_explanation():
+    data = np.array([[0, 10, 100], [2, 11, 105], [4, 12, 110]], dtype=float)
+    values = (data - data.mean(0)) * np.array([3, 1, 2])
+    return shap.Explanation(values, base_values=227.0, data=data)
+
+
+@pytest.mark.parametrize("explanation_as_data", [False, True])
+@pytest.mark.parametrize(
+    "ind, feature_name, slope, intercept",
+    [("rank(0)", "C", 2, 17), ("rank(1)", "A", 3, 221), (2, "C", 2, 17), ("C", "C", 2, 17)],
+)
+def test_partial_dependence_feature_selection(
+    partial_dependence_explanation, explanation_as_data, ind, feature_name, slope, intercept
+):
+    explanation = partial_dependence_explanation
+    fig, ax = shap.plots.partial_dependence(
+        ind,
+        lambda data: data @ np.array([3, 1, 2]),
+        explanation if explanation_as_data else explanation.data,
+        shap_values=None if explanation_as_data else explanation,
+        feature_names=["A", "B", "C"],
+        xmin=-1,
+        xmax=1,
+        npoints=3,
+        ice=False,
+        hist=False,
+        show=False,
+    )
+
+    assert ax.get_xlabel() == feature_name
+    np.testing.assert_allclose(ax.lines[0].get_xdata(), [-1, 0, 1])
+    np.testing.assert_allclose(ax.lines[0].get_ydata(), slope * np.array([-1, 0, 1]) + intercept)
+    fig.canvas.draw()
+
+
+@pytest.mark.parametrize("explanation_as_data", [False, True])
+def test_partial_dependence_rank_pair(partial_dependence_explanation, explanation_as_data):
+    explanation = partial_dependence_explanation
+    fig, ax = shap.plots.partial_dependence(
+        ("rank(0)", "rank(1)"),
+        lambda data: data @ np.array([3, 1, 2]),
+        explanation if explanation_as_data else explanation.data,
+        shap_values=None if explanation_as_data else explanation,
+        feature_names=["A", "B", "C"],
+        npoints=3,
+        show=False,
+    )
+
+    assert ax.get_xlabel() == "C"
+    assert ax.get_ylabel() == "A"
+    fig.canvas.draw()
+
+
+@pytest.mark.parametrize("ind", [(2, 0), ("C", "A")])
+def test_partial_dependence_pair_with_shap_array(partial_dependence_explanation, ind):
+    explanation = partial_dependence_explanation
+    fig, ax = shap.plots.partial_dependence(
+        ind,
+        lambda data: data @ np.array([3, 1, 2]),
+        explanation.data,
+        shap_values=explanation.values,
+        feature_names=["A", "B", "C"],
+        npoints=3,
+        show=False,
+    )
+
+    assert ax.get_xlabel() == "C"
+    assert ax.get_ylabel() == "A"
+    fig.canvas.draw()
+
+
+@pytest.mark.parametrize("ind", ["rank(0)", ("rank(0)", 1), (0, "rank(1)")])
+def test_partial_dependence_rank_requires_shap_values(partial_dependence_explanation, ind):
+    with pytest.raises(ValueError, match="shap_values must be provided for rank-based indexing"):
+        shap.plots.partial_dependence(
+            ind,
+            lambda data: data @ np.array([3, 1, 2]),
+            partial_dependence_explanation.data,
+            show=False,
+        )


### PR DESCRIPTION
## Overview

`partial_dependence("rank(0)", ...)` raises the missing-SHAP-values error even when an `Explanation` is supplied through `shap_values` or `data`: all three feature-name resolution calls pass `None` to `convert_name`.

Forward the supplied `Explanation.values` for both one- and two-feature plots. This reuses the existing mean-absolute-SHAP ranking and preserves ordinary index/name selection, including the two-feature path's handling of an unused raw array.

Related to #2920. Ranking still requires an `Explanation`; the plot does not compute SHAP values when none are provided.

## Validation

- Added local tests using a synthetic linear model and an explicitly constructed `Explanation`. They check ranked feature selection, numerical partial-dependence curves, two-feature rendering, ordinary selectors, and the missing-values error.
- `uv run --no-sync pytest tests/plots/test_dependence.py tests/utils/test_general.py -k 'not test_dependence_use_line_collection_bug' --tb=short`: **31 passed, 1 deselected**. The excluded existing test downloads the California housing dataset.
- Pre-commit passes for both changed files. The full-repository run reports two existing Ruff `I001` import-order errors in `tests/explainers/test_exact.py` and `tests/utils/test_masked_model.py`; both files are unchanged from the base commit. All other hooks pass.

The subsequent [pre-commit.ci run](https://results.pre-commit.ci/run/github/74505259/1788976779.QWS3Tm_LSPey2M4U0YighQ) passed all 10 configured hooks, with no skipped hooks. The local baseline findings above are retained for transparency.

## Checklist

- [x] All configured pre-commit hooks pass in pre-commit.ci. See the local baseline findings above.
- [x] Unit tests added (if fixing a bug or adding a new feature)

## AI usage

Codex autonomously investigated the issue, wrote the fix and regression tests, and ran the checks. A separate Codex agent reviewed the change and identified the two-feature array compatibility case covered by the final tests.
